### PR TITLE
Pluralized 'Endpoint' in collector output name

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ var (
 		"persistentvolumeclaims":   struct{}{},
 		"namespaces":               struct{}{},
 		"horizontalpodautoscalers": struct{}{},
-		"endpoint":                 struct{}{},
+		"endpoints":                struct{}{},
 	}
 	availableCollectors = map[string]func(registry prometheus.Registerer, kubeClient clientset.Interface, namespace string){
 		"componentstatuses":        collectors.RegisterComponentStatusCollector,
@@ -86,7 +86,7 @@ var (
 		"persistentvolumeclaims":   collectors.RegisterPersistentVolumeClaimCollector,
 		"namespaces":               collectors.RegisterNamespaceCollector,
 		"horizontalpodautoscalers": collectors.RegisterHorizontalPodAutoScalerCollector,
-		"endpoint":                 collectors.RegisterEndpointCollector,
+		"endpoints":                collectors.RegisterEndpointCollector,
 	}
 )
 


### PR DESCRIPTION
Convention name for collectors referenced in configuration seems to be that they should be pluralized:
`I1221 11:02:43.323740       1 main.go:325] Active collectors: jobs,cronjobs,namespaces,endpoint,daemonsets,services,replicasets,replicationcontrollers,statefulsets,persistentvolumeclaims,componentstatuses,nodes,horizontalpodautoscalers,pods,resourcequotas,persistentvolumes,deployments,limitranges`

I didn't realize that I added 'endpoint' in singular, so this PR addresses that in the 2 areas where it is referenced, changing the word to 'endpoints' to match convention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/323)
<!-- Reviewable:end -->
