### PR TITLE
Change error message

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -36,7 +36,7 @@ func BenchmarkKubeStateMetrics(t *testing.B) {
 	kubeClient := fake.NewSimpleClientset()
 
 	if err := injectFixtures(kubeClient, 1000); err != nil {
-		t.Errorf("error injecting pod add: %v", err)
+		t.Errorf("error injecting resources add: %v", err)
 	}
 
 	opts := options.NewOptions()

--- a/main_test.go
+++ b/main_test.go
@@ -36,7 +36,7 @@ func BenchmarkKubeStateMetrics(t *testing.B) {
 	kubeClient := fake.NewSimpleClientset()
 
 	if err := injectFixtures(kubeClient, 1000); err != nil {
-		t.Errorf("error injecting resources add: %v", err)
+		t.Errorf("error injecting resources: %v", err)
 	}
 
 	opts := options.NewOptions()


### PR DESCRIPTION
**What this PR does / why we need it**:
The test creates two resources(pod, configmap), not only pod added.
