### PR TITLE
increase log verbosity

### DIFF
--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -138,7 +138,7 @@ func (cjc *cronJobCollector) Collect(ch chan<- prometheus.Metric) {
 		cjc.collectCronJob(ch, cj)
 	}
 
-	glog.Infof("collected %d cronjobs", len(cronjobs))
+	glog.V(4).Infof("collected %d cronjobs", len(cronjobs))
 }
 
 func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, createdTime metav1.Time) (time.Time, error) {

--- a/collectors/daemonset.go
+++ b/collectors/daemonset.go
@@ -133,7 +133,7 @@ func (dc *daemonsetCollector) Collect(ch chan<- prometheus.Metric) {
 		dc.collectDaemonSet(ch, d)
 	}
 
-	glog.Infof("collected %d daemonsets", len(dss))
+	glog.V(4).Infof("collected %d daemonsets", len(dss))
 }
 
 func (dc *daemonsetCollector) collectDaemonSet(ch chan<- prometheus.Metric, d v1beta1.DaemonSet) {

--- a/collectors/deployment.go
+++ b/collectors/deployment.go
@@ -157,7 +157,7 @@ func (dc *deploymentCollector) Collect(ch chan<- prometheus.Metric) {
 		dc.collectDeployment(ch, d)
 	}
 
-	glog.Infof("collected %d deployments", len(ds))
+	glog.V(4).Infof("collected %d deployments", len(ds))
 }
 
 func deploymentLabelsDesc(labelKeys []string) *prometheus.Desc {

--- a/collectors/endpoint.go
+++ b/collectors/endpoint.go
@@ -117,7 +117,7 @@ func (ec *endpointCollector) Collect(ch chan<- prometheus.Metric) {
 		ec.collectEndpoints(ch, e)
 	}
 
-	glog.Infof("collected %d endpoints", len(endpoints))
+	glog.V(4).Infof("collected %d endpoints", len(endpoints))
 }
 
 func (ec *endpointCollector) collectEndpoints(ch chan<- prometheus.Metric, e v1.Endpoints) {

--- a/collectors/hpa.go
+++ b/collectors/hpa.go
@@ -120,6 +120,8 @@ func (hc *hpaCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, h := range hpas.Items {
 		hc.collectHPA(ch, h)
 	}
+
+	glog.V(4).Infof("collected %d jobs", len(hpas.Items))
 }
 
 func hpaLabelsDesc(labelKeys []string) *prometheus.Desc {

--- a/collectors/job.go
+++ b/collectors/job.go
@@ -162,7 +162,7 @@ func (jc *jobCollector) Collect(ch chan<- prometheus.Metric) {
 		jc.collectJob(ch, j)
 	}
 
-	glog.Infof("collected %d jobs", len(jobs))
+	glog.V(4).Infof("collected %d jobs", len(jobs))
 }
 
 func jobLabelsDesc(labelKeys []string) *prometheus.Desc {

--- a/collectors/limitrange.go
+++ b/collectors/limitrange.go
@@ -98,7 +98,7 @@ func (lrc *limitRangeCollector) Collect(ch chan<- prometheus.Metric) {
 		lrc.collectLimitRange(ch, rq)
 	}
 
-	glog.Infof("collected %d limitranges", len(limitRangeCollector.Items))
+	glog.V(4).Infof("collected %d limitranges", len(limitRangeCollector.Items))
 }
 
 func (lrc *limitRangeCollector) collectLimitRange(ch chan<- prometheus.Metric, rq v1.LimitRange) {

--- a/collectors/namespace.go
+++ b/collectors/namespace.go
@@ -110,7 +110,7 @@ func (nsc *namespaceCollector) Collect(ch chan<- prometheus.Metric) {
 		nsc.collectNamespace(ch, rq)
 	}
 
-	glog.Infof("collected %d namespaces", len(nsls))
+	glog.V(4).Infof("collected %d namespaces", len(nsls))
 }
 
 func (nsc *namespaceCollector) collectNamespace(ch chan<- prometheus.Metric, ns v1.Namespace) {

--- a/collectors/node.go
+++ b/collectors/node.go
@@ -183,7 +183,7 @@ func (nc *nodeCollector) Collect(ch chan<- prometheus.Metric) {
 		nc.collectNode(ch, n)
 	}
 
-	glog.Infof("collected %d nodes", len(nodes.Items))
+	glog.V(4).Infof("collected %d nodes", len(nodes.Items))
 }
 
 func nodeLabelsDesc(labelKeys []string) *prometheus.Desc {

--- a/collectors/persistentvolume.go
+++ b/collectors/persistentvolume.go
@@ -96,7 +96,7 @@ func (collector *persistentVolumeCollector) Collect(ch chan<- prometheus.Metric)
 		collector.collectPersistentVolume(ch, pv)
 	}
 
-	glog.Infof("collected %d persistentvolumes", len(persistentVolumeCollector.Items))
+	glog.V(4).Infof("collected %d persistentvolumes", len(persistentVolumeCollector.Items))
 }
 
 func (collector *persistentVolumeCollector) collectPersistentVolume(ch chan<- prometheus.Metric, pv v1.PersistentVolume) {

--- a/collectors/persistentvolumeclaim.go
+++ b/collectors/persistentvolumeclaim.go
@@ -109,7 +109,7 @@ func (collector *persistentVolumeClaimCollector) Collect(ch chan<- prometheus.Me
 		collector.collectPersistentVolumeClaim(ch, pvc)
 	}
 
-	glog.Infof("collected %d persistentvolumeclaims", len(persistentVolumeClaimCollector.Items))
+	glog.V(4).Infof("collected %d persistentvolumeclaims", len(persistentVolumeClaimCollector.Items))
 }
 
 // getPersistentVolumeClaimClass returns StorageClassName. If no storage class was

