### PR TITLE
Split the UT and Build in different Stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
 install:
 - mkdir -p $HOME/gopath/src/k8s.io
 - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/kube-state-metrics
-script:
-- make test-unit
-- make
+jobs:
+  include:
+    - stage: Unit Test
+      script: make test-unit
+    - stage: Build
+      script: make


### PR DESCRIPTION
Split the UT and Build Stages in different jobs of travis CI so that it's easy for user to trace what went wrong in CI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/203)
<!-- Reviewable:end -->
