### PR TITLE
add go version check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 
 go:
-- "1.10"
+- "1.10.1"
 
 install:
 - mkdir -p $HOME/gopath/src/k8s.io

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ Commit = $(shell git rev-parse --short HEAD)
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 PKG=k8s.io/kube-state-metrics
 
+
 IMAGE = $(REGISTRY)/kube-state-metrics
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
@@ -27,7 +28,7 @@ doccheck:
 	@cd Documentation; for doc in *.md; do if [ "$$doc" != "README.md" ] && ! grep -q "$$doc" *.md; then echo "ERROR: No link to documentation file $${doc} detected"; exit 1; fi; done
 	@echo OK
 
-build: clean
+build: clean validate_go_version
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(BUILDENVVAR) go build -ldflags "-s -w -X ${PKG}/version.Release=${TAG} -X ${PKG}/version.Commit=${Commit} -X ${PKG}/version.BuildDate=${BuildDate}" -o kube-state-metrics
 
 test-unit: clean build
@@ -72,4 +73,7 @@ clean:
 e2e:
 	./scripts/e2e.sh
 
-.PHONY: all build all-push all-container test-unit container push clean e2e
+validate_go_version:
+	./hacks/validate_go_version.sh
+
+.PHONY: all build all-push all-container test-unit container push clean e2e validate_go_version

--- a/hacks/validate_go_version.sh
+++ b/hacks/validate_go_version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+which go > /dev/null
+if [ $? -ne 0 ]; then
+    echo "No golang environment found"
+    exit 1
+fi
+
+# We should only compile kube-state-metrics with released golang versions.
+go_version=$(go version|awk '{print $3}'|awk -Fgo '{print $2}')
+if [[ $go_version = *"beta"* ]] || [[ $go_version = *"rc"* ]]; then
+    echo "Using a beta/rc golang version: $go_version"
+    exit 1
+fi
+
+major=$(echo $go_version|cut -d. -f1)
+minor=$(echo $go_version|cut -d. -f2)
+patch=$(echo $go_version|cut -d. -f3)
+
+# We should only compile kube-state-metrics with golang whose version is greater than 1.9.5 or 1.10.1.
+# For more info: https://github.com/kubernetes/kube-state-metrics/issues/416
+if ([ ! -z "$patch" ] && [ $major -ge 1 -a $minor -eq 9 -a $patch -ge 5 ]) || ([ ! -z "$patch" ] && [ $major -ge 1 -a $minor -eq 10 -a $patch -ge 1 ]) || [ $major -ge 1 -a $minor -gt 10 ]; then
+    echo "Compile kube-state-metrics with golang $go_version"
+    exit 0
+else
+    echo "Kube-state-metrics should only be compiled with golang whose version is greater than 1.9.5 or 1.10.1"
+    exit 1
+fi
+


### PR DESCRIPTION
Fix #416 

This PR will ad a go version check for `make build` to help us mitigate the problem encountered in https://github.com/kubernetes/kube-state-metrics/issues/416