### PR TITLE
fix container binary GOOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ all-push: $(addprefix sub-push-,$(ALL_ARCH))
 container: .container-$(ARCH)
 .container-$(ARCH):
 	cp -r * $(TEMP_DIR)
-	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(BUILDENVVAR) go build -o $(TEMP_DIR)/kube-state-metrics
+	GOOS=linux GOARCH=$(ARCH) $(BUILDENVVAR) go build -o $(TEMP_DIR)/kube-state-metrics
 	docker build -t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)
 
 ifeq ($(ARCH), amd64)


### PR DESCRIPTION
Fix #352 

This PR will make the `GOOS` for container and push target to `linux`.

/cc @brancz  @r0fls

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/355)
<!-- Reviewable:end -->
