### PR TITLE
Corrected misnamed type in log

### DIFF
--- a/collectors/hpa.go
+++ b/collectors/hpa.go
@@ -121,7 +121,7 @@ func (hc *hpaCollector) Collect(ch chan<- prometheus.Metric) {
 		hc.collectHPA(ch, h)
 	}
 
-	glog.V(4).Infof("collected %d jobs", len(hpas.Items))
+	glog.V(4).Infof("collected %d hpas", len(hpas.Items))
 }
 
 func hpaLabelsDesc(labelKeys []string) *prometheus.Desc {


### PR DESCRIPTION
hpa logging for collector misnamed 'jobs'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/361)
<!-- Reviewable:end -->
