### PR TITLE
Add a flexible node condition metric `kube_node_status_condition`

### DIFF
--- a/Documentation/node-metrics.md
+++ b/Documentation/node-metrics.md
@@ -17,3 +17,4 @@
 | kube_node_status_memory_pressure | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
 | kube_node_status_disk_pressure | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
 | kube_node_status_network_unavailable | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
+| kube_node_status_condition | Gauge | `node`=&lt;node-address&gt; <br> `type`=&lt;node-condition-type&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |

--- a/Documentation/node-metrics.md
+++ b/Documentation/node-metrics.md
@@ -5,8 +5,6 @@
 | kube_node_info | Gauge | `node`=&lt;node-address&gt; <br> `kernel_version`=&lt;kernel-version&gt; <br> `os_image`=&lt;os-image-name&gt; <br> `container_runtime_version`=&lt;container-runtime-and-version-combination&gt; <br> `kubelet_version`=&lt;kubelet-version&gt; <br> `kubeproxy_version`=&lt;kubeproxy-version&gt; |
 | kube_node_labels | Gauge | `node`=&lt;node-address&gt; <br> `label_NODE_LABEL`=&lt;NODE_LABEL&gt;  |
 | kube_node_spec_unschedulable | Gauge | `node`=&lt;node-address&gt;|
-| kube_node_status_ready| Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
-| kube_node_status_out_of_disk | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
 | kube_node_status_phase| Gauge | `node`=&lt;node-address&gt; <br> `phase`=&lt;Pending\|Running\|Terminated&gt; |
 | kube_node_status_capacity_cpu_cores | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_capacity_memory_bytes | Gauge | `node`=&lt;node-address&gt;|
@@ -14,7 +12,4 @@
 | kube_node_status_allocatable_cpu_cores | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_allocatable_memory_bytes | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_allocatable_pods | Gauge | `node`=&lt;node-address&gt;|
-| kube_node_status_memory_pressure | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
-| kube_node_status_disk_pressure | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
-| kube_node_status_network_unavailable | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
 | kube_node_status_condition | Gauge | `node`=&lt;node-address&gt; <br> `type`=&lt;node-condition-type&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |

