### PR TITLE
Add _labels for pv and pvc.

### DIFF
--- a/Documentation/persistentvolume-metrics.md
+++ b/Documentation/persistentvolume-metrics.md
@@ -3,5 +3,6 @@
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
 | kube_persistentvolume_status_phase | Gauge | `persistentvolume`=&lt;pv-name&gt; <br> `namespace`=&lt;pv-namespace&gt; <br>`phase`=&lt;Bound\|Failed\|Pending\|Available\|Released&gt;|
+| kube_persistentvolume_labels | Gauge | `persistentvolume`=&lt;persistentvolume-name&gt; <br> `namespace`=&lt;persistentvolume-namespace&gt; <br> `label_PERSISTENTVOLUME_LABEL`=&lt;PERSISTENTVOLUME_LABEL&gt;  |
 | kube_persistentvolume_info | Gauge | `persistentvolume`=&lt;pv-name&gt; <br> `namespace`=&lt;pv-namespace&gt;<br> `storageclass`=&lt;storageclass-name&gt; |
 

--- a/Documentation/persistentvolumeclaim-metrics.md
+++ b/Documentation/persistentvolumeclaim-metrics.md
@@ -3,6 +3,7 @@
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
 | kube_persistentvolumeclaim_info | Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt;<br>`volumename`=&lt;volumename&gt; |
+| kube_persistentvolumeclaim_labels | Gauge | `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `label_PERSISTENTVOLUMECLAIM_LABEL`=&lt;PERSISTENTVOLUMECLAIM_LABEL&gt;  |
 | kube_persistentvolumeclaim_status_phase | Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `phase`=&lt;Pending\|Bound\|Lost&gt; |
 | kube_persistentvolumeclaim_resource_requests_storage_bytes | Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; |
 

--- a/collectors/persistentvolumeclaim_test.go
+++ b/collectors/persistentvolumeclaim_test.go
@@ -38,6 +38,8 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 	const metadata = `
 		# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
 		# TYPE kube_persistentvolumeclaim_info gauge
+		# HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
+		# TYPE kube_persistentvolumeclaim_labels gauge
 		# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
 		# TYPE kube_persistentvolumeclaim_status_phase gauge
 		# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
@@ -56,6 +58,9 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mysql-data",
 						Namespace: "default",
+						Labels: map[string]string{
+							"app": "mysql-server",
+						},
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
 						StorageClassName: &storageClassName,
@@ -106,8 +111,11 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Lost"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Pending"} 1
 				kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
+				kube_persistentvolumeclaim_labels{namespace="",persistentvolumeclaim="mongo-data"} 1
+				kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="prometheus-data"} 1
+				kube_persistentvolumeclaim_labels{label_app="mysql-server",namespace="default",persistentvolumeclaim="mysql-data"} 1
 			`,
-			metrics: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes"},
+			metrics: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels"},
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
This adds kube_persistentvolume_labels, and
kube_persistentvolumeclaim_lables. These are useful for associating the
pv and pvc with the app they were deployed for (via labels)