### PR TITLE
Change kube_cronjob_status_last_schedule_time from a counter to a gauge

### DIFF
--- a/Documentation/cronjob-metrics.md
+++ b/Documentation/cronjob-metrics.md
@@ -4,6 +4,6 @@
 | ---------- | ----------- | ----------- |
 | kube_cronjob_info | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; <br> `schedule`=&lt;schedule&gt; <br> `concurrency_policy`=&lt;concurrency-policy&gt; |
 | kube_cronjob_status_active | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; |
-| kube_cronjob_status_last_schedule_time | Counter | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; |
+| kube_cronjob_status_last_schedule_time | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; |
 | kube_cronjob_spec_suspend | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; |
 | kube_cronjob_spec_starting_deadline_seconds | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; |

--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -136,10 +136,6 @@ func (jc *cronJobCollector) collectCronJob(ch chan<- prometheus.Metric, j v2batc
 		lv = append([]string{j.Namespace, j.Name}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
-	addCounter := func(desc *prometheus.Desc, v float64, lv ...string) {
-		lv = append([]string{j.Namespace, j.Name}, lv...)
-		ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, v, lv...)
-	}
 
 	if j.Spec.StartingDeadlineSeconds != nil {
 		addGauge(descCronJobSpecStartingDeadlineSeconds, float64(*j.Spec.StartingDeadlineSeconds))
@@ -158,6 +154,6 @@ func (jc *cronJobCollector) collectCronJob(ch chan<- prometheus.Metric, j v2batc
 	addGauge(descCronJobSpecSuspend, boolFloat64(*j.Spec.Suspend))
 
 	if j.Status.LastScheduleTime != nil {
-		addCounter(descCronJobStatusLastScheduleTime, float64(j.Status.LastScheduleTime.Unix()))
+		addGauge(descCronJobStatusLastScheduleTime, float64(j.Status.LastScheduleTime.Unix()))
 	}
 }

--- a/collectors/cronjob_test.go
+++ b/collectors/cronjob_test.go
@@ -56,7 +56,7 @@ func TestCronJobCollector(t *testing.T) {
 		# HELP kube_cronjob_status_active Active holds pointers to currently running jobs.
 		# TYPE kube_cronjob_status_active gauge
 		# HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
-		# TYPE kube_cronjob_status_last_schedule_time counter
+		# TYPE kube_cronjob_status_last_schedule_time gauge
 		# HELP kube_cronjob_next_schedule_time Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.
 		# TYPE kube_cronjob_next_schedule_time gauge
 	`


### PR DESCRIPTION
If I understand correctly `kube_cronjob_status_last_schedule_time` should actually be a gauge (we shouldn't be adding unix timestamps together)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/172)
<!-- Reviewable:end -->
