### PR TITLE
Add hpa conditions

### DIFF
--- a/collectors/hpa_test.go
+++ b/collectors/hpa_test.go
@@ -19,7 +19,7 @@ package collectors
 import (
 	"testing"
 
-	autoscaling "k8s.io/api/autoscaling/v1"
+	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/collectors/node.go
+++ b/collectors/node.go
@@ -266,28 +266,3 @@ func (nc *nodeCollector) collectNode(ch chan<- prometheus.Metric, n v1.Node) {
 	addResource(descNodeStatusAllocatableMemory, n.Status.Allocatable, v1.ResourceMemory)
 	addResource(descNodeStatusAllocatablePods, n.Status.Allocatable, v1.ResourcePods)
 }
-
-// addConditionMetrics generates one metric for each possible node condition
-// status. For this function to work properly, the last label in the metric
-// description must be the condition.
-func addConditionMetrics(ch chan<- prometheus.Metric, desc *prometheus.Desc, cs v1.ConditionStatus, lv ...string) {
-	ch <- prometheus.MustNewConstMetric(
-		desc, prometheus.GaugeValue, boolFloat64(cs == v1.ConditionTrue),
-		append(lv, "true")...,
-	)
-	ch <- prometheus.MustNewConstMetric(
-		desc, prometheus.GaugeValue, boolFloat64(cs == v1.ConditionFalse),
-		append(lv, "false")...,
-	)
-	ch <- prometheus.MustNewConstMetric(
-		desc, prometheus.GaugeValue, boolFloat64(cs == v1.ConditionUnknown),
-		append(lv, "unknown")...,
-	)
-}
-
-func boolFloat64(b bool) float64 {
-	if b {
-		return 1
-	}
-	return 0
-}


### PR DESCRIPTION
Fixed after discussion in Slack, thanks to @DirectXMan12 
This now uses a explicitly versioned client as recommended anyways.

---
Not working yet, need to understand the versioning and would welcome somebody pointing me in the right direction to solve this in a backward compatible way. The HPA conditions are part of the HPA status since v2beta1. When I update the import though, I get this error:

```
E0417 12:51:00.051078   17716 reflector.go:386] k8s.io/kube-state-metrics/collectors/collectors.go:62: expected type *v2beta1.HorizontalPodAutoscaler, but watch event object had type *v1.HorizontalPodAutoscaler
```