### PR TITLE
Fix the deployment definition for v0.4.1

### DIFF
--- a/kubernetes/deployment.yml
+++ b/kubernetes/deployment.yml
@@ -8,10 +8,10 @@ spec:
     metadata:
       labels:
         app: kube-state-metrics
-        version: "v0.3.0"
+        version: "v0.4.1"
     spec:
       containers:
       - name: kube-state-metrics
-        image: gcr.io/google_containers/kube-state-metrics:v0.3.0
+        image: gcr.io/google_containers/kube-state-metrics:v0.4.1
         ports:
         - containerPort: 8080


### PR DESCRIPTION
The deployment .yaml for v0.4.1 called out the docker image with tag 0.3.0. You'll probably have to bump version to 0.4.2 in order to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/96)
<!-- Reviewable:end -->
