### PR TITLE
prometheus client: disable metric consistency

### DIFF
--- a/vendor/github.com/prometheus/client_golang/prometheus/registry.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/registry.go
@@ -409,9 +409,9 @@ func (r *Registry) MustRegister(cs ...Collector) {
 // Gather implements Gatherer.
 func (r *Registry) Gather() ([]*dto.MetricFamily, error) {
 	var (
-		metricChan        = make(chan Metric, capMetricChan)
-		metricHashes      = map[uint64]struct{}{}
-		dimHashes         = map[string]uint64{}
+		metricChan = make(chan Metric, capMetricChan)
+		//metricHashes      = map[uint64]struct{}{}
+		//dimHashes         = map[string]uint64{}
 		wg                sync.WaitGroup
 		errs              MultiError          // The collected errors to return in the end.
 		registeredDescIDs map[uint64]struct{} // Only used for pedantic checks
@@ -542,10 +542,10 @@ func (r *Registry) Gather() ([]*dto.MetricFamily, error) {
 			}
 			metricFamiliesByName[desc.fqName] = metricFamily
 		}
-		if err := checkMetricConsistency(metricFamily, dtoMetric, metricHashes, dimHashes); err != nil {
-			errs = append(errs, err)
-			continue
-		}
+		//if err := checkMetricConsistency(metricFamily, dtoMetric, metricHashes, dimHashes); err != nil {
+		//errs = append(errs, err)
+		//continue
+		//}
 		if r.pedanticChecksEnabled {
 			// Is the desc registered at all?
 			if _, exist := registeredDescIDs[desc.id]; !exist {
@@ -587,9 +587,9 @@ type Gatherers []Gatherer
 func (gs Gatherers) Gather() ([]*dto.MetricFamily, error) {
 	var (
 		metricFamiliesByName = map[string]*dto.MetricFamily{}
-		metricHashes         = map[uint64]struct{}{}
-		dimHashes            = map[string]uint64{}
-		errs                 MultiError // The collected errors to return in the end.
+		//metricHashes         = map[uint64]struct{}{}
+		//dimHashes            = map[string]uint64{}
+		errs MultiError // The collected errors to return in the end.
 	)
 
 	for i, g := range gs {
@@ -628,10 +628,10 @@ func (gs Gatherers) Gather() ([]*dto.MetricFamily, error) {
 				metricFamiliesByName[mf.GetName()] = existingMF
 			}
 			for _, m := range mf.Metric {
-				if err := checkMetricConsistency(existingMF, m, metricHashes, dimHashes); err != nil {
-					errs = append(errs, err)
-					continue
-				}
+				//if err := checkMetricConsistency(existingMF, m, metricHashes, dimHashes); err != nil {
+				//errs = append(errs, err)
+				//continue
+				//}
 				existingMF.Metric = append(existingMF.Metric, m)
 			}
 		}


### PR DESCRIPTION
This reverts the client_golang library back to the state that we need and was previously released with `v0.5.0`. #185 updated the deps and I missed to note that we were overriding this manual patch.

Fixes #192

@fabxc @andyxning @matthiasr 

@cofyc as you reported this, could you quickly try this out and report whether it fixes the behavior you were seeing?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/194)
<!-- Reviewable:end -->
