### PR TITLE
Added metrics describing the cpu and mem requests per container .

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ additional metrics!
 | kube_pod_container_status_terminated | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 | kube_pod_container_status_ready | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 | kube_pod_container_status_restarts | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; |
+| kube_pod_container_requested_cpu_millicores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
+| kube_pod_container_requested_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
 
 ## kube-state-metrics vs. Heapster
 

--- a/pod.go
+++ b/pod.go
@@ -76,13 +76,13 @@ var (
 
 	descPodContainerRequestedCpuMilliCores = prometheus.NewDesc(
 		"kube_pod_container_requested_cpu_millicores",
-		"The number of requested cpu millicores by a container",
+		"The number of requested cpu millicores by a container.",
 		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 
 	descPodContainerRequestedMemoryBytes = prometheus.NewDesc(
 		"kube_pod_container_requested_memory_bytes",
-		"The number of requested memory bytes  by a container",
+		"The number of requested memory bytes  by a container.",
 		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 )
@@ -162,12 +162,14 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 	nodeName := p.Spec.NodeName
 	for _, c := range p.Spec.Containers {
 		req := c.Resources.Requests
-		cpu := req[v1.ResourceCPU]
-		mem := req[v1.ResourceMemory]
+		if cpu, ok := req[v1.ResourceCPU]; ok {
+			addGauge(descPodContainerRequestedCpuMilliCores, float64(cpu.MilliValue()),
+				c.Name, nodeName)
+		}
+		if mem, ok := req[v1.ResourceMemory]; ok {
+			addGauge(descPodContainerRequestedMemoryBytes, float64(mem.Value()),
+				c.Name, nodeName)
+		}
 
-		addGauge(descPodContainerRequestedCpuMilliCores, float64(cpu.MilliValue()),
-			c.Name, nodeName)
-		addGauge(descPodContainerRequestedMemoryBytes, float64(mem.Value()),
-			c.Name, nodeName)
 	}
 }

--- a/pod.go
+++ b/pod.go
@@ -73,6 +73,18 @@ var (
 		"The number of container restarts per container.",
 		[]string{"namespace", "pod", "container"}, nil,
 	)
+
+	descPodContainerRequestedCpuMilliCores = prometheus.NewDesc(
+		"kube_pod_container_requested_cpu_millicores",
+		"The number of requested cpu millicores by a container",
+		[]string{"namespace", "pod", "container", "node"}, nil,
+	)
+
+	descPodContainerRequestedMemoryBytes = prometheus.NewDesc(
+		"kube_pod_container_requested_memory_bytes",
+		"The number of requested memory bytes  by a container",
+		[]string{"namespace", "pod", "container", "node"}, nil,
+	)
 )
 
 type podStore interface {
@@ -96,6 +108,8 @@ func (pc *podCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descPodContainerStatusTerminated
 	ch <- descPodContainerStatusReady
 	ch <- descPodContainerStatusRestarts
+	ch <- descPodContainerRequestedCpuMilliCores
+	ch <- descPodContainerRequestedMemoryBytes
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -143,5 +157,17 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 		addGauge(descPodContainerStatusTerminated, boolFloat64(cs.State.Terminated != nil), cs.Name)
 		addGauge(descPodContainerStatusReady, boolFloat64(cs.Ready), cs.Name)
 		addCounter(descPodContainerStatusRestarts, float64(cs.RestartCount), cs.Name)
+	}
+
+	nodeName := p.Spec.NodeName
+	for _, c := range p.Spec.Containers {
+		req := c.Resources.Requests
+		cpu := req[v1.ResourceCPU]
+		mem := req[v1.ResourceMemory]
+
+		addGauge(descPodContainerRequestedCpuMilliCores, float64(cpu.MilliValue()),
+			c.Name, nodeName)
+		addGauge(descPodContainerRequestedMemoryBytes, float64(mem.Value()),
+			c.Name, nodeName)
 	}
 }

--- a/pod_test.go
+++ b/pod_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"testing"
 
