### PR TITLE
Makefile: retrieve tag through git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 REGISTRY = gcr.io/google_containers
-TAG = v0.3.0
+TAG = $(shell git describe --abbrev=0)
 
 deps:
 	go get github.com/tools/godep


### PR DESCRIPTION
Before this we had to remember to bump the version in the Makefile (which we forgot in the last two releases), now it will automatically be retrieved through git.

Closes #89 

@fabxc 

/cc @andyxning @andrewhowdencom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/90)
<!-- Reviewable:end -->
