### PR TITLE
Fix default port in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ such as deployments, nodes and pods.
 
 The metrics are exported through the [Prometheus golang
 client](https://github.com/prometheus/client_golang) on the HTTP endpoint `/metrics` on
-the listening port (default 80). They are served either as plaintext or
+the listening port (default 8080). They are served either as plaintext or
 protobuf depending on the `Accept` header. They are designed to be consumed
 either by Prometheus itself or by a scraper that is compatible with scraping
 a Prometheus client endpoint. You can also open `/metrics` in a browser to see


### PR DESCRIPTION
The default port is actually 8080.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/95)
<!-- Reviewable:end -->
