### PR TITLE
add generic node resource capacity and allocatable

### DIFF
--- a/Documentation/node-metrics.md
+++ b/Documentation/node-metrics.md
@@ -7,10 +7,12 @@
 | kube_node_spec_unschedulable | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_spec_taint | Gauge | `node`=&lt;node-address&gt; <br> `key`=&lt;taint-key&gt; <br> `value=`&lt;taint-value&gt; <br> `effect=`&lt;taint-effect&gt; |
 | kube_node_status_phase| Gauge | `node`=&lt;node-address&gt; <br> `phase`=&lt;Pending\|Running\|Terminated&gt; |
+| kube_node_status_capacity | Gauge | `node`=&lt;node-address&gt; <br> `resource`=&lt;resource-name&gt; <br> `unit=`&lt;resource-unit&gt;|
 | kube_node_status_capacity_cpu_cores | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_capacity_nvidia_gpu_cards | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_capacity_memory_bytes | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_capacity_pods | Gauge | `node`=&lt;node-address&gt;|
+| kube_node_status_allocatable | Gauge | `node`=&lt;node-address&gt; <br> `resource`=&lt;resource-name&gt; <br> `unit=`&lt;resource-unit&gt;|
 | kube_node_status_allocatable_cpu_cores | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_allocatable_nvidia_gpu_cards | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_status_allocatable_memory_bytes | Gauge | `node`=&lt;node-address&gt;|

--- a/README.md
+++ b/README.md
@@ -114,7 +114,17 @@ representing the resource name and `unit` labels representing the resource unit.
   * kube_pod_container_resource_limits_memory_bytes
   * kube_pod_container_resource_requests_nvidia_gpu_devices
   * kube_pod_container_resource_limits_nvidia_gpu_devices
-  
+* **The following non-generic resource metrics for nodes are marked deprecated. They will be removed in kube-state-metrics v2.0.0.**
+`kube_node_status_capacity` and `kube_node_status_allocatable` are the replacements with `resource` labels
+representing the resource name and `unit` labels representing the resource unit.
+  * kube_node_status_capacity_pods
+  * kube_node_status_capacity_cpu_cores
+  * kube_node_status_capacity_nvidia_gpu_cards
+  * kube_node_status_capacity_memory_bytes
+  * kube_node_status_allocatable_pods
+  * kube_node_status_allocatable_cpu_cores
+  * kube_node_status_allocatable_nvidia_gpu_cards
+  * kube_node_status_allocatable_memory_bytes
 
 ### Kube-state-metrics self metrics
 kube-state-metrics exposes its own metrics under `--telemetry-host` and `--telemetry-port` (default 81).

