### PR TITLE
fix make test units with cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 all: build
 
 FLAGS =
-ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+COMMONENVVAR = GOOS=linux GOARCH=amd64
+BUILDENVVAR = CGO_ENABLED=0
+TESTENVVAR = 
 REGISTRY = gcr.io/google_containers
 TAG = v0.3.0
 
@@ -9,10 +11,10 @@ deps:
 	go get github.com/tools/godep
 
 build: clean deps
-	$(ENVVAR) godep go build -o kube-state-metrics 
+	$(COMMONENVVAR) $(BUILDENVVAR) godep go build -o kube-state-metrics 
 
 test-unit: clean deps build
-	$(ENVVAR) godep go test --race . $(FLAGS)
+	$(COMMONENVVAR) $(TESTENVVAR) godep go test --race . $(FLAGS)
 
 container: build
 	docker build -t ${REGISTRY}/kube-state-metrics:$(TAG) .


### PR DESCRIPTION
`go test -race` can not be run with cgo disabled. This will result `make test-unit` failed.

FYI:
* https://blog.golang.org/race-detector
* https://github.com/golang/go/issues/14481

/cc @brancz @vdavidoff

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/81)
<!-- Reviewable:end -->
