### PR TITLE
Cut 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.1 / 2017-08-24
+
+* [BUGFIX] Fix nil pointer panic when pods have an owner without controllers.
+
 ## v1.0.0 / 2017-08-09
 
 After a testing period of one week, there were no additional bugs found or features introduced.

--- a/collectors/pod.go
+++ b/collectors/pod.go
@@ -276,7 +276,11 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 		addGauge(descPodOwner, 1, "<none>", "<none>", "<none>")
 	} else {
 		for _, owner := range owners {
-			addGauge(descPodOwner, 1, owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller))
+			if owner.Controller != nil {
+				addGauge(descPodOwner, 1, owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller))
+			} else {
+				addGauge(descPodOwner, 1, owner.Kind, owner.Name, "false")
+			}
 		}
 	}
 

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: gcr.io/google_containers/kube-state-metrics:v1.0.0
+        image: gcr.io/google_containers/kube-state-metrics:v1.0.1
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION
Backporting this as it's going to take a bit of time until we release `v1.1.0`, as there are few more things to figure out for that. But to ensure people have an official release and don't get nil panics I wanted to just backport this.

The fix that is being backported is #240, which was originally reported in #239.

@fabxc @andyxning @matthiasr 

I'll coordinate publishing the images with @loburm / @piosz .

/cc @smarterclayton

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/242)
<!-- Reviewable:end -->
