### PR TITLE
Update README.md to reference 1.3.1 as latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ release.
 #### Container Image
 
 The latest container image can be found at:
-* `quay.io/coreos/kube-state-metrics:v1.3.0`
-* `k8s.gcr.io/kube-state-metrics:v1.3.0`
+* `quay.io/coreos/kube-state-metrics:v1.3.1`
+* `k8s.gcr.io/kube-state-metrics:v1.3.1`
 
 **Note**:
 The recommended docker registry for kube-state-metrics is `quay.io`. kube-state-metrics on


### PR DESCRIPTION
As discussed in #443 version 1.3.1 is the latest official release and should be referenced in the README.md