### PR TITLE
Add PVC requested storage metric and storageclass label

### DIFF
--- a/Documentation/persistentvolumeclaim-metrics.md
+++ b/Documentation/persistentvolumeclaim-metrics.md
@@ -2,4 +2,5 @@
 
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
-| kube_persistentvolumeclaim_status_phase| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `phase`=&lt;Pending\|Bound\|Lost&gt; |
+| kube_persistentvolumeclaim_status_phase| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; <br> `phase`=&lt;Pending\|Bound\|Lost&gt; |
+| kube_persistentvolumeclaim_resource_requests_storage| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; |

--- a/Documentation/persistentvolumeclaim-metrics.md
+++ b/Documentation/persistentvolumeclaim-metrics.md
@@ -2,9 +2,9 @@
 
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
-| kube_persistentvolumeclaim_info| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; |
-| kube_persistentvolumeclaim_status_phase| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; <br> `phase`=&lt;Pending\|Bound\|Lost&gt; |
-| kube_persistentvolumeclaim_resource_requests_storage| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; |
+| kube_persistentvolumeclaim_info | Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; |
+| kube_persistentvolumeclaim_status_phase | Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `phase`=&lt;Pending\|Bound\|Lost&gt; |
+| kube_persistentvolumeclaim_resource_requests_storage_bytes | Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; |
 
 Note:
 

--- a/Documentation/persistentvolumeclaim-metrics.md
+++ b/Documentation/persistentvolumeclaim-metrics.md
@@ -4,3 +4,7 @@
 | ---------- | ----------- | ----------- |
 | kube_persistentvolumeclaim_status_phase| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; <br> `phase`=&lt;Pending\|Bound\|Lost&gt; |
 | kube_persistentvolumeclaim_resource_requests_storage| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; |
+
+Note:
+
+- A special `<none>` string will be used if PVC has no storage class.

--- a/Documentation/persistentvolumeclaim-metrics.md
+++ b/Documentation/persistentvolumeclaim-metrics.md
@@ -2,6 +2,7 @@
 
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
+| kube_persistentvolumeclaim_info| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; |
 | kube_persistentvolumeclaim_status_phase| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; <br> `phase`=&lt;Pending\|Bound\|Lost&gt; |
 | kube_persistentvolumeclaim_resource_requests_storage| Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt; |
 

--- a/collectors/persistentvolumeclaim.go
+++ b/collectors/persistentvolumeclaim.go
@@ -109,7 +109,8 @@ func getPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
 		return *claim.Spec.StorageClassName
 	}
 
