### PR TITLE
If --cluster-info is false, kubeconfig needs to be valid.

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,8 +74,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *apiserver == "" && !(*inCluster) {
-		glog.Fatalf("--apiserver not set and --in-cluster is false; apiserver must be set to a valid URL")
+	if isNotExists(*kubeconfig) && !(*inCluster) {
+		glog.Fatalf("kubeconfig invalid and --in-cluster is false; kubeconfig must be set to a valid file(kubeconfig default file name: $HOME/.kube/config)")
 	}
 	glog.Infof("apiServer set to: %v", *apiserver)
 
@@ -88,6 +88,14 @@ func main() {
 
 	initializeMetricCollection(kubeClient)
 	metricsServer()
+}
+
+func isNotExists(file string) bool {
+	if file == "" {
+		file = clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+	}
+	_, err := os.Stat(file)
+	return os.IsNotExist(err)
 }
 
 func createKubeClient() (kubeClient clientset.Interface, err error) {


### PR DESCRIPTION
## WHY


```bash
$ docker run -p :8080 gcr.io/google_containers/kube-state-metrics:v0.3.0 --in-cluster=false
F0111 08:01:30.648367       1 main.go:78] --apiserver not set and --in-cluster is false; apiserver must be set to a valid URL
goroutine 1 [running]:
k8s.io/kube-state-metrics/vendor/github.com/golang/glog.stacks(0x1cc5700, 0xc400000000, 0x7e, 0xd3)
	src/k8s.io/kube-state-metrics/vendor/github.com/golang/glog/glog.go:766 +0xa5
k8s.io/kube-state-metrics/vendor/github.com/golang/glog.(*loggingT).output(0x1ca5220, 0xc400000003, 0xc42006acc0, 0x1c402df, 0x7, 0x4e, 0x0)
	src/k8s.io/kube-state-metrics/vendor/github.com/golang/glog/glog.go:717 +0x337
k8s.io/kube-state-metrics/vendor/github.com/golang/glog.(*loggingT).printf(0x1ca5220, 0xc400000003, 0x14a177f, 0x53, 0x0, 0x0, 0x0)
	src/k8s.io/kube-state-metrics/vendor/github.com/golang/glog/glog.go:655 +0x14c
k8s.io/kube-state-metrics/vendor/github.com/golang/glog.Fatalf(0x14a177f, 0x53, 0x0, 0x0, 0x0)
	src/k8s.io/kube-state-metrics/vendor/github.com/golang/glog/glog.go:1145 +0x67
main.main()
```

- Add `--apiserver` flag

```bash
$ docker run -p :8080 gcr.io/google_containers/kube-state-metrics:v0.3.0 --in-cluster=false --apiserver=https://xxx.xxx.xxx.xxx
F0111 07:28:31.482691       1 main.go:86] Failed to create client: invalid configuration: no configuration has been provided
goroutine 1 [running]:
k8s.io/kube-state-metrics/vendor/github.com/golang/glog.stacks(0x1cc5700, 0xc400000000, 0x7d, 0xbe)
	src/k8s.io/kube-state-metrics/vendor/github.com/golang/glog/glog.go:766 +0xa5
k8s.io/kube-state-metrics/vendor/github.com/golang/glog.(*loggingT).output(0x1ca5220, 0xc400000003, 0xc42006acc0, 0x1c402df, 0x7, 0x56, 0x0)
	src/k8s.io/kube-state-metrics/vendor/github.com/golang/glog/glog.go:717 +0x337
k8s.io/kube-state-metrics/vendor/github.com/golang/glog.(*loggingT).printf(0x1ca5220, 0x3, 0x1475343, 0x1b, 0xc420689ed8, 0x1, 0x1)
	src/k8s.io/kube-state-metrics/vendor/github.com/golang/glog/glog.go:655 +0x14c
k8s.io/kube-state-metrics/vendor/github.com/golang/glog.Fatalf(0x1475343, 0x1b, 0xc420689ed8, 0x1, 0x1)
	src/k8s.io/kube-state-metrics/vendor/github.com/golang/glog/glog.go:1145 +0x67
main.main()
	src/k8s.io/kube-state-metrics/main.go:86 +0x20b
```

ref. https://github.com/kubernetes/kube-state-metrics/issues/46#issuecomment-271647623

> I can confirm that --apiserver=http://... works, without setting --in-cluster=false.


- It can be done by setting arbitrary `--apiserver` and kubeconfig correctly

```bash
$ docker run -v /.kube/config:/.kube/config -p :8080 gcr.io/google_containers/kube-state-metrics:v0.3.0 --in-cluster=false --apiserver=https://xxx.xxx.xxx.xxx
```

or

```bash
$ docker run -v /.kube/config:/.kube/config -p :8080 gcr.io/google_containers/kube-state-metrics:v0.3.0 --in-cluster=false --apiserver=hoo
```

I think If `--in-cluster` is` false`,  `--apiserver` flag not be used. Instead kubeconfig needs to be valid.

## WHAT

if `in-cluster` is `false`,
  - check kubeconfig is valid.
  - delete `--apiserver` check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/68)
<!-- Reviewable:end -->
