### PR TITLE
fix statefulset observedgeneration is nil

### DIFF
--- a/collectors/statefulset.go
+++ b/collectors/statefulset.go
@@ -1,13 +1,13 @@
 package collectors
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/client-go/pkg/apis/apps/v1beta1"
 	"github.com/golang/glog"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/apis/apps/v1beta1"
+	"k8s.io/client-go/tools/cache"
 )
 
 var (
@@ -112,7 +112,9 @@ func (dc *statefulSetCollector) collectStatefulSet(ch chan<- prometheus.Metric, 
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
 	addGauge(descStatefulSetStatusReplicas, float64(statefulSet.Status.Replicas))
-	addGauge(descStatefulSetStatusObservedGeneration, float64(*statefulSet.Status.ObservedGeneration))
+	if statefulSet.Status.ObservedGeneration != nil {
+		addGauge(descStatefulSetStatusObservedGeneration, float64(*statefulSet.Status.ObservedGeneration))
+	}
 	addGauge(descStatefulSetSpecReplicas, float64(*statefulSet.Spec.Replicas))
 	addGauge(descStatefulSetMetadataGeneration, float64(statefulSet.ObjectMeta.Generation))
 

--- a/collectors/statefulset_test.go
+++ b/collectors/statefulset_test.go
@@ -1,14 +1,16 @@
 package collectors
 
 import (
-	"k8s.io/client-go/pkg/apis/apps/v1beta1"
 	"testing"
+
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/apps/v1beta1"
 )
 
 var (
 	statefulSet1Replicas int32 = 3
 	statefulSet2Replicas int32 = 6
+	statefulSet3Replicas int32 = 9
 
 	statefulSet1ObservedGeneration int64 = 1
 	statefulSet2ObservedGeneration int64 = 2
@@ -45,51 +47,72 @@ func TestStatefuleSetCollector(t *testing.T) {
 			depls: []v1beta1.StatefulSet{
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:       "statefulset1",
-						Namespace:  "ns1",
+						Name:      "statefulset1",
+						Namespace: "ns1",
 						Labels: map[string]string{
 							"app": "example1",
 						},
 						Generation: 3,
 					},
 					Spec: v1beta1.StatefulSetSpec{
-						Replicas:            &statefulSet1Replicas,
-						ServiceName:   		 "statefulset1service",
+						Replicas:    &statefulSet1Replicas,
+						ServiceName: "statefulset1service",
 					},
 					Status: v1beta1.StatefulSetStatus{
 						ObservedGeneration: &statefulSet1ObservedGeneration,
-						Replicas: 2,
+						Replicas:           2,
 					},
 				}, {
 					ObjectMeta: v1.ObjectMeta{
-						Name:       "statefulset2",
-						Namespace:  "ns2",
+						Name:      "statefulset2",
+						Namespace: "ns2",
 						Labels: map[string]string{
 							"app": "example2",
 						},
 						Generation: 21,
 					},
 					Spec: v1beta1.StatefulSetSpec{
-						Replicas:            &statefulSet2Replicas,
-						ServiceName:   		 "statefulset2service",
+						Replicas:    &statefulSet2Replicas,
+						ServiceName: "statefulset2service",
 					},
 					Status: v1beta1.StatefulSetStatus{
 						ObservedGeneration: &statefulSet2ObservedGeneration,
-						Replicas: 5,
+						Replicas:           5,
+					},
+				}, {
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "statefulset3",
+						Namespace: "ns3",
+						Labels: map[string]string{
+							"app": "example3",
+						},
+						Generation: 36,
+					},
+					Spec: v1beta1.StatefulSetSpec{
+						Replicas:    &statefulSet3Replicas,
+						ServiceName: "statefulset2service",
+					},
+					Status: v1beta1.StatefulSetStatus{
+						ObservedGeneration: nil,
+						Replicas:           7,
 					},
 				},
 			},
 			want: metadata + `
  				kube_statefulset_status_replicas{namespace="ns1",statefulset="statefulset1"} 2
  				kube_statefulset_status_replicas{namespace="ns2",statefulset="statefulset2"} 5
+ 				kube_statefulset_status_replicas{namespace="ns3",statefulset="statefulset3"} 7
  				kube_statefulset_status_observed_generation{namespace="ns1",statefulset="statefulset1"} 1
  				kube_statefulset_status_observed_generation{namespace="ns2",statefulset="statefulset2"} 2
  				kube_statefulset_replicas{namespace="ns1",statefulset="statefulset1"} 3
  				kube_statefulset_replicas{namespace="ns2",statefulset="statefulset2"} 6
+ 				kube_statefulset_replicas{namespace="ns3",statefulset="statefulset3"} 9
  				kube_statefulset_metadata_generation{namespace="ns1",statefulset="statefulset1"} 3
  				kube_statefulset_metadata_generation{namespace="ns2",statefulset="statefulset2"} 21
+ 				kube_statefulset_metadata_generation{namespace="ns3",statefulset="statefulset3"} 36
 				kube_statefulset_labels{label_app="example1",namespace="ns1",statefulset="statefulset1"} 1
 				kube_statefulset_labels{label_app="example2",namespace="ns2",statefulset="statefulset2"} 1
+				kube_statefulset_labels{label_app="example3",namespace="ns3",statefulset="statefulset3"} 1
  			`,
 		},
 	}
@@ -103,4 +126,4 @@ func TestStatefuleSetCollector(t *testing.T) {
 			t.Errorf("unexpected collecting result:\n%s", err)
 		}
 	}
-} 
+}


### PR DESCRIPTION
Fix #174

I am not so familiar with statefulset. However, according to the [comment](https://github.com/kubernetes/kube-state-metrics/blob/master/vendor/k8s.io/client-go/pkg/apis/apps/v1beta1/types.go#L87-L95) about `ObservedGeneration` and  [the function in Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/statefulset/stateful_set_utils.go#L351-L362). `ObservedGeneration` is optional and may be `nil`.  Deference a `nil` will panic the app.

We should filter out `ObservedGeneration` when it is `nil`.

/cc @shiranp @brancz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/176)
<!-- Reviewable:end -->
