### PR TITLE
*: cut 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.0 / 2017-08-09
+
+After a testing period of one week, there were no additional bugs found or features introduced.
+
 ## v1.0.0-rc.1 / 2017-08-02
 
 * [CHANGE] Remove `kube_node_status_ready`, `kube_node_status_out_of_disk`, `kube_node_status_memory_pressure`, `kube_node_status_disk_pressure`, and `kube_node_status_network_unavailable` metrics in favor of one generic `kube_node_status_condition` metric.
@@ -10,7 +14,6 @@
 * [FEATURE] Add `kube_pod_owner` metrics.
 * [ENHANCEMENT] Add `provider_id` label to `kube_node_info` metric.
 * [BUGFIX] Fix various nil pointer panics.
-
 
 ## v0.5.0 / 2017-05-03
 

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: gcr.io/google_containers/kube-state-metrics:v1.0.0-rc.1
+        image: gcr.io/google_containers/kube-state-metrics:v1.0.0
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION
As we haven't had any bug reports or code changes over the past week, here goes the final 1.0 release.

As I'm a bit short on time today, but wanted to get this out there I already marked the date to be tomorrow as I'm not planing on finishing the release today, but giving everyone the chance to review once more over night/day around the globe.

:tada: It's happening :tada: 

@fabxc @matthiasr @piosz @loburm @andyxning 

I'll synchronize with @loburm tomorrow to make sure we have the container images online at the point where we merge this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/213)
<!-- Reviewable:end -->
