### PR TITLE
remove namepspace reference from persistentvolumes docs.

### DIFF
--- a/Documentation/persistentvolume-metrics.md
+++ b/Documentation/persistentvolume-metrics.md
@@ -2,7 +2,7 @@
 
 | Metric name| Metric type | Labels/tags |
 | ---------- | ----------- | ----------- |
-| kube_persistentvolume_status_phase | Gauge | `persistentvolume`=&lt;pv-name&gt; <br> `namespace`=&lt;pv-namespace&gt; <br>`phase`=&lt;Bound\|Failed\|Pending\|Available\|Released&gt;|
-| kube_persistentvolume_labels | Gauge | `persistentvolume`=&lt;persistentvolume-name&gt; <br> `namespace`=&lt;persistentvolume-namespace&gt; <br> `label_PERSISTENTVOLUME_LABEL`=&lt;PERSISTENTVOLUME_LABEL&gt;  |
-| kube_persistentvolume_info | Gauge | `persistentvolume`=&lt;pv-name&gt; <br> `namespace`=&lt;pv-namespace&gt;<br> `storageclass`=&lt;storageclass-name&gt; |
+| kube_persistentvolume_status_phase | Gauge | `persistentvolume`=&lt;pv-name&gt; <br>`phase`=&lt;Bound\|Failed\|Pending\|Available\|Released&gt;|
+| kube_persistentvolume_labels | Gauge | `persistentvolume`=&lt;persistentvolume-name&gt; <br> `label_PERSISTENTVOLUME_LABEL`=&lt;PERSISTENTVOLUME_LABEL&gt;  |
+| kube_persistentvolume_info | Gauge | `persistentvolume`=&lt;pv-name&gt; <br> `storageclass`=&lt;storageclass-name&gt; |
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
remove namespace reference from persistentvolumes docs
