### PR TITLE
add ksm version command line argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 FLAGS =
 BUILDENVVAR = CGO_ENABLED=0
-TESTENVVAR = 
+TESTENVVAR =
 REGISTRY = quay.io/coreos
 TAG = $(shell git describe --abbrev=0)
 PKGS = $(shell go list ./... | grep -v /vendor/)
 ARCH ?= $(shell go env GOARCH)
+BuildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+Commit = $(shell git rev-parse --short HEAD)
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
-
+PKG=k8s.io/kube-state-metrics
 
 IMAGE = $(REGISTRY)/kube-state-metrics
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
 gofmtcheck:
-	@go fmt $(PKGS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi     
+	@go fmt $(PKGS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
 
 doccheck:
 	@echo "- Checking if documentation is up to date..."
@@ -26,7 +28,8 @@ doccheck:
 	@echo OK
 
 build: clean
-	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(BUILDENVVAR) go build -o kube-state-metrics
+	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(BUILDENVVAR) go build -ldflags "-s -w -X ${PKG}/version.Release=${TAG} -X ${PKG}/version.Commit=${Commit} -X ${PKG}/version.BuildDate=${BuildDate}" \
+	-o kube-state-metrics
 
 test-unit: clean build
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(TESTENVVAR) go test --race $(FLAGS) $(PKGS)

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"sort"
 	"strings"
@@ -35,9 +36,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"net/http/pprof"
-
 	"k8s.io/kube-state-metrics/collectors"
+	"k8s.io/kube-state-metrics/version"
 )
 
 const (
@@ -145,6 +145,7 @@ func main() {
 	flags.IntVar(&options.port, "port", 80, `Port to expose metrics on.`)
 	flags.Var(&options.collectors, "collectors", fmt.Sprintf("Comma-separated list of collectors to be enabled. Defaults to %q", &defaultCollectors))
 	flags.StringVar(&options.namespace, "namespace", metav1.NamespaceAll, "namespace to be enabled for collecting resources")
+	versionFlag := flags.BoolP("version", "", false, "kube-state-metrics version information")
 
 	flags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
@@ -154,6 +155,11 @@ func main() {
 	err := flags.Parse(os.Args)
 	if err != nil {
 		glog.Fatalf("Error: %s", err)
+	}
+
+	if *versionFlag {
+		fmt.Printf("%#v", version.GetVersion())
+		os.Exit(0)
 	}
 
 	if options.help {
@@ -245,10 +251,12 @@ func createKubeClient(inCluster bool, apiserver string, kubeconfig string) (kube
 	// can't reach the server, making debugging hard. This makes it easier to
 	// figure out if apiserver is configured incorrectly.
 	glog.Infof("Testing communication with server")
-	_, err = kubeClient.Discovery().ServerVersion()
+	v, err := kubeClient.Discovery().ServerVersion()
 	if err != nil {
 		return nil, fmt.Errorf("ERROR communicating with apiserver: %v", err)
 	}
+	glog.Infof("Running with Kubernetes cluster version: v%s.%s. git version: %s. git tree state: %s. commit: %s. platform: %s",
+		v.Major, v.Minor, v.GitVersion, v.GitTreeState, v.GitCommit, v.Platform)
 	glog.Infof("Communication with server successful")
 
 	return kubeClient, nil

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	// Release returns the release version
+	Release = "UNKNOWN"
+	// Commit returns the short sha from git
+	Commit = "UNKNOWN"
+	// BuildDate is the build date
+	BuildDate = ""
+)
+
+type Version struct {
+	GitCommit string
+	BuildDate string
+	Release   string
+	GoVersion string
+	Compiler  string
+	Platform  string
+}
+
+// GetVersion returns kube-state-metrics version
+func GetVersion() Version {
+	return Version{
+		GitCommit: Commit,
+		BuildDate: BuildDate,
+		Release:   Release,
+		GoVersion: runtime.Version(),
+		Compiler:  runtime.Compiler,
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
add ksm buildinfo api and scrapy tagert info which log kubernetes cluster version
/cc @andyxning  @brancz 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/301)
<!-- Reviewable:end -->
