### PR TITLE
Add metrics for namespace label and created time

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -19,3 +19,4 @@ Per group of metrics there is one file for each metrics. See each file for speci
 * [ResourceQuota Metrics](resourcequota-metrics.md)
 * [Service Metrics](service-metrics.md)
 * [StatefulSet Metrics](statefulset-metrics.md)
+* [Namespace Metrics](namespace-metrics.md)

--- a/Documentation/namespace-metrics.md
+++ b/Documentation/namespace-metrics.md
@@ -2,4 +2,6 @@
 
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
-| kube_namespace_status_phase| Gauge | `name`=&lt;namespace&gt; <br> `status`=&lt;Active\|Terminating&gt; |
+| kube_namespace_status_phase| Gauge | `namespace`=&lt;ns1&gt; <br> `status`=&lt;Active\|Terminating&gt; |
+| kube_namespace_labels | Gauge | `namespace`=&lt;ns1&gt; <br> `label_NS_LABEL`=&lt;NS_LABEL&gt; |
+| kube_namespace_created | Gauge | `namespace`=&lt;ns1&gt; |

--- a/Documentation/namespace-metrics.md
+++ b/Documentation/namespace-metrics.md
@@ -1,0 +1,5 @@
+# Namespace Metrics
+
+| Metric name| Metric type | Labels/tags |
+| ---------- | ----------- | ----------- |
+| kube_namespace_status_phase| Gauge | `name`=&lt;namespace&gt; <br> `status`=&lt;Active\|Terminating&gt; |

--- a/collectors/namespace.go
+++ b/collectors/namespace.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/net/context"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descNamespacePhase = prometheus.NewDesc(
+		"kube_namespace_status_phase",
+		"kubernetes namespace status phase.",
+		[]string{
+			"name",
+			"phase",
+		}, nil,
+	)
+)
+
+// NamespaceLister define NamespaceLister type
+type NamespaceLister func() ([]v1.Namespace, error)
+
+// List return namespace list
+func (l NamespaceLister) List() ([]v1.Namespace, error) {
+	return l()
+}
+
+// RegisterNamespaceCollector registry namespace collector
+func RegisterNamespaceCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+	client := kubeClient.CoreV1().RESTClient()
+
+	nslw := cache.NewListWatchFromClient(client, "namespaces", api.NamespaceAll, nil)
+	nsinf := cache.NewSharedInformer(nslw, &v1.Namespace{}, resyncPeriod)
+
+	namespaceLister := NamespaceLister(func() (namespaces []v1.Namespace, err error) {
+		for _, ns := range nsinf.GetStore().List() {
+			namespaces = append(namespaces, *(ns.(*v1.Namespace)))
+		}
+		return namespaces, nil
+	})
+
+	registry.MustRegister(&namespaceCollector{store: namespaceLister})
+	go nsinf.Run(context.Background().Done())
+}
+
+type namespaceStore interface {
+	List() ([]v1.Namespace, error)
+}
+
+// namespaceCollector collects metrics about all namespace in the cluster.
+type namespaceCollector struct {
+	store namespaceStore
+}
+
+// Describe implements the prometheus.Collector interface.
+func (nsc *namespaceCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descNamespacePhase
+}
+
+// Collect implements the prometheus.Collector interface.
+func (nsc *namespaceCollector) Collect(ch chan<- prometheus.Metric) {
+	nsls, err := nsc.store.List()
+	if err != nil {
+		glog.Errorf("listing namespace failed: %s", err)
+		return
+	}
+
+	for _, rq := range nsls {
+		nsc.collectNamespace(ch, rq)
+	}
+}
+
+func (nsc *namespaceCollector) collectNamespace(ch chan<- prometheus.Metric, rq v1.Namespace) {
+	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
+		lv = append([]string{rq.Name}, lv...)
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
+	}
+
+	addGauge(descNamespacePhase, boolFloat64(rq.Status.Phase == v1.NamespaceActive), string(v1.NamespaceActive))
+	addGauge(descNamespacePhase, boolFloat64(rq.Status.Phase == v1.NamespaceTerminating), string(v1.NamespaceTerminating))
+
+}

