### PR TITLE
update client-go version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Kubernetes clusters. The supported Kubernetes cluster version is determined by `
 The compatibility matrix for client-go and Kubernetes cluster can be found 
 [here](https://github.com/kubernetes/client-go#compatibility-matrix). 
 All additional compatibility is only best effort, or happens to still/already be supported.
-Currently, `client-go` is in version `v2.0.0-alpha.1`.
+Currently, `client-go` is in version `v4.0.0-beta.0`.
 
 ## Container Image
 


### PR DESCRIPTION
Fix #185 

It's my fault not updating client-go version to `v4.0.0-beta.0` in readme in #185. This PR updates the version info about client-go to `v4.0.0-beta.0` in Readme. 

/cc @brancz @fabxc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/191)
<!-- Reviewable:end -->
