### PR TITLE
adjust client-go User-Agent

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,6 +116,7 @@ func createKubeClient(apiserver string, kubeconfig string) (clientset.Interface,
 		return nil, err
 	}
 
+	config.UserAgent = version.GetVersion().String()
 	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
 	config.ContentType = "application/vnd.kubernetes.protobuf"
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,6 +15,8 @@ package version
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 )
 
@@ -34,6 +36,12 @@ type Version struct {
 	GoVersion string
 	Compiler  string
 	Platform  string
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("%s/%s (%s/%s) kube-state-metrics/%s",
+		filepath.Base(os.Args[0]), v.Release,
+		runtime.GOOS, runtime.GOARCH, v.GitCommit)
 }
 
 // GetVersion returns kube-state-metrics version


### PR DESCRIPTION
**What this PR does / why we need it**:
This RP will customize User-Agent client-go uses. This will make the User-Agent more useful and be in more Kubernetes's format:
`kube-state-metrics/v1.3.0 (linux/amd64) kube-state-metrics/64fdc24`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

