### PR TITLE
Add provider ID to Node collector

### DIFF
--- a/collectors/node.go
+++ b/collectors/node.go
@@ -41,6 +41,7 @@ var (
 			"container_runtime_version",
 			"kubelet_version",
 			"kubeproxy_version",
+			"provider_id",
 		}, nil,
 	)
 
@@ -204,6 +205,7 @@ func (nc *nodeCollector) collectNode(ch chan<- prometheus.Metric, n v1.Node) {
 		n.Status.NodeInfo.ContainerRuntimeVersion,
 		n.Status.NodeInfo.KubeletVersion,
 		n.Status.NodeInfo.KubeProxyVersion,
+		n.Spec.ProviderID,
 	)
 	labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
 	addGauge(nodeLabelsDesc(labelKeys), 1, labelValues...)

--- a/collectors/node_test.go
+++ b/collectors/node_test.go
@@ -85,10 +85,13 @@ func TestNodeCollector(t *testing.T) {
 							ContainerRuntimeVersion: "rkt",
 						},
 					},
+					Spec: v1.NodeSpec{
+						ProviderID: "provider://i-uniqueid",
+					},
 				},
 			},
 			want: metadata + `
-				kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage"} 1
+				kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",provider_id="provider://i-uniqueid"} 1
 				kube_node_labels{node="127.0.0.1"} 1
 				kube_node_spec_unschedulable{node="127.0.0.1"} 0
 			`,
@@ -105,6 +108,7 @@ func TestNodeCollector(t *testing.T) {
 					},
 					Spec: v1.NodeSpec{
 						Unschedulable: true,
+						ProviderID:    "provider://i-randomidentifier",
 					},
 					Status: v1.NodeStatus{
 						NodeInfo: v1.NodeSystemInfo{
@@ -128,7 +132,7 @@ func TestNodeCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage"} 1
+				kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",provider_id="provider://i-randomidentifier"} 1
 				kube_node_labels{label_type="master",node="127.0.0.1"} 1
 				kube_node_spec_unschedulable{node="127.0.0.1"} 1
 				kube_node_status_capacity_cpu_cores{node="127.0.0.1"} 4.3


### PR DESCRIPTION
This PR adds the provider ID of a Node to the labels which the Node collector makes available for scraping. This is useful for joining kube-state-metrics data with cloud provider data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/156)
<!-- Reviewable:end -->