--- a/collectors/pod.go
+++ b/collectors/pod.go
@@ -243,7 +243,7 @@ func (pc *podCollector) Collect(ch chan<- prometheus.Metric) {
 		pc.collectPod(ch, p)
 	}
 
-	glog.Infof("collected %d pods", len(pods))
+	glog.V(4).Infof("collected %d pods", len(pods))
 }
 
 func kubeLabelsToPrometheusLabels(labels map[string]string) ([]string, []string) {

--- a/collectors/replicaset.go
+++ b/collectors/replicaset.go
@@ -121,7 +121,7 @@ func (dc *replicasetCollector) Collect(ch chan<- prometheus.Metric) {
 		dc.collectReplicaSet(ch, d)
 	}
 
-	glog.Infof("collected %d replicasets", len(rss))
+	glog.V(4).Infof("collected %d replicasets", len(rss))
 }
 
 func (dc *replicasetCollector) collectReplicaSet(ch chan<- prometheus.Metric, d v1beta1.ReplicaSet) {

--- a/collectors/replicationcontroller.go
+++ b/collectors/replicationcontroller.go
@@ -127,7 +127,7 @@ func (dc *replicationcontrollerCollector) Collect(ch chan<- prometheus.Metric) {
 		dc.collectReplicationController(ch, d)
 	}
 
-	glog.Infof("collected %d replicationcontrollers", len(rcs))
+	glog.V(4).Infof("collected %d replicationcontrollers", len(rcs))
 }
 
 func (dc *replicationcontrollerCollector) collectReplicationController(ch chan<- prometheus.Metric, d v1.ReplicationController) {

--- a/collectors/resourcequota.go
+++ b/collectors/resourcequota.go
@@ -96,7 +96,7 @@ func (rqc *resourceQuotaCollector) Collect(ch chan<- prometheus.Metric) {
 		rqc.collectResourceQuota(ch, rq)
 	}
 
-	glog.Infof("collected %d resourcequotas", len(resourceQuota.Items))
+	glog.V(4).Infof("collected %d resourcequotas", len(resourceQuota.Items))
 }
 
 func (rqc *resourceQuotaCollector) collectResourceQuota(ch chan<- prometheus.Metric, rq v1.ResourceQuota) {

--- a/collectors/service.go
+++ b/collectors/service.go
@@ -109,7 +109,7 @@ func (sc *serviceCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, s := range services {
 		sc.collectService(ch, s)
 	}
-	glog.Infof("collected %d services", len(services))
+	glog.V(4).Infof("collected %d services", len(services))
 }
 
 func serviceLabelsDesc(labelKeys []string) *prometheus.Desc {

--- a/collectors/statefulset.go
+++ b/collectors/statefulset.go
@@ -144,7 +144,7 @@ func (sc *statefulSetCollector) Collect(ch chan<- prometheus.Metric) {
 		sc.collectStatefulSet(ch, d)
 	}
 
-	glog.Infof("collected %d statefulsets", len(sss))
+	glog.V(4).Infof("collected %d statefulsets", len(sss))
 }
 
 func statefulSetLabelsDesc(labelKeys []string) *prometheus.Desc {


### PR DESCRIPTION
Increase log verbosity to `V(4)` to decrease useless log in kube-state-metrics common use. This has been discussed in slack sig-instrumentation.

/cc @brancz @DirectXMan12

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/354)
<!-- Reviewable:end -->
