### PR TITLE
collectors: Report pod's completion time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+
+* [FEATURE] Add `kube_pod_completion_time` metric.
+
 ## v1.2.0 / 2018-01-15
 
 After a testing period of 10 days, there were no additional bugs found or features introduced.

--- a/Documentation/pod-metrics.md
+++ b/Documentation/pod-metrics.md
@@ -4,6 +4,7 @@
 | ---------- | ----------- | ----------- |
 | kube_pod_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `host_ip`=&lt;host-ip&gt; <br> `pod_ip`=&lt;pod-ip&gt; <br> `node`=&lt;node-name&gt;<br> `created_by_kind`=&lt;created_by_kind&gt;<br> `created_by_name`=&lt;created_by_name&gt;<br> |
 | kube_pod_start_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
+| kube_pod_completion_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 | kube_pod_owner | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  |
 | kube_pod_labels | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `label_POD_LABEL`=&lt;POD_LABEL&gt;  |
 | kube_pod_status_phase | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `phase`=&lt;Pending\|Running\|Succeeded\|Failed\|Unknown&gt; |

--- a/collectors/pod_test.go
+++ b/collectors/pod_test.go
@@ -66,6 +66,8 @@ func TestPodCollector(t *testing.T) {
 		# TYPE kube_pod_info gauge
 		# HELP kube_pod_start_time Start time in unix timestamp for a pod.
 		# TYPE kube_pod_start_time gauge
+		# HELP kube_pod_completion_time Completion time in unix timestamp for a pod.
+		# TYPE kube_pod_completion_time gauge
 		# HELP kube_pod_owner Information about the Pod's owner.
 		# TYPE kube_pod_owner gauge
 		# HELP kube_pod_status_phase The pods current phase.
@@ -429,6 +431,35 @@ func TestPodCollector(t *testing.T) {
 					Status: v1.PodStatus{
 						HostIP: "1.1.1.1",
 						PodIP:  "2.3.4.5",
+						ContainerStatuses: []v1.ContainerStatus{
+							v1.ContainerStatus{
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{
+										FinishedAt: metav1.Time{
+											Time: time.Unix(1501777018, 0),
+										},
+									},
+								},
+							},
+							v1.ContainerStatus{
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{
+										FinishedAt: metav1.Time{
+											Time: time.Unix(1501888018, 0),
+										},
+									},
+								},
+							},
+							v1.ContainerStatus{
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{
+										FinishedAt: metav1.Time{
+											Time: time.Unix(1501666018, 0),
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -437,10 +468,11 @@ func TestPodCollector(t *testing.T) {
 				kube_pod_info{created_by_kind="<none>",created_by_name="<none>",host_ip="1.1.1.1",namespace="ns1",pod="pod1",node="node1",pod_ip="1.2.3.4"} 1
 				kube_pod_info{created_by_kind="ReplicaSet",created_by_name="rs-name",host_ip="1.1.1.1",namespace="ns2",pod="pod2",node="node2",pod_ip="2.3.4.5"} 1
 				kube_pod_start_time{namespace="ns1",pod="pod1"} 1501569018
+				kube_pod_completion_time{namespace="ns2",pod="pod2"} 1501888018
 				kube_pod_owner{namespace="ns1",pod="pod1",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
 				kube_pod_owner{namespace="ns2",pod="pod2",owner_kind="ReplicaSet",owner_name="rs-name",owner_is_controller="true"} 1
 				`,
-			metrics: []string{"kube_pod_created", "kube_pod_info", "kube_pod_start_time", "kube_pod_owner"},
+			metrics: []string{"kube_pod_created", "kube_pod_info", "kube_pod_start_time", "kube_pod_completion_time", "kube_pod_owner"},
 		}, {
 			pods: []v1.Pod{
 				{


### PR DESCRIPTION
This metric alongside `pod_start_time` can help determine total Pod's lifetime. Useful for example to get average duration it takes Openshift's BuildConfigs to build images.

The `pod_completion_time` calculation logic is based [this piece of code](https://github.com/openshift/origin-web-console/blob/57086c97efd8e5983d250d3aef110f61e0a5eab0/app/scripts/filters/resources.js#L1102-L1116) in [origin-web-console](https://github.com/openshift/origin-web-console)