### PR TITLE
add check for nil before deference

### DIFF
--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -151,7 +151,9 @@ func (jc *cronJobCollector) collectCronJob(ch chan<- prometheus.Metric, j v2batc
 
 	addGauge(descCronJobInfo, 1, j.Spec.Schedule, string(j.Spec.ConcurrencyPolicy))
 	addGauge(descCronJobStatusActive, float64(len(j.Status.Active)))
-	addGauge(descCronJobSpecSuspend, boolFloat64(*j.Spec.Suspend))
+	if j.Spec.Suspend != nil {
+		addGauge(descCronJobSpecSuspend, boolFloat64(*j.Spec.Suspend))
+	}
 
 	if j.Status.LastScheduleTime != nil {
 		addGauge(descCronJobStatusLastScheduleTime, float64(j.Status.LastScheduleTime.Unix()))

--- a/collectors/replicaset.go
+++ b/collectors/replicaset.go
@@ -121,6 +121,8 @@ func (dc *replicasetCollector) collectReplicaSet(ch chan<- prometheus.Metric, d 
 	addGauge(descReplicaSetStatusFullyLabeledReplicas, float64(d.Status.FullyLabeledReplicas))
 	addGauge(descReplicaSetStatusReadyReplicas, float64(d.Status.ReadyReplicas))
 	addGauge(descReplicaSetStatusObservedGeneration, float64(d.Status.ObservedGeneration))
-	addGauge(descReplicaSetSpecReplicas, float64(*d.Spec.Replicas))
+	if d.Spec.Replicas != nil {
+		addGauge(descReplicaSetSpecReplicas, float64(*d.Spec.Replicas))
+	}
 	addGauge(descReplicaSetMetadataGeneration, float64(d.ObjectMeta.Generation))
 }

--- a/collectors/replicationcontroller.go
+++ b/collectors/replicationcontroller.go
@@ -128,6 +128,8 @@ func (dc *replicationcontrollerCollector) collectReplicationController(ch chan<-
 	addGauge(descReplicationControllerStatusReadyReplicas, float64(d.Status.ReadyReplicas))
 	addGauge(descReplicationControllerStatusAvailableReplicas, float64(d.Status.AvailableReplicas))
 	addGauge(descReplicationControllerStatusObservedGeneration, float64(d.Status.ObservedGeneration))
-	addGauge(descReplicationControllerSpecReplicas, float64(*d.Spec.Replicas))
+	if d.Spec.Replicas != nil {
+		addGauge(descReplicationControllerSpecReplicas, float64(*d.Spec.Replicas))
+	}
 	addGauge(descReplicationControllerMetadataGeneration, float64(d.ObjectMeta.Generation))
 }

--- a/collectors/statefulset.go
+++ b/collectors/statefulset.go
@@ -115,7 +115,10 @@ func (dc *statefulSetCollector) collectStatefulSet(ch chan<- prometheus.Metric, 
 	if statefulSet.Status.ObservedGeneration != nil {
 		addGauge(descStatefulSetStatusObservedGeneration, float64(*statefulSet.Status.ObservedGeneration))
 	}
-	addGauge(descStatefulSetSpecReplicas, float64(*statefulSet.Spec.Replicas))
+
+	if statefulSet.Spec.Replicas != nil {
+		addGauge(descStatefulSetSpecReplicas, float64(*statefulSet.Spec.Replicas))
+	}
 	addGauge(descStatefulSetMetadataGeneration, float64(statefulSet.ObjectMeta.Generation))
 
 	labelKeys, labelValues := kubeLabelsToPrometheusLabels(statefulSet.Labels)


### PR DESCRIPTION
This PR will check for pointer values before dereference to avoid panic dereferencing a nil pointer.

/cc @brancz @fabxc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/190)
<!-- Reviewable:end -->
