### PR TITLE
Added node name to container status queries and adapted tests

### DIFF
--- a/pod.go
+++ b/pod.go
@@ -51,27 +51,27 @@ var (
 	descPodContainerStatusWaiting = prometheus.NewDesc(
 		"kube_pod_container_status_waiting",
 		"Describes whether the container is currently in waiting state.",
-		[]string{"namespace", "pod", "container"}, nil,
+		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 	descPodContainerStatusRunning = prometheus.NewDesc(
 		"kube_pod_container_status_running",
 		"Describes whether the container is currently in running state.",
-		[]string{"namespace", "pod", "container"}, nil,
+		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 	descPodContainerStatusTerminated = prometheus.NewDesc(
 		"kube_pod_container_status_terminated",
 		"Describes whether the container is currently in terminated state.",
-		[]string{"namespace", "pod", "container"}, nil,
+		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 	descPodContainerStatusReady = prometheus.NewDesc(
 		"kube_pod_container_status_ready",
 		"Describes whether the containers readiness check succeeded.",
-		[]string{"namespace", "pod", "container"}, nil,
+		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 	descPodContainerStatusRestarts = prometheus.NewDesc(
 		"kube_pod_container_status_restarts",
 		"The number of container restarts per container.",
-		[]string{"namespace", "pod", "container"}, nil,
+		[]string{"namespace", "pod", "container", "node"}, nil,
 	)
 
 	descPodContainerResourceRequestsCpuCores = prometheus.NewDesc(
@@ -167,11 +167,11 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 		addGauge(descPodContainerInfo, 1,
 			cs.Name, cs.Image, cs.ImageID, cs.ContainerID,
 		)
-		addGauge(descPodContainerStatusWaiting, boolFloat64(cs.State.Waiting != nil), cs.Name)
-		addGauge(descPodContainerStatusRunning, boolFloat64(cs.State.Running != nil), cs.Name)
-		addGauge(descPodContainerStatusTerminated, boolFloat64(cs.State.Terminated != nil), cs.Name)
-		addGauge(descPodContainerStatusReady, boolFloat64(cs.Ready), cs.Name)
-		addCounter(descPodContainerStatusRestarts, float64(cs.RestartCount), cs.Name)
+		addGauge(descPodContainerStatusWaiting, boolFloat64(cs.State.Waiting != nil), cs.Name, nodeName)
+		addGauge(descPodContainerStatusRunning, boolFloat64(cs.State.Running != nil), cs.Name, nodeName)
+		addGauge(descPodContainerStatusTerminated, boolFloat64(cs.State.Terminated != nil), cs.Name, nodeName)
+		addGauge(descPodContainerStatusReady, boolFloat64(cs.Ready), cs.Name, nodeName)
+		addCounter(descPodContainerStatusRestarts, float64(cs.RestartCount), cs.Name, nodeName)
 	}
 
 	for _, c := range p.Spec.Containers {

--- a/pod_test.go
+++ b/pod_test.go
@@ -118,6 +118,9 @@ func TestPodCollector(t *testing.T) {
 		}, {
 			pods: []v1.Pod{
 				{
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: "ns1",
@@ -131,6 +134,9 @@ func TestPodCollector(t *testing.T) {
 						},
 					},
 				}, {
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
@@ -150,14 +156,17 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_status_ready{container="container1",namespace="ns1",pod="pod1"} 1
-				kube_pod_container_status_ready{container="container2",namespace="ns2",pod="pod2"} 1
-				kube_pod_container_status_ready{container="container3",namespace="ns2",pod="pod2"} 0
+				kube_pod_container_status_ready{container="container1",namespace="ns1",node="node1",pod="pod1"} 1
+				kube_pod_container_status_ready{container="container2",namespace="ns2",node="node1",pod="pod2"} 1
+				kube_pod_container_status_ready{container="container3",namespace="ns2",node="node1",pod="pod2"} 0
 				`,
 			metrics: []string{"kube_pod_container_status_ready"},
 		}, {
 			pods: []v1.Pod{
 				{
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: "ns1",
@@ -171,6 +180,9 @@ func TestPodCollector(t *testing.T) {
 						},
 					},
 				}, {
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
@@ -190,14 +202,17 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_status_restarts{container="container1",namespace="ns1",pod="pod1"} 0
-				kube_pod_container_status_restarts{container="container2",namespace="ns2",pod="pod2"} 0
-				kube_pod_container_status_restarts{container="container3",namespace="ns2",pod="pod2"} 1
+				kube_pod_container_status_restarts{container="container1",namespace="ns1",node="node1",pod="pod1"} 0
+				kube_pod_container_status_restarts{container="container2",namespace="ns2",node="node1",pod="pod2"} 0
+				kube_pod_container_status_restarts{container="container3",namespace="ns2",node="node1",pod="pod2"} 1
 				`,
 			metrics: []string{"kube_pod_container_status_restarts"},
 		}, {
 			pods: []v1.Pod{
 				{
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: "ns1",
@@ -213,6 +228,9 @@ func TestPodCollector(t *testing.T) {
 						},
 					},
 				}, {
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: "ns2",
@@ -236,15 +254,15 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_container_status_running{container="container1",namespace="ns1",pod="pod1"} 1
-				kube_pod_container_status_running{container="container2",namespace="ns2",pod="pod2"} 0
-				kube_pod_container_status_running{container="container3",namespace="ns2",pod="pod2"} 0
-				kube_pod_container_status_terminated{container="container1",namespace="ns1",pod="pod1"} 0
-				kube_pod_container_status_terminated{container="container2",namespace="ns2",pod="pod2"} 1
-				kube_pod_container_status_terminated{container="container3",namespace="ns2",pod="pod2"} 0
-				kube_pod_container_status_waiting{container="container1",namespace="ns1",pod="pod1"} 0
-				kube_pod_container_status_waiting{container="container2",namespace="ns2",pod="pod2"} 0
-				kube_pod_container_status_waiting{container="container3",namespace="ns2",pod="pod2"} 1
+				kube_pod_container_status_running{container="container1",namespace="ns1",node="node1",pod="pod1"} 1
+				kube_pod_container_status_running{container="container2",namespace="ns2",node="node1",pod="pod2"} 0
+				kube_pod_container_status_running{container="container3",namespace="ns2",node="node1",pod="pod2"} 0
+				kube_pod_container_status_terminated{container="container1",namespace="ns1",node="node1",pod="pod1"} 0
+				kube_pod_container_status_terminated{container="container2",namespace="ns2",node="node1",pod="pod2"} 1
+				kube_pod_container_status_terminated{container="container3",namespace="ns2",node="node1",pod="pod2"} 0
+				kube_pod_container_status_waiting{container="container1",namespace="ns1",node="node1",pod="pod1"} 0
+				kube_pod_container_status_waiting{container="container2",namespace="ns2",node="node1",pod="pod2"} 0
+				kube_pod_container_status_waiting{container="container3",namespace="ns2",node="node1",pod="pod2"} 1
 				`,
 			metrics: []string{
 				"kube_pod_container_status_running",


### PR DESCRIPTION
Hi, this is simply a useful addition to the container status gauge metrics. 

Background: I'm using Google Cloud's Stackdriver Monitoring and the entries require a bit more context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/65)
<!-- Reviewable:end -->