+	"k8s.io/client-go/1.4/pkg/api/resource"
 	"k8s.io/client-go/1.4/pkg/api/v1"
 )
 
@@ -54,6 +55,10 @@ func TestPodCollector(t *testing.T) {
 		# TYPE kube_pod_status_ready gauge
 		# HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
 		# TYPE kube_pod_status_scheduled gauge
+		# HELP kube_pod_container_requested_cpu_millicores The number of requested cpu millicores by a container
+		# TYPE kube_pod_container_requested_cpu_millicores gauge
+		# HELP kube_pod_container_requested_memory_bytes The number of requested memory bytes  by a container
+		# TYPE kube_pod_container_requested_memory_bytes gauge
 	`
 	cases := []struct {
 		pods    []v1.Pod
@@ -372,6 +377,80 @@ func TestPodCollector(t *testing.T) {
 				kube_pod_status_scheduled{condition="unknown",namespace="ns2",pod="pod2"} 0
 			`,
 			metrics: []string{"kube_pod_status_scheduled"},
+		}, {
+			pods: []v1.Pod{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "pod1_con1",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewMilliQuantity(int64(200), resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(100000000, resource.DecimalSI),
+									},
+								},
+							},
+							v1.Container{
+								Name: "pod1_con2",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewMilliQuantity(int64(300), resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(200000000, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				}, {
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "ns2",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node2",
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "pod2_con1",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewMilliQuantity(int64(400), resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(300000000, resource.DecimalSI),
+									},
+								},
+							},
+							v1.Container{
+								Name: "pod2_con2",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewMilliQuantity(int64(500), resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(400000000, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: metadata + `
+		kube_pod_container_requested_cpu_millicores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 200
+		kube_pod_container_requested_cpu_millicores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 300
+		kube_pod_container_requested_cpu_millicores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 400
+		kube_pod_container_requested_cpu_millicores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 500
+		kube_pod_container_requested_memory_bytes{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 1e+08
+		kube_pod_container_requested_memory_bytes{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 2e+08
+		kube_pod_container_requested_memory_bytes{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 3e+08
+		kube_pod_container_requested_memory_bytes{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 4e+08
+		`,
+			metrics: []string{
+				"kube_pod_container_requested_cpu_millicores",
+				"kube_pod_container_requested_memory_bytes",
+			},
 		},
 	}
 	for _, c := range cases {

--- a/pod_test.go
+++ b/pod_test.go
@@ -55,9 +55,9 @@ func TestPodCollector(t *testing.T) {
 		# TYPE kube_pod_status_ready gauge
 		# HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
 		# TYPE kube_pod_status_scheduled gauge
-		# HELP kube_pod_container_requested_cpu_millicores The number of requested cpu millicores by a container
+		# HELP kube_pod_container_requested_cpu_millicores The number of requested cpu millicores by a container.
 		# TYPE kube_pod_container_requested_cpu_millicores gauge
-		# HELP kube_pod_container_requested_memory_bytes The number of requested memory bytes  by a container
+		# HELP kube_pod_container_requested_memory_bytes The number of requested memory bytes  by a container.
 		# TYPE kube_pod_container_requested_memory_bytes gauge
 	`
 	cases := []struct {
@@ -432,6 +432,10 @@ func TestPodCollector(t *testing.T) {
 										v1.ResourceMemory: *resource.NewQuantity(400000000, resource.DecimalSI),
 									},
 								},
+							},
+							// A container without a resource specicication. No metrics will be emitted for that.
+							v1.Container{
+								Name: "pod2_con3",
 							},
 						},
 					},


### PR DESCRIPTION
These metrics are retrieved using the v1 api directly.
No additional acucmulation or computation is done.

The state is maintained per container in a pod in kubernetes.
This change exposes the state in kubernetes via  kube-state-metrics

The metrics are also tagged by the node,where  the containers are residing.
Our use case for these metrics are as follows:

We would like to accumulate these per node and understand how much
remaining un-requested resourced are available in each node.

This would give an indication of the "utilization" of the cluster to us.