### PR TITLE
fix hpa stale imports

### DIFF
--- a/collectors/hpa.go
+++ b/collectors/hpa.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
+	autoscaling "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
-	autoscaling "k8s.io/client-go/pkg/apis/autoscaling/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -72,7 +72,7 @@ func (l HPALister) List() (autoscaling.HorizontalPodAutoscalerList, error) {
 
 func RegisterHorizontalPodAutoScalerCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
 	client := kubeClient.Autoscaling().RESTClient()
-	hpalw := cache.NewListWatchFromClient(client, "horizontalpodautoscalers", api.NamespaceAll, nil)
+	hpalw := cache.NewListWatchFromClient(client, "horizontalpodautoscalers", metav1.NamespaceAll, nil)
 	hpainf := cache.NewSharedInformer(hpalw, &autoscaling.HorizontalPodAutoscaler{}, resyncPeriod)
 
 	hpaLister := HPALister(func() (hpas autoscaling.HorizontalPodAutoscalerList, err error) {

--- a/collectors/hpa_test.go
+++ b/collectors/hpa_test.go
@@ -19,8 +19,8 @@ package collectors
 import (
 	"testing"
 
+	autoscaling "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	autoscaling "k8s.io/client-go/pkg/apis/autoscaling/v1"
 )
 
 var (


### PR DESCRIPTION
Quick fix hpa stale imports.

> collectors/hpa.go:25:2: cannot find package "k8s.io/client-go/pkg/api" in any of:
	/home/travis/gopath/src/k8s.io/kube-state-metrics/vendor/k8s.io/client-go/pkg/api (vendor tree)
	/home/travis/.gimme/versions/go1.8.linux.amd64/src/k8s.io/client-go/pkg/api (from $GOROOT)
	/home/travis/gopath/src/k8s.io/client-go/pkg/api (from $GOPATH)
collectors/hpa.go:26:2: cannot find package "k8s.io/client-go/pkg/apis/autoscaling/v1" in any of:
	/home/travis/gopath/src/k8s.io/kube-state-metrics/vendor/k8s.io/client-go/pkg/apis/autoscaling/v1 (vendor tree)
	/home/travis/.gimme/versions/go1.8.linux.amd64/src/k8s.io/client-go/pkg/apis/autoscaling/v1 (from $GOROOT)
	/home/travis/gopath/src/k8s.io/client-go/pkg/apis/autoscaling/v1 (from $GOPATH)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/283)
<!-- Reviewable:end -->
