### PR TITLE
add readme for supported kubernetes version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ either by Prometheus itself or by a scraper that is compatible with scraping
 a Prometheus client endpoint. You can also open `/metrics` in a browser to see
 the raw metrics.
 
-*Requires Kubernetes 1.2+*
+## Kubernetes Version
+
+kube-state-metrics uses [`client-go`](https://github.com/kubernetes/client-go) to talk with
+Kubernetes clusters. The supported Kubernetes cluster version is determined by `client-go`.
+The compatibility matrix for client-go and Kubernetes cluster can be found 
+[here](https://github.com/kubernetes/client-go#compatibility-matrix). 
+All additional compatibility is only best effort, or happens to still/already be supported.
+Currently, `client-go` is in version `v2.0.0-alpha.1`.
 
 ## Container Image
 


### PR DESCRIPTION
Fix #129 partially.

Add readme about the supported Kubernetes version for kube-state-metrics.   This makes the supported Kubernetes version info more clear. :)

/cc @brancz @cemo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/178)
<!-- Reviewable:end -->
