### PR TITLE
add generic pod resource request and limit

### DIFF
--- a/Documentation/pod-metrics.md
+++ b/Documentation/pod-metrics.md
@@ -19,8 +19,10 @@
 | kube_pod_container_status_ready | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 | kube_pod_container_status_restarts_total | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; |
 | kube_pod_container_resource_requests_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
+| kube_pod_container_resource_requests | Gauge | `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt; <br> `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
 | kube_pod_container_resource_requests_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
 | kube_pod_container_resource_limits_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
+| kube_pod_container_resource_limits | Gauge | `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt; <br> `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
 | kube_pod_container_resource_limits_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
 | kube_pod_container_resource_requests_nvidia_gpu_devices | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |
 | kube_pod_container_resource_limits_nvidia_gpu_devices | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; |

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -90,12 +90,12 @@
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
-			"Comment": "v0.3-162-gc0656ed",
+			"Comment": "v0.4-3-gc0656ed",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/sortkeys",
-			"Comment": "v0.3-162-gc0656ed",
+			"Comment": "v0.4-3-gc0656ed",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
@@ -1024,6 +1024,16 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/core",
+			"Comment": "v1.9.0",
+			"Rev": "925c127ec6b946659ad0fd596fa959be43f0cc05"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/helper",
+			"Comment": "v1.9.0",
+			"Rev": "925c127ec6b946659ad0fd596fa959be43f0cc05"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/core/v1/helper",
 			"Comment": "v1.9.0",
 			"Rev": "925c127ec6b946659ad0fd596fa959be43f0cc05"
 		},

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ the raw metrics.
   - [Resource group version compatibility](#resource-group-version-compatibility)
   - [Container Image](#container-image)
 - [Metrics Documentation](#metrics-documentation)
+- [Metrics Deprecation](#metrics-deprecation)
 - [Kube-state-metrics self metrics](#kube-state-metrics-self-metrics)
 - [Resource recommendation](#resource-recommendation)
 - [kube-state-metrics vs. Heapster](#kube-state-metrics-vs-heapster)
@@ -102,6 +103,18 @@ additional metrics!
 > which may be changed at any given release.
 
 See the [`Documentation`](Documentation) directory for documentation of the exposed metrics.
+
+### Metrics Deprecation
+* **The following non-generic resource metrics for pods are marked deprecated. They will be removed in kube-state-metrics v2.0.0.**
+`kube_pod_container_resource_requests` and `kube_pod_container_resource_limits` are the replacements with `resource` labels
+representing the resource name and `unit` labels representing the resource unit.
+  * kube_pod_container_resource_requests_cpu_cores
+  * kube_pod_container_resource_limits_cpu_cores
+  * kube_pod_container_resource_requests_memory_bytes
+  * kube_pod_container_resource_limits_memory_bytes
+  * kube_pod_container_resource_requests_nvidia_gpu_devices
+  * kube_pod_container_resource_limits_nvidia_gpu_devices
+  
 
 ### Kube-state-metrics self metrics
 kube-state-metrics exposes its own metrics under `--telemetry-host` and `--telemetry-port` (default 81).

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 	go telemetryServer(ksmMetricsRegistry, opts.TelemetryHost, opts.TelemetryPort)
 
 	registry := prometheus.NewRegistry()
-	registerCollectors(registry, kubeClient, collectors, namespaces)
+	registerCollectors(registry, kubeClient, collectors, namespaces, opts)
 	metricsServer(registry, opts.Host, opts.Port)
 }
 
@@ -200,12 +200,12 @@ func metricsServer(registry prometheus.Gatherer, host string, port int) {
 
 // registerCollectors creates and starts informers and initializes and
 // registers metrics for collection.
-func registerCollectors(registry prometheus.Registerer, kubeClient clientset.Interface, enabledCollectors options.CollectorSet, namespaces options.NamespaceList) {
+func registerCollectors(registry prometheus.Registerer, kubeClient clientset.Interface, enabledCollectors options.CollectorSet, namespaces options.NamespaceList, opts *options.Options) {
 	activeCollectors := []string{}
 	for c := range enabledCollectors {
-		f, ok := options.AvailableCollectors[c]
+		f, ok := kcollectors.AvailableCollectors[c]
 		if ok {
-			f(registry, kubeClient, namespaces)
+			f(registry, kubeClient, namespaces, opts)
 			activeCollectors = append(activeCollectors, c)
 		}
 	}

--- a/pkg/collectors/configmap.go
+++ b/pkg/collectors/configmap.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -50,7 +51,7 @@ func (l ConfigMapLister) List() ([]v1.ConfigMap, error) {
 	return l()
 }
 
-func RegisterConfigMapCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
+func RegisterConfigMapCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string, opts *options.Options) {
 	client := kubeClient.CoreV1().RESTClient()
 	glog.Infof("collect configmap with %s", client.APIVersion())
 
@@ -65,7 +66,7 @@ func RegisterConfigMapCollector(registry prometheus.Registerer, kubeClient kuber
 		return configMaps, nil
 	})
 
-	registry.MustRegister(&configMapCollector{store: configMapLister})
+	registry.MustRegister(&configMapCollector{store: configMapLister, opts: opts})
 	cminfs.Run(context.Background().Done())
 }
 
@@ -76,6 +77,7 @@ type configMapStore interface {
 // configMapCollector collects metrics about all configMaps in the cluster.
 type configMapCollector struct {
 	store configMapStore
+	opts  *options.Options
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/pkg/collectors/configmap_test.go
+++ b/pkg/collectors/configmap_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockConfigMapStore struct {
@@ -85,6 +86,7 @@ func TestConfigMapCollector(t *testing.T) {
 			store: mockConfigMapStore{
 				f: func() ([]v1.ConfigMap, error) { return c.configMaps, nil },
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(cmc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/cronjob_test.go
+++ b/pkg/collectors/cronjob_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -231,6 +232,7 @@ func TestCronJobCollector(t *testing.T) {
 			store: mockCronJobStore{
 				f: func() ([]batchv1beta1.CronJob, error) { return c.cronJobs, nil },
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(cjc, c.want, nil); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/daemonset.go
+++ b/pkg/collectors/daemonset.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -87,7 +88,7 @@ func (l DaemonSetLister) List() ([]v1beta1.DaemonSet, error) {
 	return l()
 }
 
-func RegisterDaemonSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
+func RegisterDaemonSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string, opts *options.Options) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
 	glog.Infof("collect daemonset with %s", client.APIVersion())
 
@@ -102,7 +103,7 @@ func RegisterDaemonSetCollector(registry prometheus.Registerer, kubeClient kuber
 		return daemonsets, nil
 	})
 
-	registry.MustRegister(&daemonsetCollector{store: dsLister})
+	registry.MustRegister(&daemonsetCollector{store: dsLister, opts: opts})
 	dsinfs.Run(context.Background().Done())
 }
 
@@ -113,6 +114,7 @@ type daemonsetStore interface {
 // daemonsetCollector collects metrics about all daemonsets in the cluster.
 type daemonsetCollector struct {
 	store daemonsetStore
+	opts  *options.Options
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/pkg/collectors/daemonset_test.go
+++ b/pkg/collectors/daemonset_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockDaemonSetStore struct {
@@ -154,6 +155,7 @@ func TestDaemonSetCollector(t *testing.T) {
 			store: mockDaemonSetStore{
 				f: func() ([]v1beta1.DaemonSet, error) { return c.dss, nil },
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(dc, c.want, nil); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/deployment.go
+++ b/pkg/collectors/deployment.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -106,7 +107,7 @@ func (l DeploymentLister) List() ([]v1beta1.Deployment, error) {
 	return l()
 }
 
-func RegisterDeploymentCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
+func RegisterDeploymentCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string, opts *options.Options) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
 	glog.Infof("collect deployment with %s", client.APIVersion())
 
@@ -121,7 +122,7 @@ func RegisterDeploymentCollector(registry prometheus.Registerer, kubeClient kube
 		return deployments, nil
 	})
 
-	registry.MustRegister(&deploymentCollector{store: dplLister})
+	registry.MustRegister(&deploymentCollector{store: dplLister, opts: opts})
 	dinfs.Run(context.Background().Done())
 }
 
@@ -132,6 +133,7 @@ type deploymentStore interface {
 // deploymentCollector collects metrics about all deployments in the cluster.
 type deploymentCollector struct {
 	store deploymentStore
+	opts  *options.Options
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/pkg/collectors/deployment_test.go
+++ b/pkg/collectors/deployment_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -166,6 +167,7 @@ func TestDeploymentCollector(t *testing.T) {
 			store: mockDeploymentStore{
 				f: func() ([]v1beta1.Deployment, error) { return c.depls, nil },
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(dc, c.want, nil); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/endpoint.go
+++ b/pkg/collectors/endpoint.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -66,7 +67,7 @@ func (l EndpointLister) List() ([]v1.Endpoints, error) {
 	return l()
 }
 
-func RegisterEndpointCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
+func RegisterEndpointCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string, opts *options.Options) {
 	client := kubeClient.CoreV1().RESTClient()
 	glog.Infof("collect endpoint with %s", client.APIVersion())
 
@@ -81,7 +82,7 @@ func RegisterEndpointCollector(registry prometheus.Registerer, kubeClient kubern
 		return endpoints, nil
 	})
 
-	registry.MustRegister(&endpointCollector{store: endpointLister})
+	registry.MustRegister(&endpointCollector{store: endpointLister, opts: opts})
 	sinfs.Run(context.Background().Done())
 }
 
@@ -92,6 +93,7 @@ type endpointStore interface {
 // endpointCollector collects metrics about all endpoints in the cluster.
 type endpointCollector struct {
 	store endpointStore
+	opts  *options.Options
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/pkg/collectors/endpoint_test.go
+++ b/pkg/collectors/endpoint_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockEndpointStore struct {
@@ -112,6 +113,7 @@ func TestEndpointCollector(t *testing.T) {
 					return c.endpoints, nil
 				},
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(sc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/hpa_test.go
+++ b/pkg/collectors/hpa_test.go
@@ -22,6 +22,7 @@ import (
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -103,6 +104,7 @@ func TestHPACollector(t *testing.T) {
 					return autoscaling.HorizontalPodAutoscalerList{Items: c.hpas}, nil
 				},
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(hc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/job_test.go
+++ b/pkg/collectors/job_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -256,6 +257,7 @@ func TestJobCollector(t *testing.T) {
 			store: mockJobStore{
 				f: func() ([]v1batch.Job, error) { return c.jobs, nil },
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(jc, c.want, nil); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/limitrange_test.go
+++ b/pkg/collectors/limitrange_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockLimitRangeStore struct {
@@ -99,6 +100,7 @@ func TestLimitRangeollector(t *testing.T) {
 					return v1.LimitRangeList{Items: c.ranges}, nil
 				},
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(dc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/namespace.go
+++ b/pkg/collectors/namespace.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -71,7 +72,7 @@ func (l NamespaceLister) List() ([]v1.Namespace, error) {
 }
 
 // RegisterNamespaceCollector registry namespace collector
-func RegisterNamespaceCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
+func RegisterNamespaceCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string, opts *options.Options) {
 	client := kubeClient.CoreV1().RESTClient()
 	glog.Infof("collect namespace with %s", client.APIVersion())
 
@@ -86,7 +87,7 @@ func RegisterNamespaceCollector(registry prometheus.Registerer, kubeClient kuber
 		return namespaces, nil
 	})
 
-	registry.MustRegister(&namespaceCollector{store: namespaceLister})
+	registry.MustRegister(&namespaceCollector{store: namespaceLister, opts: opts})
 	nsinfs.Run(context.Background().Done())
 }
 
@@ -97,6 +98,7 @@ type namespaceStore interface {
 // namespaceCollector collects metrics about all namespace in the cluster.
 type namespaceCollector struct {
 	store namespaceStore
+	opts  *options.Options
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/pkg/collectors/namespace_test.go
+++ b/pkg/collectors/namespace_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockNamespaceStore struct {
@@ -140,6 +141,7 @@ func TestNamespaceCollector(t *testing.T) {
 			store: mockNamespaceStore{
 				list: func() ([]v1.Namespace, error) { return c.ns, nil },
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(nsc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/node.go
+++ b/pkg/collectors/node.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -129,7 +130,7 @@ func (l NodeLister) List() (v1.NodeList, error) {
 	return l()
 }
 
-func RegisterNodeCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
+func RegisterNodeCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string, opts *options.Options) {
 	client := kubeClient.CoreV1().RESTClient()
 	glog.Infof("collect node with %s", client.APIVersion())
 
@@ -144,7 +145,7 @@ func RegisterNodeCollector(registry prometheus.Registerer, kubeClient kubernetes
 		return machines, nil
 	})
 
-	registry.MustRegister(&nodeCollector{store: nodeLister})
+	registry.MustRegister(&nodeCollector{store: nodeLister, opts: opts})
 	ninfs.Run(context.Background().Done())
 }
 
@@ -155,6 +156,7 @@ type nodeStore interface {
 // nodeCollector collects metrics about all nodes in the cluster.
 type nodeCollector struct {
 	store nodeStore
+	opts  *options.Options
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/pkg/collectors/node_test.go
+++ b/pkg/collectors/node_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockNodeStore struct {
@@ -297,6 +298,7 @@ func TestNodeCollector(t *testing.T) {
 					return v1.NodeList{Items: c.nodes}, nil
 				},
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(dc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/persistentvolume_test.go
+++ b/pkg/collectors/persistentvolume_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockPersistentVolumeStore struct {
@@ -188,6 +189,7 @@ func TestPersistentVolumeCollector(t *testing.T) {
 					return v1.PersistentVolumeList{Items: c.pvs}, nil
 				},
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(dc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/persistentvolumeclaim_test.go
+++ b/pkg/collectors/persistentvolumeclaim_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockPersistentVolumeClaimStore struct {
@@ -126,6 +127,7 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 					return v1.PersistentVolumeClaimList{Items: c.pvcs}, nil
 				},
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(dc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/replicaset.go
+++ b/pkg/collectors/replicaset.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -68,7 +69,7 @@ func (l ReplicaSetLister) List() ([]v1beta1.ReplicaSet, error) {
 	return l()
 }
 
-func RegisterReplicaSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
+func RegisterReplicaSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string, opts *options.Options) {
 	client := kubeClient.ExtensionsV1beta1().RESTClient()
 	glog.Infof("collect replicaset with %s", client.APIVersion())
 
@@ -83,7 +84,7 @@ func RegisterReplicaSetCollector(registry prometheus.Registerer, kubeClient kube
 		return replicasets, nil
 	})
 
-	registry.MustRegister(&replicasetCollector{store: replicaSetLister})
+	registry.MustRegister(&replicasetCollector{store: replicaSetLister, opts: opts})
 	rsinfs.Run(context.Background().Done())
 }
 
@@ -94,6 +95,7 @@ type replicasetStore interface {
 // replicasetCollector collects metrics about all replicasets in the cluster.
 type replicasetCollector struct {
 	store replicasetStore
+	opts  *options.Options
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/pkg/collectors/replicaset_test.go
+++ b/pkg/collectors/replicaset_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -118,6 +119,7 @@ func TestReplicaSetCollector(t *testing.T) {
 			store: mockReplicaSetStore{
 				f: func() ([]v1beta1.ReplicaSet, error) { return c.rss, nil },
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(dc, c.want, nil); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/replicationcontroller.go
+++ b/pkg/collectors/replicationcontroller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -74,7 +75,7 @@ func (l ReplicationControllerLister) List() ([]v1.ReplicationController, error) 
 	return l()
 }
 
-func RegisterReplicationControllerCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
+func RegisterReplicationControllerCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string, opts *options.Options) {
 	client := kubeClient.CoreV1().RESTClient()
 	glog.Infof("collect replicationcontroller with %s", client.APIVersion())
 
@@ -89,7 +90,7 @@ func RegisterReplicationControllerCollector(registry prometheus.Registerer, kube
 		return rcs, nil
 	})
 
-	registry.MustRegister(&replicationcontrollerCollector{store: replicationControllerLister})
+	registry.MustRegister(&replicationcontrollerCollector{store: replicationControllerLister, opts: opts})
 	rcinfs.Run(context.Background().Done())
 }
 
@@ -99,6 +100,7 @@ type replicationcontrollerStore interface {
 
 type replicationcontrollerCollector struct {
 	store replicationcontrollerStore
+	opts  *options.Options
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/pkg/collectors/replicationcontroller_test.go
+++ b/pkg/collectors/replicationcontroller_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -124,6 +125,7 @@ func TestReplicationControllerCollector(t *testing.T) {
 			store: mockReplicationControllerStore{
 				f: func() ([]v1.ReplicationController, error) { return c.rss, nil },
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(dc, c.want, nil); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/resourcequota_test.go
+++ b/pkg/collectors/resourcequota_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockResourceQuotaStore struct {
@@ -155,6 +156,7 @@ func TestResourceQuotaCollector(t *testing.T) {
 					return v1.ResourceQuotaList{Items: c.quotas}, nil
 				},
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(dc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/secret_test.go
+++ b/pkg/collectors/secret_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockSecretStore struct {
@@ -110,6 +111,7 @@ func TestSecretCollector(t *testing.T) {
 			store: mockSecretStore{
 				f: func() ([]v1.Secret, error) { return c.secrets, nil },
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(sc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/service_test.go
+++ b/pkg/collectors/service_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 type mockServiceStore struct {
@@ -136,6 +137,7 @@ func TestServiceCollector(t *testing.T) {
 					return c.services, nil
 				},
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(sc, c.want, c.metrics); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/collectors/statefulset.go
+++ b/pkg/collectors/statefulset.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -90,7 +91,7 @@ func (l StatefulSetLister) List() ([]v1beta1.StatefulSet, error) {
 	return l()
 }
 
-func RegisterStatefulSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string) {
+func RegisterStatefulSetCollector(registry prometheus.Registerer, kubeClient kubernetes.Interface, namespaces []string, opts *options.Options) {
 	client := kubeClient.AppsV1beta1().RESTClient()
 	glog.Infof("collect statefulset with %s", client.APIVersion())
 
@@ -105,7 +106,7 @@ func RegisterStatefulSetCollector(registry prometheus.Registerer, kubeClient kub
 		return statefulSets, nil
 	})
 
-	registry.MustRegister(&statefulSetCollector{store: statefulSetLister})
+	registry.MustRegister(&statefulSetCollector{store: statefulSetLister, opts: opts})
 	dinfs.Run(context.Background().Done())
 }
 
@@ -115,6 +116,7 @@ type statefulSetStore interface {
 
 type statefulSetCollector struct {
 	store statefulSetStore
+	opts  *options.Options
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/pkg/collectors/statefulset_test.go
+++ b/pkg/collectors/statefulset_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/apps/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/collectors/testutils"
+	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 var (
@@ -161,6 +162,7 @@ func TestStatefuleSetCollector(t *testing.T) {
 			store: mockStatefulSetStore{
 				f: func() ([]v1beta1.StatefulSet, error) { return c.depls, nil },
 			},
+			opts: &options.Options{},
 		}
 		if err := testutils.GatherAndCompare(sc, c.want, nil); err != nil {
 			t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/options/collector.go
+++ b/pkg/options/collector.go
@@ -17,10 +17,7 @@ limitations under the License.
 package options
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientset "k8s.io/client-go/kubernetes"
-	kcollectors "k8s.io/kube-state-metrics/pkg/collectors"
 )
 
 var (
@@ -40,31 +37,10 @@ var (
 		"statefulsets":             struct{}{},
 		"persistentvolumes":        struct{}{},
 		"persistentvolumeclaims":   struct{}{},
-		"Namespaces":               struct{}{},
+		"namespaces":               struct{}{},
 		"horizontalpodautoscalers": struct{}{},
 		"endpoints":                struct{}{},
 		"secrets":                  struct{}{},
 		"configmaps":               struct{}{},
-	}
-	AvailableCollectors = map[string]func(registry prometheus.Registerer, kubeClient clientset.Interface, namespaces []string){
-		"cronjobs":                 kcollectors.RegisterCronJobCollector,
-		"daemonsets":               kcollectors.RegisterDaemonSetCollector,
-		"deployments":              kcollectors.RegisterDeploymentCollector,
-		"jobs":                     kcollectors.RegisterJobCollector,
-		"limitranges":              kcollectors.RegisterLimitRangeCollector,
-		"nodes":                    kcollectors.RegisterNodeCollector,
-		"pods":                     kcollectors.RegisterPodCollector,
-		"replicasets":              kcollectors.RegisterReplicaSetCollector,
-		"replicationcontrollers":   kcollectors.RegisterReplicationControllerCollector,
-		"resourcequotas":           kcollectors.RegisterResourceQuotaCollector,
-		"services":                 kcollectors.RegisterServiceCollector,
-		"statefulsets":             kcollectors.RegisterStatefulSetCollector,
-		"persistentvolumes":        kcollectors.RegisterPersistentVolumeCollector,
-		"persistentvolumeclaims":   kcollectors.RegisterPersistentVolumeClaimCollector,
-		"Namespaces":               kcollectors.RegisterNamespaceCollector,
-		"horizontalpodautoscalers": kcollectors.RegisterHorizontalPodAutoScalerCollector,
-		"endpoints":                kcollectors.RegisterEndpointCollector,
-		"secrets":                  kcollectors.RegisterSecretCollector,
-		"configmaps":               kcollectors.RegisterConfigMapCollector,
 	}
 )

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -24,28 +24,29 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type options struct {
-	Apiserver     string
-	Kubeconfig    string
-	Help          bool
-	Port          int
-	Host          string
-	TelemetryPort int
-	TelemetryHost string
-	Collectors    CollectorSet
-	Namespaces    NamespaceList
-	Version       bool
+type Options struct {
+	Apiserver                           string
+	Kubeconfig                          string
+	Help                                bool
+	Port                                int
+	Host                                string
+	TelemetryPort                       int
+	TelemetryHost                       string
+	Collectors                          CollectorSet
+	Namespaces                          NamespaceList
+	Version                             bool
+	DisablePodNonGenericResourceMetrics bool
 
 	flags *pflag.FlagSet
 }
 
-func NewOptions() *options {
-	return &options{
+func NewOptions() *Options {
+	return &Options{
 		Collectors: CollectorSet{},
 	}
 }
 
-func (o *options) AddFlags() {
+func (o *Options) AddFlags() {
 	o.flags = pflag.NewFlagSet("", pflag.ExitOnError)
 	// add glog flags
 	o.flags.AddGoFlagSet(flag.CommandLine)
@@ -68,13 +69,14 @@ func (o *options) AddFlags() {
 	o.flags.Var(&o.Collectors, "collectors", fmt.Sprintf("Comma-separated list of collectors to be enabled. Defaults to %q", &DefaultCollectors))
 	o.flags.Var(&o.Namespaces, "namespace", fmt.Sprintf("Comma-separated list of namespaces to be enabled. Defaults to %q", &DefaultNamespaces))
 	o.flags.BoolVarP(&o.Version, "version", "", false, "kube-state-metrics build version information")
+	o.flags.BoolVarP(&o.DisablePodNonGenericResourceMetrics, "disable-pod-non-generic-resource-metrics", "", false, "Disable pod non generic resource request and limit metrics")
 }
 
-func (o *options) Parse() error {
+func (o *Options) Parse() error {
 	err := o.flags.Parse(os.Args)
 	return err
 }
 
-func (o *options) Usage() {
+func (o *Options) Usage() {
 	o.flags.Usage()
 }

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -40,7 +40,7 @@ func (c *CollectorSet) Set(value string) error {
 	for _, col := range cols {
 		col = strings.TrimSpace(col)
 		if len(col) != 0 {
-			_, ok := AvailableCollectors[col]
+			_, ok := DefaultCollectors[col]
 			if !ok {
 				return fmt.Errorf("collector \"%s\" does not exist", col)
 			}

--- a/vendor/k8s.io/kubernetes/pkg/apis/core/helper/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/apis/core/helper/BUILD
@@ -1,0 +1,51 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["helpers_test.go"],
+    importpath = "k8s.io/kubernetes/pkg/apis/core/helper",
+    library = ":go_default_library",
+    deps = [
+        "//pkg/apis/core:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["helpers.go"],
+    importpath = "k8s.io/kubernetes/pkg/apis/core/helper",
+    deps = [
+        "//pkg/apis/core:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/selection:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//pkg/apis/core/helper/qos:all-srcs",
+    ],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/apis/core/helper/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/core/helper/helpers.go
@@ -1,0 +1,644 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+// IsHugePageResourceName returns true if the resource name has the huge page
+// resource prefix.
+func IsHugePageResourceName(name core.ResourceName) bool {
+	return strings.HasPrefix(string(name), core.ResourceHugePagesPrefix)
+}
+
+// IsQuotaHugePageResourceName returns true if the resource name has the quota
+// related huge page resource prefix.
+func IsQuotaHugePageResourceName(name core.ResourceName) bool {
+	return strings.HasPrefix(string(name), core.ResourceHugePagesPrefix) || strings.HasPrefix(string(name), core.ResourceRequestsHugePagesPrefix)
+}
+
+// HugePageResourceName returns a ResourceName with the canonical hugepage
+// prefix prepended for the specified page size.  The page size is converted
+// to its canonical representation.
+func HugePageResourceName(pageSize resource.Quantity) core.ResourceName {
+	return core.ResourceName(fmt.Sprintf("%s%s", core.ResourceHugePagesPrefix, pageSize.String()))
+}
+
+// HugePageSizeFromResourceName returns the page size for the specified huge page
+// resource name.  If the specified input is not a valid huge page resource name
+// an error is returned.
+func HugePageSizeFromResourceName(name core.ResourceName) (resource.Quantity, error) {
+	if !IsHugePageResourceName(name) {
+		return resource.Quantity{}, fmt.Errorf("resource name: %s is not valid hugepage name", name)
+	}
+	pageSize := strings.TrimPrefix(string(name), core.ResourceHugePagesPrefix)
+	return resource.ParseQuantity(pageSize)
+}
+
+// NonConvertibleFields iterates over the provided map and filters out all but
+// any keys with the "non-convertible.kubernetes.io" prefix.
+func NonConvertibleFields(annotations map[string]string) map[string]string {
+	nonConvertibleKeys := map[string]string{}
+	for key, value := range annotations {
+		if strings.HasPrefix(key, core.NonConvertibleAnnotationPrefix) {
+			nonConvertibleKeys[key] = value
+		}
+	}
+	return nonConvertibleKeys
+}
+
+// Semantic can do semantic deep equality checks for core objects.
+// Example: apiequality.Semantic.DeepEqual(aPod, aPodWithNonNilButEmptyMaps) == true
+var Semantic = conversion.EqualitiesOrDie(
+	func(a, b resource.Quantity) bool {
+		// Ignore formatting, only care that numeric value stayed the same.
+		// TODO: if we decide it's important, it should be safe to start comparing the format.
+		//
+		// Uninitialized quantities are equivalent to 0 quantities.
+		return a.Cmp(b) == 0
+	},
+	func(a, b metav1.MicroTime) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b metav1.Time) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b labels.Selector) bool {
+		return a.String() == b.String()
+	},
+	func(a, b fields.Selector) bool {
+		return a.String() == b.String()
+	},
+)
+
+var standardResourceQuotaScopes = sets.NewString(
+	string(core.ResourceQuotaScopeTerminating),
+	string(core.ResourceQuotaScopeNotTerminating),
+	string(core.ResourceQuotaScopeBestEffort),
+	string(core.ResourceQuotaScopeNotBestEffort),
+)
+
+// IsStandardResourceQuotaScope returns true if the scope is a standard value
+func IsStandardResourceQuotaScope(str string) bool {
+	return standardResourceQuotaScopes.Has(str)
+}
+
+var podObjectCountQuotaResources = sets.NewString(
+	string(core.ResourcePods),
+)
+
+var podComputeQuotaResources = sets.NewString(
+	string(core.ResourceCPU),
+	string(core.ResourceMemory),
+	string(core.ResourceLimitsCPU),
+	string(core.ResourceLimitsMemory),
+	string(core.ResourceRequestsCPU),
+	string(core.ResourceRequestsMemory),
+)
+
+// IsResourceQuotaScopeValidForResource returns true if the resource applies to the specified scope
+func IsResourceQuotaScopeValidForResource(scope core.ResourceQuotaScope, resource string) bool {
+	switch scope {
+	case core.ResourceQuotaScopeTerminating, core.ResourceQuotaScopeNotTerminating, core.ResourceQuotaScopeNotBestEffort:
+		return podObjectCountQuotaResources.Has(resource) || podComputeQuotaResources.Has(resource)
+	case core.ResourceQuotaScopeBestEffort:
+		return podObjectCountQuotaResources.Has(resource)
+	default:
+		return true
+	}
+}
+
+var standardContainerResources = sets.NewString(
+	string(core.ResourceCPU),
+	string(core.ResourceMemory),
+	string(core.ResourceEphemeralStorage),
+)
+
+// IsStandardContainerResourceName returns true if the container can make a resource request
+// for the specified resource
+func IsStandardContainerResourceName(str string) bool {
+	return standardContainerResources.Has(str) || IsHugePageResourceName(core.ResourceName(str))
+}
+
+// IsExtendedResourceName returns true if the resource name is not in the
+// default namespace.
+func IsExtendedResourceName(name core.ResourceName) bool {
+	return !IsDefaultNamespaceResource(name)
+}
+
+// IsDefaultNamespaceResource returns true if the resource name is in the
+// *kubernetes.io/ namespace. Partially-qualified (unprefixed) names are
+// implicitly in the kubernetes.io/ namespace.
+func IsDefaultNamespaceResource(name core.ResourceName) bool {
+	return !strings.Contains(string(name), "/") ||
+		strings.Contains(string(name), core.ResourceDefaultNamespacePrefix)
+}
+
+var overcommitBlacklist = sets.NewString(string(core.ResourceNvidiaGPU))
+
+// IsOvercommitAllowed returns true if the resource is in the default
+// namespace and not blacklisted.
+func IsOvercommitAllowed(name core.ResourceName) bool {
+	return IsDefaultNamespaceResource(name) &&
+		!IsHugePageResourceName(name) &&
+		!overcommitBlacklist.Has(string(name))
+}
+
+var standardLimitRangeTypes = sets.NewString(
+	string(core.LimitTypePod),
+	string(core.LimitTypeContainer),
+	string(core.LimitTypePersistentVolumeClaim),
+)
+
+// IsStandardLimitRangeType returns true if the type is Pod or Container
+func IsStandardLimitRangeType(str string) bool {
+	return standardLimitRangeTypes.Has(str)
+}
+
+var standardQuotaResources = sets.NewString(
+	string(core.ResourceCPU),
+	string(core.ResourceMemory),
+	string(core.ResourceEphemeralStorage),
+	string(core.ResourceRequestsCPU),
+	string(core.ResourceRequestsMemory),
+	string(core.ResourceRequestsStorage),
+	string(core.ResourceRequestsEphemeralStorage),
+	string(core.ResourceLimitsCPU),
+	string(core.ResourceLimitsMemory),
+	string(core.ResourceLimitsEphemeralStorage),
+	string(core.ResourcePods),
+	string(core.ResourceQuotas),
+	string(core.ResourceServices),
+	string(core.ResourceReplicationControllers),
+	string(core.ResourceSecrets),
+	string(core.ResourcePersistentVolumeClaims),
+	string(core.ResourceConfigMaps),
+	string(core.ResourceServicesNodePorts),
+	string(core.ResourceServicesLoadBalancers),
+)
+
+// IsStandardQuotaResourceName returns true if the resource is known to
+// the quota tracking system
+func IsStandardQuotaResourceName(str string) bool {
+	return standardQuotaResources.Has(str) || IsQuotaHugePageResourceName(core.ResourceName(str))
+}
+
+var standardResources = sets.NewString(
+	string(core.ResourceCPU),
+	string(core.ResourceMemory),
+	string(core.ResourceEphemeralStorage),
+	string(core.ResourceRequestsCPU),
+	string(core.ResourceRequestsMemory),
+	string(core.ResourceRequestsEphemeralStorage),
+	string(core.ResourceLimitsCPU),
+	string(core.ResourceLimitsMemory),
+	string(core.ResourceLimitsEphemeralStorage),
+	string(core.ResourcePods),
+	string(core.ResourceQuotas),
+	string(core.ResourceServices),
+	string(core.ResourceReplicationControllers),
+	string(core.ResourceSecrets),
+	string(core.ResourceConfigMaps),
+	string(core.ResourcePersistentVolumeClaims),
+	string(core.ResourceStorage),
+	string(core.ResourceRequestsStorage),
+	string(core.ResourceServicesNodePorts),
+	string(core.ResourceServicesLoadBalancers),
+)
+
+// IsStandardResourceName returns true if the resource is known to the system
+func IsStandardResourceName(str string) bool {
+	return standardResources.Has(str) || IsQuotaHugePageResourceName(core.ResourceName(str))
+}
+
+var integerResources = sets.NewString(
+	string(core.ResourcePods),
+	string(core.ResourceQuotas),
+	string(core.ResourceServices),
+	string(core.ResourceReplicationControllers),
+	string(core.ResourceSecrets),
+	string(core.ResourceConfigMaps),
+	string(core.ResourcePersistentVolumeClaims),
+	string(core.ResourceServicesNodePorts),
+	string(core.ResourceServicesLoadBalancers),
+)
+
+// IsIntegerResourceName returns true if the resource is measured in integer values
+func IsIntegerResourceName(str string) bool {
+	return integerResources.Has(str) || IsExtendedResourceName(core.ResourceName(str))
+}
+
+// Extended and HugePages resources
+func IsScalarResourceName(name core.ResourceName) bool {
+	return IsExtendedResourceName(name) || IsHugePageResourceName(name)
+}
+
+// this function aims to check if the service's ClusterIP is set or not
+// the objective is not to perform validation here
+func IsServiceIPSet(service *core.Service) bool {
+	return service.Spec.ClusterIP != core.ClusterIPNone && service.Spec.ClusterIP != ""
+}
+
+// this function aims to check if the service's cluster IP is requested or not
+func IsServiceIPRequested(service *core.Service) bool {
+	// ExternalName services are CNAME aliases to external ones. Ignore the IP.
+	if service.Spec.Type == core.ServiceTypeExternalName {
+		return false
+	}
+	return service.Spec.ClusterIP == ""
+}
+
+var standardFinalizers = sets.NewString(
+	string(core.FinalizerKubernetes),
+	metav1.FinalizerOrphanDependents,
+	metav1.FinalizerDeleteDependents,
+)
+
+// HasAnnotation returns a bool if passed in annotation exists
+func HasAnnotation(obj core.ObjectMeta, ann string) bool {
+	_, found := obj.Annotations[ann]
+	return found
+}
+
+// SetMetaDataAnnotation sets the annotation and value
+func SetMetaDataAnnotation(obj *core.ObjectMeta, ann string, value string) {
+	if obj.Annotations == nil {
+		obj.Annotations = make(map[string]string)
+	}
+	obj.Annotations[ann] = value
+}
+
+func IsStandardFinalizerName(str string) bool {
+	return standardFinalizers.Has(str)
+}
+
+// AddToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,
+// only if they do not already exist
+func AddToNodeAddresses(addresses *[]core.NodeAddress, addAddresses ...core.NodeAddress) {
+	for _, add := range addAddresses {
+		exists := false
+		for _, existing := range *addresses {
+			if existing.Address == add.Address && existing.Type == add.Type {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			*addresses = append(*addresses, add)
+		}
+	}
+}
+
+// TODO: make method on LoadBalancerStatus?
+func LoadBalancerStatusEqual(l, r *core.LoadBalancerStatus) bool {
+	return ingressSliceEqual(l.Ingress, r.Ingress)
+}
+
+func ingressSliceEqual(lhs, rhs []core.LoadBalancerIngress) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+	for i := range lhs {
+		if !ingressEqual(&lhs[i], &rhs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func ingressEqual(lhs, rhs *core.LoadBalancerIngress) bool {
+	if lhs.IP != rhs.IP {
+		return false
+	}
+	if lhs.Hostname != rhs.Hostname {
+		return false
+	}
+	return true
+}
+
+// TODO: make method on LoadBalancerStatus?
+func LoadBalancerStatusDeepCopy(lb *core.LoadBalancerStatus) *core.LoadBalancerStatus {
+	c := &core.LoadBalancerStatus{}
+	c.Ingress = make([]core.LoadBalancerIngress, len(lb.Ingress))
+	for i := range lb.Ingress {
+		c.Ingress[i] = lb.Ingress[i]
+	}
+	return c
+}
+
+// GetAccessModesAsString returns a string representation of an array of access modes.
+// modes, when present, are always in the same order: RWO,ROX,RWX.
+func GetAccessModesAsString(modes []core.PersistentVolumeAccessMode) string {
+	modes = removeDuplicateAccessModes(modes)
+	modesStr := []string{}
+	if containsAccessMode(modes, core.ReadWriteOnce) {
+		modesStr = append(modesStr, "RWO")
+	}
+	if containsAccessMode(modes, core.ReadOnlyMany) {
+		modesStr = append(modesStr, "ROX")
+	}
+	if containsAccessMode(modes, core.ReadWriteMany) {
+		modesStr = append(modesStr, "RWX")
+	}
+	return strings.Join(modesStr, ",")
+}
+
+// GetAccessModesAsString returns an array of AccessModes from a string created by GetAccessModesAsString
+func GetAccessModesFromString(modes string) []core.PersistentVolumeAccessMode {
+	strmodes := strings.Split(modes, ",")
+	accessModes := []core.PersistentVolumeAccessMode{}
+	for _, s := range strmodes {
+		s = strings.Trim(s, " ")
+		switch {
+		case s == "RWO":
+			accessModes = append(accessModes, core.ReadWriteOnce)
+		case s == "ROX":
+			accessModes = append(accessModes, core.ReadOnlyMany)
+		case s == "RWX":
+			accessModes = append(accessModes, core.ReadWriteMany)
+		}
+	}
+	return accessModes
+}
+
+// removeDuplicateAccessModes returns an array of access modes without any duplicates
+func removeDuplicateAccessModes(modes []core.PersistentVolumeAccessMode) []core.PersistentVolumeAccessMode {
+	accessModes := []core.PersistentVolumeAccessMode{}
+	for _, m := range modes {
+		if !containsAccessMode(accessModes, m) {
+			accessModes = append(accessModes, m)
+		}
+	}
+	return accessModes
+}
+
+func containsAccessMode(modes []core.PersistentVolumeAccessMode, mode core.PersistentVolumeAccessMode) bool {
+	for _, m := range modes {
+		if m == mode {
+			return true
+		}
+	}
+	return false
+}
+
+// NodeSelectorRequirementsAsSelector converts the []NodeSelectorRequirement core type into a struct that implements
+// labels.Selector.
+func NodeSelectorRequirementsAsSelector(nsm []core.NodeSelectorRequirement) (labels.Selector, error) {
+	if len(nsm) == 0 {
+		return labels.Nothing(), nil
+	}
+	selector := labels.NewSelector()
+	for _, expr := range nsm {
+		var op selection.Operator
+		switch expr.Operator {
+		case core.NodeSelectorOpIn:
+			op = selection.In
+		case core.NodeSelectorOpNotIn:
+			op = selection.NotIn
+		case core.NodeSelectorOpExists:
+			op = selection.Exists
+		case core.NodeSelectorOpDoesNotExist:
+			op = selection.DoesNotExist
+		case core.NodeSelectorOpGt:
+			op = selection.GreaterThan
+		case core.NodeSelectorOpLt:
+			op = selection.LessThan
+		default:
+			return nil, fmt.Errorf("%q is not a valid node selector operator", expr.Operator)
+		}
+		r, err := labels.NewRequirement(expr.Key, op, expr.Values)
+		if err != nil {
+			return nil, err
+		}
+		selector = selector.Add(*r)
+	}
+	return selector, nil
+}
+
+// GetTolerationsFromPodAnnotations gets the json serialized tolerations data from Pod.Annotations
+// and converts it to the []Toleration type in core.
+func GetTolerationsFromPodAnnotations(annotations map[string]string) ([]core.Toleration, error) {
+	var tolerations []core.Toleration
+	if len(annotations) > 0 && annotations[core.TolerationsAnnotationKey] != "" {
+		err := json.Unmarshal([]byte(annotations[core.TolerationsAnnotationKey]), &tolerations)
+		if err != nil {
+			return tolerations, err
+		}
+	}
+	return tolerations, nil
+}
+
+// AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPod(pod *core.Pod, toleration *core.Toleration) bool {
+	podTolerations := pod.Spec.Tolerations
+
+	var newTolerations []core.Toleration
+	updated := false
+	for i := range podTolerations {
+		if toleration.MatchToleration(&podTolerations[i]) {
+			if Semantic.DeepEqual(toleration, podTolerations[i]) {
+				return false
+			}
+			newTolerations = append(newTolerations, *toleration)
+			updated = true
+			continue
+		}
+
+		newTolerations = append(newTolerations, podTolerations[i])
+	}
+
+	if !updated {
+		newTolerations = append(newTolerations, *toleration)
+	}
+
+	pod.Spec.Tolerations = newTolerations
+	return true
+}
+
+// TolerationToleratesTaint checks if the toleration tolerates the taint.
+func TolerationToleratesTaint(toleration *core.Toleration, taint *core.Taint) bool {
+	if len(toleration.Effect) != 0 && toleration.Effect != taint.Effect {
+		return false
+	}
+
+	if toleration.Key != taint.Key {
+		return false
+	}
+	// TODO: Use proper defaulting when Toleration becomes a field of PodSpec
+	if (len(toleration.Operator) == 0 || toleration.Operator == core.TolerationOpEqual) && toleration.Value == taint.Value {
+		return true
+	}
+	if toleration.Operator == core.TolerationOpExists {
+		return true
+	}
+	return false
+}
+
+// TaintToleratedByTolerations checks if taint is tolerated by any of the tolerations.
+func TaintToleratedByTolerations(taint *core.Taint, tolerations []core.Toleration) bool {
+	tolerated := false
+	for i := range tolerations {
+		if TolerationToleratesTaint(&tolerations[i], taint) {
+			tolerated = true
+			break
+		}
+	}
+	return tolerated
+}
+
+// GetTaintsFromNodeAnnotations gets the json serialized taints data from Pod.Annotations
+// and converts it to the []Taint type in core.
+func GetTaintsFromNodeAnnotations(annotations map[string]string) ([]core.Taint, error) {
+	var taints []core.Taint
+	if len(annotations) > 0 && annotations[core.TaintsAnnotationKey] != "" {
+		err := json.Unmarshal([]byte(annotations[core.TaintsAnnotationKey]), &taints)
+		if err != nil {
+			return []core.Taint{}, err
+		}
+	}
+	return taints, nil
+}
+
+// SysctlsFromPodAnnotations parses the sysctl annotations into a slice of safe Sysctls
+// and a slice of unsafe Sysctls. This is only a convenience wrapper around
+// SysctlsFromPodAnnotation.
+func SysctlsFromPodAnnotations(a map[string]string) ([]core.Sysctl, []core.Sysctl, error) {
+	safe, err := SysctlsFromPodAnnotation(a[core.SysctlsPodAnnotationKey])
+	if err != nil {
+		return nil, nil, err
+	}
+	unsafe, err := SysctlsFromPodAnnotation(a[core.UnsafeSysctlsPodAnnotationKey])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return safe, unsafe, nil
+}
+
+// SysctlsFromPodAnnotation parses an annotation value into a slice of Sysctls.
+func SysctlsFromPodAnnotation(annotation string) ([]core.Sysctl, error) {
+	if len(annotation) == 0 {
+		return nil, nil
+	}
+
+	kvs := strings.Split(annotation, ",")
+	sysctls := make([]core.Sysctl, len(kvs))
+	for i, kv := range kvs {
+		cs := strings.Split(kv, "=")
+		if len(cs) != 2 || len(cs[0]) == 0 {
+			return nil, fmt.Errorf("sysctl %q not of the format sysctl_name=value", kv)
+		}
+		sysctls[i].Name = cs[0]
+		sysctls[i].Value = cs[1]
+	}
+	return sysctls, nil
+}
+
+// PodAnnotationsFromSysctls creates an annotation value for a slice of Sysctls.
+func PodAnnotationsFromSysctls(sysctls []core.Sysctl) string {
+	if len(sysctls) == 0 {
+		return ""
+	}
+
+	kvs := make([]string, len(sysctls))
+	for i := range sysctls {
+		kvs[i] = fmt.Sprintf("%s=%s", sysctls[i].Name, sysctls[i].Value)
+	}
+	return strings.Join(kvs, ",")
+}
+
+// GetPersistentVolumeClass returns StorageClassName.
+func GetPersistentVolumeClass(volume *core.PersistentVolume) string {
+	// Use beta annotation first
+	if class, found := volume.Annotations[core.BetaStorageClassAnnotation]; found {
+		return class
+	}
+
+	return volume.Spec.StorageClassName
+}
+
+// GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
+// requested, it returns "".
+func GetPersistentVolumeClaimClass(claim *core.PersistentVolumeClaim) string {
+	// Use beta annotation first
+	if class, found := claim.Annotations[core.BetaStorageClassAnnotation]; found {
+		return class
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return *claim.Spec.StorageClassName
+	}
+
+	return ""
+}
+
+// PersistentVolumeClaimHasClass returns true if given claim has set StorageClassName field.
+func PersistentVolumeClaimHasClass(claim *core.PersistentVolumeClaim) bool {
+	// Use beta annotation first
+	if _, found := claim.Annotations[core.BetaStorageClassAnnotation]; found {
+		return true
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return true
+	}
+
+	return false
+}
+
+// GetStorageNodeAffinityFromAnnotation gets the json serialized data from PersistentVolume.Annotations
+// and converts it to the NodeAffinity type in core.
+// TODO: update when storage node affinity graduates to beta
+func GetStorageNodeAffinityFromAnnotation(annotations map[string]string) (*core.NodeAffinity, error) {
+	if len(annotations) > 0 && annotations[core.AlphaStorageNodeAffinityAnnotation] != "" {
+		var affinity core.NodeAffinity
+		err := json.Unmarshal([]byte(annotations[core.AlphaStorageNodeAffinityAnnotation]), &affinity)
+		if err != nil {
+			return nil, err
+		}
+		return &affinity, nil
+	}
+	return nil, nil
+}
+
+// Converts NodeAffinity type to Alpha annotation for use in PersistentVolumes
+// TODO: update when storage node affinity graduates to beta
+func StorageNodeAffinityToAlphaAnnotation(annotations map[string]string, affinity *core.NodeAffinity) error {
+	if affinity == nil {
+		return nil
+	}
+
+	json, err := json.Marshal(*affinity)
+	if err != nil {
+		return err
+	}
+	annotations[core.AlphaStorageNodeAffinityAnnotation] = string(json)
+	return nil
+}

--- a/vendor/k8s.io/kubernetes/pkg/apis/core/v1/helper/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/apis/core/v1/helper/BUILD
@@ -1,0 +1,51 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["helpers_test.go"],
+    importpath = "k8s.io/kubernetes/pkg/apis/core/v1/helper",
+    library = ":go_default_library",
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["helpers.go"],
+    importpath = "k8s.io/kubernetes/pkg/apis/core/v1/helper",
+    deps = [
+        "//pkg/apis/core/helper:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/selection:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//pkg/apis/core/v1/helper/qos:all-srcs",
+    ],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/apis/core/v1/helper/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/core/v1/helper/helpers.go
@@ -1,0 +1,461 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/apis/core/helper"
+)
+
+// IsExtendedResourceName returns true if the resource name is not in the
+// default namespace.
+func IsExtendedResourceName(name v1.ResourceName) bool {
+	return !IsDefaultNamespaceResource(name)
+}
+
+// IsDefaultNamespaceResource returns true if the resource name is in the
+// *kubernetes.io/ namespace. Partially-qualified (unprefixed) names are
+// implicitly in the kubernetes.io/ namespace.
+func IsDefaultNamespaceResource(name v1.ResourceName) bool {
+	return !strings.Contains(string(name), "/") ||
+		strings.Contains(string(name), v1.ResourceDefaultNamespacePrefix)
+
+}
+
+// IsHugePageResourceName returns true if the resource name has the huge page
+// resource prefix.
+func IsHugePageResourceName(name v1.ResourceName) bool {
+	return strings.HasPrefix(string(name), v1.ResourceHugePagesPrefix)
+}
+
+// HugePageResourceName returns a ResourceName with the canonical hugepage
+// prefix prepended for the specified page size.  The page size is converted
+// to its canonical representation.
+func HugePageResourceName(pageSize resource.Quantity) v1.ResourceName {
+	return v1.ResourceName(fmt.Sprintf("%s%s", v1.ResourceHugePagesPrefix, pageSize.String()))
+}
+
+// HugePageSizeFromResourceName returns the page size for the specified huge page
+// resource name.  If the specified input is not a valid huge page resource name
+// an error is returned.
+func HugePageSizeFromResourceName(name v1.ResourceName) (resource.Quantity, error) {
+	if !IsHugePageResourceName(name) {
+		return resource.Quantity{}, fmt.Errorf("resource name: %s is not valid hugepage name", name)
+	}
+	pageSize := strings.TrimPrefix(string(name), v1.ResourceHugePagesPrefix)
+	return resource.ParseQuantity(pageSize)
+}
+
+var overcommitBlacklist = sets.NewString(string(v1.ResourceNvidiaGPU))
+
+// IsOvercommitAllowed returns true if the resource is in the default
+// namespace and not blacklisted and is not hugepages.
+func IsOvercommitAllowed(name v1.ResourceName) bool {
+	return IsDefaultNamespaceResource(name) &&
+		!IsHugePageResourceName(name) &&
+		!overcommitBlacklist.Has(string(name))
+}
+
+// Extended and Hugepages resources
+func IsScalarResourceName(name v1.ResourceName) bool {
+	return IsExtendedResourceName(name) || IsHugePageResourceName(name)
+}
+
+// this function aims to check if the service's ClusterIP is set or not
+// the objective is not to perform validation here
+func IsServiceIPSet(service *v1.Service) bool {
+	return service.Spec.ClusterIP != v1.ClusterIPNone && service.Spec.ClusterIP != ""
+}
+
+// this function aims to check if the service's cluster IP is requested or not
+func IsServiceIPRequested(service *v1.Service) bool {
+	// ExternalName services are CNAME aliases to external ones. Ignore the IP.
+	if service.Spec.Type == v1.ServiceTypeExternalName {
+		return false
+	}
+	return service.Spec.ClusterIP == ""
+}
+
+// AddToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,
+// only if they do not already exist
+func AddToNodeAddresses(addresses *[]v1.NodeAddress, addAddresses ...v1.NodeAddress) {
+	for _, add := range addAddresses {
+		exists := false
+		for _, existing := range *addresses {
+			if existing.Address == add.Address && existing.Type == add.Type {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			*addresses = append(*addresses, add)
+		}
+	}
+}
+
+// TODO: make method on LoadBalancerStatus?
+func LoadBalancerStatusEqual(l, r *v1.LoadBalancerStatus) bool {
+	return ingressSliceEqual(l.Ingress, r.Ingress)
+}
+
+func ingressSliceEqual(lhs, rhs []v1.LoadBalancerIngress) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+	for i := range lhs {
+		if !ingressEqual(&lhs[i], &rhs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func ingressEqual(lhs, rhs *v1.LoadBalancerIngress) bool {
+	if lhs.IP != rhs.IP {
+		return false
+	}
+	if lhs.Hostname != rhs.Hostname {
+		return false
+	}
+	return true
+}
+
+// TODO: make method on LoadBalancerStatus?
+func LoadBalancerStatusDeepCopy(lb *v1.LoadBalancerStatus) *v1.LoadBalancerStatus {
+	c := &v1.LoadBalancerStatus{}
+	c.Ingress = make([]v1.LoadBalancerIngress, len(lb.Ingress))
+	for i := range lb.Ingress {
+		c.Ingress[i] = lb.Ingress[i]
+	}
+	return c
+}
+
+// GetAccessModesAsString returns a string representation of an array of access modes.
+// modes, when present, are always in the same order: RWO,ROX,RWX.
+func GetAccessModesAsString(modes []v1.PersistentVolumeAccessMode) string {
+	modes = removeDuplicateAccessModes(modes)
+	modesStr := []string{}
+	if containsAccessMode(modes, v1.ReadWriteOnce) {
+		modesStr = append(modesStr, "RWO")
+	}
+	if containsAccessMode(modes, v1.ReadOnlyMany) {
+		modesStr = append(modesStr, "ROX")
+	}
+	if containsAccessMode(modes, v1.ReadWriteMany) {
+		modesStr = append(modesStr, "RWX")
+	}
+	return strings.Join(modesStr, ",")
+}
+
+// GetAccessModesAsString returns an array of AccessModes from a string created by GetAccessModesAsString
+func GetAccessModesFromString(modes string) []v1.PersistentVolumeAccessMode {
+	strmodes := strings.Split(modes, ",")
+	accessModes := []v1.PersistentVolumeAccessMode{}
+	for _, s := range strmodes {
+		s = strings.Trim(s, " ")
+		switch {
+		case s == "RWO":
+			accessModes = append(accessModes, v1.ReadWriteOnce)
+		case s == "ROX":
+			accessModes = append(accessModes, v1.ReadOnlyMany)
+		case s == "RWX":
+			accessModes = append(accessModes, v1.ReadWriteMany)
+		}
+	}
+	return accessModes
+}
+
+// removeDuplicateAccessModes returns an array of access modes without any duplicates
+func removeDuplicateAccessModes(modes []v1.PersistentVolumeAccessMode) []v1.PersistentVolumeAccessMode {
+	accessModes := []v1.PersistentVolumeAccessMode{}
+	for _, m := range modes {
+		if !containsAccessMode(accessModes, m) {
+			accessModes = append(accessModes, m)
+		}
+	}
+	return accessModes
+}
+
+func containsAccessMode(modes []v1.PersistentVolumeAccessMode, mode v1.PersistentVolumeAccessMode) bool {
+	for _, m := range modes {
+		if m == mode {
+			return true
+		}
+	}
+	return false
+}
+
+// NodeSelectorRequirementsAsSelector converts the []NodeSelectorRequirement api type into a struct that implements
+// labels.Selector.
+func NodeSelectorRequirementsAsSelector(nsm []v1.NodeSelectorRequirement) (labels.Selector, error) {
+	if len(nsm) == 0 {
+		return labels.Nothing(), nil
+	}
+	selector := labels.NewSelector()
+	for _, expr := range nsm {
+		var op selection.Operator
+		switch expr.Operator {
+		case v1.NodeSelectorOpIn:
+			op = selection.In
+		case v1.NodeSelectorOpNotIn:
+			op = selection.NotIn
+		case v1.NodeSelectorOpExists:
+			op = selection.Exists
+		case v1.NodeSelectorOpDoesNotExist:
+			op = selection.DoesNotExist
+		case v1.NodeSelectorOpGt:
+			op = selection.GreaterThan
+		case v1.NodeSelectorOpLt:
+			op = selection.LessThan
+		default:
+			return nil, fmt.Errorf("%q is not a valid node selector operator", expr.Operator)
+		}
+		r, err := labels.NewRequirement(expr.Key, op, expr.Values)
+		if err != nil {
+			return nil, err
+		}
+		selector = selector.Add(*r)
+	}
+	return selector, nil
+}
+
+// AddOrUpdateTolerationInPodSpec tries to add a toleration to the toleration list in PodSpec.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPodSpec(spec *v1.PodSpec, toleration *v1.Toleration) bool {
+	podTolerations := spec.Tolerations
+
+	var newTolerations []v1.Toleration
+	updated := false
+	for i := range podTolerations {
+		if toleration.MatchToleration(&podTolerations[i]) {
+			if helper.Semantic.DeepEqual(toleration, podTolerations[i]) {
+				return false
+			}
+			newTolerations = append(newTolerations, *toleration)
+			updated = true
+			continue
+		}
+
+		newTolerations = append(newTolerations, podTolerations[i])
+	}
+
+	if !updated {
+		newTolerations = append(newTolerations, *toleration)
+	}
+
+	spec.Tolerations = newTolerations
+	return true
+}
+
+// AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPod(pod *v1.Pod, toleration *v1.Toleration) bool {
+	return AddOrUpdateTolerationInPodSpec(&pod.Spec, toleration)
+}
+
+// TolerationsTolerateTaint checks if taint is tolerated by any of the tolerations.
+func TolerationsTolerateTaint(tolerations []v1.Toleration, taint *v1.Taint) bool {
+	for i := range tolerations {
+		if tolerations[i].ToleratesTaint(taint) {
+			return true
+		}
+	}
+	return false
+}
+
+type taintsFilterFunc func(*v1.Taint) bool
+
+// TolerationsTolerateTaintsWithFilter checks if given tolerations tolerates
+// all the taints that apply to the filter in given taint list.
+func TolerationsTolerateTaintsWithFilter(tolerations []v1.Toleration, taints []v1.Taint, applyFilter taintsFilterFunc) bool {
+	if len(taints) == 0 {
+		return true
+	}
+
+	for i := range taints {
+		if applyFilter != nil && !applyFilter(&taints[i]) {
+			continue
+		}
+
+		if !TolerationsTolerateTaint(tolerations, &taints[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Returns true and list of Tolerations matching all Taints if all are tolerated, or false otherwise.
+func GetMatchingTolerations(taints []v1.Taint, tolerations []v1.Toleration) (bool, []v1.Toleration) {
+	if len(taints) == 0 {
+		return true, []v1.Toleration{}
+	}
+	if len(tolerations) == 0 && len(taints) > 0 {
+		return false, []v1.Toleration{}
+	}
+	result := []v1.Toleration{}
+	for i := range taints {
+		tolerated := false
+		for j := range tolerations {
+			if tolerations[j].ToleratesTaint(&taints[i]) {
+				result = append(result, tolerations[j])
+				tolerated = true
+				break
+			}
+		}
+		if !tolerated {
+			return false, []v1.Toleration{}
+		}
+	}
+	return true, result
+}
+
+func GetAvoidPodsFromNodeAnnotations(annotations map[string]string) (v1.AvoidPods, error) {
+	var avoidPods v1.AvoidPods
+	if len(annotations) > 0 && annotations[v1.PreferAvoidPodsAnnotationKey] != "" {
+		err := json.Unmarshal([]byte(annotations[v1.PreferAvoidPodsAnnotationKey]), &avoidPods)
+		if err != nil {
+			return avoidPods, err
+		}
+	}
+	return avoidPods, nil
+}
+
+// SysctlsFromPodAnnotations parses the sysctl annotations into a slice of safe Sysctls
+// and a slice of unsafe Sysctls. This is only a convenience wrapper around
+// SysctlsFromPodAnnotation.
+func SysctlsFromPodAnnotations(a map[string]string) ([]v1.Sysctl, []v1.Sysctl, error) {
+	safe, err := SysctlsFromPodAnnotation(a[v1.SysctlsPodAnnotationKey])
+	if err != nil {
+		return nil, nil, err
+	}
+	unsafe, err := SysctlsFromPodAnnotation(a[v1.UnsafeSysctlsPodAnnotationKey])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return safe, unsafe, nil
+}
+
+// SysctlsFromPodAnnotation parses an annotation value into a slice of Sysctls.
+func SysctlsFromPodAnnotation(annotation string) ([]v1.Sysctl, error) {
+	if len(annotation) == 0 {
+		return nil, nil
+	}
+
+	kvs := strings.Split(annotation, ",")
+	sysctls := make([]v1.Sysctl, len(kvs))
+	for i, kv := range kvs {
+		cs := strings.Split(kv, "=")
+		if len(cs) != 2 || len(cs[0]) == 0 {
+			return nil, fmt.Errorf("sysctl %q not of the format sysctl_name=value", kv)
+		}
+		sysctls[i].Name = cs[0]
+		sysctls[i].Value = cs[1]
+	}
+	return sysctls, nil
+}
+
+// PodAnnotationsFromSysctls creates an annotation value for a slice of Sysctls.
+func PodAnnotationsFromSysctls(sysctls []v1.Sysctl) string {
+	if len(sysctls) == 0 {
+		return ""
+	}
+
+	kvs := make([]string, len(sysctls))
+	for i := range sysctls {
+		kvs[i] = fmt.Sprintf("%s=%s", sysctls[i].Name, sysctls[i].Value)
+	}
+	return strings.Join(kvs, ",")
+}
+
+// GetPersistentVolumeClass returns StorageClassName.
+func GetPersistentVolumeClass(volume *v1.PersistentVolume) string {
+	// Use beta annotation first
+	if class, found := volume.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return class
+	}
+
+	return volume.Spec.StorageClassName
+}
+
+// GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
+// requested, it returns "".
+func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
+	// Use beta annotation first
+	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return class
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return *claim.Spec.StorageClassName
+	}
+
+	return ""
+}
+
+// PersistentVolumeClaimHasClass returns true if given claim has set StorageClassName field.
+func PersistentVolumeClaimHasClass(claim *v1.PersistentVolumeClaim) bool {
+	// Use beta annotation first
+	if _, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return true
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return true
+	}
+
+	return false
+}
+
+// GetStorageNodeAffinityFromAnnotation gets the json serialized data from PersistentVolume.Annotations
+// and converts it to the NodeAffinity type in api.
+// TODO: update when storage node affinity graduates to beta
+func GetStorageNodeAffinityFromAnnotation(annotations map[string]string) (*v1.NodeAffinity, error) {
+	if len(annotations) > 0 && annotations[v1.AlphaStorageNodeAffinityAnnotation] != "" {
+		var affinity v1.NodeAffinity
+		err := json.Unmarshal([]byte(annotations[v1.AlphaStorageNodeAffinityAnnotation]), &affinity)
+		if err != nil {
+			return nil, err
+		}
+		return &affinity, nil
+	}
+	return nil, nil
+}
+
+// Converts NodeAffinity type to Alpha annotation for use in PersistentVolumes
+// TODO: update when storage node affinity graduates to beta
+func StorageNodeAffinityToAlphaAnnotation(annotations map[string]string, affinity *v1.NodeAffinity) error {
+	if affinity == nil {
+		return nil
+	}
+
+	json, err := json.Marshal(*affinity)
+	if err != nil {
+		return err
+	}
+	annotations[v1.AlphaStorageNodeAffinityAnnotation] = string(json)
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR
* Adds `disable-pod-none-generic-resource-metrics` command line argument to kube-state-metrics to disable old not labeled resource metrics.
* Adds generic new `kube_pod_container_resource_requests ` and `kube_pod_container_resource_limits `.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #408 

