### PR TITLE
Allow setting host/ip to bind HTTP server to

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,10 +20,12 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -130,6 +132,7 @@ type options struct {
 	kubeconfig string
 	help       bool
 	port       int
+	host       string
 	collectors collectorSet
 	namespace  string
 	version    bool
@@ -148,6 +151,7 @@ func main() {
 	flags.StringVar(&options.kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file")
 	flags.BoolVarP(&options.help, "help", "h", false, "Print help text")
 	flags.IntVar(&options.port, "port", 80, `Port to expose metrics on.`)
+	flags.StringVar(&options.host, "host", "0.0.0.0", `Host to expose metrics on.`)
 	flags.Var(&options.collectors, "collectors", fmt.Sprintf("Comma-separated list of collectors to be enabled. Defaults to %q", &defaultCollectors))
 	flags.StringVar(&options.namespace, "namespace", metav1.NamespaceAll, "namespace to be enabled for collecting resources")
 	flags.BoolVarP(&options.version, "version", "", false, "kube-state-metrics build version information")
@@ -202,7 +206,7 @@ func main() {
 
 	registry := prometheus.NewRegistry()
 	registerCollectors(registry, kubeClient, collectors, options.namespace)
-	metricsServer(registry, options.port)
+	metricsServer(registry, options.host, options.port)
 }
 
 func isNotExists(file string) bool {
@@ -267,9 +271,9 @@ func createKubeClient(inCluster bool, apiserver string, kubeconfig string) (kube
 	return kubeClient, nil
 }
 
-func metricsServer(registry prometheus.Gatherer, port int) {
+func metricsServer(registry prometheus.Gatherer, host string, port int) {
 	// Address to listen on for web interface and telemetry
-	listenAddress := fmt.Sprintf(":%d", port)
+	listenAddress := net.JoinHostPort(host, strconv.Itoa(port))
 
 	glog.Infof("Starting metrics server: %s", listenAddress)
 


### PR DESCRIPTION
If one wants to use a proxy to be the only path to the metrics endpoint that kube-state-metrics exposes, we need to be able to allow binding to a specific interface rather than all (which is what we are currently doing). When the `--host` flag is not set, the previous behavior is continued, meaning this is not a breaking change.

@andyxning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/318)
<!-- Reviewable:end -->
