### PR TITLE
Add Unreleased section in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+## Unreleased
 
 * [FEATURE] Add `kube_pod_completion_time` metric.
 


### PR DESCRIPTION
As per https://keepachangelog.com/en/1.0.0/#effort and the [discussion here](https://github.com/kubernetes/kube-state-metrics/pull/396#discussion_r174003166)