### PR TITLE
Guard owner.controller dereference (it can be nil)

### DIFF
--- a/collectors/pod.go
+++ b/collectors/pod.go
@@ -297,7 +297,11 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 		addGauge(descPodOwner, 1, "<none>", "<none>", "<none>")
 	} else {
 		for _, owner := range owners {
-			addGauge(descPodOwner, 1, owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller))
+			if owner.Controller != nil {
+				addGauge(descPodOwner, 1, owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller))
+			} else {
+				addGauge(descPodOwner, 1, owner.Kind, owner.Name, "false")
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #239

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/240)
<!-- Reviewable:end -->
