### PR TITLE
Collect labels for deployments and statefulsets.

### DIFF
--- a/collectors/deployment.go
+++ b/collectors/deployment.go
@@ -161,6 +161,9 @@ func (dc *deploymentCollector) collectDeployment(ch chan<- prometheus.Metric, d 
 		lv = append([]string{d.Namespace, d.Name}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
+
+	labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
+	addGauge(deploymentLabelsDesc(labelKeys), 1, labelValues...)
 	addGauge(descDeploymentStatusReplicas, float64(d.Status.Replicas))
 	addGauge(descDeploymentStatusReplicasAvailable, float64(d.Status.AvailableReplicas))
 	addGauge(descDeploymentStatusReplicasUnavailable, float64(d.Status.UnavailableReplicas))
@@ -180,7 +183,4 @@ func (dc *deploymentCollector) collectDeployment(ch chan<- prometheus.Metric, d 
 	} else {
 		addGauge(descDeploymentStrategyRollingUpdateMaxUnavailable, float64(maxUnavailable))
 	}
-
-	labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
-	addGauge(deploymentLabelsDesc(labelKeys), 1, labelValues...)
 }

--- a/collectors/deployment.go
+++ b/collectors/deployment.go
@@ -82,6 +82,12 @@ var (
 		"Sequence number representing a specific generation of the desired state.",
 		[]string{"namespace", "deployment"}, nil,
 	)
+
+	descDeploymentLabels = prometheus.NewDesc(
+		descDeploymentLabelsName,
+		descDeploymentLabelsHelp,
+		descDeploymentLabelsDefaultLabels, nil,
+	)
 )
 
 type DeploymentLister func() ([]v1beta1.Deployment, error)
@@ -126,6 +132,7 @@ func (dc *deploymentCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descDeploymentStrategyRollingUpdateMaxUnavailable
 	ch <- descDeploymentSpecReplicas
 	ch <- descDeploymentMetadataGeneration
+	ch <- descDeploymentLabels
 }
 
 // Collect implements the prometheus.Collector interface.

--- a/collectors/deployment_test.go
+++ b/collectors/deployment_test.go
@@ -71,6 +71,8 @@ func TestDeploymentCollector(t *testing.T) {
 		# TYPE kube_deployment_status_observed_generation gauge
                 # HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable Maximum number of unavailable replicas during a rolling update of a deployment.
 		# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
+		# HELP kube_deployment_labels Kubernetes labels converted to Prometheus labels.
+		# TYPE kube_deployment_labels gauge
 	`
 	cases := []struct {
 		depls []v1beta1.Deployment
@@ -82,6 +84,9 @@ func TestDeploymentCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:       "depl1",
 						Namespace:  "ns1",
+						Labels: map[string]string{
+							"app": "example1",
+						},
 						Generation: 21,
 					},
 					Status: v1beta1.DeploymentStatus{
@@ -103,6 +108,9 @@ func TestDeploymentCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:       "depl2",
 						Namespace:  "ns2",
+						Labels: map[string]string{
+							"app": "example2",
+						},
 						Generation: 14,
 					},
 					Status: v1beta1.DeploymentStatus{
@@ -136,6 +144,8 @@ func TestDeploymentCollector(t *testing.T) {
 				kube_deployment_status_replicas_unavailable{namespace="ns2",deployment="depl2"} 0
 				kube_deployment_status_replicas_updated{namespace="ns1",deployment="depl1"} 2
 				kube_deployment_status_replicas_updated{namespace="ns2",deployment="depl2"} 1
+				kube_deployment_labels{label_app="example1",namespace="ns1",deployment="depl1"} 1
+				kube_deployment_labels{label_app="example2",namespace="ns2",deployment="depl2"} 1
 			`,
 		},
 	}

--- a/collectors/statefulset.go
+++ b/collectors/statefulset.go
@@ -38,6 +38,12 @@ var (
 		"Sequence number representing a specific generation of the desired state for the StatefulSet.",
 		[]string{"namespace", "statefulset"}, nil,
 	)
+
+	descStatefulSetLabels = prometheus.NewDesc(
+		descStatefulSetLabelsName,
+		descStatefulSetLabelsHelp,
+		descStatefulSetLabelsDefaultLabels, nil,
+	)
 )
 
 type StatefulSetLister func() ([]v1beta1.StatefulSet, error)
