### PR TITLE
update kube-state-metrics version to v1.3.1

### DIFF
--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.0
+        image: quay.io/coreos/kube-state-metrics:v1.3.1
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the kube-state-metrics version to v1.3.1

