### PR TITLE
Pod Metric Labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,20 @@ additional metrics!
 
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
-| kube_pod_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `host_ip`=&lt;host-ip&gt; <br> `pod_ip`=&lt;pod-ip&gt; <br> `start_time`=&lt;date-time since kubelet acknowledged pod&gt; |
-| kube_pod_status_phase | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `phase`=&lt;Pending\|Running\|Succeeded\|Failed\|Unknown&gt; |
-| kube_pod_status_ready | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
-| kube_pod_status_scheduled | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
-| kube_pod_container_info | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `image`=&lt;image-name&gt; <br> `image_id`=&lt;image-id&gt; <br> `container_id`=&lt;containerid&gt; |
-| kube_pod_container_status_waiting | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
-| kube_pod_container_status_running | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
-| kube_pod_container_status_terminated | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
-| kube_pod_container_status_ready | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
-| kube_pod_container_status_restarts | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; |
-| kube_pod_container_requested_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
-| kube_pod_container_requested_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
-| kube_pod_container_limits_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
-| kube_pod_container_limits_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-address&gt; |
+| kube_pod_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `host_ip`=&lt;host-ip&gt; <br> `pod_ip`=&lt;pod-ip&gt; <br> `start_time`=&lt;date-time since kubelet acknowledged pod&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_status_phase | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `phase`=&lt;Pending\|Running\|Succeeded\|Failed\|Unknown&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_status_ready | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_status_scheduled | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_container_info | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `image`=&lt;image-name&gt; <br> `image_id`=&lt;image-id&gt; <br> `container_id`=&lt;containerid&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_container_status_waiting | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_container_status_running | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_container_status_terminated | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_container_status_ready | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_container_status_restarts | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_container_requested_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
+| kube_pod_container_requested_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
+| kube_pod_container_limits_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
+| kube_pod_container_limits_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
 
 ## kube-state-metrics vs. Heapster
 

--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ additional metrics!
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
 | kube_pod_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `host_ip`=&lt;host-ip&gt; <br> `pod_ip`=&lt;pod-ip&gt; <br> `start_time`=&lt;date-time since kubelet acknowledged pod&gt; <br> `node`=&lt;node-name&gt; |
-| kube_pod_status_phase | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `phase`=&lt;Pending\|Running\|Succeeded\|Failed\|Unknown&gt; <br> `node`=&lt;node-name&gt; |
-| kube_pod_status_ready | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; <br> `node`=&lt;node-name&gt; |
-| kube_pod_status_scheduled | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; <br> `node`=&lt;node-name&gt; |
-| kube_pod_container_info | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `image`=&lt;image-name&gt; <br> `image_id`=&lt;image-id&gt; <br> `container_id`=&lt;containerid&gt; <br> `node`=&lt;node-name&gt; |
-| kube_pod_container_status_waiting | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt;node-name&gt; |
-| kube_pod_container_status_running | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt;node-name&gt; |
-| kube_pod_container_status_terminated | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt;node-name&gt; |
-| kube_pod_container_status_ready | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt;node-name&gt; |
-| kube_pod_container_status_restarts | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; <br> `node`=&lt;node-name&gt; |
+| kube_pod_status_phase | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `phase`=&lt;Pending\|Running\|Succeeded\|Failed\|Unknown&gt; |
+| kube_pod_status_ready | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
+| kube_pod_status_scheduled | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
+| kube_pod_container_info | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `image`=&lt;image-name&gt; <br> `image_id`=&lt;image-id&gt; <br> `container_id`=&lt;containerid&gt; |
+| kube_pod_container_status_waiting | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
+| kube_pod_container_status_running | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
+| kube_pod_container_status_terminated | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
+| kube_pod_container_status_ready | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
+| kube_pod_container_status_restarts | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; |
 | kube_pod_container_requested_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
 | kube_pod_container_requested_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
 | kube_pod_container_limits_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |

