### PR TITLE
kubernetes: Add correct componentstatuses to ClusterRole

### DIFF
--- a/kubernetes/kube-state-metrics-cluster-role.yaml
+++ b/kubernetes/kube-state-metrics-cluster-role.yaml
@@ -14,6 +14,7 @@ rules:
   - persistentvolumeclaims
   - namespaces
   - endpoints
+  - componentstatuses
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:


### PR DESCRIPTION
I believe this is all that needs to be fixed in regards to the errors previously printed.

@andyxning @zouyee

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/333)
<!-- Reviewable:end -->
