### PR TITLE
Improve a usage message for collectors flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/golang/glog"
@@ -83,7 +84,9 @@ type collectorSet map[string]struct{}
 
 func (c *collectorSet) String() string {
 	s := *c
-	return strings.Join(s.asSlice(), ",")
+	ss := s.asSlice()
+	sort.Strings(ss)
+	return strings.Join(ss, ",")
 }
 
 func (c *collectorSet) Set(value string) error {

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func (c collectorSet) isEmpty() bool {
 }
 
 func (c *collectorSet) Type() string {
-	return "map[string]struct{}"
+	return "string"
 }
 
 type options struct {
@@ -138,7 +138,7 @@ func main() {
 	flags.StringVar(&options.kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file")
 	flags.BoolVarP(&options.help, "help", "h", false, "Print help text")
 	flags.IntVar(&options.port, "port", 80, `Port to expose metrics on.`)
-	flags.Var(&options.collectors, "collectors", "Collectors to be enabled")
+	flags.Var(&options.collectors, "collectors", fmt.Sprintf("Comma-separated list of collectors to be enabled. Defaults to %q", &defaultCollectors))
 	flags.StringVar(&options.namespace, "namespace", api.NamespaceAll, "namespace to be enabled for collecting resources")
 
 	flags.Usage = func() {


### PR DESCRIPTION
This PR Improves a usage message for collectors flag. It makes a sentence clear and shows a default value.

```
      --collectors string                Comma-separated list of collectors to be enabled. Defaults to "services,persistentvolumeclaims,nodes,replicationcontrollers,statefulsets,replicasets,resourcequotas,jobs,namespaces,daemonsets,deployments,limitranges,pods,cronjobs"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/262)
<!-- Reviewable:end -->
