### PR TITLE
kubernetes: Add missing RBAC roles

### DIFF
--- a/kubernetes/kube-state-metrics-cluster-role.yaml
+++ b/kubernetes/kube-state-metrics-cluster-role.yaml
@@ -12,6 +12,7 @@ rules:
   - replicationcontrollers
   - limitranges
   - persistentvolumeclaims
+  - persistentvolumes
   - namespaces
   - endpoints
   verbs: ["list", "watch"]
@@ -29,4 +30,8 @@ rules:
   resources:
   - cronjobs
   - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
   verbs: ["list", "watch"]


### PR DESCRIPTION
While doing some testing for the next release, I found out that we're missing some RBAC roles in the example.

@andyxning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/334)
<!-- Reviewable:end -->
