### PR TITLE
add support for quay latest image tag

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -107,7 +107,7 @@ kubectl version
 # query kube-state-metrics image tag
 make container
 docker images -a
-ksm_image_tag=`docker images -a|grep 'quay.io/coreos/kube-state-metrics'|awk '{print $2}'|sort -u`
+ksm_image_tag=`docker images -a|grep 'quay.io/coreos/kube-state-metrics'|grep -v 'latest'|awk '{print $2}'|sort -u`
 echo "local kube-state-metrics image tag: $ksm_image_tag"
 
 # update kube-state-metrics image tag in kube-state-metrics-deployment.yaml


### PR DESCRIPTION
Partially fix #443 

This PR adds two functionalities:
* add the new `quay-push` target to push images to quay.io
* add the support for tag the `latest` tag when release with a new version

BTW, i do not think it is the right way to use `latest` tag for any docker images. But since kube-state-metrics has been released under support for `latest` tag, we should keep this release procedure.