-	return ""
+	// Special non-empty string to indicate absence of storage class.
+	return "<none>"
 }
 
 func (collector *persistentVolumeClaimCollector) collectPersistentVolumeClaim(ch chan<- prometheus.Metric, pvc v1.PersistentVolumeClaim) {

--- a/collectors/persistentvolumeclaim.go
+++ b/collectors/persistentvolumeclaim.go
@@ -31,8 +31,8 @@ var (
 		"Information about persistent volume claim.",
 		[]string{
 			"namespace",
-			"storageclass",
 			"persistentvolumeclaim",
+			"storageclass",
 		}, nil,
 	)
 	descPersistentVolumeClaimStatusPhase = prometheus.NewDesc(
@@ -40,17 +40,15 @@ var (
 		"The phase the persistent volume claim is currently in.",
 		[]string{
 			"namespace",
-			"storageclass",
 			"persistentvolumeclaim",
 			"phase",
 		}, nil,
 	)
 	descPersistentVolumeClaimResourceRequestsStorage = prometheus.NewDesc(
-		"kube_persistentvolumeclaim_resource_requests_storage",
+		"kube_persistentvolumeclaim_resource_requests_storage_bytes",
 		"The capacity of storage requested by the persistent volume claim.",
 		[]string{
 			"namespace",
-			"storageclass",
 			"persistentvolumeclaim",
 		}, nil,
 	)
@@ -124,13 +122,13 @@ func getPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
 }
 
 func (collector *persistentVolumeClaimCollector) collectPersistentVolumeClaim(ch chan<- prometheus.Metric, pvc v1.PersistentVolumeClaim) {
-	storageClassName := getPersistentVolumeClaimClass(&pvc)
 	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
-		lv = append([]string{pvc.Namespace, storageClassName, pvc.Name}, lv...)
+		lv = append([]string{pvc.Namespace, pvc.Name}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
 
-	addGauge(descPersistentVolumeClaimInfo, 1)
+	storageClassName := getPersistentVolumeClaimClass(&pvc)
+	addGauge(descPersistentVolumeClaimInfo, 1, storageClassName)
 
 	// Set current phase to 1, others to 0 if it is set.
 	if p := pvc.Status.Phase; p != "" {

--- a/collectors/persistentvolumeclaim_test.go
+++ b/collectors/persistentvolumeclaim_test.go
@@ -40,8 +40,8 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 		# TYPE kube_persistentvolumeclaim_info gauge
 		# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
 		# TYPE kube_persistentvolumeclaim_status_phase gauge
-		# HELP kube_persistentvolumeclaim_resource_requests_storage The capacity of storage requested by the persistent volume claim.
-		# TYPE kube_persistentvolumeclaim_resource_requests_storage gauge
+		# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
+		# TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
 	`
 	storageClassName := "rbd"
 	cases := []struct {
@@ -94,18 +94,18 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 				kube_persistentvolumeclaim_info{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>"} 1
 				kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd"} 1
 				kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="prometheus-data",storageclass="rbd"} 1
-				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",phase="Bound"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",phase="Lost"} 1
-				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",phase="Pending"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",phase="Bound"} 1
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",phase="Lost"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",phase="Pending"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",storageclass="rbd",phase="Bound"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",storageclass="rbd",phase="Lost"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",storageclass="rbd",phase="Pending"} 1
-				kube_persistentvolumeclaim_resource_requests_storage{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd"} 1.073741824e+09
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Bound"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Lost"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Pending"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Bound"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Lost"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Bound"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Lost"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Pending"} 1
+				kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
 			`,
-			metrics: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage"},
+			metrics: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes"},
 		},
 	}
 	for _, c := range cases {

--- a/collectors/persistentvolumeclaim_test.go
+++ b/collectors/persistentvolumeclaim_test.go
@@ -19,6 +19,7 @@ package collectors
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 )
@@ -35,9 +36,12 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
-		# HELP kube_persistentvolumeclaim_status_phase The phase the claim is currently in.
+		# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
 		# TYPE kube_persistentvolumeclaim_status_phase gauge
+		# HELP kube_persistentvolumeclaim_resource_requests_storage The capacity of storage requested by the persistent volume claim.
+		# TYPE kube_persistentvolumeclaim_resource_requests_storage gauge
 	`
+	storageClassName := "rbd"
 	cases := []struct {
 		pvcs    []v1.PersistentVolumeClaim
 		metrics []string // which metrics should be checked
@@ -51,6 +55,14 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 						Name:      "mysql-data",
 						Namespace: "default",
 					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClassName,
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
 					Status: v1.PersistentVolumeClaimStatus{
 						Phase: v1.ClaimBound,
 					},
@@ -60,6 +72,9 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 						Name:      "prometheus-data",
 						Namespace: "default",
 					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClassName,
+					},
 					Status: v1.PersistentVolumeClaimStatus{
 						Phase: v1.ClaimPending,
 					},
@@ -68,23 +83,27 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mongo-data",
 					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClassName,
+					},
 					Status: v1.PersistentVolumeClaimStatus{
 						Phase: v1.ClaimLost,
 					},
 				},
 			},
 			want: metadata + `
-				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Bound"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Lost"} 1
-				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Pending"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Bound"} 1
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Lost"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Bound"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Lost"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Pending"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="rbd",phase="Bound"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="rbd",phase="Lost"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="rbd",phase="Pending"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",phase="Bound"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",phase="Lost"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",phase="Pending"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",storageclass="rbd",phase="Bound"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",storageclass="rbd",phase="Lost"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",storageclass="rbd",phase="Pending"} 1
+				kube_persistentvolumeclaim_resource_requests_storage{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd"} 1.073741824e+09
 			`,
-			metrics: []string{"kube_persistentvolumeclaim_status_phase"},
+			metrics: []string{"kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage"},
 		},
 	}
 	for _, c := range cases {

--- a/collectors/persistentvolumeclaim_test.go
+++ b/collectors/persistentvolumeclaim_test.go
@@ -83,18 +83,15 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "mongo-data",
 					},
-					Spec: v1.PersistentVolumeClaimSpec{
-						StorageClassName: &storageClassName,
-					},
 					Status: v1.PersistentVolumeClaimStatus{
 						Phase: v1.ClaimLost,
 					},
 				},
 			},
 			want: metadata + `
-				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="rbd",phase="Bound"} 0
-				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="rbd",phase="Lost"} 1
-				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="rbd",phase="Pending"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",phase="Bound"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",phase="Lost"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",phase="Pending"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",phase="Bound"} 1
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",phase="Lost"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",phase="Pending"} 0

