### PR TITLE
Match deployment resources to recommendation

### DIFF
--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -25,10 +25,10 @@ spec:
           timeoutSeconds: 5
         resources:
           requests:
-            memory: 30Mi
+            memory: 200Mi
             cpu: 100m
           limits:
-            memory: 50Mi
+            memory: 200Mi
             cpu: 200m
       - name: addon-resizer
         image: gcr.io/google_containers/addon-resizer:1.0
@@ -53,7 +53,7 @@ spec:
           - --container=kube-state-metrics
           - --cpu=100m
           - --extra-cpu=1m
-          - --memory=30Mi
+          - --memory=200Mi
           - --extra-memory=2Mi
-          - --threshold=5
+          - --threshold=100
           - --deployment=kube-state-metrics

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -25,7 +25,7 @@ spec:
           timeoutSeconds: 5
         resources:
           requests:
-            memory: 200Mi
+            memory: 100Mi
             cpu: 100m
           limits:
             memory: 200Mi
@@ -53,7 +53,7 @@ spec:
           - --container=kube-state-metrics
           - --cpu=100m
           - --extra-cpu=1m
-          - --memory=200Mi
+          - --memory=100Mi
           - --extra-memory=2Mi
-          - --threshold=100
+          - --threshold=5
           - --deployment=kube-state-metrics


### PR DESCRIPTION
Adjust the deployment to match the recommended resources (#196). The baseline resources are set to the basic recommendation for a 100 node cluster.

Pod nanny (#200) does not support "the baseline includes the first 100 nodes", so instead set the threshold until it needs to adjust wide. This over-estimates resource needs for intermediate cluster sizes, but I'd rather be on the safe side. @WIZARD-CXY is this sensible?

Fixes #112.

/cc @brancz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/238)
<!-- Reviewable:end -->