--- a/pkg/collectors/node_test.go
+++ b/pkg/collectors/node_test.go
@@ -51,6 +51,8 @@ func TestNodeCollector(t *testing.T) {
 		# TYPE kube_node_spec_taint gauge
 		# TYPE kube_node_status_phase gauge
 		# HELP kube_node_status_phase The phase the node is currently in.
+		# TYPE kube_node_status_capacity gauge
+		# HELP kube_node_status_capacity The capacity for different resources of a node.
 		# TYPE kube_node_status_capacity_pods gauge
 		# HELP kube_node_status_capacity_pods The total pod resources of the node.
 		# TYPE kube_node_status_capacity_cpu_cores gauge
@@ -59,6 +61,8 @@ func TestNodeCollector(t *testing.T) {
 		# TYPE kube_node_status_capacity_nvidia_gpu_cards gauge
 		# TYPE kube_node_status_capacity_memory_bytes gauge
 		# HELP kube_node_status_capacity_memory_bytes The total memory resources of the node.
+		# TYPE kube_node_status_allocatable gauge
+		# HELP kube_node_status_allocatable The allocatable for different resources of a node that are available for scheduling.
 		# TYPE kube_node_status_allocatable_pods gauge
 		# HELP kube_node_status_allocatable_pods The pod resources of a node that are available for scheduling.
 		# TYPE kube_node_status_allocatable_cpu_cores gauge
@@ -126,16 +130,22 @@ func TestNodeCollector(t *testing.T) {
 							ContainerRuntimeVersion: "rkt",
 						},
 						Capacity: v1.ResourceList{
-							v1.ResourceCPU:       resource.MustParse("4.3"),
-							v1.ResourceNvidiaGPU: resource.MustParse("4"),
-							v1.ResourceMemory:    resource.MustParse("2G"),
-							v1.ResourcePods:      resource.MustParse("1000"),
+							v1.ResourceCPU:                    resource.MustParse("4.3"),
+							v1.ResourceNvidiaGPU:              resource.MustParse("4"),
+							v1.ResourceMemory:                 resource.MustParse("2G"),
+							v1.ResourcePods:                   resource.MustParse("1000"),
+							v1.ResourceStorage:                resource.MustParse("3G"),
+							v1.ResourceEphemeralStorage:       resource.MustParse("4G"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("4"),
 						},
 						Allocatable: v1.ResourceList{
-							v1.ResourceCPU:       resource.MustParse("3"),
-							v1.ResourceNvidiaGPU: resource.MustParse("2"),
-							v1.ResourceMemory:    resource.MustParse("1G"),
-							v1.ResourcePods:      resource.MustParse("555"),
+							v1.ResourceCPU:                    resource.MustParse("3"),
+							v1.ResourceNvidiaGPU:              resource.MustParse("2"),
+							v1.ResourceMemory:                 resource.MustParse("1G"),
+							v1.ResourcePods:                   resource.MustParse("555"),
+							v1.ResourceStorage:                resource.MustParse("2G"),
+							v1.ResourceEphemeralStorage:       resource.MustParse("3G"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
 						},
 					},
 				},
@@ -145,10 +155,24 @@ func TestNodeCollector(t *testing.T) {
 				kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",provider_id="provider://i-randomidentifier"} 1
 				kube_node_labels{label_type="master",node="127.0.0.1"} 1
 				kube_node_spec_unschedulable{node="127.0.0.1"} 1
+				kube_node_status_capacity{node="127.0.0.1",resource="cpu",unit="core"} 4.3
+				kube_node_status_capacity{node="127.0.0.1",resource="alpha_kubernetes_io_nvidia_gpu",unit="integer"} 4
+				kube_node_status_capacity{node="127.0.0.1",resource="memory",unit="byte"}2e9
+				kube_node_status_capacity{node="127.0.0.1",resource="pods",unit="integer"} 1000
+				kube_node_status_capacity{node="127.0.0.1",resource="nvidia_com_gpu",unit="integer"} 4
+				kube_node_status_capacity{node="127.0.0.1",resource="storage",unit="byte"} 3e9
+				kube_node_status_capacity{node="127.0.0.1",resource="ephemeral_storage",unit="byte"} 4e9
 				kube_node_status_capacity_cpu_cores{node="127.0.0.1"} 4.3
 				kube_node_status_capacity_nvidia_gpu_cards{node="127.0.0.1"} 4
 				kube_node_status_capacity_memory_bytes{node="127.0.0.1"} 2e9
 				kube_node_status_capacity_pods{node="127.0.0.1"} 1000
+				kube_node_status_allocatable{node="127.0.0.1",resource="cpu",unit="core"} 3
+				kube_node_status_allocatable{node="127.0.0.1",resource="alpha_kubernetes_io_nvidia_gpu",unit="integer"} 2
+				kube_node_status_allocatable{node="127.0.0.1",resource="memory",unit="byte"} 1e9
+				kube_node_status_allocatable{node="127.0.0.1",resource="pods",unit="integer"} 555
+				kube_node_status_allocatable{node="127.0.0.1",resource="nvidia_com_gpu",unit="integer"} 1
+				kube_node_status_allocatable{node="127.0.0.1",resource="storage",unit="byte"} 2e9
+				kube_node_status_allocatable{node="127.0.0.1",resource="ephemeral_storage",unit="byte"} 3e9
 				kube_node_status_allocatable_cpu_cores{node="127.0.0.1"} 3
 				kube_node_status_allocatable_nvidia_gpu_cards{node="127.0.0.1"} 2
 				kube_node_status_allocatable_memory_bytes{node="127.0.0.1"} 1e9

--- a/pkg/collectors/pod.go
+++ b/pkg/collectors/pod.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-state-metrics/pkg/constant"
 	"k8s.io/kube-state-metrics/pkg/options"
 	"k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/util/node"
@@ -461,25 +462,25 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 			switch resourceName {
 			case v1.ResourceCPU:
 				addGauge(descPodContainerResourceRequests, float64(val.MilliValue())/1000,
-					c.Name, nodeName, sanitizeLabelName(string(resourceName)), "core")
+					c.Name, nodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore))
 			case v1.ResourceStorage:
 				fallthrough
 			case v1.ResourceEphemeralStorage:
 				fallthrough
 			case v1.ResourceMemory:
 				addGauge(descPodContainerResourceRequests, float64(val.Value()),
-					c.Name, nodeName, sanitizeLabelName(string(resourceName)), "byte")
+					c.Name, nodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte))
 			case v1.ResourceNvidiaGPU:
 				addGauge(descPodContainerResourceRequests, float64(val.Value()),
-					c.Name, nodeName, sanitizeLabelName(string(resourceName)), "integer")
+					c.Name, nodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger))
 			default:
 				if helper.IsHugePageResourceName(resourceName) {
 					addGauge(descPodContainerResourceRequests, float64(val.Value()),
-						c.Name, nodeName, sanitizeLabelName(string(resourceName)), "byte")
+						c.Name, nodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte))
 				}
 				if helper.IsExtendedResourceName(resourceName) {
 					addGauge(descPodContainerResourceRequests, float64(val.Value()),
-						c.Name, nodeName, sanitizeLabelName(string(resourceName)), "integer")
+						c.Name, nodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger))
 				}
 			}
 		}