--- a/collectors/persistentvolumeclaim_test.go
+++ b/collectors/persistentvolumeclaim_test.go
@@ -36,6 +36,8 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
+		# TYPE kube_persistentvolumeclaim_info gauge
 		# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
 		# TYPE kube_persistentvolumeclaim_status_phase gauge
 		# HELP kube_persistentvolumeclaim_resource_requests_storage The capacity of storage requested by the persistent volume claim.
@@ -89,6 +91,9 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_persistentvolumeclaim_info{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>"} 1
+				kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd"} 1
+				kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="prometheus-data",storageclass="rbd"} 1
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",phase="Bound"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",phase="Lost"} 1
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",phase="Pending"} 0
@@ -100,7 +105,7 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",storageclass="rbd",phase="Pending"} 1
 				kube_persistentvolumeclaim_resource_requests_storage{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd"} 1.073741824e+09
 			`,
-			metrics: []string{"kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage"},
+			metrics: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage"},
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
**What this PR does / why we need it**:

With `kube_persistentvolumeclaim_resource_requests_storage` metric, we can monitor users requested capacity. This is like `kube_pod_container_resource_requests_(cpu_cores|memory_bytes)` metrics.

With new label `storageclass` in pvc metrics, we can group metrics by storage class. In practice, a cluster may have multiple storage class for different dynamic volume types. For example, in our multi-tenant cluster, we deployed rbd/nfs storage classes and corresponding provisioners. For monitor/alerting, it's better if we can distinguish metrics by storage class name.

**Special notes for your reviewer**:

Example output:

```
# curl -s http://localhost:80/metrics | grep '^kube_persistent'
kube_persistentvolumeclaim_resource_requests_storage{namespace="default",persistentvolumeclaim="mongo-persistent-storage-mongo-0",storageclass="rbd"} 1.073741824e+09
kube_persistentvolumeclaim_resource_requests_storage{namespace="default",persistentvolumeclaim="registry-storage",storageclass="rbd"} 2.147483648e+09
kube_persistentvolumeclaim_resource_requests_storage{namespace="kube-system",persistentvolumeclaim="alertmanager-kirk-monitor-db-alertmanager-kirk-monitor-0",storageclass="rbd"} 1.073741824e+09
kube_persistentvolumeclaim_resource_requests_storage{namespace="kube-system",persistentvolumeclaim="kirk-monitor-grafana",storageclass="rbd"} 1.073741824e+09
kube_persistentvolumeclaim_resource_requests_storage{namespace="kube-system",persistentvolumeclaim="prometheus-kirk-monitor-db-prometheus-kirk-monitor-0",storageclass="rbd"} 1.073741824e+09
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/226)
<!-- Reviewable:end -->