### PR TITLE
normalize cpu cores unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ additional metrics!
 | kube_pod_container_status_terminated | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 | kube_pod_container_status_ready | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 | kube_pod_container_status_restarts | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; |
-| kube_pod_container_requested_cpu_millicores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
+| kube_pod_container_requested_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
 | kube_pod_container_requested_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
 
 ## kube-state-metrics vs. Heapster

--- a/pod.go
+++ b/pod.go
@@ -74,9 +74,9 @@ var (
 		[]string{"namespace", "pod", "container"}, nil,
 	)
 
-	descPodContainerRequestedCpuMilliCores = prometheus.NewDesc(
-		"kube_pod_container_requested_cpu_millicores",
-		"The number of requested cpu millicores by a container.",
+	descPodContainerRequestedCpuCores = prometheus.NewDesc(
+		"kube_pod_container_requested_cpu_cores",
+		"The number of requested cpu cores by a container.",
 		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 
@@ -108,7 +108,7 @@ func (pc *podCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descPodContainerStatusTerminated
 	ch <- descPodContainerStatusReady
 	ch <- descPodContainerStatusRestarts
-	ch <- descPodContainerRequestedCpuMilliCores
+	ch <- descPodContainerRequestedCpuCores
 	ch <- descPodContainerRequestedMemoryBytes
 }
 
@@ -163,7 +163,7 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 	for _, c := range p.Spec.Containers {
 		req := c.Resources.Requests
 		if cpu, ok := req[v1.ResourceCPU]; ok {
-			addGauge(descPodContainerRequestedCpuMilliCores, float64(cpu.MilliValue()),
+			addGauge(descPodContainerRequestedCpuCores, float64(cpu.MilliValue())/1000,
 				c.Name, nodeName)
 		}
 		if mem, ok := req[v1.ResourceMemory]; ok {

--- a/pod_test.go
+++ b/pod_test.go
@@ -55,8 +55,8 @@ func TestPodCollector(t *testing.T) {
 		# TYPE kube_pod_status_ready gauge
 		# HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
 		# TYPE kube_pod_status_scheduled gauge
-		# HELP kube_pod_container_requested_cpu_millicores The number of requested cpu millicores by a container.
-		# TYPE kube_pod_container_requested_cpu_millicores gauge
+		# HELP kube_pod_container_requested_cpu_cores The number of requested cpu cores by a container.
+		# TYPE kube_pod_container_requested_cpu_cores gauge
 		# HELP kube_pod_container_requested_memory_bytes The number of requested memory bytes  by a container.
 		# TYPE kube_pod_container_requested_memory_bytes gauge
 	`
@@ -391,8 +391,8 @@ func TestPodCollector(t *testing.T) {
 								Name: "pod1_con1",
 								Resources: v1.ResourceRequirements{
 									Requests: map[v1.ResourceName]resource.Quantity{
-										v1.ResourceCPU:    *resource.NewMilliQuantity(int64(200), resource.DecimalSI),
-										v1.ResourceMemory: *resource.NewQuantity(100000000, resource.DecimalSI),
+										v1.ResourceCPU:    resource.MustParse("200m"),
+										v1.ResourceMemory: resource.MustParse("100M"),
 									},
 								},
 							},
@@ -400,8 +400,8 @@ func TestPodCollector(t *testing.T) {
 								Name: "pod1_con2",
 								Resources: v1.ResourceRequirements{
 									Requests: map[v1.ResourceName]resource.Quantity{
-										v1.ResourceCPU:    *resource.NewMilliQuantity(int64(300), resource.DecimalSI),
-										v1.ResourceMemory: *resource.NewQuantity(200000000, resource.DecimalSI),
+										v1.ResourceCPU:    resource.MustParse("300m"),
+										v1.ResourceMemory: resource.MustParse("200M"),
 									},
 								},
 							},
@@ -419,8 +419,8 @@ func TestPodCollector(t *testing.T) {
 								Name: "pod2_con1",
 								Resources: v1.ResourceRequirements{
 									Requests: map[v1.ResourceName]resource.Quantity{
-										v1.ResourceCPU:    *resource.NewMilliQuantity(int64(400), resource.DecimalSI),
-										v1.ResourceMemory: *resource.NewQuantity(300000000, resource.DecimalSI),
+										v1.ResourceCPU:    resource.MustParse("400m"),
+										v1.ResourceMemory: resource.MustParse("300M"),
 									},
 								},
 							},
@@ -428,8 +428,8 @@ func TestPodCollector(t *testing.T) {
 								Name: "pod2_con2",
 								Resources: v1.ResourceRequirements{
 									Requests: map[v1.ResourceName]resource.Quantity{
-										v1.ResourceCPU:    *resource.NewMilliQuantity(int64(500), resource.DecimalSI),
-										v1.ResourceMemory: *resource.NewQuantity(400000000, resource.DecimalSI),
+										v1.ResourceCPU:    resource.MustParse("500m"),
+										v1.ResourceMemory: resource.MustParse("400M"),
 									},
 								},
 							},
@@ -442,17 +442,17 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-		kube_pod_container_requested_cpu_millicores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 200
-		kube_pod_container_requested_cpu_millicores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 300
-		kube_pod_container_requested_cpu_millicores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 400
-		kube_pod_container_requested_cpu_millicores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 500
+		kube_pod_container_requested_cpu_cores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 0.2
+		kube_pod_container_requested_cpu_cores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 0.3
+		kube_pod_container_requested_cpu_cores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 0.4
+		kube_pod_container_requested_cpu_cores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 0.5
 		kube_pod_container_requested_memory_bytes{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 1e+08
 		kube_pod_container_requested_memory_bytes{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 2e+08
 		kube_pod_container_requested_memory_bytes{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 3e+08
 		kube_pod_container_requested_memory_bytes{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 4e+08
 		`,
 			metrics: []string{
-				"kube_pod_container_requested_cpu_millicores",
+				"kube_pod_container_requested_cpu_cores",
 				"kube_pod_container_requested_memory_bytes",
 			},
 		},


### PR DESCRIPTION
As @fabxc pointed out in [this comment](https://github.com/kubernetes/kube-state-metrics/pull/35#discussion_r83591789) it is best practice to use base units.

@ahakanbaba