### PR TITLE
Add deployment metadata.generation metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ additional metrics!
 | kube_deployment_status_replicas_observed_generation | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; |
 | kube_deployment_spec_replicas | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; |
 | kube_deployment_spec_paused | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; |
+| kube_deployment_metadata_generation | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; |
 
 ### Pod Metrics
 

--- a/deployment.go
+++ b/deployment.go
@@ -61,6 +61,12 @@ var (
 		"Whether the deployment is paused and will not be processed by the deployment controller.",
 		[]string{"namespace", "deployment"}, nil,
 	)
+
+	descDeploymentMetadataGeneration = prometheus.NewDesc(
+		"kube_deployment_metadata_generation",
+		"Sequence number representing a specific generation of the desired state.",
+		[]string{"namespace", "deployment"}, nil,
+	)
 )
 
 type deploymentStore interface {
@@ -81,6 +87,7 @@ func (dc *deploymentCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descDeploymentStatusObservedGeneration
 	ch <- descDeploymentSpecPaused
 	ch <- descDeploymentSpecReplicas
+	ch <- descDeploymentMetadataGeneration
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -107,4 +114,5 @@ func (dc *deploymentCollector) collectDeployment(ch chan<- prometheus.Metric, d 
 	addGauge(descDeploymentStatusObservedGeneration, float64(d.Status.ObservedGeneration))
 	addGauge(descDeploymentSpecPaused, boolFloat64(d.Spec.Paused))
 	addGauge(descDeploymentSpecReplicas, float64(*d.Spec.Replicas))
+	addGauge(descDeploymentMetadataGeneration, float64(d.ObjectMeta.Generation))
 }

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -49,6 +49,8 @@ func TestDeploymentCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_deployment_metadata_generation Sequence number representing a specific generation of the desired state.
+		# TYPE kube_deployment_metadata_generation gauge
 		# HELP kube_deployment_spec_paused Whether the deployment is paused and will not be processed by the deployment controller.
 		# TYPE kube_deployment_spec_paused gauge
 		# HELP kube_deployment_spec_replicas Number of desired pods for a deployment.
@@ -72,8 +74,9 @@ func TestDeploymentCollector(t *testing.T) {
 			depls: []v1beta1.Deployment{
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "depl1",
-						Namespace: "ns1",
+						Name:       "depl1",
+						Namespace:  "ns1",
+						Generation: 21,
 					},
 					Status: v1beta1.DeploymentStatus{
 						Replicas:            15,
@@ -87,8 +90,9 @@ func TestDeploymentCollector(t *testing.T) {
 					},
 				}, {
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "depl2",
-						Namespace: "ns2",
+						Name:       "depl2",
+						Namespace:  "ns2",
+						Generation: 14,
 					},
 					Status: v1beta1.DeploymentStatus{
 						Replicas:            10,
@@ -104,6 +108,8 @@ func TestDeploymentCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_deployment_metadata_generation{namespace="ns1",deployment="depl1"} 21
+				kube_deployment_metadata_generation{namespace="ns2",deployment="depl2"} 14
 				kube_deployment_spec_paused{namespace="ns1",deployment="depl1"} 0
 				kube_deployment_spec_paused{namespace="ns2",deployment="depl2"} 1
 				kube_deployment_spec_replicas{namespace="ns1",deployment="depl1"} 200
@@ -182,7 +188,7 @@ metric output does not match expectation; want:
 
 got:
 
-%s       
+%s
 `, buf2.String(), buf1.String())
 	}
 	return nil


### PR DESCRIPTION
This PR adds deployment `metadata.generation` metric
Fixes #32 