### PR TITLE
Add kube_cronjob_next_schedule_time metric to documentation

### DIFF
--- a/Documentation/cronjob-metrics.md
+++ b/Documentation/cronjob-metrics.md
@@ -3,6 +3,7 @@
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
 | kube_cronjob_info | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; <br> `schedule`=&lt;schedule&gt; <br> `concurrency_policy`=&lt;concurrency-policy&gt; |
+| kube_cronjob_next_schedule_time  | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; |
 | kube_cronjob_status_active | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; |
 | kube_cronjob_status_last_schedule_time | Counter | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; |
 | kube_cronjob_spec_suspend | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; |


### PR DESCRIPTION
The new `kube_cronjob_next_schedule_time` metric was missing from the documentation, this adds it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/171)
<!-- Reviewable:end -->
