### PR TITLE
fix travis ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ jobs:
     - stage: Unit Test
       script: make test-unit
     - stage: Build
-      script: make
+      script: make build
     - stage: Check that all metrics are documented
       script: make doccheck


### PR DESCRIPTION
As for now `make` does not equal to `make build`. We should make it explicitly to test with `make build`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/284)
<!-- Reviewable:end -->
