### PR TITLE
move default image registry to quay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ FLAGS =
 COMMONENVVAR = GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
 BUILDENVVAR = CGO_ENABLED=0
 TESTENVVAR = 
-REGISTRY = gcr.io/google_containers
+REGISTRY = quay.io/coreos
 TAG = $(shell git describe --abbrev=0)
 PKGS = $(shell go list ./... | grep -v /vendor/)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ Currently, `client-go` is in version `v4.0.0-beta.0`.
 
 ## Container Image
 
-The latest container image can be found at `gcr.io/google_containers/kube-state-metrics:v0.5.0`.
+The latest container image can be found at:
+* `quay.io/coreos/kube-state-metrics:v1.0.1`
+* `gcr.io/google_containers/kube-state-metrics:v1.0.1`
+
+**Note**:
+The recommended docker registry for kube-state-metrics is `quay.io`. kube-state-metrics on
+`gcr.io` is only maintained on best effort as it requires external help from Google employees.
 
 ## Metrics Documentation
 

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: gcr.io/google_containers/kube-state-metrics:v1.0.1
+        image: quay.io/coreos/kube-state-metrics:v1.0.1
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION
This PR will move kube-state-metrics image registry from `gcr.io` to `quay.io`.

This is mainly because there are some times([#224 comment](https://github.com/kubernetes/kube-state-metrics/pull/244#issuecomment-325298896), [#88 comment](https://github.com/kubernetes/kube-state-metrics/pull/88#issuecomment-279228915)) the latest image can not be pushed to gcr.io timely. Users may be delayed to use the latest kube-state-metrics for this reason.  A better way was to use `quay.io` as the docker registry as @brancz should be able to push the latest image when a new kube-state-metrics is released.

/cc @brancz @loburm @fabxc @piosz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/246)
<!-- Reviewable:end -->
