### PR TITLE
add NodeMemoryPressure, NodeDiskPressure, NodeNetworkUnavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ additional metrics!
 | kube_node_status_allocatable_cpu_cores | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_allocatable_memory_bytes | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_allocatable_pods | Gauge | `node`=&lt;node-address&gt;|
+| kube_node_status_memory_pressure | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
+| kube_node_status_disk_pressure | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
+| kube_node_status_network_unavailable | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
 
 ### DaemonSet Metrics
 

--- a/node.go
+++ b/node.go
@@ -61,6 +61,21 @@ var (
 		"The phase the node is currently in.",
 		[]string{"node", "phase"}, nil,
 	)
+	descNodeStatusMemoryPressure = prometheus.NewDesc(
+		"kube_node_status_memory_pressure",
+		"Wether the kubelet is under pressure due to insufficient available memory.",
+		[]string{"node", "condition"}, nil,
+	)
+	descNodeStatusDiskPressure = prometheus.NewDesc(
+		"kube_node_status_disk_pressure",
+		"Wether the kubelet is under pressure due to insufficient available disk.",
+		[]string{"node", "condition"}, nil,
+	)
+	descNodeStatusNetworkUnavailable = prometheus.NewDesc(
+		"kube_node_status_network_unavailable",
+		"Wether the network for the node is not correctly configured.",
+		[]string{"node", "condition"}, nil,
+	)
 
 	descNodeStatusCapacityPods = prometheus.NewDesc(
 		"kube_node_status_capacity_pods",
@@ -131,6 +146,9 @@ func (nc *nodeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descNodeInfo
 	ch <- descNodeSpecUnschedulable
 	ch <- descNodeStatusReady
+	ch <- descNodeStatusMemoryPressure
+	ch <- descNodeStatusDiskPressure
+	ch <- descNodeStatusNetworkUnavailable
 	ch <- descNodeStatusOutOfDisk
 	ch <- descNodeStatusPhase
 	ch <- descNodeStatusCapacityCPU
@@ -171,13 +189,18 @@ func (nc *nodeCollector) collectNode(ch chan<- prometheus.Metric, n v1.Node) {
 	addGauge(descNodeSpecUnschedulable, boolFloat64(n.Spec.Unschedulable))
 
 	// Collect node conditions and while default to false.
-	// TODO(fabxc): add remaining conditions: NodeMemoryPressure,  NodeDiskPressure, NodeNetworkUnavailable
 	for _, c := range n.Status.Conditions {
 		switch c.Type {
 		case v1.NodeReady:
 			addConditionMetrics(ch, descNodeStatusReady, c.Status, n.Name)
 		case v1.NodeOutOfDisk:
 			addConditionMetrics(ch, descNodeStatusOutOfDisk, c.Status, n.Name)
+		case v1.NodeMemoryPressure:
+			addConditionMetrics(ch, descNodeStatusMemoryPressure, c.Status, n.Name)
+		case v1.NodeDiskPressure:
+			addConditionMetrics(ch, descNodeStatusDiskPressure, c.Status, n.Name)
+		case v1.NodeNetworkUnavailable:
+			addConditionMetrics(ch, descNodeStatusNetworkUnavailable, c.Status, n.Name)
 		}
 	}
 

--- a/node.go
+++ b/node.go
@@ -63,17 +63,17 @@ var (
 	)
 	descNodeStatusMemoryPressure = prometheus.NewDesc(
 		"kube_node_status_memory_pressure",
-		"Wether the kubelet is under pressure due to insufficient available memory.",
+		"Whether the kubelet is under pressure due to insufficient available memory.",
 		[]string{"node", "condition"}, nil,
 	)
 	descNodeStatusDiskPressure = prometheus.NewDesc(
 		"kube_node_status_disk_pressure",
-		"Wether the kubelet is under pressure due to insufficient available disk.",
+		"Whether the kubelet is under pressure due to insufficient available disk.",
 		[]string{"node", "condition"}, nil,
 	)
 	descNodeStatusNetworkUnavailable = prometheus.NewDesc(
 		"kube_node_status_network_unavailable",
-		"Wether the network for the node is not correctly configured.",
+		"Whether the network is correctly configured for the node.",
 		[]string{"node", "condition"}, nil,
 	)
 

--- a/node_test.go
+++ b/node_test.go
@@ -55,11 +55,11 @@ func TestNodeCollector(t *testing.T) {
 		# HELP kube_node_status_allocatable_cpu_cores The CPU resources of a node that are available for scheduling.
 		# TYPE kube_node_status_allocatable_memory_bytes gauge
 		# HELP kube_node_status_allocatable_memory_bytes The memory resources of a node that are available for scheduling.
-                # HELP kube_node_status_memory_pressure Wether the kubelet is under pressure due to insufficient available memory.
+                # HELP kube_node_status_memory_pressure Whether the kubelet is under pressure due to insufficient available memory.
                 # TYPE kube_node_status_memory_pressure gauge
-                # HELP kube_node_status_disk_pressure Wether the kubelet is under pressure due to insufficient available disk.
+                # HELP kube_node_status_disk_pressure Whether the kubelet is under pressure due to insufficient available disk.
                 # TYPE kube_node_status_disk_pressure gauge
-                # HELP kube_node_status_network_unavailable Wether the network for the node is not correctly configured.
+                # HELP kube_node_status_network_unavailable Whether the network is correctly configured for the node.
                 # TYPE kube_node_status_network_unavailable gauge
 	`
 	cases := []struct {

--- a/node_test.go
+++ b/node_test.go
@@ -267,6 +267,100 @@ func TestNodeCollector(t *testing.T) {
 			`,
 			metrics: []string{"kube_node_status_memory_pressure"},
 		},
+		// Verify DiskPressure
+		{
+			nodes: []v1.Node{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "127.0.0.1",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeDiskPressure, Status: v1.ConditionTrue},
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "127.0.0.2",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeDiskPressure, Status: v1.ConditionUnknown},
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "127.0.0.3",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeDiskPressure, Status: v1.ConditionFalse},
+						},
+					},
+				},
+			},
+			want: metadata + `
+				kube_node_status_disk_pressure{node="127.0.0.1",condition="true"} 1
+				kube_node_status_disk_pressure{node="127.0.0.1",condition="false"} 0
+				kube_node_status_disk_pressure{node="127.0.0.1",condition="unknown"} 0
+				kube_node_status_disk_pressure{node="127.0.0.2",condition="true"} 0
+				kube_node_status_disk_pressure{node="127.0.0.2",condition="false"} 0
+				kube_node_status_disk_pressure{node="127.0.0.2",condition="unknown"} 1
+				kube_node_status_disk_pressure{node="127.0.0.3",condition="true"} 0
+				kube_node_status_disk_pressure{node="127.0.0.3",condition="false"} 1
+				kube_node_status_disk_pressure{node="127.0.0.3",condition="unknown"} 0
+			`,
+			metrics: []string{"kube_node_status_disk_pressure"},
+		},
+		// Verify NetworkUnavailable
+		{
+			nodes: []v1.Node{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "127.0.0.1",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionTrue},
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "127.0.0.2",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionUnknown},
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "127.0.0.3",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionFalse},
+						},
+					},
+				},
+			},
+			want: metadata + `
+				kube_node_status_network_unavailable{node="127.0.0.1",condition="true"} 1
+				kube_node_status_network_unavailable{node="127.0.0.1",condition="false"} 0
+				kube_node_status_network_unavailable{node="127.0.0.1",condition="unknown"} 0
+				kube_node_status_network_unavailable{node="127.0.0.2",condition="true"} 0
+				kube_node_status_network_unavailable{node="127.0.0.2",condition="false"} 0
+				kube_node_status_network_unavailable{node="127.0.0.2",condition="unknown"} 1
+				kube_node_status_network_unavailable{node="127.0.0.3",condition="true"} 0
+				kube_node_status_network_unavailable{node="127.0.0.3",condition="false"} 1
+				kube_node_status_network_unavailable{node="127.0.0.3",condition="unknown"} 0
+			`,
+			metrics: []string{"kube_node_status_network_unavailable"},
+		},
 	}
 	for _, c := range cases {
 		dc := &nodeCollector{


### PR DESCRIPTION
Adding node condition KernelDeadlock as introduced by the [Node Problem Detector](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json)  and fix [TODO](https://github.com/kubernetes/kube-state-metrics/blob/master/node.go#L174) by adding NodeMemoryPressure,  NodeDiskPressure, NodeNetworkUnavailable.
Comes with tests. Also updated readme. 

**Tests are expected to fail** for now since https://github.com/kubernetes/kubernetes/pull/44099 is still pending. Tested successfully by modifying the respective types.go in the vendor folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/121)
<!-- Reviewable:end -->
