### PR TITLE
collectors/pod: flatten created by label and extract owners

### DIFF
--- a/Documentation/pod-metrics.md
+++ b/Documentation/pod-metrics.md
@@ -2,7 +2,8 @@
 
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
-| kube_pod_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `host_ip`=&lt;host-ip&gt; <br> `pod_ip`=&lt;pod-ip&gt; <br> `start_time`=&lt;date-time since kubelet acknowledged pod&gt; <br> `node`=&lt;node-name&gt;<br> `created_by`=&lt;created_by&gt;<br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  |
+| kube_pod_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `host_ip`=&lt;host-ip&gt; <br> `pod_ip`=&lt;pod-ip&gt; <br> `start_time`=&lt;date-time since kubelet acknowledged pod&gt; <br> `node`=&lt;node-name&gt;<br> `created_by_kind`=&lt;created_by_kind&gt;<br> `created_by_name`=&lt;created_by_name&gt;<br> |
+| kube_pod_owner | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  |
 | kube_pod_labels | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `label_POD_LABEL`=&lt;POD_LABEL&gt;  |
 | kube_pod_status_phase | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `phase`=&lt;Pending\|Running\|Succeeded\|Failed\|Unknown&gt; |
 | kube_pod_status_ready | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |

--- a/collectors/pod_test.go
+++ b/collectors/pod_test.go
@@ -52,6 +52,8 @@ func TestPodCollector(t *testing.T) {
 		# TYPE kube_pod_container_status_waiting gauge
 		# HELP kube_pod_info Information about pod.
 		# TYPE kube_pod_info gauge
+		# HELP kube_pod_owner Information about the Pod's owner.
+		# TYPE kube_pod_owner gauge
 		# HELP kube_pod_status_phase The pods current phase.
 		# TYPE kube_pod_status_phase gauge
 		# HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
@@ -290,10 +292,12 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_pod_info{created_by="<none>",host_ip="1.1.1.1",namespace="ns1",pod="pod1",node="node1",pod_ip="1.2.3.4",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
-				kube_pod_info{created_by="<none>",host_ip="1.1.1.1",namespace="ns2",pod="pod2",node="node2",pod_ip="2.3.4.5",owner_kind="ReplicaSet",owner_name="rs-name",owner_is_controller="true"} 1
+				kube_pod_info{created_by_kind="<none>",created_by_name="<none>",host_ip="1.1.1.1",namespace="ns1",pod="pod1",node="node1",pod_ip="1.2.3.4"} 1
+				kube_pod_info{created_by_kind="<none>",created_by_name="<none>",host_ip="1.1.1.1",namespace="ns2",pod="pod2",node="node2",pod_ip="2.3.4.5"} 1
+				kube_pod_owner{namespace="ns1",pod="pod1",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+				kube_pod_owner{namespace="ns2",pod="pod2",owner_kind="ReplicaSet",owner_name="rs-name",owner_is_controller="true"} 1
 				`,
-			metrics: []string{"kube_pod_info"},
+			metrics: []string{"kube_pod_info", "kube_pod_owner"},
 		}, {
 			pods: []v1.Pod{
 				{


### PR DESCRIPTION
The created by label previously was in the format "<kind>/<name>", this
is now normalized in to a respective label for each.

Additionally it is possible that a Pod has multiple OwnerReferences.
Previously multiple `kube_pod_info` metrics were generated for each
OwnerReference, unnecessarily duplicating all other labels of the
`kube_pod_info` metric.

The owner part has not been released yet, so it's non breaking,
however, the `created_by` label is breaking. This will be noted in
the changelog.

@fabxc @andyxning @mxinden @gouthamve

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/154)
<!-- Reviewable:end -->
