### PR TITLE
Dockerfile: Remove `VOLUME` directive.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:3.7
 
 COPY kube-state-metrics /
-VOLUME /tmp
 
 ENTRYPOINT ["/kube-state-metrics", "--port=8080", "--telemetry-port=8081"]
 


### PR DESCRIPTION
The `VOLUME` directive causes Docker to provision host storage to cover
the implicitly requested volume mount. For security reasons this may be
disallowed by Kubernetes clusters, causing kube-state-metrics containers
to fail to be created.

Besides that, this directive does not do anything and to my knowledge
never did.

@andyxning 

cc @ironcladlou 