### PR TITLE
Cut 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.2.0 / 2018-01-15
+
+After a testing period of 10 days, there were no additional bugs found or features introduced.
+
 ## v1.2.0-rc.0 / 2018-01-05
 
 * [CHANGE] The CronJob collector now expects the version to be v1beta1.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ release.
 #### Container Image
 
 The latest container image can be found at:
-* `quay.io/coreos/kube-state-metrics:v1.2.0-rc.0`
-* `k8s.gcr.io/kube-state-metrics:v1.2.0-rc.0`
+* `quay.io/coreos/kube-state-metrics:v1.2.0`
+* `k8s.gcr.io/kube-state-metrics:v1.2.0`
 
 **Note**:
 The recommended docker registry for kube-state-metrics is `quay.io`. kube-state-metrics on

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.2.0-rc.0
+        image: quay.io/coreos/kube-state-metrics:v1.2.0
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION
After a testing period of 10 days, there were no additional bugs found or features introduced. So we're cutting the final 1.2.0 release.

@andyxning @zouyee 

@piosz @loburm stay tuned to push the container images to k8s.gcr.io.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/345)
<!-- Reviewable:end -->