@@ -488,25 +489,25 @@ func (pc *podCollector) collectPod(ch chan<- prometheus.Metric, p v1.Pod) {
 			switch resourceName {
 			case v1.ResourceCPU:
 				addGauge(descPodContainerResourceLimits, float64(val.MilliValue())/1000,
-					c.Name, nodeName, sanitizeLabelName(string(resourceName)), "core")
+					c.Name, nodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore))
 			case v1.ResourceStorage:
 				fallthrough
 			case v1.ResourceEphemeralStorage:
 				fallthrough
 			case v1.ResourceMemory:
 				addGauge(descPodContainerResourceLimits, float64(val.Value()),
-					c.Name, nodeName, sanitizeLabelName(string(resourceName)), "byte")
+					c.Name, nodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte))
 			case v1.ResourceNvidiaGPU:
 				addGauge(descPodContainerResourceLimits, float64(val.Value()),
-					c.Name, nodeName, sanitizeLabelName(string(resourceName)), "integer")
+					c.Name, nodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger))
 			default:
 				if helper.IsHugePageResourceName(resourceName) {
 					addGauge(descPodContainerResourceLimits, float64(val.Value()),
-						c.Name, nodeName, sanitizeLabelName(string(resourceName)), "byte")
+						c.Name, nodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte))
 				}
 				if helper.IsExtendedResourceName(resourceName) {
 					addGauge(descPodContainerResourceLimits, float64(val.Value()),
-						c.Name, nodeName, sanitizeLabelName(string(resourceName)), "integer")
+						c.Name, nodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger))
 				}
 			}
 		}

--- a/pkg/constant/resource_unit.go
+++ b/pkg/constant/resource_unit.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constant
+
+type ResourceUnit string
+
+const (
+	UnitByte    ResourceUnit = "byte"
+	UnitCore    ResourceUnit = "core"
+	UnitInteger ResourceUnit = "integer"
+)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -25,17 +25,18 @@ import (
 )
 
 type Options struct {
-	Apiserver                           string
-	Kubeconfig                          string
-	Help                                bool
-	Port                                int
-	Host                                string
-	TelemetryPort                       int
-	TelemetryHost                       string
-	Collectors                          CollectorSet
-	Namespaces                          NamespaceList
-	Version                             bool
-	DisablePodNonGenericResourceMetrics bool
+	Apiserver                            string
+	Kubeconfig                           string
+	Help                                 bool
+	Port                                 int
+	Host                                 string
+	TelemetryPort                        int
+	TelemetryHost                        string
+	Collectors                           CollectorSet
+	Namespaces                           NamespaceList
+	Version                              bool
+	DisablePodNonGenericResourceMetrics  bool
+	DisableNodeNonGenericResourceMetrics bool
 
 	flags *pflag.FlagSet
 }
@@ -70,6 +71,7 @@ func (o *Options) AddFlags() {
 	o.flags.Var(&o.Namespaces, "namespace", fmt.Sprintf("Comma-separated list of namespaces to be enabled. Defaults to %q", &DefaultNamespaces))
 	o.flags.BoolVarP(&o.Version, "version", "", false, "kube-state-metrics build version information")
 	o.flags.BoolVarP(&o.DisablePodNonGenericResourceMetrics, "disable-pod-non-generic-resource-metrics", "", false, "Disable pod non generic resource request and limit metrics")
+	o.flags.BoolVarP(&o.DisableNodeNonGenericResourceMetrics, "disable-node-non-generic-resource-metrics", "", false, "Disable node non generic resource request and limit metrics")
 }
 
 func (o *Options) Parse() error {


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adds `disable-node-none-generic-resource-metrics` command line argument to kube-state-metrics to disable old not labeled resource metrics.
* Adds generic new `kube_node_status_capacity` and `kube_node_status_allocatable`.


