### PR TITLE
Adds time_to_schedule and time_to_start metrics

### DIFF
--- a/Documentation/pod-metrics.md
+++ b/Documentation/pod-metrics.md
@@ -26,4 +26,5 @@
 | kube_pod_container_resource_limits_nvidia_gpu_devices | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
 | kube_pod_created | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 | kube_pod_spec_volumes_persistentvolumeclaims_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `volume`=&lt;volume-name&gt;  <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-claimname&gt; |
-| kube_pod_spec_volumes_persistentvolumeclaims_readonly | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt;  <br> `volume`=&lt;volume-name&gt;  <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-claimname&gt; | kube_pod_status_scheduled_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
+| kube_pod_spec_volumes_persistentvolumeclaims_readonly | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt;  <br> `volume`=&lt;volume-name&gt;  <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-claimname&gt; |
+| kube_pod_status_scheduled_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |

--- a/Documentation/pod-metrics.md
+++ b/Documentation/pod-metrics.md
@@ -26,4 +26,4 @@
 | kube_pod_container_resource_limits_nvidia_gpu_devices | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
 | kube_pod_created | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 | kube_pod_spec_volumes_persistentvolumeclaims_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `volume`=&lt;volume-name&gt;  <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-claimname&gt; |
-| kube_pod_spec_volumes_persistentvolumeclaims_readonly | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt;  <br> `volume`=&lt;volume-name&gt;  <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-claimname&gt; |
+| kube_pod_spec_volumes_persistentvolumeclaims_readonly | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt;  <br> `volume`=&lt;volume-name&gt;  <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-claimname&gt; | kube_pod_status_scheduled_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |

--- a/collectors/pod_test.go
+++ b/collectors/pod_test.go
@@ -65,6 +65,8 @@ func TestPodCollector(t *testing.T) {
 		# TYPE kube_pod_container_status_waiting_reason gauge
 		# HELP kube_pod_info Information about pod.
 		# TYPE kube_pod_info gauge
+		# HELP kube_pod_status_scheduled_time Unix timestamp when pod moved into scheduled status
+		# TYPE kube_pod_status_scheduled_time gauge
 		# HELP kube_pod_start_time Start time in unix timestamp for a pod.
 		# TYPE kube_pod_start_time gauge
 		# HELP kube_pod_completion_time Completion time in unix timestamp for a pod.
@@ -588,6 +590,9 @@ func TestPodCollector(t *testing.T) {
 							v1.PodCondition{
 								Type:   v1.PodScheduled,
 								Status: v1.ConditionTrue,
+								LastTransitionTime: metav1.Time{
+									Time: time.Unix(1501666018, 0),
+								},
 							},
 						},
 					},
@@ -607,6 +612,7 @@ func TestPodCollector(t *testing.T) {
 				},
 			},
 			want: metadata + `
+				kube_pod_status_scheduled_time{namespace="ns1",pod="pod1"} 1.501666018e+09
 				kube_pod_status_scheduled{condition="false",namespace="ns1",pod="pod1"} 0
 				kube_pod_status_scheduled{condition="false",namespace="ns2",pod="pod2"} 1
 				kube_pod_status_scheduled{condition="true",namespace="ns1",pod="pod1"} 1
@@ -614,7 +620,7 @@ func TestPodCollector(t *testing.T) {
 				kube_pod_status_scheduled{condition="unknown",namespace="ns1",pod="pod1"} 0
 				kube_pod_status_scheduled{condition="unknown",namespace="ns2",pod="pod2"} 0
 			`,
-			metrics: []string{"kube_pod_status_scheduled"},
+			metrics: []string{"kube_pod_status_scheduled", "kube_pod_status_scheduled_time"},
 		}, {
 			pods: []v1.Pod{
 				{


### PR DESCRIPTION
This PR adds two metrics with the aim of tracking the beginning of the pod lifecycle better. They are named `kube_pod_time_to_schedule` and `kube_pod_time_to_start`.

I tried to get the results I wanted by just adding/subtracting various existing metrics in Prometheus but there's a bit of conditional logic required to make the most sense out of the created vs started timestamps for a pod object.