--- a/collectors/node.go
+++ b/collectors/node.go
@@ -60,7 +60,7 @@ var (
 	descNodeStatusCondition = prometheus.NewDesc(
 		"kube_node_status_condition",
 		"The condition of a cluster node.",
-		[]string{"node", "type", "condition"}, nil,
+		[]string{"node", "condition", "status"}, nil,
 	)
 
 	descNodeStatusPhase = prometheus.NewDesc(

--- a/collectors/node.go
+++ b/collectors/node.go
@@ -63,35 +63,10 @@ var (
 		[]string{"node", "type", "condition"}, nil,
 	)
 
-	descNodeStatusReady = prometheus.NewDesc(
-		"kube_node_status_ready",
-		"The ready status of a cluster node.",
-		[]string{"node", "condition"}, nil,
-	)
-	descNodeStatusOutOfDisk = prometheus.NewDesc(
-		"kube_node_status_out_of_disk",
-		"Whether the node is out of disk space",
-		[]string{"node", "condition"}, nil,
-	)
 	descNodeStatusPhase = prometheus.NewDesc(
 		"kube_node_status_phase",
 		"The phase the node is currently in.",
 		[]string{"node", "phase"}, nil,
-	)
-	descNodeStatusMemoryPressure = prometheus.NewDesc(
-		"kube_node_status_memory_pressure",
-		"Whether the kubelet is under pressure due to insufficient available memory.",
-		[]string{"node", "condition"}, nil,
-	)
-	descNodeStatusDiskPressure = prometheus.NewDesc(
-		"kube_node_status_disk_pressure",
-		"Whether the kubelet is under pressure due to insufficient available disk.",
-		[]string{"node", "condition"}, nil,
-	)
-	descNodeStatusNetworkUnavailable = prometheus.NewDesc(
-		"kube_node_status_network_unavailable",
-		"Whether the network is correctly configured for the node.",
-		[]string{"node", "condition"}, nil,
 	)
 
 	descNodeStatusCapacityPods = prometheus.NewDesc(
@@ -163,11 +138,6 @@ func (nc *nodeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descNodeInfo
 	ch <- descNodeLabels
 	ch <- descNodeSpecUnschedulable
-	ch <- descNodeStatusReady
-	ch <- descNodeStatusMemoryPressure
-	ch <- descNodeStatusDiskPressure
-	ch <- descNodeStatusNetworkUnavailable
-	ch <- descNodeStatusOutOfDisk
 	ch <- descNodeStatusCondition
 	ch <- descNodeStatusPhase
 	ch <- descNodeStatusCapacityCPU
@@ -221,19 +191,6 @@ func (nc *nodeCollector) collectNode(ch chan<- prometheus.Metric, n v1.Node) {
 
 	// Collect node conditions and while default to false.
 	for _, c := range n.Status.Conditions {
-		// Each core type expose a particular metric.
-		switch c.Type {
-		case v1.NodeReady:
-			addConditionMetrics(ch, descNodeStatusReady, c.Status, n.Name)
-		case v1.NodeOutOfDisk:
-			addConditionMetrics(ch, descNodeStatusOutOfDisk, c.Status, n.Name)
-		case v1.NodeMemoryPressure:
-			addConditionMetrics(ch, descNodeStatusMemoryPressure, c.Status, n.Name)
-		case v1.NodeDiskPressure:
-			addConditionMetrics(ch, descNodeStatusDiskPressure, c.Status, n.Name)
-		case v1.NodeNetworkUnavailable:
-			addConditionMetrics(ch, descNodeStatusNetworkUnavailable, c.Status, n.Name)
-		}
 		// This all-in-one metric family contains all conditions for extensibility.
 		// Third party plugin may report customized condition for cluster node
 		// (e.g. node-problem-detector), and Kubernetes may add new core

--- a/collectors/node.go
+++ b/collectors/node.go
@@ -60,7 +60,7 @@ var (
 	descNodeStatusCondition = prometheus.NewDesc(
 		"kube_node_status_condition",
 		"The condition of a cluster node.",
-		[]string{"node", "type", "status"}, nil,
+		[]string{"node", "type", "condition"}, nil,
 	)
 
 	descNodeStatusReady = prometheus.NewDesc(

--- a/collectors/node_test.go
+++ b/collectors/node_test.go
@@ -375,6 +375,77 @@ func TestNodeCollector(t *testing.T) {
 			`,
 			metrics: []string{"kube_node_status_network_unavailable"},
 		},
+		// Verify StatusCondition
+		{
+			nodes: []v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.1",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionTrue},
+							{Type: v1.NodeReady, Status: v1.ConditionTrue},
+							{Type: v1.NodeConditionType("CustomizedType"), Status: v1.ConditionTrue},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.2",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionUnknown},
+							{Type: v1.NodeReady, Status: v1.ConditionUnknown},
+							{Type: v1.NodeConditionType("CustomizedType"), Status: v1.ConditionUnknown},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.3",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionFalse},
+							{Type: v1.NodeReady, Status: v1.ConditionFalse},
+							{Type: v1.NodeConditionType("CustomizedType"), Status: v1.ConditionFalse},
+						},
+					},
+				},
+			},
+			want: metadata + `
+				kube_node_status_condition{node="127.0.0.1",type="NetworkUnavailable",condition="true"} 1
+				kube_node_status_condition{node="127.0.0.1",type="NetworkUnavailable",condition="false"} 0
+				kube_node_status_condition{node="127.0.0.1",type="NetworkUnavailable",condition="unknown"} 0
+				kube_node_status_condition{node="127.0.0.2",type="NetworkUnavailable",condition="true"} 0
+				kube_node_status_condition{node="127.0.0.2",type="NetworkUnavailable",condition="false"} 0
+				kube_node_status_condition{node="127.0.0.2",type="NetworkUnavailable",condition="unknown"} 1
+				kube_node_status_condition{node="127.0.0.3",type="NetworkUnavailable",condition="true"} 0
+				kube_node_status_condition{node="127.0.0.3",type="NetworkUnavailable",condition="false"} 1
+				kube_node_status_condition{node="127.0.0.3",type="NetworkUnavailable",condition="unknown"} 0
+				kube_node_status_condition{node="127.0.0.1",type="Ready",condition="true"} 1
+				kube_node_status_condition{node="127.0.0.1",type="Ready",condition="false"} 0
+				kube_node_status_condition{node="127.0.0.1",type="Ready",condition="unknown"} 0
+				kube_node_status_condition{node="127.0.0.2",type="Ready",condition="true"} 0
+				kube_node_status_condition{node="127.0.0.2",type="Ready",condition="false"} 0
+				kube_node_status_condition{node="127.0.0.2",type="Ready",condition="unknown"} 1
+				kube_node_status_condition{node="127.0.0.3",type="Ready",condition="true"} 0
+				kube_node_status_condition{node="127.0.0.3",type="Ready",condition="false"} 1
+				kube_node_status_condition{node="127.0.0.3",type="Ready",condition="unknown"} 0
+				kube_node_status_condition{node="127.0.0.1",type="CustomizedType",condition="true"} 1
+				kube_node_status_condition{node="127.0.0.1",type="CustomizedType",condition="false"} 0
+				kube_node_status_condition{node="127.0.0.1",type="CustomizedType",condition="unknown"} 0
+				kube_node_status_condition{node="127.0.0.2",type="CustomizedType",condition="true"} 0
+				kube_node_status_condition{node="127.0.0.2",type="CustomizedType",condition="false"} 0
+				kube_node_status_condition{node="127.0.0.2",type="CustomizedType",condition="unknown"} 1
+				kube_node_status_condition{node="127.0.0.3",type="CustomizedType",condition="true"} 0
+				kube_node_status_condition{node="127.0.0.3",type="CustomizedType",condition="false"} 1
+				kube_node_status_condition{node="127.0.0.3",type="CustomizedType",condition="unknown"} 0
+			`,
+			metrics: []string{"kube_node_status_condition"},
+		},
 	}
 	for _, c := range cases {
 		dc := &nodeCollector{

--- a/collectors/node_test.go
+++ b/collectors/node_test.go
@@ -220,33 +220,33 @@ func TestNodeCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
-				kube_node_status_condition{node="127.0.0.1",type="NetworkUnavailable",condition="true"} 1
-				kube_node_status_condition{node="127.0.0.1",type="NetworkUnavailable",condition="false"} 0
-				kube_node_status_condition{node="127.0.0.1",type="NetworkUnavailable",condition="unknown"} 0
-				kube_node_status_condition{node="127.0.0.2",type="NetworkUnavailable",condition="true"} 0
-				kube_node_status_condition{node="127.0.0.2",type="NetworkUnavailable",condition="false"} 0
-				kube_node_status_condition{node="127.0.0.2",type="NetworkUnavailable",condition="unknown"} 1
-				kube_node_status_condition{node="127.0.0.3",type="NetworkUnavailable",condition="true"} 0
-				kube_node_status_condition{node="127.0.0.3",type="NetworkUnavailable",condition="false"} 1
-				kube_node_status_condition{node="127.0.0.3",type="NetworkUnavailable",condition="unknown"} 0
-				kube_node_status_condition{node="127.0.0.1",type="Ready",condition="true"} 1
-				kube_node_status_condition{node="127.0.0.1",type="Ready",condition="false"} 0
-				kube_node_status_condition{node="127.0.0.1",type="Ready",condition="unknown"} 0
-				kube_node_status_condition{node="127.0.0.2",type="Ready",condition="true"} 0
-				kube_node_status_condition{node="127.0.0.2",type="Ready",condition="false"} 0
-				kube_node_status_condition{node="127.0.0.2",type="Ready",condition="unknown"} 1
-				kube_node_status_condition{node="127.0.0.3",type="Ready",condition="true"} 0
-				kube_node_status_condition{node="127.0.0.3",type="Ready",condition="false"} 1
-				kube_node_status_condition{node="127.0.0.3",type="Ready",condition="unknown"} 0
-				kube_node_status_condition{node="127.0.0.1",type="CustomizedType",condition="true"} 1
-				kube_node_status_condition{node="127.0.0.1",type="CustomizedType",condition="false"} 0
-				kube_node_status_condition{node="127.0.0.1",type="CustomizedType",condition="unknown"} 0
-				kube_node_status_condition{node="127.0.0.2",type="CustomizedType",condition="true"} 0
-				kube_node_status_condition{node="127.0.0.2",type="CustomizedType",condition="false"} 0
-				kube_node_status_condition{node="127.0.0.2",type="CustomizedType",condition="unknown"} 1
-				kube_node_status_condition{node="127.0.0.3",type="CustomizedType",condition="true"} 0
-				kube_node_status_condition{node="127.0.0.3",type="CustomizedType",condition="false"} 1
-				kube_node_status_condition{node="127.0.0.3",type="CustomizedType",condition="unknown"} 0
+				kube_node_status_condition{node="127.0.0.1",condition="NetworkUnavailable",status="true"} 1
+				kube_node_status_condition{node="127.0.0.1",condition="NetworkUnavailable",status="false"} 0
+				kube_node_status_condition{node="127.0.0.1",condition="NetworkUnavailable",status="unknown"} 0
+				kube_node_status_condition{node="127.0.0.2",condition="NetworkUnavailable",status="true"} 0
+				kube_node_status_condition{node="127.0.0.2",condition="NetworkUnavailable",status="false"} 0
+				kube_node_status_condition{node="127.0.0.2",condition="NetworkUnavailable",status="unknown"} 1
+				kube_node_status_condition{node="127.0.0.3",condition="NetworkUnavailable",status="true"} 0
+				kube_node_status_condition{node="127.0.0.3",condition="NetworkUnavailable",status="false"} 1
+				kube_node_status_condition{node="127.0.0.3",condition="NetworkUnavailable",status="unknown"} 0
+				kube_node_status_condition{node="127.0.0.1",condition="Ready",status="true"} 1
+				kube_node_status_condition{node="127.0.0.1",condition="Ready",status="false"} 0
+				kube_node_status_condition{node="127.0.0.1",condition="Ready",status="unknown"} 0
+				kube_node_status_condition{node="127.0.0.2",condition="Ready",status="true"} 0
+				kube_node_status_condition{node="127.0.0.2",condition="Ready",status="false"} 0
+				kube_node_status_condition{node="127.0.0.2",condition="Ready",status="unknown"} 1
+				kube_node_status_condition{node="127.0.0.3",condition="Ready",status="true"} 0
+				kube_node_status_condition{node="127.0.0.3",condition="Ready",status="false"} 1
+				kube_node_status_condition{node="127.0.0.3",condition="Ready",status="unknown"} 0
+				kube_node_status_condition{node="127.0.0.1",condition="CustomizedType",status="true"} 1
+				kube_node_status_condition{node="127.0.0.1",condition="CustomizedType",status="false"} 0
+				kube_node_status_condition{node="127.0.0.1",condition="CustomizedType",status="unknown"} 0
+				kube_node_status_condition{node="127.0.0.2",condition="CustomizedType",status="true"} 0
+				kube_node_status_condition{node="127.0.0.2",condition="CustomizedType",status="false"} 0
+				kube_node_status_condition{node="127.0.0.2",condition="CustomizedType",status="unknown"} 1
+				kube_node_status_condition{node="127.0.0.3",condition="CustomizedType",status="true"} 0
+				kube_node_status_condition{node="127.0.0.3",condition="CustomizedType",status="false"} 1
+				kube_node_status_condition{node="127.0.0.3",condition="CustomizedType",status="unknown"} 0
 			`,
 			metrics: []string{"kube_node_status_condition"},
 		},

--- a/collectors/node_test.go
+++ b/collectors/node_test.go
@@ -64,6 +64,8 @@ func TestNodeCollector(t *testing.T) {
 		# TYPE kube_node_status_disk_pressure gauge
 		# HELP kube_node_status_network_unavailable Whether the network is correctly configured for the node.
 		# TYPE kube_node_status_network_unavailable gauge
+		# HELP kube_node_status_condition The condition of a cluster node.
+		# TYPE kube_node_status_condition gauge
 	`
 	cases := []struct {
 		nodes   []v1.Node

--- a/collectors/node_test.go
+++ b/collectors/node_test.go
@@ -42,8 +42,6 @@ func TestNodeCollector(t *testing.T) {
 		# TYPE kube_node_labels gauge
 		# HELP kube_node_spec_unschedulable Whether a node can schedule new pods.
 		# TYPE kube_node_spec_unschedulable gauge
-		# HELP kube_node_status_ready The ready status of a cluster node.
-		# TYPE kube_node_status_ready gauge
 		# TYPE kube_node_status_phase gauge
 		# HELP kube_node_status_phase The phase the node is currently in.
 		# TYPE kube_node_status_capacity_pods gauge
@@ -58,12 +56,6 @@ func TestNodeCollector(t *testing.T) {
 		# HELP kube_node_status_allocatable_cpu_cores The CPU resources of a node that are available for scheduling.
 		# TYPE kube_node_status_allocatable_memory_bytes gauge
 		# HELP kube_node_status_allocatable_memory_bytes The memory resources of a node that are available for scheduling.
-		# HELP kube_node_status_memory_pressure Whether the kubelet is under pressure due to insufficient available memory.
-		# TYPE kube_node_status_memory_pressure gauge
-		# HELP kube_node_status_disk_pressure Whether the kubelet is under pressure due to insufficient available disk.
-		# TYPE kube_node_status_disk_pressure gauge
-		# HELP kube_node_status_network_unavailable Whether the network is correctly configured for the node.
-		# TYPE kube_node_status_network_unavailable gauge
 		# HELP kube_node_status_condition The condition of a cluster node.
 		# TYPE kube_node_status_condition gauge
 	`
@@ -146,53 +138,6 @@ func TestNodeCollector(t *testing.T) {
 				kube_node_status_allocatable_pods{node="127.0.0.1"} 555
 			`,
 		},
-		// Verify condition enumerations.
-		{
-			nodes: []v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.1",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeReady, Status: v1.ConditionTrue},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.2",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeReady, Status: v1.ConditionUnknown},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.3",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeReady, Status: v1.ConditionFalse},
-						},
-					},
-				},
-			},
-			want: metadata + `
-				kube_node_status_ready{node="127.0.0.1",condition="true"} 1
-				kube_node_status_ready{node="127.0.0.1",condition="false"} 0
-				kube_node_status_ready{node="127.0.0.1",condition="unknown"} 0
-				kube_node_status_ready{node="127.0.0.2",condition="true"} 0
-				kube_node_status_ready{node="127.0.0.2",condition="false"} 0
-				kube_node_status_ready{node="127.0.0.2",condition="unknown"} 1
-				kube_node_status_ready{node="127.0.0.3",condition="true"} 0
-				kube_node_status_ready{node="127.0.0.3",condition="false"} 1
-				kube_node_status_ready{node="127.0.0.3",condition="unknown"} 0
-			`,
-			metrics: []string{"kube_node_status_ready"},
-		},
 		// Verify phase enumerations.
 		{
 			nodes: []v1.Node{
@@ -233,147 +178,6 @@ func TestNodeCollector(t *testing.T) {
 				kube_node_status_phase{node="127.0.0.3",phase="Pending"} 0
 			`,
 			metrics: []string{"kube_node_status_phase"},
-		},
-		// Verify MemoryPressure
-		{
-			nodes: []v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.1",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeMemoryPressure, Status: v1.ConditionTrue},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.2",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeMemoryPressure, Status: v1.ConditionUnknown},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.3",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeMemoryPressure, Status: v1.ConditionFalse},
-						},
-					},
-				},
-			},
-			want: metadata + `
-				kube_node_status_memory_pressure{node="127.0.0.1",condition="true"} 1
-				kube_node_status_memory_pressure{node="127.0.0.1",condition="false"} 0
-				kube_node_status_memory_pressure{node="127.0.0.1",condition="unknown"} 0
-				kube_node_status_memory_pressure{node="127.0.0.2",condition="true"} 0
-				kube_node_status_memory_pressure{node="127.0.0.2",condition="false"} 0
-				kube_node_status_memory_pressure{node="127.0.0.2",condition="unknown"} 1
-				kube_node_status_memory_pressure{node="127.0.0.3",condition="true"} 0
-				kube_node_status_memory_pressure{node="127.0.0.3",condition="false"} 1
-				kube_node_status_memory_pressure{node="127.0.0.3",condition="unknown"} 0
-			`,
-			metrics: []string{"kube_node_status_memory_pressure"},
-		},
-		// Verify DiskPressure
-		{
-			nodes: []v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.1",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeDiskPressure, Status: v1.ConditionTrue},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.2",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeDiskPressure, Status: v1.ConditionUnknown},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.3",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeDiskPressure, Status: v1.ConditionFalse},
-						},
-					},
-				},
-			},
-			want: metadata + `
-				kube_node_status_disk_pressure{node="127.0.0.1",condition="true"} 1
-				kube_node_status_disk_pressure{node="127.0.0.1",condition="false"} 0
-				kube_node_status_disk_pressure{node="127.0.0.1",condition="unknown"} 0
-				kube_node_status_disk_pressure{node="127.0.0.2",condition="true"} 0
-				kube_node_status_disk_pressure{node="127.0.0.2",condition="false"} 0
-				kube_node_status_disk_pressure{node="127.0.0.2",condition="unknown"} 1
-				kube_node_status_disk_pressure{node="127.0.0.3",condition="true"} 0
-				kube_node_status_disk_pressure{node="127.0.0.3",condition="false"} 1
-				kube_node_status_disk_pressure{node="127.0.0.3",condition="unknown"} 0
-			`,
-			metrics: []string{"kube_node_status_disk_pressure"},
-		},
-		// Verify NetworkUnavailable
-		{
-			nodes: []v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.1",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionTrue},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.2",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionUnknown},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "127.0.0.3",
-					},
-					Status: v1.NodeStatus{
-						Conditions: []v1.NodeCondition{
-							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionFalse},
-						},
-					},
-				},
-			},
-			want: metadata + `
-				kube_node_status_network_unavailable{node="127.0.0.1",condition="true"} 1
-				kube_node_status_network_unavailable{node="127.0.0.1",condition="false"} 0
-				kube_node_status_network_unavailable{node="127.0.0.1",condition="unknown"} 0
-				kube_node_status_network_unavailable{node="127.0.0.2",condition="true"} 0
-				kube_node_status_network_unavailable{node="127.0.0.2",condition="false"} 0
-				kube_node_status_network_unavailable{node="127.0.0.2",condition="unknown"} 1
-				kube_node_status_network_unavailable{node="127.0.0.3",condition="true"} 0
-				kube_node_status_network_unavailable{node="127.0.0.3",condition="false"} 1
-				kube_node_status_network_unavailable{node="127.0.0.3",condition="unknown"} 0
-			`,
-			metrics: []string{"kube_node_status_network_unavailable"},
 		},
 		// Verify StatusCondition
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

This metric use `type` label to enumerate all conditions contained in
node Status.Conditions array.

Condition is enumerable, and finite. Adding it in label, makes it
extensible. Especially, Kuberentes community already have a project
[node-problem-detector](https://github.com/kubernetes/node-problem-detector) which reports customized condition `KernelDeadlock` for cluster node.

**Special notes for your reviewer**:

If `kube-state-metrics` can expose all types of conditions, it will be very convenient to monitor all possible node conditions, whether they are reported by Kubernetes core or by third-party addons, like`node-problem-detector`.

And if new node conditions are added in [kubernetes](https://github.com/kubernetes/kubernetes) in future, they will be exposed automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/193)
<!-- Reviewable:end -->
