### PR TITLE
deployment: skip max unavailable if rolling update is unset

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -150,6 +150,10 @@ func (dc *deploymentCollector) collectDeployment(ch chan<- prometheus.Metric, d 
 	addGauge(descDeploymentSpecReplicas, float64(*d.Spec.Replicas))
 	addGauge(descDeploymentMetadataGeneration, float64(d.ObjectMeta.Generation))
 
+	if d.Spec.Strategy.RollingUpdate == nil {
+		return
+	}
+
 	maxUnavailable, err := intstr.GetValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*d.Spec.Replicas), true)
 	if err != nil {
 		glog.Errorf("Error converting RollingUpdate MaxUnavailable to int: %s", err)

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -115,11 +115,6 @@ func TestDeploymentCollector(t *testing.T) {
 					Spec: v1beta1.DeploymentSpec{
 						Paused:   true,
 						Replicas: &depl2Replicas,
-						Strategy: v1beta1.DeploymentStrategy{
-							RollingUpdate: &v1beta1.RollingUpdateDeployment{
-								MaxUnavailable: &depl2MaxUnavailable,
-							},
-						},
 					},
 				},
 			},
@@ -130,6 +125,9 @@ func TestDeploymentCollector(t *testing.T) {
 				kube_deployment_spec_paused{namespace="ns2",deployment="depl2"} 1
 				kube_deployment_spec_replicas{namespace="ns1",deployment="depl1"} 200
 				kube_deployment_spec_replicas{namespace="ns2",deployment="depl2"} 5
+				kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="depl1",namespace="ns1"} 10
+				kube_deployment_status_observed_generation{namespace="ns1",deployment="depl1"} 111
+				kube_deployment_status_observed_generation{namespace="ns2",deployment="depl2"} 1111
 				kube_deployment_status_replicas{namespace="ns1",deployment="depl1"} 15
 				kube_deployment_status_replicas{namespace="ns2",deployment="depl2"} 10
 				kube_deployment_status_replicas_available{namespace="ns1",deployment="depl1"} 10
@@ -138,10 +136,6 @@ func TestDeploymentCollector(t *testing.T) {
 				kube_deployment_status_replicas_unavailable{namespace="ns2",deployment="depl2"} 0
 				kube_deployment_status_replicas_updated{namespace="ns1",deployment="depl1"} 2
 				kube_deployment_status_replicas_updated{namespace="ns2",deployment="depl2"} 1
-				kube_deployment_status_observed_generation{namespace="ns1",deployment="depl1"} 111
-				kube_deployment_status_observed_generation{namespace="ns2",deployment="depl2"} 1111
-				kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="ns1",deployment="depl1"} 10
-				kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="ns2",deployment="depl2"} 1
 			`,
 		},
 	}


### PR DESCRIPTION
This previously caused panics when objects did not have the
RollingUpdate struct set.

I also validated, that the tests would now also panic, without the fix.

Closes #84. I'll create a patch release with this once the fix is merged.

@alexsomesan @fabxc 

/cc @rvrignaud @stvnwrgs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/86)
<!-- Reviewable:end -->
