### PR TITLE
add namespace cmd arg

### DIFF
--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
+
 	v2batch "k8s.io/client-go/pkg/apis/batch/v2alpha1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -75,9 +75,9 @@ func (l CronJobLister) List() ([]v2batch.CronJob, error) {
 	return l()
 }
 
-func RegisterCronJobCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterCronJobCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.BatchV2alpha1().RESTClient()
-	cjlw := cache.NewListWatchFromClient(client, "cronjobs", api.NamespaceAll, nil)
+	cjlw := cache.NewListWatchFromClient(client, "cronjobs", namespace, nil)
 	cjinf := cache.NewSharedInformer(cjlw, &v2batch.CronJob{}, resyncPeriod)
 
 	cronJobLister := CronJobLister(func() (cronjobs []v2batch.CronJob, err error) {

--- a/collectors/daemonset.go
+++ b/collectors/daemonset.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -65,9 +64,9 @@ func (l DaemonSetLister) List() ([]v1beta1.DaemonSet, error) {
 	return l()
 }
 
-func RegisterDaemonSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterDaemonSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
-	dslw := cache.NewListWatchFromClient(client, "daemonsets", api.NamespaceAll, nil)
+	dslw := cache.NewListWatchFromClient(client, "daemonsets", namespace, nil)
 	dsinf := cache.NewSharedInformer(dslw, &v1beta1.DaemonSet{}, resyncPeriod)
 
 	dsLister := DaemonSetLister(func() (daemonsets []v1beta1.DaemonSet, err error) {

--- a/collectors/deployment.go
+++ b/collectors/deployment.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -102,9 +101,9 @@ func (l DeploymentLister) List() ([]v1beta1.Deployment, error) {
 	return l()
 }
 
-func RegisterDeploymentCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterDeploymentCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
-	dlw := cache.NewListWatchFromClient(client, "deployments", api.NamespaceAll, nil)
+	dlw := cache.NewListWatchFromClient(client, "deployments", namespace, nil)
 	dinf := cache.NewSharedInformer(dlw, &v1beta1.Deployment{}, resyncPeriod)
 
 	dplLister := DeploymentLister(func() (deployments []v1beta1.Deployment, err error) {

--- a/collectors/job.go
+++ b/collectors/job.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	v1batch "k8s.io/client-go/pkg/apis/batch/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -95,9 +94,9 @@ func (l JobLister) List() ([]v1batch.Job, error) {
 	return l()
 }
 
-func RegisterJobCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterJobCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.BatchV1().RESTClient()
-	jlw := cache.NewListWatchFromClient(client, "jobs", api.NamespaceAll, nil)
+	jlw := cache.NewListWatchFromClient(client, "jobs", namespace, nil)
 	jinf := cache.NewSharedInformer(jlw, &v1batch.Job{}, resyncPeriod)
 
 	jobLister := JobLister(func() (jobs []v1batch.Job, err error) {

--- a/collectors/limitrange.go
+++ b/collectors/limitrange.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -52,9 +51,9 @@ func (l LimitRangeLister) List() (v1.LimitRangeList, error) {
 	return l()
 }
 
-func RegisterLimitRangeCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterLimitRangeCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
-	rqlw := cache.NewListWatchFromClient(client, "limitranges", api.NamespaceAll, nil)
+	rqlw := cache.NewListWatchFromClient(client, "limitranges", namespace, nil)
 	rqinf := cache.NewSharedInformer(rqlw, &v1.LimitRange{}, resyncPeriod)
 
 	limitRangeLister := LimitRangeLister(func() (ranges v1.LimitRangeList, err error) {

--- a/collectors/node.go
+++ b/collectors/node.go
@@ -114,7 +114,7 @@ func (l NodeLister) List() (v1.NodeList, error) {
 	return l()
 }
 
-func RegisterNodeCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterNodeCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
 	nlw := cache.NewListWatchFromClient(client, "nodes", api.NamespaceAll, nil)
 	ninf := cache.NewSharedInformer(nlw, &v1.Node{}, resyncPeriod)

--- a/collectors/persistentvolumeclaim.go
+++ b/collectors/persistentvolumeclaim.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -44,9 +43,9 @@ func (l PersistentVolumeClaimLister) List() (v1.PersistentVolumeClaimList, error
 	return l()
 }
 
-func RegisterPersistentVolumeClaimCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterPersistentVolumeClaimCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
-	pvclw := cache.NewListWatchFromClient(client, "persistentvolumeclaims", api.NamespaceAll, nil)
+	pvclw := cache.NewListWatchFromClient(client, "persistentvolumeclaims", namespace, nil)
 	pvcinf := cache.NewSharedInformer(pvclw, &v1.PersistentVolumeClaim{}, resyncPeriod)
 
 	persistentVolumeClaimLister := PersistentVolumeClaimLister(func() (pvcs v1.PersistentVolumeClaimList, err error) {

--- a/collectors/pod.go
+++ b/collectors/pod.go
@@ -151,9 +151,9 @@ func (l PodLister) List() ([]v1.Pod, error) {
 	return l()
 }
 
-func RegisterPodCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterPodCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
-	plw := cache.NewListWatchFromClient(client, "pods", api.NamespaceAll, nil)
+	plw := cache.NewListWatchFromClient(client, "pods", namespace, nil)
 	pinf := cache.NewSharedInformer(plw, &v1.Pod{}, resyncPeriod)
 
 	podLister := PodLister(func() (pods []v1.Pod, err error) {

--- a/collectors/replicaset.go
+++ b/collectors/replicaset.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -70,9 +69,9 @@ func (l ReplicaSetLister) List() ([]v1beta1.ReplicaSet, error) {
 	return l()
 }
 
-func RegisterReplicaSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterReplicaSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
-	rslw := cache.NewListWatchFromClient(client, "replicasets", api.NamespaceAll, nil)
+	rslw := cache.NewListWatchFromClient(client, "replicasets", namespace, nil)
 	rsinf := cache.NewSharedInformer(rslw, &v1beta1.ReplicaSet{}, resyncPeriod)
 
 	replicaSetLister := ReplicaSetLister(func() (replicasets []v1beta1.ReplicaSet, err error) {

--- a/collectors/replicationcontroller.go
+++ b/collectors/replicationcontroller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -76,9 +75,9 @@ func (l ReplicationControllerLister) List() ([]v1.ReplicationController, error) 
 	return l()
 }
 
-func RegisterReplicationControllerCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterReplicationControllerCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
-	rclw := cache.NewListWatchFromClient(client, "replicationcontrollers", api.NamespaceAll, nil)
+	rclw := cache.NewListWatchFromClient(client, "replicationcontrollers", namespace, nil)
 	rcinf := cache.NewSharedInformer(rclw, &v1.ReplicationController{}, resyncPeriod)
 
 	replicationControllerLister := ReplicationControllerLister(func() (rcs []v1.ReplicationController, err error) {

--- a/collectors/resourcequota.go
+++ b/collectors/resourcequota.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -50,9 +49,9 @@ func (l ResourceQuotaLister) List() (v1.ResourceQuotaList, error) {
 	return l()
 }
 
-func RegisterResourceQuotaCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterResourceQuotaCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
-	rqlw := cache.NewListWatchFromClient(client, "resourcequotas", api.NamespaceAll, nil)
+	rqlw := cache.NewListWatchFromClient(client, "resourcequotas", namespace, nil)
 	rqinf := cache.NewSharedInformer(rqlw, &v1.ResourceQuota{}, resyncPeriod)
 
 	resourceQuotaLister := ResourceQuotaLister(func() (quotas v1.ResourceQuotaList, err error) {

--- a/collectors/service.go
+++ b/collectors/service.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -56,9 +55,9 @@ func (l ServiceLister) List() ([]v1.Service, error) {
 	return l()
 }
 
-func RegisterServiceCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterServiceCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
-	slw := cache.NewListWatchFromClient(client, "services", api.NamespaceAll, nil)
+	slw := cache.NewListWatchFromClient(client, "services", namespace, nil)
 	sinf := cache.NewSharedInformer(slw, &v1.Service{}, resyncPeriod)
 
 	serviceLister := ServiceLister(func() (services []v1.Service, err error) {

--- a/collectors/statefulset.go
+++ b/collectors/statefulset.go
@@ -5,7 +5,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/apis/apps/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -58,9 +57,9 @@ func (l StatefulSetLister) List() ([]v1beta1.StatefulSet, error) {
 	return l()
 }
 
-func RegisterStatefulSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterStatefulSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.AppsV1beta1().RESTClient()
-	dlw := cache.NewListWatchFromClient(client, "statefulsets", api.NamespaceAll, nil)
+	dlw := cache.NewListWatchFromClient(client, "statefulsets", namespace, nil)
 	dinf := cache.NewSharedInformer(dlw, &v1beta1.StatefulSet{}, resyncPeriod)
 
 	statefulSetLister := StatefulSetLister(func() (statefulSets []v1beta1.StatefulSet, err error) {


### PR DESCRIPTION
Fix #152

This PR add `namespaces` command line argument to kube-state-metrics. It's value is in the same format as `collectors`. If specified with delimited namespaces, kube-state-metrics will only collect resources in those namespaces.

/cc @brancz @matthiasr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/201)
<!-- Reviewable:end -->