--- a/collectors/namespace.go
+++ b/collectors/namespace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors All rights reserved.
+Copyright 2017 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,11 +27,27 @@ import (
 )
 
 var (
+	descNamespaceLabelsName          = "kube_namespace_labels"
+	descNamespaceLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descNamespaceLabelsDefaultLabels = []string{"namespace"}
+
+	descNamespaceCreated = prometheus.NewDesc(
+		"kube_namespace_created",
+		"Unix creation timestamp",
+		[]string{"namespace"}, nil,
+	)
+
+	descNamespaceLabels = prometheus.NewDesc(
+		descNamespaceLabelsName,
+		descNamespaceLabelsHelp,
+		descNamespaceLabelsDefaultLabels, nil,
+	)
+
 	descNamespacePhase = prometheus.NewDesc(
 		"kube_namespace_status_phase",
 		"kubernetes namespace status phase.",
 		[]string{
-			"name",
+			"namespace",
 			"phase",
 		}, nil,
 	)
@@ -46,7 +62,7 @@ func (l NamespaceLister) List() ([]v1.Namespace, error) {
 }
 
 // RegisterNamespaceCollector registry namespace collector
-func RegisterNamespaceCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface) {
+func RegisterNamespaceCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
 
 	nslw := cache.NewListWatchFromClient(client, "namespaces", api.NamespaceAll, nil)
@@ -74,6 +90,8 @@ type namespaceCollector struct {
 
 // Describe implements the prometheus.Collector interface.
 func (nsc *namespaceCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descNamespaceCreated
+	ch <- descNamespaceLabels
 	ch <- descNamespacePhase
 }
 
@@ -90,13 +108,28 @@ func (nsc *namespaceCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (nsc *namespaceCollector) collectNamespace(ch chan<- prometheus.Metric, rq v1.Namespace) {
+func (nsc *namespaceCollector) collectNamespace(ch chan<- prometheus.Metric, ns v1.Namespace) {
 	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
-		lv = append([]string{rq.Name}, lv...)
+		lv = append([]string{ns.Name}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
 
-	addGauge(descNamespacePhase, boolFloat64(rq.Status.Phase == v1.NamespaceActive), string(v1.NamespaceActive))
-	addGauge(descNamespacePhase, boolFloat64(rq.Status.Phase == v1.NamespaceTerminating), string(v1.NamespaceTerminating))
+	addGauge(descNamespacePhase, boolFloat64(ns.Status.Phase == v1.NamespaceActive), string(v1.NamespaceActive))
+	addGauge(descNamespacePhase, boolFloat64(ns.Status.Phase == v1.NamespaceTerminating), string(v1.NamespaceTerminating))
 
+	if !ns.CreationTimestamp.IsZero() {
+		addGauge(descNamespaceCreated, float64(ns.CreationTimestamp.Unix()))
+	}
+
+	labelKeys, labelValues := kubeLabelsToPrometheusLabels(ns.Labels)
+	addGauge(namespaceLabelsDesc(labelKeys), 1, labelValues...)
+}
+
+func namespaceLabelsDesc(labelKeys []string) *prometheus.Desc {
+	return prometheus.NewDesc(
+		descNamespaceLabelsName,
+		descNamespaceLabelsHelp,
+		append(descNamespaceLabelsDefaultLabels, labelKeys...),
+		nil,
+	)
 }

--- a/collectors/namespace_test.go
+++ b/collectors/namespace_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+type mockNamespaceStore struct {
+	list func() ([]v1.Namespace, error)
+}
+
+func (ns mockNamespaceStore) List() ([]v1.Namespace, error) {
+	return ns.list()
+}
+
+func TestNamespaceCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+
+	const metadata = `
+	# HELP kube_namespace_status_phase kubernetes namespace status phase.
+	# TYPE kube_namespace_status_phase gauge
+	`
+	cases := []struct {
+		ns      []v1.Namespace
+		metrics []string // which metrics should be checked
+		want    string
+	}{
+		{
+			ns: []v1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nsActiveTest",
+					},
+					Spec: v1.NamespaceSpec{
+						Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
+					},
+					Status: v1.NamespaceStatus{
+						Phase: v1.NamespaceActive,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nsTerminateTest",
+					},
+					Spec: v1.NamespaceSpec{
+						Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
+					},
+					Status: v1.NamespaceStatus{
+						Phase: v1.NamespaceTerminating,
+					},
+				},
+			},
+
+			want: metadata + `
+		kube_namespace_status_phase{name="nsActiveTest",phase="Active"} 1
+		kube_namespace_status_phase{name="nsActiveTest",phase="Terminating"} 0
+		kube_namespace_status_phase{name="nsTerminateTest",phase="Active"} 0
+		kube_namespace_status_phase{name="nsTerminateTest",phase="Terminating"} 1
+		`,
+		},
+	}
+
+	for _, c := range cases {
+		dc := &namespaceCollector{
+			store: &mockNamespaceStore{
+				list: func() ([]v1.Namespace, error) {
+					return c.ns, nil
+				},
+			},
+		}
+		if err := gatherAndCompare(dc, c.want, c.metrics); err != nil {
+			t.Errorf("unexpected collecting result:\n%s", err)
+		}
+	}
+}

--- a/collectors/statefulset.go
+++ b/collectors/statefulset.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package collectors
 
 import (

--- a/collectors/statefulset_test.go
+++ b/collectors/statefulset_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package collectors
 
 import (

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ var (
 		"cronjobs":               struct{}{},
 		"statefulsets":           struct{}{},
 		"persistentvolumeclaims": struct{}{},
+		"namespaces":             struct{}{},
 	}
 	availableCollectors = map[string]func(registry prometheus.Registerer, kubeClient clientset.Interface, namespace string){
 		"cronjobs":               collectors.RegisterCronJobCollector,
@@ -72,6 +73,7 @@ var (
 		"services":               collectors.RegisterServiceCollector,
 		"statefulsets":           collectors.RegisterStatefulSetCollector,
 		"persistentvolumeclaims": collectors.RegisterPersistentVolumeClaimCollector,
+		"namespaces":             collectors.RegisterNamespaceCollector,
 	}
 )
 


### PR DESCRIPTION
This allows prometheus reporting based on labels per namespace.

For example, if each namespace has a team label, you can report on the
memory use per team like this:

    sum(sum(container_memory_usage_bytes) by(namespace) * on(namespace)
    group_right() kube_namespace_labels) by (label_team)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/234)
<!-- Reviewable:end -->
