### PR TITLE
Fix job nil deference

### DIFF
--- a/collectors/job.go
+++ b/collectors/job.go
@@ -153,8 +153,14 @@ func (jc *jobCollector) collectJob(ch chan<- prometheus.Metric, j v1batch.Job) {
 	}
 
 	addGauge(descJobInfo, 1)
-	addGauge(descJobSpecParallelism, float64(*j.Spec.Parallelism))
-	addGauge(descJobSpecCompletions, float64(*j.Spec.Completions))
+
+	if j.Spec.Parallelism != nil {
+		addGauge(descJobSpecParallelism, float64(*j.Spec.Parallelism))
+	}
+
+	if j.Spec.Completions != nil {
+		addGauge(descJobSpecCompletions, float64(*j.Spec.Completions))
+	}
 
 	if j.Spec.ActiveDeadlineSeconds != nil {
 		addGauge(descJobSpecActiveDeadlineSeconds, float64(*j.Spec.ActiveDeadlineSeconds))
@@ -172,10 +178,10 @@ func (jc *jobCollector) collectJob(ch chan<- prometheus.Metric, j v1batch.Job) {
 
 	for _, c := range j.Status.Conditions {
 		switch c.Type {
-			case v1batch.JobComplete:
-				addConditionMetrics(ch, descJobConditionComplete, c.Status, j.Namespace, j.Name)
-			case v1batch.JobFailed:
-				addConditionMetrics(ch, descJobConditionFailed, c.Status, j.Namespace, j.Name)
+		case v1batch.JobComplete:
+			addConditionMetrics(ch, descJobConditionComplete, c.Status, j.Namespace, j.Name)
+		case v1batch.JobFailed:
+			addConditionMetrics(ch, descJobConditionFailed, c.Status, j.Namespace, j.Name)
 		}
 	}
 }


### PR DESCRIPTION
Fix #174 about job collector.

This PR will fix [the panic](https://github.com/kubernetes/kube-state-metrics/issues/174#issuecomment-318907880) when collecting job metrics.

/cc @brancz @fabxc @shiranp

Btw, i will re-check all the de-reference about pointers when collecting metrics for all collector later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/187)
<!-- Reviewable:end -->
