### PR TITLE
remove incorrect changelog line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * [FEATURE] Add StatefulSet metrics.
 * [FEATURE] Add Job and CronJob metrics.
 * [FEATURE] Add label metrics for deployments.
-* [FEATURE] Add `kube_node_status_disk_pressure` metric.
 * [FEATURE] Add `kube_pod_owner` metrics.
 * [ENHANCEMENT] Add `provider_id` label to `kube_node_info` metric.
 * [BUGFIX] Fix various nil pointer panics.


### PR DESCRIPTION
As mentioned in this https://github.com/kubernetes/kube-state-metrics/pull/198#issuecomment-319677172, this line is incorrect.

@andyxning thanks for catching!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/199)
<!-- Reviewable:end -->
