### PR TITLE
Add creation time metrics for all collectors

### DIFF
--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -37,6 +37,11 @@ var (
 		"Info about cronjob.",
 		[]string{"namespace", "cronjob", "schedule", "concurrency_policy"}, nil,
 	)
+	descCronJobCreated = prometheus.NewDesc(
+		"kube_cronjob_created",
+		"Unix creation timestamp",
+		[]string{"namespace", "cronjob"}, nil,
+	)
 	descCronJobStatusActive = prometheus.NewDesc(
 		"kube_cronjob_status_active",
 		"Active holds pointers to currently running jobs.",
@@ -98,6 +103,7 @@ type cronJobCollector struct {
 // Describe implements the prometheus.Collector interface.
 func (dc *cronJobCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descCronJobInfo
+	ch <- descCronJobCreated
 	ch <- descCronJobStatusActive
 	ch <- descCronJobStatusLastScheduleTime
 	ch <- descCronJobSpecSuspend
@@ -150,6 +156,9 @@ func (jc *cronJobCollector) collectCronJob(ch chan<- prometheus.Metric, j v2batc
 	}
 
 	addGauge(descCronJobInfo, 1, j.Spec.Schedule, string(j.Spec.ConcurrencyPolicy))
+	if !j.CreationTimestamp.IsZero() {
+		addGauge(descCronJobCreated, float64(j.CreationTimestamp.Unix()))
+	}
 	addGauge(descCronJobStatusActive, float64(len(j.Status.Active)))
 	if j.Spec.Suspend != nil {
 		addGauge(descCronJobSpecSuspend, boolFloat64(*j.Spec.Suspend))

--- a/collectors/daemonset.go
+++ b/collectors/daemonset.go
@@ -27,6 +27,11 @@ import (
 )
 
 var (
+	descDaemonSetCreated = prometheus.NewDesc(
+		"kube_daemonset_created",
+		"Unix creation timestamp",
+		[]string{"namespace", "daemonset"}, nil,
+	)
 	descDaemonSetCurrentNumberScheduled = prometheus.NewDesc(
 		"kube_daemonset_status_current_number_scheduled",
 		"The number of nodes running at least one daemon pod and are supposed to.",
@@ -87,6 +92,7 @@ type daemonsetCollector struct {
 
 // Describe implements the prometheus.Collector interface.
 func (dc *daemonsetCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descDaemonSetCreated
 	ch <- descDaemonSetCurrentNumberScheduled
 	ch <- descDaemonSetNumberMisscheduled
 	ch <- descDaemonSetDesiredNumberScheduled
@@ -110,6 +116,9 @@ func (dc *daemonsetCollector) collectDaemonSet(ch chan<- prometheus.Metric, d v1
 	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
 		lv = append([]string{d.Namespace, d.Name}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
+	}
+	if !d.CreationTimestamp.IsZero() {
+		addGauge(descDaemonSetCreated, float64(d.CreationTimestamp.Unix()))
 	}
 	addGauge(descDaemonSetCurrentNumberScheduled, float64(d.Status.CurrentNumberScheduled))
 	addGauge(descDaemonSetNumberMisscheduled, float64(d.Status.NumberMisscheduled))

--- a/collectors/daemonset_test.go
+++ b/collectors/daemonset_test.go
@@ -18,6 +18,7 @@ package collectors
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
@@ -35,6 +36,8 @@ func TestDaemonSetCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_daemonset_created Unix creation timestamp
+		# TYPE kube_daemonset_created gauge
 	  # HELP kube_daemonset_metadata_generation Sequence number representing a specific generation of the desired state.
 		# TYPE kube_daemonset_metadata_generation gauge
 		# HELP kube_daemonset_status_current_number_scheduled The number of nodes running at least one daemon pod and are supposed to.
@@ -67,6 +70,7 @@ func TestDaemonSetCollector(t *testing.T) {
 				}, {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "ds2",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Namespace:  "ns2",
 						Generation: 14,
 					},
@@ -79,6 +83,7 @@ func TestDaemonSetCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_daemonset_created{daemonset="ds2",namespace="ns2"} 1.5e+09
 				kube_daemonset_metadata_generation{namespace="ns1",daemonset="ds1"} 21
 				kube_daemonset_metadata_generation{namespace="ns2",daemonset="ds2"} 14
 				kube_daemonset_status_current_number_scheduled{namespace="ns1",daemonset="ds1"} 15

--- a/collectors/deployment_test.go
+++ b/collectors/deployment_test.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -53,6 +54,8 @@ func TestDeploymentCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_deployment_created Unix creation timestamp
+		# TYPE kube_deployment_created gauge
 		# HELP kube_deployment_metadata_generation Sequence number representing a specific generation of the desired state.
 		# TYPE kube_deployment_metadata_generation gauge
 		# HELP kube_deployment_spec_paused Whether the deployment is paused and will not be processed by the deployment controller.
@@ -83,6 +86,7 @@ func TestDeploymentCollector(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "depl1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Namespace: "ns1",
 						Labels: map[string]string{
 							"app": "example1",
@@ -127,6 +131,7 @@ func TestDeploymentCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_deployment_created{deployment="depl1",namespace="ns1"} 1.5e+09
 				kube_deployment_metadata_generation{namespace="ns1",deployment="depl1"} 21
 				kube_deployment_metadata_generation{namespace="ns2",deployment="depl2"} 14
 				kube_deployment_spec_paused{namespace="ns1",deployment="depl1"} 0

--- a/collectors/job_test.go
+++ b/collectors/job_test.go
@@ -52,6 +52,8 @@ func TestJobCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_job_created Unix creation timestamp
+		# TYPE kube_job_created gauge
 		# HELP kube_job_complete The job has completed its execution.
 		# TYPE kube_job_complete gauge
 		# HELP kube_job_failed The job has failed its execution.
@@ -84,6 +86,7 @@ func TestJobCollector(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "RunningJob1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Namespace:  "ns1",
 						Generation: 1,
 					},
@@ -165,6 +168,8 @@ func TestJobCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_job_created{job="RunningJob1",namespace="ns1"} 1.5e+09
+				
 				kube_job_complete{condition="false",job="SuccessfulJob1",namespace="ns1"} 0
 				kube_job_complete{condition="false",job="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 0
 

--- a/collectors/limitrange.go
+++ b/collectors/limitrange.go
@@ -38,6 +38,12 @@ var (
 			"constraint",
 		}, nil,
 	)
+
+	descLimitRangeCreated = prometheus.NewDesc(
+	    "kube_limitrange_created",
+	    "Unix creation timestamp",
+	    []string{"limitrange", "namespace"}, nil,
+	)
 )
 
 type LimitRangeLister func() (v1.LimitRangeList, error)
@@ -74,6 +80,7 @@ type limitRangeCollector struct {
 // Describe implements the prometheus.Collector interface.
 func (lrc *limitRangeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descLimitRange
+	ch <- descLimitRangeCreated
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -94,6 +101,10 @@ func (lrc *limitRangeCollector) collectLimitRange(ch chan<- prometheus.Metric, r
 		lv = append([]string{rq.Name, rq.Namespace}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
+	if !rq.CreationTimestamp.IsZero() {
+		addGauge(descLimitRangeCreated, float64(rq.CreationTimestamp.Unix()))
+	}
+
 	rawLimitRanges := rq.Spec.Limits
 	for _, rawLimitRange := range rawLimitRanges {
 		for resource, min := range rawLimitRange.Min {

--- a/collectors/limitrange_test.go
+++ b/collectors/limitrange_test.go
@@ -18,6 +18,7 @@ package collectors
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +39,8 @@ func TestLimitRangeollector(t *testing.T) {
 	testMemory := "2.1G"
 	testMemoryQuantity := resource.MustParse(testMemory)
 	const metadata = `
+	# HELP kube_limitrange_created Unix creation timestamp
+	# TYPE kube_limitrange_created gauge
 	# HELP kube_limitrange Information about limit range.
 	# TYPE kube_limitrange gauge
 	`
@@ -51,6 +54,7 @@ func TestLimitRangeollector(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "quotaTest",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Namespace: "testNS",
 					},
 					Spec: v1.LimitRangeSpec{
@@ -78,6 +82,7 @@ func TestLimitRangeollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+		kube_limitrange_created{limitrange="quotaTest",namespace="testNS"} 1.5e+09
 		kube_limitrange{limitrange="quotaTest",namespace="testNS",resource="memory",type="Pod",constraint="min"} 2.1e+09
 		kube_limitrange{limitrange="quotaTest",namespace="testNS",resource="memory",type="Pod",constraint="max"} 2.1e+09
 		kube_limitrange{limitrange="quotaTest",namespace="testNS",resource="memory",type="Pod",constraint="default"} 2.1e+09

--- a/collectors/node.go
+++ b/collectors/node.go
@@ -45,6 +45,12 @@ var (
 		}, nil,
 	)
 
+	descNodeCreated = prometheus.NewDesc(
+		"kube_node_created",
+		"Unix creation timestamp",
+		[]string{"node"}, nil,
+	)
+
 	descNodeLabels = prometheus.NewDesc(
 		descNodeLabelsName,
 		descNodeLabelsHelp,
@@ -155,6 +161,7 @@ type nodeCollector struct {
 // Describe implements the prometheus.Collector interface.
 func (nc *nodeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descNodeInfo
+	ch <- descNodeCreated
 	ch <- descNodeLabels
 	ch <- descNodeSpecUnschedulable
 	ch <- descNodeStatusReady
@@ -207,6 +214,9 @@ func (nc *nodeCollector) collectNode(ch chan<- prometheus.Metric, n v1.Node) {
 		n.Status.NodeInfo.KubeProxyVersion,
 		n.Spec.ProviderID,
 	)
+	if !n.CreationTimestamp.IsZero() {
+		addGauge(descNodeCreated, float64(n.CreationTimestamp.Unix()))
+	}
 	labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
 	addGauge(nodeLabelsDesc(labelKeys), 1, labelValues...)
 

--- a/collectors/node_test.go
+++ b/collectors/node_test.go
@@ -18,6 +18,7 @@ package collectors
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,8 @@ func TestNodeCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_node_created Unix creation timestamp
+		# TYPE kube_node_created gauge
 		# HELP kube_node_info Information about a cluster node.
 		# TYPE kube_node_info gauge
 		# HELP kube_node_labels Kubernetes labels converted to Prometheus labels.
@@ -103,6 +106,7 @@ func TestNodeCollector(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "127.0.0.1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Labels: map[string]string{
 							"type": "master",
 						},
@@ -133,6 +137,7 @@ func TestNodeCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_node_created{node="127.0.0.1"} 1.5e+09
 				kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",provider_id="provider://i-randomidentifier"} 1
 				kube_node_labels{label_type="master",node="127.0.0.1"} 1
 				kube_node_spec_unschedulable{node="127.0.0.1"} 1

--- a/collectors/pod.go
+++ b/collectors/pod.go
@@ -60,6 +60,12 @@ var (
 		descPodLabelsDefaultLabels, nil,
 	)
 
+	descPodCreated = prometheus.NewDesc(
+		"kube_pod_created",
+		"Unix creation timestamp",
+		[]string{"namespace", "pod"}, nil,
+	)
+
 	descPodStatusPhase = prometheus.NewDesc(
 		"kube_pod_status_phase",
 		"The pods current phase.",
@@ -176,6 +182,7 @@ func (pc *podCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descPodStartTime
 	ch <- descPodOwner
 	ch <- descPodLabels
+	ch <- descPodCreated
 	ch <- descPodStatusPhase
 	ch <- descPodStatusReady
 	ch <- descPodStatusScheduled
@@ -289,6 +296,10 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 		addGauge(descPodStatusPhase, boolFloat64(p == v1.PodSucceeded), string(v1.PodSucceeded))
 		addGauge(descPodStatusPhase, boolFloat64(p == v1.PodFailed), string(v1.PodFailed))
 		addGauge(descPodStatusPhase, boolFloat64(p == v1.PodUnknown), string(v1.PodUnknown))
+	}
+
+	if !p.CreationTimestamp.IsZero() {
+		addGauge(descPodCreated, float64(p.CreationTimestamp.Unix()))
 	}
 
 	for _, c := range p.Status.Conditions {

--- a/collectors/pod_test.go
+++ b/collectors/pod_test.go
@@ -18,6 +18,7 @@ package collectors
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +42,8 @@ func TestPodCollector(t *testing.T) {
 	metav1StartTime := metav1.Unix(int64(startTime), 0)
 
 	const metadata = `
+		# HELP kube_pod_created Unix creation timestamp
+		# TYPE kube_pod_created gauge
 		# HELP kube_pod_container_info Information about a container in a pod.
 		# TYPE kube_pod_container_info gauge
 		# HELP kube_pod_labels Kubernetes labels converted to Prometheus labels.
@@ -268,6 +271,7 @@ func TestPodCollector(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Namespace: "ns1",
 					},
 					Spec: v1.PodSpec{
@@ -300,13 +304,14 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_pod_created{namespace="ns1",pod="pod1"} 1.5e+09
 				kube_pod_info{created_by_kind="<none>",created_by_name="<none>",host_ip="1.1.1.1",namespace="ns1",pod="pod1",node="node1",pod_ip="1.2.3.4"} 1
 				kube_pod_info{created_by_kind="<none>",created_by_name="<none>",host_ip="1.1.1.1",namespace="ns2",pod="pod2",node="node2",pod_ip="2.3.4.5"} 1
 				kube_pod_start_time{namespace="ns1",pod="pod1"} 1501569018
 				kube_pod_owner{namespace="ns1",pod="pod1",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
 				kube_pod_owner{namespace="ns2",pod="pod2",owner_kind="ReplicaSet",owner_name="rs-name",owner_is_controller="true"} 1
 				`,
-			metrics: []string{"kube_pod_info", "kube_pod_start_time", "kube_pod_owner"},
+			metrics: []string{"kube_pod_created", "kube_pod_info", "kube_pod_start_time", "kube_pod_owner"},
 		}, {
 			pods: []v1.Pod{
 				{

--- a/collectors/replicaset.go
+++ b/collectors/replicaset.go
@@ -27,6 +27,11 @@ import (
 )
 
 var (
+	descReplicaSetCreated = prometheus.NewDesc(
+		"kube_replicaset_created",
+		"Unix creation timestamp",
+		[]string{"namespace", "replicaset"}, nil,
+	)
 	descReplicaSetStatusReplicas = prometheus.NewDesc(
 		"kube_replicaset_status_replicas",
 		"The number of replicas per ReplicaSet.",
@@ -92,6 +97,7 @@ type replicasetCollector struct {
 
 // Describe implements the prometheus.Collector interface.
 func (dc *replicasetCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descReplicaSetCreated
 	ch <- descReplicaSetStatusReplicas
 	ch <- descReplicaSetStatusFullyLabeledReplicas
 	ch <- descReplicaSetStatusReadyReplicas
@@ -116,6 +122,9 @@ func (dc *replicasetCollector) collectReplicaSet(ch chan<- prometheus.Metric, d 
 	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
 		lv = append([]string{d.Namespace, d.Name}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
+	}
+	if !d.CreationTimestamp.IsZero() {
+		addGauge(descReplicaSetCreated, float64(d.CreationTimestamp.Unix()))
 	}
 	addGauge(descReplicaSetStatusReplicas, float64(d.Status.Replicas))
 	addGauge(descReplicaSetStatusFullyLabeledReplicas, float64(d.Status.FullyLabeledReplicas))

--- a/collectors/replicaset_test.go
+++ b/collectors/replicaset_test.go
@@ -18,6 +18,7 @@ package collectors
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
@@ -40,6 +41,8 @@ func TestReplicaSetCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_replicaset_created Unix creation timestamp
+		# TYPE kube_replicaset_created gauge
 	  # HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
 		# TYPE kube_replicaset_metadata_generation gauge
 		# HELP kube_replicaset_status_replicas The number of replicas per ReplicaSet.
@@ -62,6 +65,7 @@ func TestReplicaSetCollector(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "rs1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Namespace:  "ns1",
 						Generation: 21,
 					},
@@ -92,6 +96,7 @@ func TestReplicaSetCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_replicaset_created{namespace="ns1",replicaset="rs1"} 1.5e+09
 				kube_replicaset_metadata_generation{namespace="ns1",replicaset="rs1"} 21
 				kube_replicaset_metadata_generation{namespace="ns2",replicaset="rs2"} 14
 				kube_replicaset_status_replicas{namespace="ns1",replicaset="rs1"} 5

--- a/collectors/replicationcontroller.go
+++ b/collectors/replicationcontroller.go
@@ -28,6 +28,11 @@ import (
 )
 
 var (
+	descReplicationControllerCreated = prometheus.NewDesc(
+		"kube_replicationcontroller_created",
+		"Unix creation timestamp",
+		[]string{"namespace", "replicationcontroller"}, nil,
+	)
 	descReplicationControllerStatusReplicas = prometheus.NewDesc(
 		"kube_replicationcontroller_status_replicas",
 		"The number of replicas per ReplicationController.",
@@ -97,6 +102,7 @@ type replicationcontrollerCollector struct {
 
 // Describe implements the prometheus.Collector interface.
 func (dc *replicationcontrollerCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descReplicationControllerCreated
 	ch <- descReplicationControllerStatusReplicas
 	ch <- descReplicationControllerStatusFullyLabeledReplicas
 	ch <- descReplicationControllerStatusReadyReplicas
@@ -122,6 +128,9 @@ func (dc *replicationcontrollerCollector) collectReplicationController(ch chan<-
 	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
 		lv = append([]string{d.Namespace, d.Name}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
+	}
+	if !d.CreationTimestamp.IsZero() {
+		addGauge(descReplicationControllerCreated, float64(d.CreationTimestamp.Unix()))
 	}
 	addGauge(descReplicationControllerStatusReplicas, float64(d.Status.Replicas))
 	addGauge(descReplicationControllerStatusFullyLabeledReplicas, float64(d.Status.FullyLabeledReplicas))

--- a/collectors/replicationcontroller_test.go
+++ b/collectors/replicationcontroller_test.go
@@ -18,6 +18,7 @@ package collectors
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
@@ -40,6 +41,8 @@ func TestReplicationControllerCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_replicationcontroller_created Unix creation timestamp
+		# TYPE kube_replicationcontroller_created gauge
 	  # HELP kube_replicationcontroller_metadata_generation Sequence number representing a specific generation of the desired state.
 		# TYPE kube_replicationcontroller_metadata_generation gauge
 		# HELP kube_replicationcontroller_status_replicas The number of replicas per ReplicationController.
@@ -64,6 +67,7 @@ func TestReplicationControllerCollector(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "rc1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Namespace:  "ns1",
 						Generation: 21,
 					},
@@ -96,6 +100,7 @@ func TestReplicationControllerCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_replicationcontroller_created{namespace="ns1",replicationcontroller="rc1"} 1.5e+09
 				kube_replicationcontroller_metadata_generation{namespace="ns1",replicationcontroller="rc1"} 21
 				kube_replicationcontroller_metadata_generation{namespace="ns2",replicationcontroller="rc2"} 14
 				kube_replicationcontroller_status_replicas{namespace="ns1",replicationcontroller="rc1"} 5

--- a/collectors/resourcequota.go
+++ b/collectors/resourcequota.go
@@ -27,6 +27,11 @@ import (
 )
 
 var (
+	descResourceQuotaCreated = prometheus.NewDesc(
+	    "kube_resourcequota_created",
+	    "Unix creation timestamp",
+	    []string{"resourcequota", "namespace"}, nil,
+	)
 	descResourceQuota = prometheus.NewDesc(
 		"kube_resourcequota",
 		"Information about resource quota.",
@@ -72,6 +77,7 @@ type resourceQuotaCollector struct {
 
 // Describe implements the prometheus.Collector interface.
 func (rqc *resourceQuotaCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descResourceQuotaCreated
 	ch <- descResourceQuota
 }
 
@@ -94,6 +100,9 @@ func (rqc *resourceQuotaCollector) collectResourceQuota(ch chan<- prometheus.Met
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
 
+	if !rq.CreationTimestamp.IsZero() {
+		addGauge(descResourceQuotaCreated, float64(rq.CreationTimestamp.Unix()))
+	}
 	for res, qty := range rq.Status.Hard {
 		addGauge(descResourceQuota, float64(qty.MilliValue())/1000, string(res), "hard")
 	}

--- a/collectors/resourcequota_test.go
+++ b/collectors/resourcequota_test.go
@@ -18,6 +18,7 @@ package collectors
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +39,8 @@ func TestResourceQuotaCollector(t *testing.T) {
 	const metadata = `
 	# HELP kube_resourcequota Information about resource quota.
 	# TYPE kube_resourcequota gauge
+	# HELP kube_resourcequota_created Unix creation timestamp
+	# TYPE kube_resourcequota_created gauge
 	`
 	cases := []struct {
 		quotas  []v1.ResourceQuota
@@ -50,12 +53,15 @@ func TestResourceQuotaCollector(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "quotaTest",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Namespace: "testNS",
 					},
 					Status: v1.ResourceQuotaStatus{},
 				},
 			},
-			want: metadata,
+			want: metadata + `
+			kube_resourcequota_created{namespace="testNS",resourcequota="quotaTest"} 1.5e+09
+			`,
 		},
 		// Verify resource metrics.
 		{

--- a/collectors/service.go
+++ b/collectors/service.go
@@ -37,6 +37,12 @@ var (
 		[]string{"namespace", "service"}, nil,
 	)
 
+	descServiceCreated = prometheus.NewDesc(
+		"kube_service_created",
+		"Unix creation timestamp",
+		[]string{"namespace", "service"}, nil,
+	)
+
 	descServiceLabels = prometheus.NewDesc(
 		descServiceLabelsName,
 		descServiceLabelsHelp,
@@ -79,6 +85,7 @@ type serviceCollector struct {
 func (pc *serviceCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descServiceInfo
 	ch <- descServiceLabels
+	ch <- descServiceCreated
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -112,6 +119,9 @@ func (sc *serviceCollector) collectService(ch chan<- prometheus.Metric, s v1.Ser
 	}
 
 	addGauge(descServiceInfo, 1)
+	if !s.CreationTimestamp.IsZero() {
+		addGauge(descServiceCreated, float64(s.CreationTimestamp.Unix()))
+	}
 	labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
 	addGauge(serviceLabelsDesc(labelKeys), 1, labelValues...)
 }

--- a/collectors/service_test.go
+++ b/collectors/service_test.go
@@ -18,6 +18,7 @@ package collectors
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
@@ -37,6 +38,8 @@ func TestServiceCollector(t *testing.T) {
 	const metadata = `
 		# HELP kube_service_info Information about service.
 		# TYPE kube_service_info gauge
+		# HELP kube_service_created Unix creation timestamp
+		# TYPE kube_service_created gauge
 		# HELP kube_service_labels Kubernetes labels converted to Prometheus labels.
 		# TYPE kube_service_labels gauge
 	`
@@ -50,6 +53,7 @@ func TestServiceCollector(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-service",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Namespace: "default",
 						Labels: map[string]string{
 							"app": "example",
@@ -59,6 +63,7 @@ func TestServiceCollector(t *testing.T) {
 			},
 			want: metadata + `
 				kube_service_info{namespace="default",service="test-service"} 1
+				kube_service_created{namespace="default",service="test-service"} 1.5e+09
 				kube_service_labels{label_app="example",namespace="default",service="test-service"} 1
 			`,
 		},

--- a/collectors/statefulset.go
+++ b/collectors/statefulset.go
@@ -15,6 +15,12 @@ var (
 	descStatefulSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descStatefulSetLabelsDefaultLabels = []string{"namespace", "statefulset"}
 
+	descStatefulSetCreated = prometheus.NewDesc(
+		"kube_statefulset_created",
+		"Unix creation timestamp",
+		[]string{"namespace", "statefulset"}, nil,
+	)
+
 	descStatefulSetStatusReplicas = prometheus.NewDesc(
 		"kube_statefulset_status_replicas",
 		"The number of replicas per StatefulSet.",
@@ -78,6 +84,7 @@ type statefulSetCollector struct {
 
 // Describe implements the prometheus.Collector interface.
 func (dc *statefulSetCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descStatefulSetCreated
 	ch <- descStatefulSetStatusReplicas
 	ch <- descStatefulSetStatusObservedGeneration
 	ch <- descStatefulSetSpecReplicas
@@ -110,6 +117,9 @@ func (dc *statefulSetCollector) collectStatefulSet(ch chan<- prometheus.Metric, 
 	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
 		lv = append([]string{statefulSet.Namespace, statefulSet.Name}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
+	}
+	if !statefulSet.CreationTimestamp.IsZero() {
+			addGauge(descStatefulSetCreated, float64(statefulSet.CreationTimestamp.Unix()))
 	}
 	addGauge(descStatefulSetStatusReplicas, float64(statefulSet.Status.Replicas))
 	if statefulSet.Status.ObservedGeneration != nil {

--- a/collectors/statefulset_test.go
+++ b/collectors/statefulset_test.go
@@ -2,6 +2,7 @@ package collectors
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/apis/apps/v1beta1"
@@ -28,6 +29,8 @@ func TestStatefuleSetCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_statefulset_created Unix creation timestamp
+		# TYPE kube_statefulset_created gauge
  		# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
  		# TYPE kube_statefulset_status_replicas gauge
  		# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
@@ -48,6 +51,7 @@ func TestStatefuleSetCollector(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "statefulset1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						Namespace: "ns1",
 						Labels: map[string]string{
 							"app": "example1",
@@ -99,6 +103,7 @@ func TestStatefuleSetCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_statefulset_created{namespace="ns1",statefulset="statefulset1"} 1.5e+09
  				kube_statefulset_status_replicas{namespace="ns1",statefulset="statefulset1"} 2
  				kube_statefulset_status_replicas{namespace="ns2",statefulset="statefulset2"} 5
  				kube_statefulset_status_replicas{namespace="ns3",statefulset="statefulset3"} 7


### PR DESCRIPTION
We want to track when pods are created so that we can monitor various pod-age-related metrics, like "are there pods that are > 30 minutes old and stuck in the 'Pending' state".

While adding a 'pod created time' metric I figured it made sense to add a created time metric for all the other collectors as well since they all have a `CreationTimestamp` that's easy to expose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/182)
<!-- Reviewable:end -->
