### PR TITLE
use golang image to compile ksm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: required
 
 language: go
 
-go:
-- "1.10"
-
 install:
 - mkdir -p $HOME/gopath/src/k8s.io
 - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/kube-state-metrics


### PR DESCRIPTION
Fix #421

This PR will add support for using golang container to compile kube-state-metrics.