### PR TITLE
Omit static compute resource requests and limits from deployment

### DIFF
--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -26,13 +26,6 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
-        resources:
-          requests:
-            memory: 100Mi
-            cpu: 100m
-          limits:
-            memory: 200Mi
-            cpu: 200m
       - name: addon-resizer
         image: gcr.io/google_containers/addon-resizer:1.0
         resources:


### PR DESCRIPTION
The addon-resizer will dynamically set the pod compute resource values. If the
values are also set statically in the deployment configuration, reapplying the
configuration will result in the pods getting replaced. Without the static
resource, the deployment configuration can be reapplied, and the pods will not
be replaced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/285)
<!-- Reviewable:end -->
