### PR TITLE
fix service and limitrange rbac roles and fix order and naming

### DIFF
--- a/kubernetes/kube-state-metrics-cluster-role.yaml
+++ b/kubernetes/kube-state-metrics-cluster-role.yaml
@@ -7,8 +7,10 @@ rules:
   resources:
   - nodes
   - pods
+  - services
   - resourcequotas
   - replicationcontrollers
+  - limitranges
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:

--- a/main.go
+++ b/main.go
@@ -45,23 +45,23 @@ var (
 	defaultCollectors = collectorSet{
 		"daemonsets":             struct{}{},
 		"deployments":            struct{}{},
-		"pods":                   struct{}{},
+		"limitranges":            struct{}{},
 		"nodes":                  struct{}{},
-		"resourcequotas":         struct{}{},
-		"limitrange":             struct{}{},
+		"pods":                   struct{}{},
 		"replicasets":            struct{}{},
 		"replicationcontrollers": struct{}{},
+		"resourcequotas":         struct{}{},
 		"services":               struct{}{},
 	}
 	availableCollectors = map[string]func(registry prometheus.Registerer, kubeClient clientset.Interface){
 		"daemonsets":             RegisterDaemonSetCollector,
 		"deployments":            RegisterDeploymentCollector,
-		"pods":                   RegisterPodCollector,
+		"limitranges":            RegisterLimitRangeCollector,
 		"nodes":                  RegisterNodeCollector,
-		"resourcequotas":         RegisterResourceQuotaCollector,
-		"limitrange":             RegisterLimitRangeCollector,
+		"pods":                   RegisterPodCollector,
 		"replicasets":            RegisterReplicaSetCollector,
 		"replicationcontrollers": RegisterReplicationControllerCollector,
+		"resourcequotas":         RegisterResourceQuotaCollector,
 		"services":               RegisterServiceCollector,
 	}
 )


### PR DESCRIPTION
I noticed an inconsistency of the name of the LimitRange collector. In contrast to all the other collectors the LimitRange collector was singular. In addition I ordered the collectors in lexicographical order for ease to sync the list of available and default collectors.

In addition to that the default provided RBAC roles did not contain the recently added Services as well as LimitRange resources.

@fabxc @mxinden @andyxning 

This should be merged before #132 so we don't introduce a collector breaking change as the LimitRange collector has not been released yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/133)
<!-- Reviewable:end -->
