### PR TITLE
healthcheck metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ additional metrics!
 | kube_pod_container_status_restarts | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; |
 | kube_pod_container_requested_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
 | kube_pod_container_requested_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
+| kube_pod_healthcheck_num_of_failures | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
+| kube_pod_healthcheck_seconds_since_last_failure | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 
 ## kube-state-metrics vs. Heapster
 

--- a/event.go
+++ b/event.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+)
+
+var (
+	descPodNumOfHealthcheckFailures = prometheus.NewDesc(
+		"kube_pod_healthcheck_num_of_failures",
+		"Number of healthcheck failures for a given pod.",
+		[]string{"namespace", "pod"}, nil,
+	)
+	descSecondsSinceLastHealthcheckFailure = prometheus.NewDesc(
+		"kube_pod_healthcheck_seconds_since_last_failure",
+		"Number of seconds since of last healthcheck failure.",
+		[]string{"namespace", "pod"}, nil,
+	)
+)
+
+type eventStore interface {
+	List() (events []v1.Event, err error)
+}
+
+// eventCollector collects metrics about selected events in the cluster.
+type eventCollector struct {
+	store eventStore
+}
+
+// Describe implements the prometheus.Collector interface.
+func (pc *eventCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descPodNumOfHealthcheckFailures
+	ch <- descSecondsSinceLastHealthcheckFailure
+}
+
+// Collect implements the prometheus.Collector interface.
+func (pc *eventCollector) Collect(ch chan<- prometheus.Metric) {
+	events, err := pc.store.List()
+	if err != nil {
+		glog.Errorf("listing events failed: %s", err)
+		return
+	}
+	for _, ev := range events {
+		pc.collectEvent(ch, ev)
+	}
+}
+
+func (pc *eventCollector) collectEvent(ch chan<- prometheus.Metric, ev v1.Event) {
+	addConstMetric := func(desc *prometheus.Desc, t prometheus.ValueType, v float64, lv ...string) {
+		lv = append([]string{ev.Namespace, ev.Name}, lv...)
+		ch <- prometheus.MustNewConstMetric(desc, t, v, lv...)
+	}
+	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
+		addConstMetric(desc, prometheus.GaugeValue, v, lv...)
+	}
+	if ev.InvolvedObject.Kind == "Pod" {
+		if (ev.Reason == "Unhealthy") && (ev.Count > 0) {
+			addGauge(descPodNumOfHealthcheckFailures, float64(ev.Count))
+			addGauge(descSecondsSinceLastHealthcheckFailure,
+				float64(int(time.Since(ev.LastTimestamp.Time).Seconds())))
+		}
+	}
+}

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+)
+
+type mockEventStore struct {
+	f func() ([]v1.Event, error)
+}
+
+func (ds mockEventStore) List() (events []v1.Event, err error) {
+	return ds.f()
+}
+
+func TestEventCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+	const metadata = `
+		# HELP kube_pod_healthcheck_num_of_failures Number of healthcheck failures for a given pod.
+		# TYPE kube_pod_healthcheck_num_of_failures gauge
+		# HELP kube_pod_healthcheck_seconds_since_last_failure Number of seconds since of last healthcheck failure.
+		# TYPE kube_pod_healthcheck_seconds_since_last_failure gauge
+	`
+
+	var now = time.Now()
+	var minus5 = now.Add(-5 * time.Minute)
+	var minus10 = now.Add(-10 * time.Minute)
+
+	cases := []struct {
+		events  []v1.Event
+		metrics []string
+		want    string
+	}{
+		{
+			events: []v1.Event{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "ns1",
+						Name:      "pod1",
+					},
+					InvolvedObject: v1.ObjectReference{
+						Kind:      "Pod",
+						Namespace: "ns1",
+						Name:      "pod1",
+					},
+					Reason:        "Unhealthy",
+					Count:         35,
+					LastTimestamp: unversioned.NewTime(minus5),
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "ns2",
+						Name:      "pod2",
+					},
+					InvolvedObject: v1.ObjectReference{
+						Kind:      "Pod",
+						Namespace: "ns2",
+						Name:      "pod2",
+					},
+					Reason:        "Unhealthy",
+					Count:         17,
+					LastTimestamp: unversioned.NewTime(minus10),
+				},
+			},
+			want: metadata + `
+				kube_pod_healthcheck_num_of_failures{namespace="ns1",pod="pod1"} 35
+				kube_pod_healthcheck_num_of_failures{namespace="ns2",pod="pod2"} 17
+				kube_pod_healthcheck_seconds_since_last_failure{namespace="ns1",pod="pod1"} 300
+				kube_pod_healthcheck_seconds_since_last_failure{namespace="ns2",pod="pod2"} 600
+				`,
+			metrics: []string{
+				"kube_pod_healthcheck_num_of_failures",
+				"kube_pod_healthcheck_seconds_since_last_failure",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		ec := &eventCollector{
+			store: mockEventStore{
+				f: func() ([]v1.Event, error) { return c.events, nil },
+			},
+		}
+		if err := gatherAndCompare(ec, c.want, c.metrics); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	}
+}


### PR DESCRIPTION
This does the following:
- adds event watcher (with pod events filtering)
- adds 2 healthcheck related metrics:
  - total number of healthcheck failures
  - seconds since last healthcheck failure

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/45)
<!-- Reviewable:end -->
