### PR TITLE
log the group version for resources

### DIFF
--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -77,6 +77,7 @@ func (l CronJobLister) List() ([]v2batch.CronJob, error) {
 
 func RegisterCronJobCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.BatchV2alpha1().RESTClient()
+	glog.Infof("collect cronjob with %s", client.APIVersion())
 	cjlw := cache.NewListWatchFromClient(client, "cronjobs", namespace, nil)
 	cjinf := cache.NewSharedInformer(cjlw, &v2batch.CronJob{}, resyncPeriod)
 

--- a/collectors/daemonset.go
+++ b/collectors/daemonset.go
@@ -66,6 +66,7 @@ func (l DaemonSetLister) List() ([]v1beta1.DaemonSet, error) {
 
 func RegisterDaemonSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
+	glog.Infof("collect daemonset with %s", client.APIVersion())
 	dslw := cache.NewListWatchFromClient(client, "daemonsets", namespace, nil)
 	dsinf := cache.NewSharedInformer(dslw, &v1beta1.DaemonSet{}, resyncPeriod)
 

--- a/collectors/deployment.go
+++ b/collectors/deployment.go
@@ -103,6 +103,7 @@ func (l DeploymentLister) List() ([]v1beta1.Deployment, error) {
 
 func RegisterDeploymentCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
+	glog.Infof("collect deployment with %s", client.APIVersion())
 	dlw := cache.NewListWatchFromClient(client, "deployments", namespace, nil)
 	dinf := cache.NewSharedInformer(dlw, &v1beta1.Deployment{}, resyncPeriod)
 

--- a/collectors/job.go
+++ b/collectors/job.go
@@ -96,6 +96,7 @@ func (l JobLister) List() ([]v1batch.Job, error) {
 
 func RegisterJobCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.BatchV1().RESTClient()
+	glog.Infof("collect job with %s", client.APIVersion())
 	jlw := cache.NewListWatchFromClient(client, "jobs", namespace, nil)
 	jinf := cache.NewSharedInformer(jlw, &v1batch.Job{}, resyncPeriod)
 

--- a/collectors/limitrange.go
+++ b/collectors/limitrange.go
@@ -53,6 +53,7 @@ func (l LimitRangeLister) List() (v1.LimitRangeList, error) {
 
 func RegisterLimitRangeCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
+	glog.Infof("collect limitrange with %s", client.APIVersion())
 	rqlw := cache.NewListWatchFromClient(client, "limitranges", namespace, nil)
 	rqinf := cache.NewSharedInformer(rqlw, &v1.LimitRange{}, resyncPeriod)
 

--- a/collectors/namespace.go
+++ b/collectors/namespace.go
@@ -64,7 +64,7 @@ func (l NamespaceLister) List() ([]v1.Namespace, error) {
 // RegisterNamespaceCollector registry namespace collector
 func RegisterNamespaceCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
-
+	glog.Infof("collect namespace with %s", client.APIVersion())
 	nslw := cache.NewListWatchFromClient(client, "namespaces", api.NamespaceAll, nil)
 	nsinf := cache.NewSharedInformer(nslw, &v1.Namespace{}, resyncPeriod)
 

--- a/collectors/node.go
+++ b/collectors/node.go
@@ -126,6 +126,7 @@ func (l NodeLister) List() (v1.NodeList, error) {
 
 func RegisterNodeCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
+	glog.Infof("collect node with %s", client.APIVersion())
 	nlw := cache.NewListWatchFromClient(client, "nodes", api.NamespaceAll, nil)
 	ninf := cache.NewSharedInformer(nlw, &v1.Node{}, resyncPeriod)
 

--- a/collectors/persistentvolumeclaim.go
+++ b/collectors/persistentvolumeclaim.go
@@ -62,6 +62,7 @@ func (l PersistentVolumeClaimLister) List() (v1.PersistentVolumeClaimList, error
 
 func RegisterPersistentVolumeClaimCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
+	glog.Infof("collect persistentvolumeclaim with %s", client.APIVersion())
 	pvclw := cache.NewListWatchFromClient(client, "persistentvolumeclaims", namespace, nil)
 	pvcinf := cache.NewSharedInformer(pvclw, &v1.PersistentVolumeClaim{}, resyncPeriod)
 

--- a/collectors/pod.go
+++ b/collectors/pod.go
@@ -172,6 +172,7 @@ func (l PodLister) List() ([]v1.Pod, error) {
 
 func RegisterPodCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
+	glog.Infof("collect pod with %s", client.APIVersion())
 	plw := cache.NewListWatchFromClient(client, "pods", namespace, nil)
 	pinf := cache.NewSharedInformer(plw, &v1.Pod{}, resyncPeriod)
 

--- a/collectors/replicaset.go
+++ b/collectors/replicaset.go
@@ -71,6 +71,7 @@ func (l ReplicaSetLister) List() ([]v1beta1.ReplicaSet, error) {
 
 func RegisterReplicaSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
+	glog.Infof("collect replicaset with %s", client.APIVersion())
 	rslw := cache.NewListWatchFromClient(client, "replicasets", namespace, nil)
 	rsinf := cache.NewSharedInformer(rslw, &v1beta1.ReplicaSet{}, resyncPeriod)
 

--- a/collectors/replicationcontroller.go
+++ b/collectors/replicationcontroller.go
@@ -77,6 +77,7 @@ func (l ReplicationControllerLister) List() ([]v1.ReplicationController, error) 
 
 func RegisterReplicationControllerCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
+	glog.Infof("collect replicationcontroller with %s", client.APIVersion())
 	rclw := cache.NewListWatchFromClient(client, "replicationcontrollers", namespace, nil)
 	rcinf := cache.NewSharedInformer(rclw, &v1.ReplicationController{}, resyncPeriod)
 

--- a/collectors/resourcequota.go
+++ b/collectors/resourcequota.go
@@ -51,6 +51,7 @@ func (l ResourceQuotaLister) List() (v1.ResourceQuotaList, error) {
 
 func RegisterResourceQuotaCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
+	glog.Infof("collect resourcequota with %s", client.APIVersion())
 	rqlw := cache.NewListWatchFromClient(client, "resourcequotas", namespace, nil)
 	rqinf := cache.NewSharedInformer(rqlw, &v1.ResourceQuota{}, resyncPeriod)
 

--- a/collectors/service.go
+++ b/collectors/service.go
@@ -57,6 +57,7 @@ func (l ServiceLister) List() ([]v1.Service, error) {
 
 func RegisterServiceCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.CoreV1().RESTClient()
+	glog.Infof("collect service with %s", client.APIVersion())
 	slw := cache.NewListWatchFromClient(client, "services", namespace, nil)
 	sinf := cache.NewSharedInformer(slw, &v1.Service{}, resyncPeriod)
 

--- a/collectors/statefulset.go
+++ b/collectors/statefulset.go
@@ -75,6 +75,7 @@ func (l StatefulSetLister) List() ([]v1beta1.StatefulSet, error) {
 
 func RegisterStatefulSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.AppsV1beta1().RESTClient()
+	glog.Infof("collect statefulset with %s", client.APIVersion())
 	dlw := cache.NewListWatchFromClient(client, "statefulsets", namespace, nil)
 	dinf := cache.NewSharedInformer(dlw, &v1beta1.StatefulSet{}, resyncPeriod)
 


### PR DESCRIPTION
This PR will log the currently used group version for each resource. This should be user friendly in debugging as discussed in [#256 comment](https://github.com/kubernetes/kube-state-metrics/issues/265#issuecomment-332525436).

/cc @brancz @matthiasr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/267)
<!-- Reviewable:end -->
