### PR TITLE
daemonset status info

### DIFF
--- a/Documentation/daemonset-metrics.md
+++ b/Documentation/daemonset-metrics.md
@@ -2,9 +2,12 @@
 
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
-| kube_daemonset_status_current_number_scheduled | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
-| kube_daemonset_status_number_misscheduled | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
-| kube_daemonset_status_desired_number_scheduled | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
-| kube_daemonset_status_number_ready | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
-| kube_daemonset_metadata_generation | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
 | kube_daemonset_created | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
+| kube_daemonset_status_current_number_scheduled | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
+| kube_daemonset_status_desired_number_scheduled | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
+| kube_daemonset_status_number_available | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
+| kube_daemonset_status_number_misscheduled | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
+| kube_daemonset_status_number_ready | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
+| kube_daemonset_status_number_unavailable | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
+| kube_daemonset_updated_number_scheduled | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |
+| kube_daemonset_metadata_generation | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; |

--- a/collectors/daemonset.go
+++ b/collectors/daemonset.go
@@ -37,19 +37,34 @@ var (
 		"The number of nodes running at least one daemon pod and are supposed to.",
 		[]string{"namespace", "daemonset"}, nil,
 	)
-	descDaemonSetNumberMisscheduled = prometheus.NewDesc(
-		"kube_daemonset_status_number_misscheduled",
-		"The number of nodes running a daemon pod but are not supposed to.",
-		[]string{"namespace", "daemonset"}, nil,
-	)
 	descDaemonSetDesiredNumberScheduled = prometheus.NewDesc(
 		"kube_daemonset_status_desired_number_scheduled",
 		"The number of nodes that should be running the daemon pod.",
 		[]string{"namespace", "daemonset"}, nil,
 	)