--- a/pod.go
+++ b/pod.go
@@ -31,47 +31,47 @@ var (
 	descPodStatusPhase = prometheus.NewDesc(
 		"kube_pod_status_phase",
 		"The pods current phase.",
-		[]string{"namespace", "pod", "phase", "node"}, nil,
+		[]string{"namespace", "pod", "phase"}, nil,
 	)
 	descPodStatusReady = prometheus.NewDesc(
 		"kube_pod_status_ready",
 		"Describes whether the pod is ready to serve requests.",
-		[]string{"namespace", "pod", "node", "condition"}, nil,
+		[]string{"namespace", "pod", "condition"}, nil,
 	)
 	descPodStatusScheduled = prometheus.NewDesc(
 		"kube_pod_status_scheduled",
 		"Describes the status of the scheduling process for the pod.",
-		[]string{"namespace", "pod", "node", "condition"}, nil,
+		[]string{"namespace", "pod", "condition"}, nil,
 	)
 	descPodContainerInfo = prometheus.NewDesc(
 		"kube_pod_container_info",
 		"Information about a container in a pod.",
-		[]string{"namespace", "pod", "container", "image", "image_id", "container_id", "node"}, nil,
+		[]string{"namespace", "pod", "container", "image", "image_id", "container_id"}, nil,
 	)
 	descPodContainerStatusWaiting = prometheus.NewDesc(
 		"kube_pod_container_status_waiting",
 		"Describes whether the container is currently in waiting state.",
-		[]string{"namespace", "pod", "container", "node"}, nil,
+		[]string{"namespace", "pod", "container"}, nil,
 	)
 	descPodContainerStatusRunning = prometheus.NewDesc(
 		"kube_pod_container_status_running",
 		"Describes whether the container is currently in running state.",
-		[]string{"namespace", "pod", "container", "node"}, nil,
+		[]string{"namespace", "pod", "container"}, nil,
 	)
 	descPodContainerStatusTerminated = prometheus.NewDesc(
 		"kube_pod_container_status_terminated",
 		"Describes whether the container is currently in terminated state.",
-		[]string{"namespace", "pod", "container", "node"}, nil,
+		[]string{"namespace", "pod", "container"}, nil,
 	)
 	descPodContainerStatusReady = prometheus.NewDesc(
 		"kube_pod_container_status_ready",
 		"Describes whether the containers readiness check succeeded.",
-		[]string{"namespace", "pod", "container", "node"}, nil,
+		[]string{"namespace", "pod", "container"}, nil,
 	)
 	descPodContainerStatusRestarts = prometheus.NewDesc(
 		"kube_pod_container_status_restarts",
 		"The number of container restarts per container.",
-		[]string{"namespace", "pod", "container", "node"}, nil,
+		[]string{"namespace", "pod", "container"}, nil,
 	)
 
 	descPodContainerRequestedCpuCores = prometheus.NewDesc(
@@ -152,26 +152,26 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 	}
 
 	addGauge(descPodInfo, 1, p.Status.HostIP, p.Status.PodIP, nodeName)
-	addGauge(descPodStatusPhase, 1, string(p.Status.Phase), nodeName)
+	addGauge(descPodStatusPhase, 1, string(p.Status.Phase))
 
 	for _, c := range p.Status.Conditions {
 		switch c.Type {
 		case v1.PodReady:
-			addConditionMetrics(ch, descPodStatusReady, c.Status, p.Namespace, p.Name, nodeName)
+			addConditionMetrics(ch, descPodStatusReady, c.Status, p.Namespace, p.Name)
 		case v1.PodScheduled:
-			addConditionMetrics(ch, descPodStatusScheduled, c.Status, p.Namespace, p.Name, nodeName)
+			addConditionMetrics(ch, descPodStatusScheduled, c.Status, p.Namespace, p.Name)
 		}
 	}
 
 	for _, cs := range p.Status.ContainerStatuses {
 		addGauge(descPodContainerInfo, 1,
-			cs.Name, cs.Image, cs.ImageID, cs.ContainerID, nodeName,
+			cs.Name, cs.Image, cs.ImageID, cs.ContainerID,
 		)
-		addGauge(descPodContainerStatusWaiting, boolFloat64(cs.State.Waiting != nil), cs.Name, nodeName)
-		addGauge(descPodContainerStatusRunning, boolFloat64(cs.State.Running != nil), cs.Name, nodeName)
-		addGauge(descPodContainerStatusTerminated, boolFloat64(cs.State.Terminated != nil), cs.Name, nodeName)
-		addGauge(descPodContainerStatusReady, boolFloat64(cs.Ready), cs.Name, nodeName)
-		addCounter(descPodContainerStatusRestarts, float64(cs.RestartCount), cs.Name, nodeName)
+		addGauge(descPodContainerStatusWaiting, boolFloat64(cs.State.Waiting != nil), cs.Name)
+		addGauge(descPodContainerStatusRunning, boolFloat64(cs.State.Running != nil), cs.Name)
+		addGauge(descPodContainerStatusTerminated, boolFloat64(cs.State.Terminated != nil), cs.Name)
+		addGauge(descPodContainerStatusReady, boolFloat64(cs.Ready), cs.Name)
+		addCounter(descPodContainerStatusRestarts, float64(cs.RestartCount), cs.Name)
 	}
 
 	for _, c := range p.Spec.Containers {

--- a/pod_test.go
+++ b/pod_test.go
@@ -76,9 +76,6 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod1",
 						Namespace: "ns1",
 					},
-					Spec: v1.PodSpec{
-						NodeName: "node1",
-					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
 							v1.ContainerStatus{
@@ -93,9 +90,6 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
-					},
-					Spec: v1.PodSpec{
-						NodeName: "node2",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -116,9 +110,9 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_info{container="container1",container_id="docker://ab123",image="gcr.io/google_containers/hyperkube1",image_id="docker://sha256:aaa",namespace="ns1",node="node1",pod="pod1"} 1
-				kube_pod_container_info{container="container2",container_id="docker://cd456",image="gcr.io/google_containers/hyperkube2",image_id="docker://sha256:bbb",namespace="ns2",node="node2",pod="pod2"} 1
-				kube_pod_container_info{container="container3",container_id="docker://ef789",image="gcr.io/google_containers/hyperkube3",image_id="docker://sha256:ccc",namespace="ns2",node="node2",pod="pod2"} 1
+				kube_pod_container_info{container="container1",container_id="docker://ab123",image="gcr.io/google_containers/hyperkube1",image_id="docker://sha256:aaa",namespace="ns1",pod="pod1"} 1
+				kube_pod_container_info{container="container2",container_id="docker://cd456",image="gcr.io/google_containers/hyperkube2",image_id="docker://sha256:bbb",namespace="ns2",pod="pod2"} 1
+				kube_pod_container_info{container="container3",container_id="docker://ef789",image="gcr.io/google_containers/hyperkube3",image_id="docker://sha256:ccc",namespace="ns2",pod="pod2"} 1
 				`,
 			metrics: []string{"kube_pod_container_info"},
 		}, {
@@ -127,9 +121,6 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: "ns1",
-					},
-					Spec: v1.PodSpec{
-						NodeName: "node1",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -143,9 +134,6 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
-					},
-					Spec: v1.PodSpec{
-						NodeName: "node2",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -162,9 +150,9 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_status_ready{container="container1",namespace="ns1",node="node1",pod="pod1"} 1
-				kube_pod_container_status_ready{container="container2",namespace="ns2",node="node2",pod="pod2"} 1
-				kube_pod_container_status_ready{container="container3",namespace="ns2",node="node2",pod="pod2"} 0
+				kube_pod_container_status_ready{container="container1",namespace="ns1",pod="pod1"} 1
+				kube_pod_container_status_ready{container="container2",namespace="ns2",pod="pod2"} 1
+				kube_pod_container_status_ready{container="container3",namespace="ns2",pod="pod2"} 0
 				`,
 			metrics: []string{"kube_pod_container_status_ready"},
 		}, {
@@ -173,9 +161,6 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: "ns1",
-					},
-					Spec: v1.PodSpec{
-						NodeName: "node1",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -189,9 +174,6 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
-					},
-					Spec: v1.PodSpec{
-						NodeName: "node2",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -208,9 +190,9 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_status_restarts{container="container1",namespace="ns1",node="node1",pod="pod1"} 0
-				kube_pod_container_status_restarts{container="container2",namespace="ns2",node="node2",pod="pod2"} 0
-				kube_pod_container_status_restarts{container="container3",namespace="ns2",node="node2",pod="pod2"} 1
+				kube_pod_container_status_restarts{container="container1",namespace="ns1",pod="pod1"} 0
+				kube_pod_container_status_restarts{container="container2",namespace="ns2",pod="pod2"} 0
+				kube_pod_container_status_restarts{container="container3",namespace="ns2",pod="pod2"} 1
 				`,
 			metrics: []string{"kube_pod_container_status_restarts"},
 		}, {
@@ -219,9 +201,6 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: "ns1",
-					},
-					Spec: v1.PodSpec{
-						NodeName: "node1",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -237,9 +216,6 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
-					},
-					Spec: v1.PodSpec{
-						NodeName: "node2",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -260,15 +236,15 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_status_running{container="container1",namespace="ns1",node="node1",pod="pod1"} 1
-				kube_pod_container_status_running{container="container2",namespace="ns2",node="node2",pod="pod2"} 0
-				kube_pod_container_status_running{container="container3",namespace="ns2",node="node2",pod="pod2"} 0
-				kube_pod_container_status_terminated{container="container1",namespace="ns1",node="node1",pod="pod1"} 0
-				kube_pod_container_status_terminated{container="container2",namespace="ns2",node="node2",pod="pod2"} 1
-				kube_pod_container_status_terminated{container="container3",namespace="ns2",node="node2",pod="pod2"} 0
-				kube_pod_container_status_waiting{container="container1",namespace="ns1",node="node1",pod="pod1"} 0
-				kube_pod_container_status_waiting{container="container2",namespace="ns2",node="node2",pod="pod2"} 0
-				kube_pod_container_status_waiting{container="container3",namespace="ns2",node="node2",pod="pod2"} 1
+				kube_pod_container_status_running{container="container1",namespace="ns1",pod="pod1"} 1
+				kube_pod_container_status_running{container="container2",namespace="ns2",pod="pod2"} 0
+				kube_pod_container_status_running{container="container3",namespace="ns2",pod="pod2"} 0
+				kube_pod_container_status_terminated{container="container1",namespace="ns1",pod="pod1"} 0
+				kube_pod_container_status_terminated{container="container2",namespace="ns2",pod="pod2"} 1
+				kube_pod_container_status_terminated{container="container3",namespace="ns2",pod="pod2"} 0
+				kube_pod_container_status_waiting{container="container1",namespace="ns1",pod="pod1"} 0
+				kube_pod_container_status_waiting{container="container2",namespace="ns2",pod="pod2"} 0
+				kube_pod_container_status_waiting{container="container3",namespace="ns2",pod="pod2"} 1
 				`,
 			metrics: []string{
 				"kube_pod_container_status_running",
@@ -315,9 +291,6 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod1",
 						Namespace: "ns1",
 					},
-					Spec: v1.PodSpec{
-						NodeName: "node1",
-					},
 					Status: v1.PodStatus{
 						Phase: "Running",
 					},
@@ -326,17 +299,14 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod2",
 						Namespace: "ns2",
 					},
-					Spec: v1.PodSpec{
-						NodeName: "node2",
-					},
 					Status: v1.PodStatus{
 						Phase: "Pending",
 					},
 				},
 			},
 			want: metadata + `
-				kube_pod_status_phase{namespace="ns1",phase="Running",node="node1",pod="pod1"} 1
-				kube_pod_status_phase{namespace="ns2",phase="Pending",node="node2",pod="pod2"} 1
+				kube_pod_status_phase{namespace="ns1",phase="Running",pod="pod1"} 1
+				kube_pod_status_phase{namespace="ns2",phase="Pending",pod="pod2"} 1
 				`,
 			metrics: []string{"kube_pod_status_phase"},
 		}, {
@@ -346,9 +316,6 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod1",
 						Namespace: "ns1",
 					},
