### PR TITLE
Update README to include note for GKE users

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ Kubernetes service and deployment will be created. The service already has a
 Prometheus service-endpoint scraping [configuration](https://raw.githubusercontent.com/prometheus/prometheus/master/documentation/examples/prometheus-kubernetes.yml), Prometheus will pick it up automatically and you can start using the generated
 metrics right away.
 
+**Note:** Google Kubernetes Engine (GKE) Users - GKE has strict role permissions that will prevent the kube-state-metrics roles and role bindings from being created. To work around this, you can give your GCP identity the cluster-admin role by running the following one-liner:
+
+```
+kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=$(gcloud info | grep Account | cut -d '[' -f 2 | cut -d ']' -f 1)
+```
+
+After running the above, if you see `Clusterrolebinding "cluster-admin-binding" created`, then you are able to continue with the setup of this service.
+
 #### Development
 
 When developing, test a metric dump against your local Kubernetes cluster by


### PR DESCRIPTION
Include a note in the README for GKE users based on a reference provided by @brancz 

Reference: https://github.com/kubernetes/kube-state-metrics/issues/270#issuecomment-335759009

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/326)
<!-- Reviewable:end -->
