### PR TITLE
Add PersistentVolumeClaim metrics

### DIFF
--- a/Documentation/persistentvolumeclaim-metrics.md
+++ b/Documentation/persistentvolumeclaim-metrics.md
@@ -1,0 +1,5 @@
+# PersistentVolumeClaim Metrics
+
+| Metric name| Metric type | Labels/tags |
+| ---------- | ----------- | ----------- |
+| kube_persistentvolumeclaim_status_phase| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `phase`=&lt;Pending\|Bound\|Lost&gt; |

--- a/collectors/persistentvolumeclaim.go
+++ b/collectors/persistentvolumeclaim.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/net/context"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descPersistentVolumeClaimStatusPhase = prometheus.NewDesc(
+		"kube_persistentvolumeclaim_status_phase",
+		"The phase the claim is currently in.",
+		[]string{
+			"namespace",
+			"persistentvolumeclaim",
+			"phase",
+		}, nil,
+	)
+)
+
+type PersistentVolumeClaimLister func() (v1.PersistentVolumeClaimList, error)
+
+func (l PersistentVolumeClaimLister) List() (v1.PersistentVolumeClaimList, error) {
+	return l()
+}
+
+func RegisterPersistentVolumeClaimCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+	client := kubeClient.CoreV1().RESTClient()
+	pvclw := cache.NewListWatchFromClient(client, "persistentvolumeclaims", api.NamespaceAll, nil)
+	pvcinf := cache.NewSharedInformer(pvclw, &v1.PersistentVolumeClaim{}, resyncPeriod)
+
+	persistentVolumeClaimLister := PersistentVolumeClaimLister(func() (pvcs v1.PersistentVolumeClaimList, err error) {
+		for _, pvc := range pvcinf.GetStore().List() {
+			pvcs.Items = append(pvcs.Items, *(pvc.(*v1.PersistentVolumeClaim)))
+		}
+		return pvcs, nil
+	})
+
+	registry.MustRegister(&persistentVolumeClaimCollector{store: persistentVolumeClaimLister})
+	go pvcinf.Run(context.Background().Done())
+}
+
+type persistentVolumeClaimStore interface {
+	List() (v1.PersistentVolumeClaimList, error)
+}
+
+// persistentVolumeClaimCollector collects metrics about all limit ranges in the cluster.
+type persistentVolumeClaimCollector struct {
+	store persistentVolumeClaimStore
+}
+
+// Describe implements the prometheus.Collector interface.
+func (collector *persistentVolumeClaimCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descPersistentVolumeClaimStatusPhase
+}
+
+// Collect implements the prometheus.Collector interface.
+func (collector *persistentVolumeClaimCollector) Collect(ch chan<- prometheus.Metric) {
+	persistentVolumeClaimCollector, err := collector.store.List()
+	if err != nil {
+		glog.Errorf("listing limit ranges failed: %s", err)
+		return
+	}
+
+	for _, pvc := range persistentVolumeClaimCollector.Items {
+		collector.collectPersistentVolumeClaim(ch, pvc)
+	}
+}
+
+func (collector *persistentVolumeClaimCollector) collectPersistentVolumeClaim(ch chan<- prometheus.Metric, pvc v1.PersistentVolumeClaim) {
+	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
+		lv = append([]string{pvc.Namespace, pvc.Name}, lv...)
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
+	}
+
+	// Set current phase to 1, others to 0 if it is set.
+	if p := pvc.Status.Phase; p != "" {
+		addGauge(descPersistentVolumeClaimStatusPhase, boolFloat64(p == v1.ClaimLost), string(v1.ClaimLost))
+		addGauge(descPersistentVolumeClaimStatusPhase, boolFloat64(p == v1.ClaimBound), string(v1.ClaimBound))
+		addGauge(descPersistentVolumeClaimStatusPhase, boolFloat64(p == v1.ClaimPending), string(v1.ClaimPending))
+	}
+}

--- a/collectors/persistentvolumeclaim_test.go
+++ b/collectors/persistentvolumeclaim_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+type mockPersistentVolumeClaimStore struct {
+	list func() (v1.PersistentVolumeClaimList, error)
+}
+
+func (ns mockPersistentVolumeClaimStore) List() (v1.PersistentVolumeClaimList, error) {
+	return ns.list()
+}
+
+func TestPersistentVolumeClaimCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+	const metadata = `
+		# HELP kube_persistentvolumeclaim_status_phase The phase the claim is currently in.
+		# TYPE kube_persistentvolumeclaim_status_phase gauge
+	`
+	cases := []struct {
+		pvcs    []v1.PersistentVolumeClaim
+		metrics []string // which metrics should be checked
+		want    string
+	}{
+		// Verify phase enumerations.
+		{
+			pvcs: []v1.PersistentVolumeClaim{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "mysql-data",
+						Namespace: "default",
+					},
+					Status: v1.PersistentVolumeClaimStatus{
+						Phase: v1.ClaimBound,
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "prometheus-data",
+						Namespace: "default",
+					},
+					Status: v1.PersistentVolumeClaimStatus{
+						Phase: v1.ClaimPending,
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "mongo-data",
+					},
+					Status: v1.PersistentVolumeClaimStatus{
+						Phase: v1.ClaimLost,
+					},
+				},
+			},
+			want: metadata + `
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Bound"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Lost"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Pending"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Bound"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Lost"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Bound"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Lost"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Pending"} 1
+			`,
+			metrics: []string{"kube_persistentvolumeclaim_status_phase"},
+		},
+	}
+	for _, c := range cases {
+		dc := &persistentVolumeClaimCollector{
+			store: &mockPersistentVolumeClaimStore{
+				list: func() (v1.PersistentVolumeClaimList, error) {
+					return v1.PersistentVolumeClaimList{Items: c.pvcs}, nil
+				},
+			},
+		}
+		if err := gatherAndCompare(dc, c.want, c.metrics); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ var (
 		"jobs":                   struct{}{},
 		"cronjobs":               struct{}{},
 		"statefulsets":           struct{}{},
+		"persistentvolumeclaims": struct{}{},
 	}
 	availableCollectors = map[string]func(registry prometheus.Registerer, kubeClient clientset.Interface){
 		"cronjobs":               collectors.RegisterCronJobCollector,
@@ -69,6 +70,7 @@ var (
 		"resourcequotas":         collectors.RegisterResourceQuotaCollector,
 		"services":               collectors.RegisterServiceCollector,
 		"statefulsets":           collectors.RegisterStatefulSetCollector,
+		"persistentvolumeclaims": collectors.RegisterPersistentVolumeClaimCollector,
 	}
 )
 


### PR DESCRIPTION
What this PR does / why we need it:

As a admin operator of  multi-tenant clusters, I need to monitor PVC bound status. If a PVC failed (for example, in case RBD Provisioner is not working or Ceph cluster is full), I can know it as soon as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/179)
<!-- Reviewable:end -->
