### PR TITLE
update image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ the raw metrics.
 
 ## Container Image
 
-The latest container image can be found at `gcr.io/google_containers/kube-state-metrics:v0.4.1`.
+The latest container image can be found at `gcr.io/google_containers/kube-state-metrics:v0.5.0`.
 
 ## Metrics
 

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: gcr.io/google_containers/kube-state-metrics:v0.4.1
+        image: gcr.io/google_containers/kube-state-metrics:v0.5.0
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION
We'll primarily distribute the kube-state-metrics container image via quay from now on as none of the kube-state-metrics maintainers have the ability to update the image on gcr (but we do for quay) and therefore it creates an unnecessary hassle when releasing.

@fabxc @mxinden @andyxning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/134)
<!-- Reviewable:end -->
