### PR TITLE
update go version to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 
 go:
-- 1.8
+- "1.10"
 
 install:
 - mkdir -p $HOME/gopath/src/k8s.io


### PR DESCRIPTION
This PR will update Golang version to 1.9 as 1.10 has been released. We should use the newer golang version. :)

/cc @brancz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kube-state-metrics/380)
<!-- Reviewable:end -->
