### PR TITLE
fix collectors argument panic

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -40,7 +40,9 @@ type options struct {
 }
 
 func NewOptions() *options {
-	return &options{}
+	return &options{
+		Collectors: CollectorSet{},
+	}
 }
 
 func (o *options) AddFlags() {

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestOptionsParse(t *testing.T) {
+	tests := []struct {
+		Desc           string
+		Args           []string
+		RecoverInvoked bool
+	}{
+		{
+			Desc:           "collectors command line argument",
+			Args:           []string{"./kube-state-metrics", "--collectors=configmaps,pods"},
+			RecoverInvoked: false,
+		},
+		{
+			Desc:           "namespace command line argument",
+			Args:           []string{"./kube-state-metrics", "--namespace=default,kube-system"},
+			RecoverInvoked: false,
+		},
+	}
+
+	for _, test := range tests {
+		var wg sync.WaitGroup
+
+		opts := NewOptions()
+		opts.AddFlags()
+
+		flags := pflag.NewFlagSet("options_test", pflag.PanicOnError)
+		flags.AddFlagSet(opts.flags)
+
+		opts.flags = flags
+
+		os.Args = test.Args
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if err := recover(); err != nil {
+					test.RecoverInvoked = true
+				}
+			}()
+
+			opts.Parse()
+		}()
+
+		wg.Wait()
+		if test.RecoverInvoked {
+			t.Errorf("Test error for Desc: %s. Test panic", test.Desc)
+		}
+	}
+}

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/golang/glog"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,7 +42,7 @@ func (c *CollectorSet) Set(value string) error {
 		if len(col) != 0 {
 			_, ok := AvailableCollectors[col]
 			if !ok {
-				glog.Fatalf("Collector \"%s\" does not exist", col)
+				return fmt.Errorf("collector \"%s\" does not exist", col)
 			}
 			s[col] = struct{}{}
 		}

--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCollectorSetSet(t *testing.T) {
+	tests := []struct {
+		Desc        string
+		Value       string
+		Wanted      CollectorSet
+		WantedError bool
+	}{
+		{
+			Desc:        "empty collectors",
+			Value:       "",
+			Wanted:      CollectorSet{},
+			WantedError: false,
+		},
+		{
+			Desc:  "normal collectors",
+			Value: "configmaps,cronjobs,daemonsets,deployments",
+			Wanted: CollectorSet(map[string]struct{}{
+				"configmaps":  {},
+				"cronjobs":    {},
+				"daemonsets":  {},
+				"deployments": {},
+			}),
+			WantedError: false,
+		},
+		{
+			Desc:        "none exist collectors",
+			Value:       "none-exists",
+			Wanted:      CollectorSet{},
+			WantedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		cs := &CollectorSet{}
+		gotError := cs.Set(test.Value)
+		if !(((gotError == nil && !test.WantedError) || (gotError != nil && test.WantedError)) && reflect.DeepEqual(*cs, test.Wanted)) {
+			t.Errorf("Test error for Desc: %s. Want: %+v. Got: %+v. Wanted Error: %v, Got Error: %v", test.Desc, test.Wanted, *cs, test.WantedError, gotError)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes panics when `--collectors` command line argument is specified. This is a regression bug in #446.

This PR adds unit tests for command line argument parse and `CollectorSet` `Set` method. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #446 

