### PR TITLE
Upgrade go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BuildDate = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 Commit = $(shell git rev-parse --short HEAD)
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 PKG=k8s.io/kube-state-metrics/pkg
-GO_VERSION=1.10.1
+GO_VERSION=1.10.3
 
 IMAGE = $(REGISTRY)/kube-state-metrics
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates to the latest version of go which includes fixes to TLS and strings packages.

@andyxning 