### PR TITLE
use alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM alpine:3.7
 
 COPY kube-state-metrics /
 VOLUME /tmp


### PR DESCRIPTION
This PR will move the base image for kube-state-metrics from `scratch` to `alpine`. Alpine has many useful binaries, such as `sh`. This will be helpful when we need to `exec` into an running kube-state-metrics container and run some debug command.

Last but not the least is that alpine image is small enough thus the kube-state-metircs image will not increase much.