### PR TITLE
Fix typo in metric description

### DIFF
--- a/pkg/collectors/pod.go
+++ b/pkg/collectors/pod.go
@@ -166,7 +166,7 @@ var (
 	)
 	descPodContainerResourceRequestsMemoryBytes = prometheus.NewDesc(
 		"kube_pod_container_resource_requests_memory_bytes",
-		"The number of requested memory bytes  by a container.",
+		"The number of requested memory bytes by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node"),
 		nil,
 	)

--- a/pkg/collectors/pod_test.go
+++ b/pkg/collectors/pod_test.go
@@ -87,7 +87,7 @@ func TestPodCollector(t *testing.T) {
 		# TYPE kube_pod_container_resource_limits gauge
 		# HELP kube_pod_container_resource_requests_cpu_cores The number of requested cpu cores by a container.
 		# TYPE kube_pod_container_resource_requests_cpu_cores gauge
-		# HELP kube_pod_container_resource_requests_memory_bytes The number of requested memory bytes  by a container.
+		# HELP kube_pod_container_resource_requests_memory_bytes The number of requested memory bytes by a container.
 		# TYPE kube_pod_container_resource_requests_memory_bytes gauge
 		# HELP kube_pod_container_resource_limits_cpu_cores The limit on cpu cores to be used by a container.
 		# TYPE kube_pod_container_resource_limits_cpu_cores gauge


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a typo in the metric description kube_pod_container_resource_requests_memory_bytes
