### PR TITLE
Cut 1.2.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v1.2.0-rc.0 / 2018-01-05
+
+* [CHANGE] The CronJob collector now expects the version to be v1beta1.
+* [FEATURE] Add `Endpoints` metrics collector.
+* [FEATURE] Add `PersistentVolume` metrics collector.
+* [FEATURE] Add `HorizontalPodAutoscaler` metrics collector.
+* [FEATURE] Add `kube_pod_container_status_terminated_reason` metric.
+* [FEATURE] Add `kube_job_labels` metric.
+* [FEATURE] Add `kube_cronjob_labels` metric.
+* [FEATURE] Add `kube_service_spec_type` metric.
+* [FEATURE] Add `kube_statefulset_status_replicas_current` metric.
+* [FEATURE] Add `kube_statefulset_status_replicas_ready` metric.
+* [FEATURE] Add `kube_statefulset_status_replicas_updated` metric.
+* [ENHANCEMENT] Allow specifying the host/IP kube-state-metrics binds to.
+* [ENHANCEMENT] Add `volumename` label to `kube_persistentvolumeclaim_info` metric.
+* [ENHANCEMENT] Add `cluster_ip` label to `kube_service_info` metric.
+* [ENHANCEMENT] Print version on startup and useful debug information at runtime.
+* [ENHANCEMENT] Add metrics for kube-state-metrics itself. For separation purposes this listens on a separate host/IP and port, both configurable respectively.
+
 ## v1.1.0 / 2017-10-19
 
 After a testing period of one week, there were no additional bugs found or features introduced.

--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ Currently, `client-go` is in version `release-5.0`.
 #### Compatibility matrix
 At most 5 kube-state-metrics releases will be recorded below.
 
-| kube-state-metrics | client-go | **Kubernetes 1.4**  | **Kubernetes 1.5** | **Kubernetes 1.6** | **Kubernetes 1.7** | **Kubernetes 1.8** |
-|--------------------|-----------|---------------------|--------------------|--------------------|--------------------|--------------------|
-| **v0.4.0** |  v2.0.0-alpha.1   |          ✓          |         ✓          |        -           |         -          |         -          |
-| **v0.5.0** |  v2.0.0-alpha.1   |          ✓          |         ✓          |        -           |         -          |         -          |
-| **v1.0.x** |  4.0.0-beta.0     |          ✓          |         ✓          |        ✓           |         ✓          |         -          |
-| **v1.1.0** |  release-5.0      |          ✓          |         ✓          |        ✓           |         ✓          |         ✓          |
-| **master** |  v5.0.0      |          ✓          |         ✓          |        ✓           |         ✓          |         ✓          |
+| kube-state-metrics | client-go | **Kubernetes 1.4**  | **Kubernetes 1.5** | **Kubernetes 1.6** | **Kubernetes 1.7** | **Kubernetes 1.8** | **Kubernetes 1.9** |
+|--------------------|-----------|---------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
+| **v0.4.0** |  v2.0.0-alpha.1   |          ✓          |         ✓          |        -           |         -          |         -          |         -          |
+| **v0.5.0** |  v2.0.0-alpha.1   |          ✓          |         ✓          |        -           |         -          |         -          |         -          |
+| **v1.0.x** |  4.0.0-beta.0     |          ✓          |         ✓          |        ✓           |         ✓          |         -          |         -          |
+| **v1.1.0** |  release-5.0      |          ✓          |         ✓          |        ✓           |         ✓          |         ✓          |         -          |
+| **v1.2.0** |  v6.0.0           |          ✓          |         ✓          |        ✓           |         ✓          |         ✓          |         ✓          |
+| **master** |  v6.0.0           |          ✓          |         ✓          |        ✓           |         ✓          |         ✓          |         ✓          |
 - `✓` Fully supported version range.
 - `-` The Kubernetes cluster has features the client-go library can't use (additional API objects, etc).
 


### PR DESCRIPTION
Happy new year :tada: ! We have gathered *a lot* of features and due to the recent Kubernetes 1.9 release, we should also release to ensure compatibility. Assuming everything goes well, we will be aiming for Monday the 15th of January for the stable 1.2.0 release.

@andyxning @zouyee @fabxc 

@piosz @loburm when merged I'd be great if one of you can push the release image to k8s.gcr.io.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/335)
<!-- Reviewable:end -->
