### PR TITLE
Fix label names of `kube_node_status_condition` in docs.

### DIFF
--- a/Documentation/node-metrics.md
+++ b/Documentation/node-metrics.md
@@ -12,4 +12,4 @@
 | kube_node_status_allocatable_cpu_cores | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_allocatable_memory_bytes | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_allocatable_pods | Gauge | `node`=&lt;node-address&gt;|
-| kube_node_status_condition | Gauge | `node`=&lt;node-address&gt; <br> `type`=&lt;node-condition-type&gt; <br> `condition`=&lt;true\|false\|unknown&gt; |
+| kube_node_status_condition | Gauge | `node`=&lt;node-address&gt; <br> `condition`=&lt;node-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; |


### PR DESCRIPTION
hi, @brancz 

Forgot to update docs in commit https://github.com/kubernetes/kube-state-metrics/commit/dda7a4f1e25df4d6e3a6a6f018a51b0808fdea91 of https://github.com/kubernetes/kube-state-metrics/pull/193.

It's my bad >_<.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/197)
<!-- Reviewable:end -->
