### PR TITLE
add kube_pod_start_time metric

### DIFF
--- a/Documentation/pod-metrics.md
+++ b/Documentation/pod-metrics.md
@@ -2,7 +2,8 @@
 
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
-| kube_pod_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `host_ip`=&lt;host-ip&gt; <br> `pod_ip`=&lt;pod-ip&gt; <br> `start_time`=&lt;date-time since kubelet acknowledged pod&gt; <br> `node`=&lt;node-name&gt;<br> `created_by_kind`=&lt;created_by_kind&gt;<br> `created_by_name`=&lt;created_by_name&gt;<br> |
+| kube_pod_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `host_ip`=&lt;host-ip&gt; <br> `pod_ip`=&lt;pod-ip&gt; <br> `node`=&lt;node-name&gt;<br> `created_by_kind`=&lt;created_by_kind&gt;<br> `created_by_name`=&lt;created_by_name&gt;<br> |
+| kube_pod_start_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 | kube_pod_owner | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  |
 | kube_pod_labels | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `label_POD_LABEL`=&lt;POD_LABEL&gt;  |
 | kube_pod_status_phase | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `phase`=&lt;Pending\|Running\|Succeeded\|Failed\|Unknown&gt; |

--- a/collectors/pod_test.go
+++ b/collectors/pod_test.go
@@ -36,6 +36,10 @@ func TestPodCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	var test = true
+
+	startTime := 1501569018
+	metav1StartTime := metav1.Unix(int64(startTime), 0)
+
 	const metadata = `
 		# HELP kube_pod_container_info Information about a container in a pod.
 		# TYPE kube_pod_container_info gauge
@@ -53,6 +57,8 @@ func TestPodCollector(t *testing.T) {
 		# TYPE kube_pod_container_status_waiting gauge
 		# HELP kube_pod_info Information about pod.
 		# TYPE kube_pod_info gauge
+		# HELP kube_pod_start_time Start time in unix timestamp for a pod.
+		# TYPE kube_pod_start_time gauge
 		# HELP kube_pod_owner Information about the Pod's owner.
 		# TYPE kube_pod_owner gauge
 		# HELP kube_pod_status_phase The pods current phase.
@@ -268,8 +274,9 @@ func TestPodCollector(t *testing.T) {
 						NodeName: "node1",
 					},
 					Status: v1.PodStatus{
-						HostIP: "1.1.1.1",
-						PodIP:  "1.2.3.4",
+						HostIP:    "1.1.1.1",
+						PodIP:     "1.2.3.4",
+						StartTime: &metav1StartTime,
 					},
 				}, {
 					ObjectMeta: metav1.ObjectMeta{
@@ -295,10 +302,11 @@ func TestPodCollector(t *testing.T) {
 			want: metadata + `
 				kube_pod_info{created_by_kind="<none>",created_by_name="<none>",host_ip="1.1.1.1",namespace="ns1",pod="pod1",node="node1",pod_ip="1.2.3.4"} 1
 				kube_pod_info{created_by_kind="<none>",created_by_name="<none>",host_ip="1.1.1.1",namespace="ns2",pod="pod2",node="node2",pod_ip="2.3.4.5"} 1
+				kube_pod_start_time{namespace="ns1",pod="pod1"} 1501569018
 				kube_pod_owner{namespace="ns1",pod="pod1",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
 				kube_pod_owner{namespace="ns2",pod="pod2",owner_kind="ReplicaSet",owner_name="rs-name",owner_is_controller="true"} 1
 				`,
-			metrics: []string{"kube_pod_info", "kube_pod_owner"},
+			metrics: []string{"kube_pod_info", "kube_pod_start_time", "kube_pod_owner"},
 		}, {
 			pods: []v1.Pod{
 				{


### PR DESCRIPTION
Fix #163

This PR add `kube_pod_start_time` metric with the value of pod start time in unix timestamp.

/cc @errordeveloper @fabxc @brancz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/184)
<!-- Reviewable:end -->
