### PR TITLE
Fix resource fractions

### DIFF
--- a/node.go
+++ b/node.go
@@ -165,7 +165,7 @@ func (nc *nodeCollector) collectNode(ch chan<- prometheus.Metric, n v1.Node) {
 	// Add capacity and allocateable resources if they are set.
 	addResource := func(d *prometheus.Desc, res v1.ResourceList, n v1.ResourceName) {
 		if v, ok := res[n]; ok {
-			addGauge(d, float64(v.Value()))
+			addGauge(d, float64(v.MilliValue())/1000)
 		}
 	}
 	addResource(descNodeStatusCapacityCPU, n.Status.Capacity, v1.ResourceCPU)

--- a/node_test.go
+++ b/node_test.go
@@ -103,7 +103,7 @@ func TestNodeCollector(t *testing.T) {
 							ContainerRuntimeVersion: "rkt",
 						},
 						Capacity: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("4"),
+							v1.ResourceCPU:    resource.MustParse("4.3"),
 							v1.ResourceMemory: resource.MustParse("2G"),
 							v1.ResourcePods:   resource.MustParse("1000"),
 						},
@@ -118,7 +118,7 @@ func TestNodeCollector(t *testing.T) {
 			want: metadata + `
 				kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage"} 1
 				kube_node_spec_unschedulable{node="127.0.0.1"} 1
-				kube_node_status_capacity_cpu_cores{node="127.0.0.1"} 4
+				kube_node_status_capacity_cpu_cores{node="127.0.0.1"} 4.3
 				kube_node_status_capacity_memory_bytes{node="127.0.0.1"} 2e9
 				kube_node_status_capacity_pods{node="127.0.0.1"} 1000
 				kube_node_status_allocateable_cpu_cores{node="127.0.0.1"} 3


### PR DESCRIPTION
This fixes the generation of resource metrics to respect milli
precision.

@brancz I realized I introduced this mistake when reviewing your last PR.