### PR TITLE
Consistently name pod container resource metrics

### DIFF
--- a/pod.go
+++ b/pod.go
@@ -74,26 +74,26 @@ var (
 		[]string{"namespace", "pod", "container"}, nil,
 	)
 
-	descPodContainerRequestedCpuCores = prometheus.NewDesc(
-		"kube_pod_container_requested_cpu_cores",
+	descPodContainerResourceRequestsCpuCores = prometheus.NewDesc(
+		"kube_pod_container_resource_requests_cpu_cores",
 		"The number of requested cpu cores by a container.",
 		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 
-	descPodContainerRequestedMemoryBytes = prometheus.NewDesc(
-		"kube_pod_container_requested_memory_bytes",
+	descPodContainerResourceRequestsMemoryBytes = prometheus.NewDesc(
+		"kube_pod_container_resource_requests_memory_bytes",
 		"The number of requested memory bytes  by a container.",
 		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 
-	descPodContainerLimitsCpuCores = prometheus.NewDesc(
-		"kube_pod_container_limits_cpu_cores",
+	descPodContainerResourceLimitsCpuCores = prometheus.NewDesc(
+		"kube_pod_container_resource_limits_cpu_cores",
 		"The limit on cpu cores to be used by a container.",
 		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 
-	descPodContainerLimitsMemoryBytes = prometheus.NewDesc(
-		"kube_pod_container_limits_memory_bytes",
+	descPodContainerResourceLimitsMemoryBytes = prometheus.NewDesc(
+		"kube_pod_container_resource_limits_memory_bytes",
 		"The limit on memory to be used by a container in bytes.",
 		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
@@ -120,10 +120,10 @@ func (pc *podCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descPodContainerStatusTerminated
 	ch <- descPodContainerStatusReady
 	ch <- descPodContainerStatusRestarts
-	ch <- descPodContainerRequestedCpuCores
-	ch <- descPodContainerRequestedMemoryBytes
-	ch <- descPodContainerLimitsCpuCores
-	ch <- descPodContainerLimitsMemoryBytes
+	ch <- descPodContainerResourceRequestsCpuCores
+	ch <- descPodContainerResourceRequestsMemoryBytes
+	ch <- descPodContainerResourceLimitsCpuCores
+	ch <- descPodContainerResourceLimitsMemoryBytes
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -179,20 +179,20 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 		lim := c.Resources.Limits
 
 		if cpu, ok := req[v1.ResourceCPU]; ok {
-			addGauge(descPodContainerRequestedCpuCores, float64(cpu.MilliValue())/1000,
+			addGauge(descPodContainerResourceRequestsCpuCores, float64(cpu.MilliValue())/1000,
 				c.Name, nodeName)
 		}
 		if mem, ok := req[v1.ResourceMemory]; ok {
-			addGauge(descPodContainerRequestedMemoryBytes, float64(mem.Value()),
+			addGauge(descPodContainerResourceRequestsMemoryBytes, float64(mem.Value()),
 				c.Name, nodeName)
 		}
 
 		if cpu, ok := lim[v1.ResourceCPU]; ok {
-			addGauge(descPodContainerLimitsCpuCores, float64(cpu.MilliValue())/1000,
+			addGauge(descPodContainerResourceLimitsCpuCores, float64(cpu.MilliValue())/1000,
 				c.Name, nodeName)
 		}
 		if mem, ok := lim[v1.ResourceMemory]; ok {
-			addGauge(descPodContainerLimitsMemoryBytes, float64(mem.Value()),
+			addGauge(descPodContainerResourceLimitsMemoryBytes, float64(mem.Value()),
 				c.Name, nodeName)
 		}
 	}

--- a/pod_test.go
+++ b/pod_test.go
@@ -55,14 +55,14 @@ func TestPodCollector(t *testing.T) {
 		# TYPE kube_pod_status_ready gauge
 		# HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
 		# TYPE kube_pod_status_scheduled gauge
-		# HELP kube_pod_container_requested_cpu_cores The number of requested cpu cores by a container.
-		# TYPE kube_pod_container_requested_cpu_cores gauge
-		# HELP kube_pod_container_requested_memory_bytes The number of requested memory bytes  by a container.
-		# TYPE kube_pod_container_requested_memory_bytes gauge
-		# HELP kube_pod_container_limits_cpu_cores The limit on cpu cores to be used by a container.
-		# TYPE kube_pod_container_limits_cpu_cores gauge
-		# HELP kube_pod_container_limits_memory_bytes The limit on memory to be used by a container in bytes.
-		# TYPE kube_pod_container_limits_memory_bytes gauge
+		# HELP kube_pod_container_resource_requests_cpu_cores The number of requested cpu cores by a container.
+		# TYPE kube_pod_container_resource_requests_cpu_cores gauge
+		# HELP kube_pod_container_resource_requests_memory_bytes The number of requested memory bytes  by a container.
+		# TYPE kube_pod_container_resource_requests_memory_bytes gauge
+		# HELP kube_pod_container_resource_limits_cpu_cores The limit on cpu cores to be used by a container.
+		# TYPE kube_pod_container_resource_limits_cpu_cores gauge
+		# HELP kube_pod_container_resource_limits_memory_bytes The limit on memory to be used by a container in bytes.
+		# TYPE kube_pod_container_resource_limits_memory_bytes gauge
 	`
 	cases := []struct {
 		pods    []v1.Pod
@@ -468,28 +468,28 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-		kube_pod_container_requested_cpu_cores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 0.2
-		kube_pod_container_requested_cpu_cores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 0.3
-		kube_pod_container_requested_cpu_cores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 0.4
-		kube_pod_container_requested_cpu_cores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 0.5
-		kube_pod_container_requested_memory_bytes{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 1e+08
-		kube_pod_container_requested_memory_bytes{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 2e+08
-		kube_pod_container_requested_memory_bytes{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 3e+08
-		kube_pod_container_requested_memory_bytes{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 4e+08
-		kube_pod_container_limits_cpu_cores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 0.2
-		kube_pod_container_limits_cpu_cores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 0.3
-		kube_pod_container_limits_cpu_cores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 0.4
-		kube_pod_container_limits_cpu_cores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 0.5
-		kube_pod_container_limits_memory_bytes{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 1e+08
-		kube_pod_container_limits_memory_bytes{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 2e+08
-		kube_pod_container_limits_memory_bytes{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 3e+08
-		kube_pod_container_limits_memory_bytes{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 4e+08
+		kube_pod_container_resource_requests_cpu_cores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 0.2
+		kube_pod_container_resource_requests_cpu_cores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 0.3
+		kube_pod_container_resource_requests_cpu_cores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 0.4
+		kube_pod_container_resource_requests_cpu_cores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 0.5
+		kube_pod_container_resource_requests_memory_bytes{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 1e+08
+		kube_pod_container_resource_requests_memory_bytes{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 2e+08
+		kube_pod_container_resource_requests_memory_bytes{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 3e+08
+		kube_pod_container_resource_requests_memory_bytes{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 4e+08
+		kube_pod_container_resource_limits_cpu_cores{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 0.2
+		kube_pod_container_resource_limits_cpu_cores{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 0.3
+		kube_pod_container_resource_limits_cpu_cores{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 0.4
+		kube_pod_container_resource_limits_cpu_cores{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 0.5
+		kube_pod_container_resource_limits_memory_bytes{container="pod1_con1",namespace="ns1",node="node1",pod="pod1"} 1e+08
+		kube_pod_container_resource_limits_memory_bytes{container="pod1_con2",namespace="ns1",node="node1",pod="pod1"} 2e+08
+		kube_pod_container_resource_limits_memory_bytes{container="pod2_con1",namespace="ns2",node="node2",pod="pod2"} 3e+08
+		kube_pod_container_resource_limits_memory_bytes{container="pod2_con2",namespace="ns2",node="node2",pod="pod2"} 4e+08
 		`,
 			metrics: []string{
-				"kube_pod_container_requested_cpu_cores",
-				"kube_pod_container_requested_memory_bytes",
-				"kube_pod_container_limits_cpu_cores",
-				"kube_pod_container_limits_memory_bytes",
+				"kube_pod_container_resource_requests_cpu_cores",
+				"kube_pod_container_resource_requests_memory_bytes",
+				"kube_pod_container_resource_limits_cpu_cores",
+				"kube_pod_container_resource_limits_memory_bytes",
 			},
 		},
 	}


### PR DESCRIPTION
As discussed in https://github.com/kubernetes/kube-state-metrics/pull/49#discussion_r88411936 this PR aims to consistently name container resource metrics.

In terms of `resource` vs. `resources` I followed the example of where we have multiple `Containers` in a `Pod` and chose `resource`. Let me know if you think this is ok.

@matthiasr @dominikschulz @fabxc @alexsomesan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/59)
<!-- Reviewable:end -->
