### PR TITLE
add autoscaler for kube-state-metrics

### DIFF
--- a/kubernetes/kube-state-metrics-cluster-role.yaml
+++ b/kubernetes/kube-state-metrics-cluster-role.yaml
@@ -5,11 +5,8 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - pods
-  verbs: ["list", "watch", "get"]
-- apiGroups: [""]
-  resources:
   - nodes
+  - pods
   - services
   - resourcequotas
   - replicationcontrollers
@@ -18,11 +15,8 @@ rules:
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:
-  - deployments
-  verbs: ["list", "watch", "get", "update"]
-- apiGroups: ["extensions"]
-  resources:
   - daemonsets
+  - deployments
   - replicasets
   verbs: ["list", "watch"]
 - apiGroups: ["apps"]
@@ -34,4 +28,3 @@ rules:
   - cronjobs
   - jobs
   verbs: ["list", "watch"]
-

--- a/kubernetes/kube-state-metrics-cluster-role.yaml
+++ b/kubernetes/kube-state-metrics-cluster-role.yaml
@@ -5,8 +5,11 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - nodes
   - pods
+  verbs: ["list", "watch", "get"]
+- apiGroups: [""]
+  resources:
+  - nodes
   - services
   - resourcequotas
   - replicationcontrollers
@@ -15,8 +18,11 @@ rules:
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:
-  - daemonsets
   - deployments
+  verbs: ["list", "watch", "get", "update"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
   - replicasets
   verbs: ["list", "watch"]
 - apiGroups: ["apps"]

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kube-state-metrics
   namespace: kube-system
 spec:
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
@@ -30,4 +30,30 @@ spec:
           limits:
             memory: 50Mi
             cpu: 200m
-
+      - name: pod-nanny
+        image: gcr.io/google_containers/addon-resizer:1.0
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 30Mi
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        command:
+          - /pod_nanny
+          - --container=kube-state-metrics
+          - --cpu=100m
+          - --extra-cpu=1m
+          - --memory=30Mi
+          - --extra-memory=2Mi
+          - --threshold=5
+          - --deployment=kube-state-metrics

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -30,7 +30,7 @@ spec:
           limits:
             memory: 50Mi
             cpu: 200m
-      - name: pod-nanny
+      - name: addon-resizer
         image: gcr.io/google_containers/addon-resizer:1.0
         resources:
           limits:

--- a/kubernetes/kube-state-metrics-role-binding.yaml
+++ b/kubernetes/kube-state-metrics-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-state-metrics-resizer
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system
+

--- a/kubernetes/kube-state-metrics-role.yaml
+++ b/kubernetes/kube-state-metrics-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: kube-state-metrics-resizer
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get"]
+- apiGroups: ["extensions"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]
+


### PR DESCRIPTION
For https://github.com/kubernetes/kube-state-metrics/issues/124
(provide deployment manifest that scales with cluster size using pod nanny)
This setup is tested on my gke cluster, now kube-state-metrics pod has two container, kube-state-metrics and pod-nanny
```
➜  kube-state-metrics git:(addautoscaler) ✗ kubectl get po -n kube-system
NAME                                                  READY     STATUS    RESTARTS   AGE
event-exporter-v0.1.4-4272745813-m1sqp                2/2       Running   0          6d
fluentd-gcp-v2.0-290kq                                2/2       Running   0          6d
fluentd-gcp-v2.0-7wmrd                                2/2       Running   0          6d
fluentd-gcp-v2.0-qtr9r                                2/2       Running   0          6d
heapster-v1.4.0-2764992688-s3q6v                      2/2       Running   0          6d
kube-dns-1413379277-387r0                             3/3       Running   0          6d
kube-dns-1413379277-z057j                             3/3       Running   0          6d
kube-dns-autoscaler-3880103346-73r5g                  1/1       Running   0          6d
kube-proxy-gke-cluster-1-default-pool-d10ff02d-cft7   1/1       Running   0          6d
kube-proxy-gke-cluster-1-default-pool-d10ff02d-mmfk   1/1       Running   0          6d
kube-proxy-gke-cluster-1-default-pool-d10ff02d-x4pg   1/1       Running   0          6d
kube-state-metrics-1585740284-w6lnr                   2/2       Running   0          1m
kubernetes-dashboard-1962351010-km5wg                 1/1       Running   0          6d
l7-default-backend-2954409777-rrwkq                   1/1       Running   0          6d
```
The cpu and memory parameters can be adjusted too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/200)
<!-- Reviewable:end -->
