### PR TITLE
replicationcontrollers are part of core not extentions

### DIFF
--- a/replicationcontroller.go
+++ b/replicationcontroller.go
@@ -72,7 +72,7 @@ func (l ReplicationControllerLister) List() ([]v1.ReplicationController, error) 
 }
 
 func RegisterReplicationControllerCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
-	client := kubeClient.Extensions().RESTClient()
+	client := kubeClient.CoreV1().RESTClient()
 	rclw := cache.NewListWatchFromClient(client, "replicationcontrollers", api.NamespaceAll, nil)
 	rcinf := cache.NewSharedInformer(rclw, &v1.ReplicationController{}, resyncPeriod)
 


### PR DESCRIPTION
Fixes #101 .

@fabxc 

/cc @tmegow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/104)
<!-- Reviewable:end -->