-					Spec: v1.PodSpec{
-						NodeName: "node1",
-					},
 					Status: v1.PodStatus{
 						Conditions: []v1.PodCondition{
 							v1.PodCondition{
@@ -362,9 +329,6 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod2",
 						Namespace: "ns2",
 					},
-					Spec: v1.PodSpec{
-						NodeName: "node2",
-					},
 					Status: v1.PodStatus{
 						Conditions: []v1.PodCondition{
 							v1.PodCondition{
@@ -376,12 +340,12 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_status_ready{condition="false",namespace="ns1",node="node1",pod="pod1"} 0
-				kube_pod_status_ready{condition="false",namespace="ns2",node="node2",pod="pod2"} 1
-				kube_pod_status_ready{condition="true",namespace="ns1",node="node1",pod="pod1"} 1
-				kube_pod_status_ready{condition="true",namespace="ns2",node="node2",pod="pod2"} 0
-				kube_pod_status_ready{condition="unknown",namespace="ns1",node="node1",pod="pod1"} 0
-				kube_pod_status_ready{condition="unknown",namespace="ns2",node="node2",pod="pod2"} 0
+				kube_pod_status_ready{condition="false",namespace="ns1",pod="pod1"} 0
+				kube_pod_status_ready{condition="false",namespace="ns2",pod="pod2"} 1
+				kube_pod_status_ready{condition="true",namespace="ns1",pod="pod1"} 1
+				kube_pod_status_ready{condition="true",namespace="ns2",pod="pod2"} 0
+				kube_pod_status_ready{condition="unknown",namespace="ns1",pod="pod1"} 0
+				kube_pod_status_ready{condition="unknown",namespace="ns2",pod="pod2"} 0
 			`,
 			metrics: []string{"kube_pod_status_ready"},
 		}, {
@@ -391,9 +355,6 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod1",
 						Namespace: "ns1",
 					},
-					Spec: v1.PodSpec{
-						NodeName: "node1",
-					},
 					Status: v1.PodStatus{
 						Conditions: []v1.PodCondition{
 							v1.PodCondition{
@@ -407,9 +368,6 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod2",
 						Namespace: "ns2",
 					},
-					Spec: v1.PodSpec{
-						NodeName: "node2",
-					},
 					Status: v1.PodStatus{
 						Conditions: []v1.PodCondition{
 							v1.PodCondition{
@@ -421,12 +379,12 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_status_scheduled{condition="false",namespace="ns1",node="node1",pod="pod1"} 0
-				kube_pod_status_scheduled{condition="false",namespace="ns2",node="node2",pod="pod2"} 1
-				kube_pod_status_scheduled{condition="true",namespace="ns1",node="node1",pod="pod1"} 1
-				kube_pod_status_scheduled{condition="true",namespace="ns2",node="node2",pod="pod2"} 0
-				kube_pod_status_scheduled{condition="unknown",namespace="ns1",node="node1",pod="pod1"} 0
-				kube_pod_status_scheduled{condition="unknown",namespace="ns2",node="node2",pod="pod2"} 0
+				kube_pod_status_scheduled{condition="false",namespace="ns1",pod="pod1"} 0
+				kube_pod_status_scheduled{condition="false",namespace="ns2",pod="pod2"} 1
+				kube_pod_status_scheduled{condition="true",namespace="ns1",pod="pod1"} 1
+				kube_pod_status_scheduled{condition="true",namespace="ns2",pod="pod2"} 0
+				kube_pod_status_scheduled{condition="unknown",namespace="ns1",pod="pod1"} 0
+				kube_pod_status_scheduled{condition="unknown",namespace="ns2",pod="pod2"} 0
 			`,
 			metrics: []string{"kube_pod_status_scheduled"},
 		}, {

--- a/pod_test.go
+++ b/pod_test.go
@@ -76,6 +76,9 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod1",
 						Namespace: "ns1",
 					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
 							v1.ContainerStatus{
@@ -90,6 +93,9 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node2",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -110,9 +116,9 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_info{container="container1",container_id="docker://ab123",image="gcr.io/google_containers/hyperkube1",image_id="docker://sha256:aaa",namespace="ns1",pod="pod1"} 1
-				kube_pod_container_info{container="container2",container_id="docker://cd456",image="gcr.io/google_containers/hyperkube2",image_id="docker://sha256:bbb",namespace="ns2",pod="pod2"} 1
-				kube_pod_container_info{container="container3",container_id="docker://ef789",image="gcr.io/google_containers/hyperkube3",image_id="docker://sha256:ccc",namespace="ns2",pod="pod2"} 1
+				kube_pod_container_info{container="container1",container_id="docker://ab123",image="gcr.io/google_containers/hyperkube1",image_id="docker://sha256:aaa",namespace="ns1",node="node1",pod="pod1"} 1
+				kube_pod_container_info{container="container2",container_id="docker://cd456",image="gcr.io/google_containers/hyperkube2",image_id="docker://sha256:bbb",namespace="ns2",node="node2",pod="pod2"} 1
+				kube_pod_container_info{container="container3",container_id="docker://ef789",image="gcr.io/google_containers/hyperkube3",image_id="docker://sha256:ccc",namespace="ns2",node="node2",pod="pod2"} 1
 				`,
 			metrics: []string{"kube_pod_container_info"},
 		}, {
@@ -121,6 +127,9 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: "ns1",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -134,6 +143,9 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node2",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -150,9 +162,9 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_status_ready{container="container1",namespace="ns1",pod="pod1"} 1
-				kube_pod_container_status_ready{container="container2",namespace="ns2",pod="pod2"} 1
-				kube_pod_container_status_ready{container="container3",namespace="ns2",pod="pod2"} 0
+				kube_pod_container_status_ready{container="container1",namespace="ns1",node="node1",pod="pod1"} 1
+				kube_pod_container_status_ready{container="container2",namespace="ns2",node="node2",pod="pod2"} 1
+				kube_pod_container_status_ready{container="container3",namespace="ns2",node="node2",pod="pod2"} 0
 				`,
 			metrics: []string{"kube_pod_container_status_ready"},
 		}, {
@@ -161,6 +173,9 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: "ns1",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -174,6 +189,9 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node2",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -190,9 +208,9 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_status_restarts{container="container1",namespace="ns1",pod="pod1"} 0
-				kube_pod_container_status_restarts{container="container2",namespace="ns2",pod="pod2"} 0
-				kube_pod_container_status_restarts{container="container3",namespace="ns2",pod="pod2"} 1
+				kube_pod_container_status_restarts{container="container1",namespace="ns1",node="node1",pod="pod1"} 0
+				kube_pod_container_status_restarts{container="container2",namespace="ns2",node="node2",pod="pod2"} 0
+				kube_pod_container_status_restarts{container="container3",namespace="ns2",node="node2",pod="pod2"} 1
 				`,
 			metrics: []string{"kube_pod_container_status_restarts"},
 		}, {
@@ -201,6 +219,9 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: "ns1",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -216,6 +237,9 @@ func TestPodCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node2",
 					},
 					Status: v1.PodStatus{
 						ContainerStatuses: []v1.ContainerStatus{
@@ -236,15 +260,15 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_status_running{container="container1",namespace="ns1",pod="pod1"} 1
-				kube_pod_container_status_running{container="container2",namespace="ns2",pod="pod2"} 0
-				kube_pod_container_status_running{container="container3",namespace="ns2",pod="pod2"} 0
-				kube_pod_container_status_terminated{container="container1",namespace="ns1",pod="pod1"} 0
-				kube_pod_container_status_terminated{container="container2",namespace="ns2",pod="pod2"} 1
-				kube_pod_container_status_terminated{container="container3",namespace="ns2",pod="pod2"} 0
-				kube_pod_container_status_waiting{container="container1",namespace="ns1",pod="pod1"} 0
-				kube_pod_container_status_waiting{container="container2",namespace="ns2",pod="pod2"} 0
-				kube_pod_container_status_waiting{container="container3",namespace="ns2",pod="pod2"} 1
+				kube_pod_container_status_running{container="container1",namespace="ns1",node="node1",pod="pod1"} 1
+				kube_pod_container_status_running{container="container2",namespace="ns2",node="node2",pod="pod2"} 0
+				kube_pod_container_status_running{container="container3",namespace="ns2",node="node2",pod="pod2"} 0
+				kube_pod_container_status_terminated{container="container1",namespace="ns1",node="node1",pod="pod1"} 0
+				kube_pod_container_status_terminated{container="container2",namespace="ns2",node="node2",pod="pod2"} 1
+				kube_pod_container_status_terminated{container="container3",namespace="ns2",node="node2",pod="pod2"} 0
+				kube_pod_container_status_waiting{container="container1",namespace="ns1",node="node1",pod="pod1"} 0
+				kube_pod_container_status_waiting{container="container2",namespace="ns2",node="node2",pod="pod2"} 0
+				kube_pod_container_status_waiting{container="container3",namespace="ns2",node="node2",pod="pod2"} 1
 				`,
 			metrics: []string{
 				"kube_pod_container_status_running",
@@ -258,6 +282,9 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod1",
 						Namespace: "ns1",
 					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					Status: v1.PodStatus{
 						HostIP: "1.1.1.1",
 						PodIP:  "1.2.3.4",
@@ -267,6 +294,9 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod2",
 						Namespace: "ns2",
 					},
+					Spec: v1.PodSpec{
+						NodeName: "node2",
+					},
 					Status: v1.PodStatus{
 						HostIP: "1.1.1.1",
 						PodIP:  "2.3.4.5",
@@ -274,8 +304,8 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_info{host_ip="1.1.1.1",namespace="ns1",pod="pod1",pod_ip="1.2.3.4"} 1
-				kube_pod_info{host_ip="1.1.1.1",namespace="ns2",pod="pod2",pod_ip="2.3.4.5"} 1
+				kube_pod_info{host_ip="1.1.1.1",namespace="ns1",pod="pod1",node="node1",pod_ip="1.2.3.4"} 1
+				kube_pod_info{host_ip="1.1.1.1",namespace="ns2",pod="pod2",node="node2",pod_ip="2.3.4.5"} 1
 				`,
 			metrics: []string{"kube_pod_info"},
 		}, {
@@ -285,6 +315,9 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod1",
 						Namespace: "ns1",
 					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					Status: v1.PodStatus{
 						Phase: "Running",
 					},
@@ -293,14 +326,17 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod2",
 						Namespace: "ns2",
 					},
+					Spec: v1.PodSpec{
+						NodeName: "node2",
+					},
 					Status: v1.PodStatus{
 						Phase: "Pending",
 					},
 				},
 			},
 			want: metadata + `
-				kube_pod_status_phase{namespace="ns1",phase="Running",pod="pod1"} 1
-				kube_pod_status_phase{namespace="ns2",phase="Pending",pod="pod2"} 1
+				kube_pod_status_phase{namespace="ns1",phase="Running",node="node1",pod="pod1"} 1
+				kube_pod_status_phase{namespace="ns2",phase="Pending",node="node2",pod="pod2"} 1
 				`,
 			metrics: []string{"kube_pod_status_phase"},
 		}, {
@@ -310,6 +346,9 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod1",
 						Namespace: "ns1",
 					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					Status: v1.PodStatus{
 						Conditions: []v1.PodCondition{
 							v1.PodCondition{
@@ -323,6 +362,9 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod2",
 						Namespace: "ns2",
 					},
+					Spec: v1.PodSpec{
+						NodeName: "node2",
+					},
 					Status: v1.PodStatus{
 						Conditions: []v1.PodCondition{
 							v1.PodCondition{
@@ -334,12 +376,12 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_status_ready{condition="false",namespace="ns1",pod="pod1"} 0
-				kube_pod_status_ready{condition="false",namespace="ns2",pod="pod2"} 1
-				kube_pod_status_ready{condition="true",namespace="ns1",pod="pod1"} 1
-				kube_pod_status_ready{condition="true",namespace="ns2",pod="pod2"} 0
-				kube_pod_status_ready{condition="unknown",namespace="ns1",pod="pod1"} 0
-				kube_pod_status_ready{condition="unknown",namespace="ns2",pod="pod2"} 0
+				kube_pod_status_ready{condition="false",namespace="ns1",node="node1",pod="pod1"} 0
+				kube_pod_status_ready{condition="false",namespace="ns2",node="node2",pod="pod2"} 1
+				kube_pod_status_ready{condition="true",namespace="ns1",node="node1",pod="pod1"} 1
+				kube_pod_status_ready{condition="true",namespace="ns2",node="node2",pod="pod2"} 0
+				kube_pod_status_ready{condition="unknown",namespace="ns1",node="node1",pod="pod1"} 0
+				kube_pod_status_ready{condition="unknown",namespace="ns2",node="node2",pod="pod2"} 0
 			`,
 			metrics: []string{"kube_pod_status_ready"},
 		}, {
@@ -349,6 +391,9 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod1",
 						Namespace: "ns1",
 					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					Status: v1.PodStatus{
 						Conditions: []v1.PodCondition{
 							v1.PodCondition{
@@ -362,6 +407,9 @@ func TestPodCollector(t *testing.T) {
 						Name:      "pod2",
 						Namespace: "ns2",
 					},
+					Spec: v1.PodSpec{
+						NodeName: "node2",
+					},
 					Status: v1.PodStatus{
 						Conditions: []v1.PodCondition{
 							v1.PodCondition{
@@ -373,12 +421,12 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_status_scheduled{condition="false",namespace="ns1",pod="pod1"} 0
-				kube_pod_status_scheduled{condition="false",namespace="ns2",pod="pod2"} 1
-				kube_pod_status_scheduled{condition="true",namespace="ns1",pod="pod1"} 1
-				kube_pod_status_scheduled{condition="true",namespace="ns2",pod="pod2"} 0
-				kube_pod_status_scheduled{condition="unknown",namespace="ns1",pod="pod1"} 0
-				kube_pod_status_scheduled{condition="unknown",namespace="ns2",pod="pod2"} 0
+				kube_pod_status_scheduled{condition="false",namespace="ns1",node="node1",pod="pod1"} 0
+				kube_pod_status_scheduled{condition="false",namespace="ns2",node="node2",pod="pod2"} 1
+				kube_pod_status_scheduled{condition="true",namespace="ns1",node="node1",pod="pod1"} 1
+				kube_pod_status_scheduled{condition="true",namespace="ns2",node="node2",pod="pod2"} 0
+				kube_pod_status_scheduled{condition="unknown",namespace="ns1",node="node1",pod="pod1"} 0
+				kube_pod_status_scheduled{condition="unknown",namespace="ns2",node="node2",pod="pod2"} 0
 			`,
 			metrics: []string{"kube_pod_status_scheduled"},
 		}, {


### PR DESCRIPTION
I want to add the Node Name to the Pod metric labels as I think it make more sense to have that in there rather than or as well as the Node IP.

I also think given that the Node IP is used elsewhere it would be worth adding it to the NodeInfo metric. I'm willing to do this but haven't started on it yet as I'd like input as to which IP to use. I'll open an issue for discussion around that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/52)
<!-- Reviewable:end -->
