### PR TITLE
fix cronjob parse

### DIFF
--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -143,7 +143,7 @@ func (cjc *cronJobCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, createdTime metav1.Time) (time.Time, error) {
-	sched, err := cron.ParseStandard(schedule)
+	sched, err := cron.Parse(schedule)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("Failed to parse cron job schedule '%s': %s", schedule, err)
 	}

--- a/collectors/cronjob_test.go
+++ b/collectors/cronjob_test.go
@@ -87,7 +87,7 @@ func TestCronJobCollector(t *testing.T) {
 						StartingDeadlineSeconds: &StartingDeadlineSeconds300,
 						ConcurrencyPolicy:       "Forbid",
 						Suspend:                 &SuspendFalse,
-						Schedule:                "0 */6 * * *",
+						Schedule:                "0 */6 * * * *",
 					},
 				}, {
 					ObjectMeta: metav1.ObjectMeta{
@@ -106,7 +106,7 @@ func TestCronJobCollector(t *testing.T) {
 						StartingDeadlineSeconds: &StartingDeadlineSeconds300,
 						ConcurrencyPolicy:       "Forbid",
 						Suspend:                 &SuspendTrue,
-						Schedule:                "0 */3 * * *",
+						Schedule:                "0 */3 * * * *",
 					},
 				}, {
 					ObjectMeta: metav1.ObjectMeta{
@@ -126,23 +126,23 @@ func TestCronJobCollector(t *testing.T) {
 						StartingDeadlineSeconds: &StartingDeadlineSeconds300,
 						ConcurrencyPolicy:       "Forbid",
 						Suspend:                 &SuspendFalse,
-						Schedule:                "25 * * * *",
+						Schedule:                "25 * * * * *",
 					},
 				},
 			},
 			want: metadata + `
 				kube_cronjob_created{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 1.5000234e+09
 
-				kube_cronjob_info{concurrency_policy="Forbid",cronjob="ActiveRunningCronJob1",namespace="ns1",schedule="0 */6 * * *"} 1
-				kube_cronjob_info{concurrency_policy="Forbid",cronjob="SuspendedCronJob1",namespace="ns1",schedule="0 */3 * * *"} 1
-				kube_cronjob_info{concurrency_policy="Forbid",cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1",schedule="25 * * * *"} 1
+				kube_cronjob_info{concurrency_policy="Forbid",cronjob="ActiveRunningCronJob1",namespace="ns1",schedule="0 */6 * * * *"} 1
+				kube_cronjob_info{concurrency_policy="Forbid",cronjob="SuspendedCronJob1",namespace="ns1",schedule="0 */3 * * * *"} 1
+				kube_cronjob_info{concurrency_policy="Forbid",cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1",schedule="25 * * * * *"} 1
 
 				kube_cronjob_labels{cronjob="ActiveCronJob1NoLastScheduled",label_app="example-active-no-last-scheduled-1",namespace="ns1"} 1
 				kube_cronjob_labels{cronjob="ActiveRunningCronJob1",label_app="example-active-running-1",namespace="ns1"} 1
 				kube_cronjob_labels{cronjob="SuspendedCronJob1",label_app="example-suspended-1",namespace="ns1"} 1
 
-				kube_cronjob_next_schedule_time{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 1.5000243e+09
-				kube_cronjob_next_schedule_time{cronjob="ActiveRunningCronJob1",namespace="ns1"} 1.500012e+09
+				kube_cronjob_next_schedule_time{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 1.500023425e+09
+				kube_cronjob_next_schedule_time{cronjob="ActiveRunningCronJob1",namespace="ns1"} 1.50000012e+09
 
 				kube_cronjob_spec_starting_deadline_seconds{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 300
 				kube_cronjob_spec_starting_deadline_seconds{cronjob="ActiveRunningCronJob1",namespace="ns1"} 300


### PR DESCRIPTION
This PR will fix cronjob parse error.

As with [Kubernetes cronjob parse](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cronjob/utils.go#L92-L108), we should also use `cron.Parse` instead of `cron.ParseStandard`.

/cc @brancz 