### PR TITLE
add go flag to parse glog flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func main() {
 	flags := pflag.NewFlagSet("", pflag.ExitOnError)
 	// add glog flags
 	flags.AddGoFlagSet(flag.CommandLine)
+	flags.Lookup("logtostderr").Value.Set("true")
 	flags.BoolVar(&options.inCluster, "in-cluster", true, `If true, use the built in kubernetes cluster for creating the client`)
 	flags.StringVar(&options.apiserver, "apiserver", "", `The URL of the apiserver to use as a master`)
 	flags.StringVar(&options.kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file")

--- a/main.go
+++ b/main.go
@@ -131,6 +131,8 @@ func main() {
 	// add glog flags
 	flags.AddGoFlagSet(flag.CommandLine)
 	flags.Lookup("logtostderr").Value.Set("true")
+	flags.Lookup("logtostderr").DefValue = "true"
+	flags.Lookup("logtostderr").NoOptDefVal = "true"
 	flags.BoolVar(&options.inCluster, "in-cluster", true, `If true, use the built in kubernetes cluster for creating the client`)
 	flags.StringVar(&options.apiserver, "apiserver", "", `The URL of the apiserver to use as a master`)
 	flags.StringVar(&options.kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file")

--- a/main.go
+++ b/main.go
@@ -126,13 +126,10 @@ type options struct {
 }
 
 func main() {
-	// configure glog
-	flag.CommandLine.Parse([]string{})
-	flag.Lookup("logtostderr").Value.Set("true")
-
 	options := &options{collectors: make(collectorSet)}
 	flags := pflag.NewFlagSet("", pflag.ExitOnError)
-
+	// add glog flags
+	flags.AddGoFlagSet(flag.CommandLine)
 	flags.BoolVar(&options.inCluster, "in-cluster", true, `If true, use the built in kubernetes cluster for creating the client`)
 	flags.StringVar(&options.apiserver, "apiserver", "", `The URL of the apiserver to use as a master`)
 	flags.StringVar(&options.kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file")


### PR DESCRIPTION
It is need to parse glog flags. So we can use  glog flags such as --v=4, --logtostderr=true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/259)
<!-- Reviewable:end -->
