### PR TITLE
add collected resource objects length log

### DIFF
--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -121,6 +121,8 @@ func (cjc *cronJobCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, cj := range cronjobs {
 		cjc.collectCronJob(ch, cj)
 	}
+
+	glog.Infof("collected %d cronjobs", len(cronjobs))
 }
 
 func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, createdTime metav1.Time) (time.Time, error) {

--- a/collectors/daemonset.go
+++ b/collectors/daemonset.go
@@ -101,14 +101,16 @@ func (dc *daemonsetCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface.
 func (dc *daemonsetCollector) Collect(ch chan<- prometheus.Metric) {
-	dpls, err := dc.store.List()
+	dss, err := dc.store.List()
 	if err != nil {
 		glog.Errorf("listing daemonsets failed: %s", err)
 		return
 	}
-	for _, d := range dpls {
+	for _, d := range dss {
 		dc.collectDaemonSet(ch, d)
 	}
+
+	glog.Infof("collected %d daemonsets", len(dss))
 }
 
 func (dc *daemonsetCollector) collectDaemonSet(ch chan<- prometheus.Metric, d v1beta1.DaemonSet) {

--- a/collectors/deployment.go
+++ b/collectors/deployment.go
@@ -143,14 +143,16 @@ func (dc *deploymentCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface.
 func (dc *deploymentCollector) Collect(ch chan<- prometheus.Metric) {
-	dpls, err := dc.store.List()
+	ds, err := dc.store.List()
 	if err != nil {
 		glog.Errorf("listing deployments failed: %s", err)
 		return
 	}
-	for _, d := range dpls {
+	for _, d := range ds {
 		dc.collectDeployment(ch, d)
 	}
+
+	glog.Infof("collected %d deployments", len(ds))
 }
 
 func deploymentLabelsDesc(labelKeys []string) *prometheus.Desc {

--- a/collectors/job.go
+++ b/collectors/job.go
@@ -145,6 +145,8 @@ func (jc *jobCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, j := range jobs {
 		jc.collectJob(ch, j)
 	}
+
+	glog.Infof("collected %d jobs", len(jobs))
 }
 
 func (jc *jobCollector) collectJob(ch chan<- prometheus.Metric, j v1batch.Job) {

--- a/collectors/limitrange.go
+++ b/collectors/limitrange.go
@@ -93,6 +93,8 @@ func (lrc *limitRangeCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, rq := range limitRangeCollector.Items {
 		lrc.collectLimitRange(ch, rq)
 	}
+
+	glog.Infof("collected %d limitranges", len(limitRangeCollector.Items))
 }
 
 func (lrc *limitRangeCollector) collectLimitRange(ch chan<- prometheus.Metric, rq v1.LimitRange) {

--- a/collectors/namespace.go
+++ b/collectors/namespace.go
@@ -106,6 +106,8 @@ func (nsc *namespaceCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, rq := range nsls {
 		nsc.collectNamespace(ch, rq)
 	}
+
+	glog.Infof("collected %d namespaces", len(nsls))
 }
 
 func (nsc *namespaceCollector) collectNamespace(ch chan<- prometheus.Metric, ns v1.Namespace) {

--- a/collectors/node.go
+++ b/collectors/node.go
@@ -177,6 +177,8 @@ func (nc *nodeCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, n := range nodes.Items {
 		nc.collectNode(ch, n)
 	}
+
+	glog.Infof("collected %d nodes", len(nodes.Items))
 }
 
 func nodeLabelsDesc(labelKeys []string) *prometheus.Desc {

--- a/collectors/persistentvolumeclaim.go
+++ b/collectors/persistentvolumeclaim.go
@@ -103,6 +103,8 @@ func (collector *persistentVolumeClaimCollector) Collect(ch chan<- prometheus.Me
 	for _, pvc := range persistentVolumeClaimCollector.Items {
 		collector.collectPersistentVolumeClaim(ch, pvc)
 	}
+
+	glog.Infof("collected %d persistentvolumeclaims", len(persistentVolumeClaimCollector.Items))
 }
 
 // getPersistentVolumeClaimClass returns StorageClassName. If no storage class was

--- a/collectors/pod.go
+++ b/collectors/pod.go
@@ -234,6 +234,8 @@ func (pc *podCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, p := range pods {
 		pc.collectPod(ch, p)
 	}
+
+	glog.Infof("collected %d pods", len(pods))
 }
 
 func kubeLabelsToPrometheusLabels(labels map[string]string) ([]string, []string) {

--- a/collectors/replicaset.go
+++ b/collectors/replicaset.go
@@ -107,14 +107,16 @@ func (dc *replicasetCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface.
 func (dc *replicasetCollector) Collect(ch chan<- prometheus.Metric) {
-	dpls, err := dc.store.List()
+	rss, err := dc.store.List()
 	if err != nil {
 		glog.Errorf("listing replicasets failed: %s", err)
 		return
 	}
-	for _, d := range dpls {
+	for _, d := range rss {
 		dc.collectReplicaSet(ch, d)
 	}
+
+	glog.Infof("collected %d replicasets", len(rss))
 }
 
 func (dc *replicasetCollector) collectReplicaSet(ch chan<- prometheus.Metric, d v1beta1.ReplicaSet) {

--- a/collectors/replicationcontroller.go
+++ b/collectors/replicationcontroller.go
@@ -113,14 +113,16 @@ func (dc *replicationcontrollerCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface.
 func (dc *replicationcontrollerCollector) Collect(ch chan<- prometheus.Metric) {
-	dpls, err := dc.store.List()
+	rcs, err := dc.store.List()
 	if err != nil {
 		glog.Errorf("listing replicationcontrollers failed: %s", err)
 		return
 	}
-	for _, d := range dpls {
+	for _, d := range rcs {
 		dc.collectReplicationController(ch, d)
 	}
+
+	glog.Infof("collected %d replicationcontrollers", len(rcs))
 }
 
 func (dc *replicationcontrollerCollector) collectReplicationController(ch chan<- prometheus.Metric, d v1.ReplicationController) {

--- a/collectors/resourcequota.go
+++ b/collectors/resourcequota.go
@@ -91,6 +91,8 @@ func (rqc *resourceQuotaCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, rq := range resourceQuota.Items {
 		rqc.collectResourceQuota(ch, rq)
 	}
+
+	glog.Infof("collected %d resourcequotas", len(resourceQuota.Items))
 }
 
 func (rqc *resourceQuotaCollector) collectResourceQuota(ch chan<- prometheus.Metric, rq v1.ResourceQuota) {

--- a/collectors/service.go
+++ b/collectors/service.go
@@ -97,6 +97,8 @@ func (sc *serviceCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, s := range services {
 		sc.collectService(ch, s)
 	}
+
+	glog.Infof("collected %d services", len(services))
 }
 
 func serviceLabelsDesc(labelKeys []string) *prometheus.Desc {

--- a/collectors/statefulset.go
+++ b/collectors/statefulset.go
@@ -109,14 +109,16 @@ func (dc *statefulSetCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface.
 func (sc *statefulSetCollector) Collect(ch chan<- prometheus.Metric) {
-	dpls, err := sc.store.List()
+	sss, err := sc.store.List()
 	if err != nil {
 		glog.Errorf("listing statefulsets failed: %s", err)
 		return
 	}
-	for _, d := range dpls {
+	for _, d := range sss {
 		sc.collectStatefulSet(ch, d)
 	}
+
+	glog.Infof("collected %d statefulsets", len(sss))
 }
 
 func statefulSetLabelsDesc(labelKeys []string) *prometheus.Desc {


### PR DESCRIPTION
This PR will add the log about collected resource object number. This may be useful for debug as described in [#122 comment](https://github.com/kubernetes/kube-state-metrics/issues/112#issuecomment-328302552).

/cc @brancz @fabxc 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/254)
<!-- Reviewable:end -->
