### PR TITLE
kubernetes: update sample manifests

### DIFF
--- a/kubernetes/kube-state-metrics-cluster-role.yaml
+++ b/kubernetes/kube-state-metrics-cluster-role.yaml
@@ -12,6 +12,7 @@ rules:
   - replicationcontrollers
   - limitranges
   - persistentvolumeclaims
+  - namespaces
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.0.1
+        image: quay.io/coreos/kube-state-metrics:v1.1.0-rc.0
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION
With rc.0 released, we should promote the usage. The only new resource being used are namespace objects, other than that, no other RBAC changes.

@andyxning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/273)
<!-- Reviewable:end -->
