### PR TITLE
Bump golang version to 1.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: go
 
 go:
-- "1.10"
+- "1.10.1"
 
 install:
 - mkdir -p $HOME/gopath/src/k8s.io


### PR DESCRIPTION
Fixes #257 (probably)

I've tried debugging #257 by rebuilding ksm with some more debugging options but after building it with go1.10.1

- memory usage dropped from 300MB-1Gi to pretty stable 55-65MB
- scrape duration went from 3s-timeout to 0.3s-1s.