### PR TITLE
enable log in the prom http handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -291,7 +291,8 @@ func telemetryServer(registry prometheus.Gatherer, host string, port int) {
 	mux := http.NewServeMux()
 
 	// Add metricsPath
-	mux.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	logger := log.New(os.Stderr, "Prometheus HTTP logger: ", log.Lshortfile)
+	mux.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorLog: logger}))
 	// Add index
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
@@ -322,7 +323,8 @@ func metricsServer(registry prometheus.Gatherer, host string, port int) {
 	mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 
 	// Add metricsPath
-	mux.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	logger := log.New(os.Stderr, "Prometheus HTTP logger: ", log.Lshortfile)
+	mux.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorLog: logger}))
 	// Add healthzPath
 	mux.HandleFunc(healthzPath, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)

--- a/main.go
+++ b/main.go
@@ -88,6 +88,13 @@ var (
 	}
 )
 
+// promLogger implements promhttp.Logger
+type promLogger struct{}
+
+func (pl promLogger) Println(v ...interface{}) {
+	glog.Error(v)
+}
+
 type collectorSet map[string]struct{}
 
 func (c *collectorSet) String() string {
@@ -291,8 +298,7 @@ func telemetryServer(registry prometheus.Gatherer, host string, port int) {
 	mux := http.NewServeMux()
 
 	// Add metricsPath
-	logger := log.New(os.Stderr, "Prometheus HTTP logger: ", log.Lshortfile)
-	mux.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorLog: logger}))
+	mux.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorLog: promLogger{}}))
 	// Add index
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
@@ -323,8 +329,7 @@ func metricsServer(registry prometheus.Gatherer, host string, port int) {
 	mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 
 	// Add metricsPath
-	logger := log.New(os.Stderr, "Prometheus HTTP logger: ", log.Lshortfile)
-	mux.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorLog: logger}))
+	mux.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorLog: promLogger{}}))
 	// Add healthzPath
 	mux.HandleFunc(healthzPath, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)


### PR DESCRIPTION
This is related to #350.

I'm happy to make this more configurable, if desired. However I think passing some log handler to prometheus is better than ignoring its logs entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/351)
<!-- Reviewable:end -->
