### PR TITLE
rename resource_quota to resourcequota

### DIFF
--- a/resourcequota.go
+++ b/resourcequota.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	descResourceQuota = prometheus.NewDesc(
-		"kube_resource_quota",
+		"kube_resourcequota",
 		"Information about resource quota.",
 		[]string{
 			"resourcequota",

--- a/resourcequota_test.go
+++ b/resourcequota_test.go
@@ -35,8 +35,8 @@ func TestResourceQuotaCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
-	# HELP kube_resource_quota Information about resource quota.
-	# TYPE kube_resource_quota gauge
+	# HELP kube_resourcequota Information about resource quota.
+	# TYPE kube_resourcequota gauge
 	`
 	cases := []struct {
 		quotas  []v1.ResourceQuota
@@ -113,30 +113,30 @@ func TestResourceQuotaCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="cpu",type="hard"} 4.3
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="cpu",type="used"} 2.1
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="memory",type="hard"} 2.1e+09
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="memory",type="used"} 5e+08
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="storage",type="hard"} 1e+10
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="storage",type="used"} 9e+09
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="pods",type="hard"} 9
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="pods",type="used"} 8
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="services",type="hard"} 8
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="services",type="used"} 7
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="replicationcontrollers",type="hard"} 7
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="replicationcontrollers",type="used"} 6
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="resourcequotas",type="hard"} 6
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="resourcequotas",type="used"} 5
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="secrets",type="hard"} 5
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="secrets",type="used"} 4
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="configmaps",type="hard"} 4
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="configmaps",type="used"} 3
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="persistentvolumeclaims",type="hard"} 3
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="persistentvolumeclaims",type="used"} 2
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="services.nodeports",type="hard"} 2
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="services.nodeports",type="used"} 1
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="services.loadbalancers",type="hard"} 1
-			kube_resource_quota{resourcequota="quotaTest",namespace="testNS",resource="services.loadbalancers",type="used"} 0
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="cpu",type="hard"} 4.3
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="cpu",type="used"} 2.1
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="memory",type="hard"} 2.1e+09
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="memory",type="used"} 5e+08
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="storage",type="hard"} 1e+10
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="storage",type="used"} 9e+09
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="pods",type="hard"} 9
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="pods",type="used"} 8
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="services",type="hard"} 8
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="services",type="used"} 7
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="replicationcontrollers",type="hard"} 7
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="replicationcontrollers",type="used"} 6
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="resourcequotas",type="hard"} 6
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="resourcequotas",type="used"} 5
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="secrets",type="hard"} 5
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="secrets",type="used"} 4
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="configmaps",type="hard"} 4
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="configmaps",type="used"} 3
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="persistentvolumeclaims",type="hard"} 3
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="persistentvolumeclaims",type="used"} 2
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="services.nodeports",type="hard"} 2
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="services.nodeports",type="used"} 1
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="services.loadbalancers",type="hard"} 1
+			kube_resourcequota{resourcequota="quotaTest",namespace="testNS",resource="services.loadbalancers",type="used"} 0
 			`,
 		},
 	}


### PR DESCRIPTION
The convention of using an object kind in the metric name is to use the
same that would be used when using `kubectl`. So in this case `kubectl
get resourcequota`.

As discussed in the metric convention document.

@fabxc @matthiasr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/60)
<!-- Reviewable:end -->
