### PR TITLE
Extend e2e tests

### DIFF
--- a/Documentation/job-metrics.md
+++ b/Documentation/job-metrics.md
@@ -10,8 +10,8 @@
 | kube_job_status_active | Gauge | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; |
 | kube_job_status_succeeded | Gauge | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; |
 | kube_job_status_failed | Gauge | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; |
-| kube_job_status_start_time | Counter | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; |
-| kube_job_status_completion_time | Counter | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; |
+| kube_job_status_start_time | Gauge | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; |
+| kube_job_status_completion_time | Gauge | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; |
 | kube_job_complete | Gauge | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; |
 | kube_job_failed | Gauge | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; |
 | kube_job_created | Gauge | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; |

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,6 @@ clean:
 	rm -f kube-state-metrics
 
 e2e:
-	./scripts/e2e.sh
+	./tests/e2e.sh
 
 .PHONY: all build all-push all-container test-unit container push clean e2e

--- a/collectors/job.go
+++ b/collectors/job.go
@@ -180,10 +180,6 @@ func (jc *jobCollector) collectJob(ch chan<- prometheus.Metric, j v1batch.Job) {
 		lv = append([]string{j.Namespace, j.Name}, lv...)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
 	}
-	addCounter := func(desc *prometheus.Desc, v float64, lv ...string) {
-		lv = append([]string{j.Namespace, j.Name}, lv...)
-		ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, v, lv...)
-	}
 
 	addGauge(descJobInfo, 1)
 
@@ -210,11 +206,11 @@ func (jc *jobCollector) collectJob(ch chan<- prometheus.Metric, j v1batch.Job) {
 	addGauge(descJobStatusActive, float64(j.Status.Active))
 
 	if j.Status.StartTime != nil {
-		addCounter(descJobStatusStartTime, float64(j.Status.StartTime.Unix()))
+		addGauge(descJobStatusStartTime, float64(j.Status.StartTime.Unix()))
 	}
 
 	if j.Status.CompletionTime != nil {
-		addCounter(descJobStatusCompletionTime, float64(j.Status.CompletionTime.Unix()))
+		addGauge(descJobStatusCompletionTime, float64(j.Status.CompletionTime.Unix()))
 	}
 
 	for _, c := range j.Status.Conditions {

--- a/collectors/job_test.go
+++ b/collectors/job_test.go
@@ -71,11 +71,11 @@ func TestJobCollector(t *testing.T) {
 		# HELP kube_job_status_active The number of actively running pods.
 		# TYPE kube_job_status_active gauge
 		# HELP kube_job_status_completion_time CompletionTime represents time when the job was completed.
-		# TYPE kube_job_status_completion_time counter
+		# TYPE kube_job_status_completion_time gauge
 		# HELP kube_job_status_failed The number of pods which reached Phase Failed.
 		# TYPE kube_job_status_failed gauge
 		# HELP kube_job_status_start_time StartTime represents time when the job was acknowledged by the Job Manager.
-		# TYPE kube_job_status_start_time counter
+		# TYPE kube_job_status_start_time gauge
 		# HELP kube_job_status_succeeded The number of pods which reached Phase Succeeded.
 		# TYPE kube_job_status_succeeded gauge
 	`

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,19 @@
+# End2end testsuite
+
+This folder contains simple e2e tests.
+When launched it spins up a kubernetes cluster using minikube, creates several kubernetes resources and launches a kube-state-metrics deployment.
+Then, it downloads kube-state-metrics' metrics and examines validity using `promtool` tool.
+
+The testsuite is run automatically using Travis.
+
+## Running locally
+
+In case you need to run e2e test manually on your local machine, you can configure the `e2e.sh` script by few environment variables.
+
+```bash
+export E2E_SETUP_MINIKUBE=        # set to empty string if you have already your own minikube binary, prevents from downloading one
+export E2E_SETUP_KUBECTL=         # set to empty string if you have already your own kubectl binary, prevents from downloading one
+export MINIKUBE_DRIVER=virtualbox # choose minikube's driver of your choice
+export SUDO=                      # if you don't need sudo, you can redefine the SUDO variable from default `sudo`
+./tests/e2e.sh
+```

--- a/tests/manifests/cronjob.yaml
+++ b/tests/manifests/cronjob.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cronjob
+  namespace: default
+spec:
+  schedule: "@hourly"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cronjob
+            image: nonexisting
+          restartPolicy: OnFailure

--- a/tests/manifests/daemonset.yaml
+++ b/tests/manifests/daemonset.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: daemonset
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      name: daemonset
+  template:
+    metadata:
+      labels:
+        name: daemonset
+    spec:
+      containers:
+      - name: daemonset
+        image: nonexisting

--- a/tests/manifests/hpa.yaml
+++ b/tests/manifests/hpa.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hpa
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: deployment
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 50

--- a/tests/manifests/job.yaml
+++ b/tests/manifests/job.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job
+  namespace: default
+spec:
+  template:
+    metadata:
+      name: job
+    spec:
+      containers:
+      - name: job
+        image: nonexisting
+      restartPolicy: Never

--- a/tests/manifests/limitrange.yaml
+++ b/tests/manifests/limitrange.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+spec:
+  limits:
+  - default:
+      memory: 1000Mi
+    defaultRequest:
+      memory: 1Mi
+    type: Container

--- a/tests/manifests/persistentvolume.yaml
+++ b/tests/manifests/persistentvolume.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: persistentvolume
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 5Gi
+  hostPath:
+    path: /data/pv0001/

--- a/tests/manifests/persistentvolumeclaim.yaml
+++ b/tests/manifests/persistentvolumeclaim.yaml
@@ -1,0 +1,16 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: persistentvolumeclaim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi
+  storageClassName: slow
+  selector:
+    matchLabels:
+      release: "stable"
+    matchExpressions:
+      - {key: environment, operator: In, values: [dev]}

--- a/tests/manifests/replicationcontroller.yaml
+++ b/tests/manifests/replicationcontroller.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: replicationcontroller
+spec:
+  selector:
+    app: replicationcontroller
+  template:
+    metadata:
+      name: replicationcontroller
+      labels:
+        app: replicationcontroller
+    spec:
+      containers:
+      - name: replicationcontroller
+        image: nonexisting

--- a/tests/manifests/resourcequota.yaml
+++ b/tests/manifests/resourcequota.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: resourcequota
+spec:
+  hard:
+    configmaps: "10"

--- a/tests/manifests/statefulset.yaml
+++ b/tests/manifests/statefulset.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: statefulset
+spec:
+  selector:
+    matchLabels:
+      app: statefulset
+  serviceName: statefulset
+  template:
+    metadata:
+      labels:
+        app: statefulset
+    spec:
+      containers:
+      - name: statefulset
+        image: nonexisting


### PR DESCRIPTION
Addressing #290. I tried to made commits readable as possible, can squash if prefered.

* I refactored e2e testsuite allowing user to overwrite whether he wants to install minikube & kubectl and also choose minikube's driver (locally when testing I want to use virtualbox and I don't want the script to download minikube and kubectl over and over to my system path).

* I added `cronjob daemonset hpa job limitrange persistentvolumeclaim replicationcontroller resourcequota statefulset` resources which are created

* I added a simple check that expected metrics are exposed

