### PR TITLE
Add permissions to list and watch ConfigMaps and Secrets

### DIFF
--- a/kubernetes/kube-state-metrics-cluster-role.yaml
+++ b/kubernetes/kube-state-metrics-cluster-role.yaml
@@ -6,6 +6,8 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
+  - configmaps
+  - secrets
   - nodes
   - pods
   - services


### PR DESCRIPTION
Required since https://github.com/kubernetes/kube-state-metrics/pull/379

Without that, the following errors are triggered:

```
E  k8s.io/kube-state-metrics/collectors/collectors.go:62: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list secrets at the cluster scope: Unknown user "system:serviceaccount:monitoring:kube-state-metrics" 
E  k8s.io/kube-state-metrics/collectors/collectors.go:62: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list configmaps at the cluster scope: Unknown user "system:serviceaccount:monitoring:kube-state-metrics" 
```

Note: here, kube-state-metrics is deployed in a custom `monitoring` namespace.