### PR TITLE
Add note about CPU limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ For clusters of more than 100 nodes, allocate at least
 
 These numbers are based on [scalability tests](https://github.com/kubernetes/kube-state-metrics/issues/124#issuecomment-318394185) at 30 pods per node.
 
+Note that if CPU limits are set too low, kube-state-metrics' internal queues will not be able to be worked off quickly enough, resulting in increased memory consumption as the queue length grows. If you experience problems resulting from high memory allocation, try increasing the CPU limits.
+
 ### kube-state-metrics vs. Heapster
 
 [Heapster](https://github.com/kubernetes/heapster) is a project which fetches


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a note about imposing CPU limitations on kube-state-metrics, and the consequent memory consumption that results. It explains the consequence of imposing too low a CPU limit, the cause of unbounded memory consumption in low-CPU environments, and offer a possible fix to users who are seeing unbounded memory consumption when use kube-state-metrics. This PR was created in response to https://github.com/kubernetes/kube-state-metrics/issues/461 as temporary advice until the recommended resources can be revised. 

Fix #461 