### PR TITLE
update kubernetes client-go tag to v5.0.0 which release with k8s 1.8.0

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -551,223 +551,223 @@
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/scheme",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta2",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1beta1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/networking/v1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/policy/v1beta1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1beta1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/settings/v1alpha1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1beta1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/version",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest/watch",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/auth",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/cache",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/latest",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/v1",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/metrics",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/pager",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/reference",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/transport",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/flowcontrol",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/homedir",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/integer",
-			"Comment": "v2.0.0-alpha.0-645-gafb4606",
-			"Rev": "afb4606c45bae77c4dc2c15291d4d7d6d792196c"
+			"Comment": "kubernetes-1.8.0",
+			"Rev": "35874c597fed17ca62cd197e516d7d5ff9a2958c"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ At most 5 kube-state-metrics releases will be recorded below.
 | **v0.5.0** |  v2.0.0-alpha.1   |          ✓          |         ✓          |        -           |         -          |         -          |
 | **v1.0.x** |  4.0.0-beta.0     |          ✓          |         ✓          |        ✓           |         ✓          |         -          |
 | **v1.1.0** |  release-5.0      |          ✓          |         ✓          |        ✓           |         ✓          |         ✓          |
-| **master** |  release-5.0      |          ✓          |         ✓          |        ✓           |         ✓          |         ✓          |
+| **master** |  v5.0.0      |          ✓          |         ✓          |        ✓           |         ✓          |         ✓          |
 - `✓` Fully supported version range.
 - `-` The Kubernetes cluster has features the client-go library can't use (additional API objects, etc).
 

--- a/vendor/k8s.io/client-go/pkg/version/base.go
+++ b/vendor/k8s.io/client-go/pkg/version/base.go
@@ -39,8 +39,8 @@ var (
 	// them irrelevant. (Next we'll take it out, which may muck with
 	// scripts consuming the kubectl version output - but most of
 	// these should be looking at gitVersion already anyways.)
-	gitMajor string = "1"  // major version, always numeric
-	gitMinor string = "8+" // minor version, numeric possibly followed by "+"
+	gitMajor string = "1" // major version, always numeric
+	gitMinor string = "8" // minor version, numeric possibly followed by "+"
 
 	// semantic version, derived by build scripts (see
 	// https://github.com/kubernetes/kubernetes/blob/master/docs/design/versioning.md
@@ -51,7 +51,7 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
-	gitVersion   string = "v1.8.0-beta.1+$Format:%h$"
+	gitVersion   string = "v1.8.0+$Format:%h$"
 	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 


### PR DESCRIPTION
update kubernetes client-go tag to v5.0.0 which release with kubernetes 1.8.0

/cc @brancz  @andyxning 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/289)
<!-- Reviewable:end -->
