### PR TITLE
pin minikube v0.25.2

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -26,7 +26,7 @@ PROMETHEUS_VERSION=2.0.0
 mkdir -p $KUBE_STATE_METRICS_LOG_DIR
 
 # setup a Kubernetes cluster
-curl -sLo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+curl -sLo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 minikube version
 


### PR DESCRIPTION
Minikube has released v0.26.0 and it seems that e2e test for kube-state-metrics is not compatible with the latest minikube release. Let's first pin minikube version to v0.25.2 and file an issue in minikube to track this.