### PR TITLE
[RFC] Allow to specify multiple namespace.

### DIFF
--- a/collectors/cronjob.go
+++ b/collectors/cronjob.go
@@ -28,8 +28,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/client-go/tools/cache"
 )
 
 var (
@@ -86,21 +84,23 @@ func (l CronJobLister) List() ([]batchv1beta1.CronJob, error) {
 	return l()
 }
 
-func RegisterCronJobCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
+func RegisterCronJobCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
 	client := kubeClient.BatchV1beta1().RESTClient()
 	glog.Infof("collect cronjob with %s", client.APIVersion())
-	cjlw := cache.NewListWatchFromClient(client, "cronjobs", namespace, fields.Everything())
-	cjinf := cache.NewSharedInformer(cjlw, &batchv1beta1.CronJob{}, resyncPeriod)
+
+	cjinfs := NewSharedInformerList(client, "cronjobs", namespaces, &batchv1beta1.CronJob{})
 
 	cronJobLister := CronJobLister(func() (cronjobs []batchv1beta1.CronJob, err error) {
-		for _, c := range cjinf.GetStore().List() {
-			cronjobs = append(cronjobs, *(c.(*batchv1beta1.CronJob)))
+		for _, cjinf := range *cjinfs {
+			for _, c := range cjinf.GetStore().List() {
+				cronjobs = append(cronjobs, *(c.(*batchv1beta1.CronJob)))
+			}
 		}
 		return cronjobs, nil
 	})
 
 	registry.MustRegister(&cronJobCollector{store: cronJobLister})
-	go cjinf.Run(context.Background().Done())
+	cjinfs.Run(context.Background().Done())
 }
 
 type cronJobStore interface {

--- a/collectors/daemonset.go
+++ b/collectors/daemonset.go
@@ -21,9 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 )
 
 var (
@@ -89,21 +87,23 @@ func (l DaemonSetLister) List() ([]v1beta1.DaemonSet, error) {
 	return l()
 }
 
-func RegisterDaemonSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
+func RegisterDaemonSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
 	glog.Infof("collect daemonset with %s", client.APIVersion())
-	dslw := cache.NewListWatchFromClient(client, "daemonsets", namespace, fields.Everything())
-	dsinf := cache.NewSharedInformer(dslw, &v1beta1.DaemonSet{}, resyncPeriod)
+
+	dsinfs := NewSharedInformerList(client, "daemonsets", namespaces, &v1beta1.DaemonSet{})
 
 	dsLister := DaemonSetLister(func() (daemonsets []v1beta1.DaemonSet, err error) {
-		for _, c := range dsinf.GetStore().List() {
-			daemonsets = append(daemonsets, *(c.(*v1beta1.DaemonSet)))
+		for _, dsinf := range *dsinfs {
+			for _, c := range dsinf.GetStore().List() {
+				daemonsets = append(daemonsets, *(c.(*v1beta1.DaemonSet)))
+			}
 		}
 		return daemonsets, nil
 	})
 
 	registry.MustRegister(&daemonsetCollector{store: dsLister})
-	go dsinf.Run(context.Background().Done())
+	dsinfs.Run(context.Background().Done())
 }
 
 type daemonsetStore interface {

--- a/collectors/replicaset.go
+++ b/collectors/replicaset.go
@@ -21,9 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 )
 
 var (
@@ -70,21 +68,23 @@ func (l ReplicaSetLister) List() ([]v1beta1.ReplicaSet, error) {
 	return l()
 }
 
-func RegisterReplicaSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespace string) {
+func RegisterReplicaSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
 	glog.Infof("collect replicaset with %s", client.APIVersion())
-	rslw := cache.NewListWatchFromClient(client, "replicasets", namespace, fields.Everything())
-	rsinf := cache.NewSharedInformer(rslw, &v1beta1.ReplicaSet{}, resyncPeriod)
+
+	rsinfs := NewSharedInformerList(client, "replicasets", namespaces, &v1beta1.ReplicaSet{})
 
 	replicaSetLister := ReplicaSetLister(func() (replicasets []v1beta1.ReplicaSet, err error) {
-		for _, c := range rsinf.GetStore().List() {
-			replicasets = append(replicasets, *(c.(*v1beta1.ReplicaSet)))
+		for _, rsinf := range *rsinfs {
+			for _, c := range rsinf.GetStore().List() {
+				replicasets = append(replicasets, *(c.(*v1beta1.ReplicaSet)))
+			}
 		}
 		return replicasets, nil
 	})
 
 	registry.MustRegister(&replicasetCollector{store: replicaSetLister})
-	go rsinf.Run(context.Background().Done())
+	rsinfs.Run(context.Background().Done())
 }
 
 type replicasetStore interface {

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func (n *namespaceList) Set(value string) error {
 }
 
 func (n *namespaceList) Type() string {
-	return "string"
+	return "namespaceList"
 }
 
 type options struct {


### PR DESCRIPTION
**I am no golang professional so I welcome any feedback or improvement tips. Also I am not very familiar with kubernetes golang library so maybe I am trying to solve it too naively. Please tell me.**

### What problem is it trying to solve
See #368 for rationale.

### What is this feature?
Allow to pass value of `--namespace` as a list to allow to monitor multiple namespaces. E. g.
```
$ ./kube-state-metrics # all namespaces
$ ./kube-state-metrics --namespace=kube-system # single namespace
$ ./kube-state-metrics --namespace=kube-system,default,ingress-nginx # multiple namespaces
```

### Is it backwards compatible?
Yes
