### PR TITLE
Update CronJobs to v1beta1

### DIFF
--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	v2batch "k8s.io/api/batch/v2alpha1"
+	v2batch "k8s.io/api/batch/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 )

--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	v2batch "k8s.io/api/batch/v1beta1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 )
@@ -70,9 +70,9 @@ var (
 	)
 )
 
-type CronJobLister func() ([]v2batch.CronJob, error)
+type CronJobLister func() ([]batchv1beta1.CronJob, error)
 
-func (l CronJobLister) List() ([]v2batch.CronJob, error) {
+func (l CronJobLister) List() ([]batchv1beta1.CronJob, error) {
 	return l()
 }
 
@@ -80,11 +80,11 @@ func RegisterCronJobCollector(registry prometheus.Registerer, kubeClient kuberne
 	client := kubeClient.BatchV2alpha1().RESTClient()
 	glog.Infof("collect cronjob with %s", client.APIVersion())
 	cjlw := cache.NewListWatchFromClient(client, "cronjobs", namespace, fields.Everything())
-	cjinf := cache.NewSharedInformer(cjlw, &v2batch.CronJob{}, resyncPeriod)
+	cjinf := cache.NewSharedInformer(cjlw, &batchv1beta1.CronJob{}, resyncPeriod)
 
-	cronJobLister := CronJobLister(func() (cronjobs []v2batch.CronJob, err error) {
+	cronJobLister := CronJobLister(func() (cronjobs []batchv1beta1.CronJob, err error) {
 		for _, c := range cjinf.GetStore().List() {
-			cronjobs = append(cronjobs, *(c.(*v2batch.CronJob)))
+			cronjobs = append(cronjobs, *(c.(*batchv1beta1.CronJob)))
 		}
 		return cronjobs, nil
 	})
@@ -94,7 +94,7 @@ func RegisterCronJobCollector(registry prometheus.Registerer, kubeClient kuberne
 }
 
 type cronJobStore interface {
-	List() (cronjobs []v2batch.CronJob, err error)
+	List() (cronjobs []batchv1beta1.CronJob, err error)
 }
 
 // cronJobCollector collects metrics about all cronjobs in the cluster.
@@ -141,7 +141,7 @@ func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, create
 	return time.Time{}, fmt.Errorf("Created time and lastScheduleTime are both zero")
 }
 
-func (jc *cronJobCollector) collectCronJob(ch chan<- prometheus.Metric, j v2batch.CronJob) {
+func (jc *cronJobCollector) collectCronJob(ch chan<- prometheus.Metric, j batchv1beta1.CronJob) {
 	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
 		lv = append([]string{j.Namespace, j.Name}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)

--- a/collectors/cronjob_test.go
+++ b/collectors/cronjob_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	v2batch "k8s.io/api/batch/v2alpha1"
+	v2batch "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/collectors/cronjob_test.go
+++ b/collectors/cronjob_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	v2batch "k8s.io/api/batch/v1beta1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -36,10 +36,10 @@ var (
 )
 
 type mockCronJobStore struct {
-	f func() ([]v2batch.CronJob, error)
+	f func() ([]batchv1beta1.CronJob, error)
 }
 
-func (cjs mockCronJobStore) List() (cronJobs []v2batch.CronJob, err error) {
+func (cjs mockCronJobStore) List() (cronJobs []batchv1beta1.CronJob, err error) {
 	return cjs.f()
 }
 
@@ -63,22 +63,22 @@ func TestCronJobCollector(t *testing.T) {
 		# TYPE kube_cronjob_next_schedule_time gauge
 	`
 	cases := []struct {
-		cronJobs []v2batch.CronJob
+		cronJobs []batchv1beta1.CronJob
 		want     string
 	}{
 		{
-			cronJobs: []v2batch.CronJob{
+			cronJobs: []batchv1beta1.CronJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "ActiveRunningCronJob1",
 						Namespace:  "ns1",
 						Generation: 1,
 					},
-					Status: v2batch.CronJobStatus{
+					Status: batchv1beta1.CronJobStatus{
 						Active:           []v1.ObjectReference{v1.ObjectReference{Name: "FakeJob1"}, v1.ObjectReference{Name: "FakeJob2"}},
 						LastScheduleTime: &metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
 					},
-					Spec: v2batch.CronJobSpec{
+					Spec: batchv1beta1.CronJobSpec{
 						StartingDeadlineSeconds: &StartingDeadlineSeconds300,
 						ConcurrencyPolicy:       "Forbid",
 						Suspend:                 &SuspendFalse,
@@ -90,11 +90,11 @@ func TestCronJobCollector(t *testing.T) {
 						Namespace:  "ns1",
 						Generation: 1,
 					},
-					Status: v2batch.CronJobStatus{
+					Status: batchv1beta1.CronJobStatus{
 						Active:           []v1.ObjectReference{},
 						LastScheduleTime: &metav1.Time{Time: SuspendedCronJob1LastScheduleTime},
 					},
-					Spec: v2batch.CronJobSpec{
+					Spec: batchv1beta1.CronJobSpec{
 						StartingDeadlineSeconds: &StartingDeadlineSeconds300,
 						ConcurrencyPolicy:       "Forbid",
 						Suspend:                 &SuspendTrue,
@@ -107,11 +107,11 @@ func TestCronJobCollector(t *testing.T) {
 						Namespace:         "ns1",
 						Generation:        1,
 					},
-					Status: v2batch.CronJobStatus{
+					Status: batchv1beta1.CronJobStatus{
 						Active:           []v1.ObjectReference{},
 						LastScheduleTime: nil,
 					},
-					Spec: v2batch.CronJobSpec{
+					Spec: batchv1beta1.CronJobSpec{
 						StartingDeadlineSeconds: &StartingDeadlineSeconds300,
 						ConcurrencyPolicy:       "Forbid",
 						Suspend:                 &SuspendFalse,
@@ -149,7 +149,7 @@ func TestCronJobCollector(t *testing.T) {
 	for _, c := range cases {
 		cjc := &cronJobCollector{
 			store: mockCronJobStore{
-				f: func() ([]v2batch.CronJob, error) { return c.cronJobs, nil },
+				f: func() ([]batchv1beta1.CronJob, error) { return c.cronJobs, nil },
 			},
 		}
 		if err := gatherAndCompare(cjc, c.want, nil); err != nil {


### PR DESCRIPTION
with kubernetes 1.8 cronjobs are at version v1beta1, and enabled per default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/291)
<!-- Reviewable:end -->
