### PR TITLE
bump deployment kube-state-metrics version to v0.4.1

### DIFF
--- a/kubernetes/deployment.yml
+++ b/kubernetes/deployment.yml
@@ -8,10 +8,10 @@ spec:
     metadata:
       labels:
         app: kube-state-metrics
-        version: "v0.3.0"
+        version: "v0.4.1"
     spec:
       containers:
       - name: kube-state-metrics
-        image: gcr.io/google_containers/kube-state-metrics:v0.3.0
+        image: gcr.io/google_containers/kube-state-metrics:v0.4.1
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Bump deployment.yml kube-state-metrics version to v0.4.1.

/cc @brancz @fabxc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/88)
<!-- Reviewable:end -->