+	descDaemonSetNumberAvailable = prometheus.NewDesc(
+		"kube_daemonset_status_number_available",
+		"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
+		[]string{"namespace", "daemonset"}, nil,
+	)
+	descDaemonSetNumberMisscheduled = prometheus.NewDesc(
+		"kube_daemonset_status_number_misscheduled",
+		"The number of nodes running a daemon pod but are not supposed to.",
+		[]string{"namespace", "daemonset"}, nil,
+	)
 	descDaemonSetNumberReady = prometheus.NewDesc(
 		"kube_daemonset_status_number_ready",
 		"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
+		[]string{"namespace", "daemonset"}, nil,
+	)
+	descDaemonSetNumberUnavailable = prometheus.NewDesc(
+		"kube_daemonset_status_number_unavailable",
+		"The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
+		[]string{"namespace", "daemonset"}, nil,
+	)
+	descDaemonSetUpdatedNumberScheduled = prometheus.NewDesc(
+		"kube_daemonset_updated_number_scheduled",
+		"The total number of nodes that are running updated daemon pod",
 		[]string{"namespace", "daemonset"}, nil,
 	)
 	descDaemonSetMetadataGeneration = prometheus.NewDesc(
@@ -95,9 +110,12 @@ type daemonsetCollector struct {
 func (dc *daemonsetCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descDaemonSetCreated
 	ch <- descDaemonSetCurrentNumberScheduled
+	ch <- descDaemonSetNumberAvailable
 	ch <- descDaemonSetNumberMisscheduled
+	ch <- descDaemonSetNumberUnavailable
 	ch <- descDaemonSetDesiredNumberScheduled
 	ch <- descDaemonSetNumberReady
+	ch <- descDaemonSetUpdatedNumberScheduled
 	ch <- descDaemonSetMetadataGeneration
 }
 
@@ -124,8 +142,11 @@ func (dc *daemonsetCollector) collectDaemonSet(ch chan<- prometheus.Metric, d v1
 		addGauge(descDaemonSetCreated, float64(d.CreationTimestamp.Unix()))
 	}
 	addGauge(descDaemonSetCurrentNumberScheduled, float64(d.Status.CurrentNumberScheduled))
+	addGauge(descDaemonSetNumberAvailable, float64(d.Status.NumberAvailable))
+	addGauge(descDaemonSetNumberUnavailable, float64(d.Status.NumberUnavailable))
 	addGauge(descDaemonSetNumberMisscheduled, float64(d.Status.NumberMisscheduled))
 	addGauge(descDaemonSetDesiredNumberScheduled, float64(d.Status.DesiredNumberScheduled))
 	addGauge(descDaemonSetNumberReady, float64(d.Status.NumberReady))
+	addGauge(descDaemonSetUpdatedNumberScheduled, float64(d.Status.UpdatedNumberScheduled))
 	addGauge(descDaemonSetMetadataGeneration, float64(d.ObjectMeta.Generation))
 }

--- a/collectors/daemonset_test.go
+++ b/collectors/daemonset_test.go
@@ -38,7 +38,7 @@ func TestDaemonSetCollector(t *testing.T) {
 	const metadata = `
 		# HELP kube_daemonset_created Unix creation timestamp
 		# TYPE kube_daemonset_created gauge
-	  # HELP kube_daemonset_metadata_generation Sequence number representing a specific generation of the desired state.
+		# HELP kube_daemonset_metadata_generation Sequence number representing a specific generation of the desired state.
 		# TYPE kube_daemonset_metadata_generation gauge
 		# HELP kube_daemonset_status_current_number_scheduled The number of nodes running at least one daemon pod and are supposed to.
 		# TYPE kube_daemonset_status_current_number_scheduled gauge
@@ -46,8 +46,14 @@ func TestDaemonSetCollector(t *testing.T) {
 		# TYPE kube_daemonset_status_number_misscheduled gauge
 		# HELP kube_daemonset_status_desired_number_scheduled The number of nodes that should be running the daemon pod.
 		# TYPE kube_daemonset_status_desired_number_scheduled gauge
+		# HELP kube_daemonset_status_number_available The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available
+		# TYPE kube_daemonset_status_number_available gauge
 		# HELP kube_daemonset_status_number_ready The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
 		# TYPE kube_daemonset_status_number_ready gauge
+		# HELP kube_daemonset_status_number_unavailable The number of nodes that should be running the daemon pod and have none of the daemon pod running and available
+		# TYPE kube_daemonset_status_number_unavailable gauge
+		# HELP kube_daemonset_updated_number_scheduled The total number of nodes that are running updated daemon pod
+		# TYPE kube_daemonset_updated_number_scheduled gauge
 	`
 	cases := []struct {
 		dss  []v1beta1.DaemonSet
@@ -80,20 +86,51 @@ func TestDaemonSetCollector(t *testing.T) {
 						DesiredNumberScheduled: 0,
 						NumberReady:            0,
 					},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ds3",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "ns3",
+						Generation:        15,
+					},
+					Status: v1beta1.DaemonSetStatus{
+						CurrentNumberScheduled: 10,
+						NumberMisscheduled:     5,
+						DesiredNumberScheduled: 15,
+						NumberReady:            5,
+						NumberAvailable:        5,
+						NumberUnavailable:      5,
+						UpdatedNumberScheduled: 5,
+					},
 				},
 			},
 			want: metadata + `
 				kube_daemonset_created{daemonset="ds2",namespace="ns2"} 1.5e+09
+				kube_daemonset_created{daemonset="ds3",namespace="ns3"} 1.5e+09
 				kube_daemonset_metadata_generation{namespace="ns1",daemonset="ds1"} 21
 				kube_daemonset_metadata_generation{namespace="ns2",daemonset="ds2"} 14
+				kube_daemonset_metadata_generation{namespace="ns3",daemonset="ds3"} 15
 				kube_daemonset_status_current_number_scheduled{namespace="ns1",daemonset="ds1"} 15
 				kube_daemonset_status_current_number_scheduled{namespace="ns2",daemonset="ds2"} 10
-				kube_daemonset_status_number_misscheduled{namespace="ns1",daemonset="ds1"} 10
-				kube_daemonset_status_number_misscheduled{namespace="ns2",daemonset="ds2"} 5
+				kube_daemonset_status_current_number_scheduled{namespace="ns3",daemonset="ds3"} 10
 				kube_daemonset_status_desired_number_scheduled{namespace="ns1",daemonset="ds1"} 5
 				kube_daemonset_status_desired_number_scheduled{namespace="ns2",daemonset="ds2"} 0
+				kube_daemonset_status_desired_number_scheduled{namespace="ns3",daemonset="ds3"} 15
+				kube_daemonset_status_number_available{daemonset="ds1",namespace="ns1"} 0
+				kube_daemonset_status_number_available{daemonset="ds2",namespace="ns2"} 0
+				kube_daemonset_status_number_available{daemonset="ds3",namespace="ns3"} 5
+				kube_daemonset_status_number_misscheduled{namespace="ns1",daemonset="ds1"} 10
+				kube_daemonset_status_number_misscheduled{namespace="ns2",daemonset="ds2"} 5
+				kube_daemonset_status_number_misscheduled{namespace="ns3",daemonset="ds3"} 5
 				kube_daemonset_status_number_ready{namespace="ns1",daemonset="ds1"} 5
 				kube_daemonset_status_number_ready{namespace="ns2",daemonset="ds2"} 0
+				kube_daemonset_status_number_ready{namespace="ns3",daemonset="ds3"} 5
+				kube_daemonset_status_number_unavailable{daemonset="ds1",namespace="ns1"} 0
+				kube_daemonset_status_number_unavailable{daemonset="ds2",namespace="ns2"} 0
+				kube_daemonset_status_number_unavailable{daemonset="ds3",namespace="ns3"} 5
+				kube_daemonset_updated_number_scheduled{daemonset="ds1",namespace="ns1"} 0
+				kube_daemonset_updated_number_scheduled{daemonset="ds2",namespace="ns2"} 0
+				kube_daemonset_updated_number_scheduled{daemonset="ds3",namespace="ns3"} 5
 			`,
 		},
 	}


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/298)
<!-- Reviewable:end -->
kube_daemonset_status_number_available(unavailable)  which different with kube_daemonset_status_number_ready
1. kube_daemonset_status_number_available 
> (available info about ds)The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and **available**
2. kube_daemonset_status_number_unavailable
> (unavailable info about ds)The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available
3. kube_daemonset_updated_number_scheduled
> nodes that are running **updated daemon pod**
/cc @brancz 