@@ -76,6 +82,7 @@ func (dc *statefulSetCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descStatefulSetStatusObservedGeneration
 	ch <- descStatefulSetSpecReplicas
 	ch <- descStatefulSetMetadataGeneration
+	ch <- descStatefulSetLabels
 }
 
 // Collect implements the prometheus.Collector interface.

--- a/collectors/statefulset.go
+++ b/collectors/statefulset.go
@@ -11,6 +11,10 @@ import (
 )
 
 var (
+	descStatefulSetLabelsName          = "kube_statefulset_labels"
+	descStatefulSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descStatefulSetLabelsDefaultLabels = []string{"namespace", "statefulset"}
+
 	descStatefulSetStatusReplicas = prometheus.NewDesc(
 		"kube_statefulset_status_replicas",
 		"The number of replicas per StatefulSet.",
@@ -86,6 +90,15 @@ func (sc *statefulSetCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
+func statefulSetLabelsDesc(labelKeys []string) *prometheus.Desc {
+	return prometheus.NewDesc(
+		descStatefulSetLabelsName,
+		descStatefulSetLabelsHelp,
+		append(descStatefulSetLabelsDefaultLabels, labelKeys...),
+		nil,
+	)
+}
+
 func (dc *statefulSetCollector) collectStatefulSet(ch chan<- prometheus.Metric, statefulSet v1beta1.StatefulSet) {
 	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
 		lv = append([]string{statefulSet.Namespace, statefulSet.Name}, lv...)
@@ -95,4 +108,7 @@ func (dc *statefulSetCollector) collectStatefulSet(ch chan<- prometheus.Metric, 
 	addGauge(descStatefulSetStatusObservedGeneration, float64(*statefulSet.Status.ObservedGeneration))
 	addGauge(descStatefulSetSpecReplicas, float64(*statefulSet.Spec.Replicas))
 	addGauge(descStatefulSetMetadataGeneration, float64(statefulSet.ObjectMeta.Generation))
-} 
+
+	labelKeys, labelValues := kubeLabelsToPrometheusLabels(statefulSet.Labels)
+	addGauge(statefulSetLabelsDesc(labelKeys), 1, labelValues...)
+}

--- a/collectors/statefulset_test.go
+++ b/collectors/statefulset_test.go
@@ -34,6 +34,8 @@ func TestStatefuleSetCollector(t *testing.T) {
  		# TYPE kube_statefulset_replicas gauge
  		# HELP kube_statefulset_metadata_generation Sequence number representing a specific generation of the desired state for the StatefulSet.
  		# TYPE kube_statefulset_metadata_generation gauge
+		# HELP kube_statefulset_labels Kubernetes labels converted to Prometheus labels.
+		# TYPE kube_statefulset_labels gauge
  	`
 	cases := []struct {
 		depls []v1beta1.StatefulSet
@@ -45,6 +47,9 @@ func TestStatefuleSetCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:       "statefulset1",
 						Namespace:  "ns1",
+						Labels: map[string]string{
+							"app": "example1",
+						},
 						Generation: 3,
 					},
 					Spec: v1beta1.StatefulSetSpec{
@@ -59,6 +64,9 @@ func TestStatefuleSetCollector(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:       "statefulset2",
 						Namespace:  "ns2",
+						Labels: map[string]string{
+							"app": "example2",
+						},
 						Generation: 21,
 					},
 					Spec: v1beta1.StatefulSetSpec{
@@ -80,6 +88,8 @@ func TestStatefuleSetCollector(t *testing.T) {
  				kube_statefulset_replicas{namespace="ns2",statefulset="statefulset2"} 6
  				kube_statefulset_metadata_generation{namespace="ns1",statefulset="statefulset1"} 3
  				kube_statefulset_metadata_generation{namespace="ns2",statefulset="statefulset2"} 21
+				kube_statefulset_labels{label_app="example1",namespace="ns1",statefulset="statefulset1"} 1
+				kube_statefulset_labels{label_app="example2",namespace="ns2",statefulset="statefulset2"} 1
  			`,
 		},
 	}


### PR DESCRIPTION
It builds but is untested because `go test` just says `?   	k8s.io/kube-state-metrics	[no test files]`.

I'm not a go programmer, so if this is not the correct way to run tests please let me know. 

I'm not sure I understand the significance of the default labels.  Copying how the service collector defines them, I've added `namespace` and the type of object being labelled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/175)
<!-- Reviewable:end -->
