### PR TITLE
add an example of joining the metrics in docs

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -63,8 +63,8 @@ Per group of metrics there is one file for each metrics. See each file for speci
 
 
 ## Join Metrics
-When an additional, not provided by default label is needed a [Prometheus matching operator](https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching) 
-can be used to extend metrics output.
+When an additional, not provided by default label is needed, a [Prometheus matching operator](https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching) 
+can be used to extend single metrics output.
 
 This example adds `label_release` to the set of default labels of the `kube_pod_status_ready` metric: 
 

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -9,6 +9,7 @@ Any contribution to improving this documentation or adding sample usages will be
 - [Metrics Stages](#metrics-stages)
 - [Metrics Deprecation](#metrics-deprecation)
 - [Exposed Metrics](#exposed-metrics)
+- [Join Metrics](#join-metrics)
 
 ## Metrics Stages
 Stages about metrics are grouped into three categories：
@@ -59,3 +60,15 @@ Per group of metrics there is one file for each metrics. See each file for speci
 * [Endpoint Metrics](endpoint-metrics.md)
 * [Secret Metrics](secret-metrics.md)
 * [ConfigMap Metrics](configmap-metrics.md)
+
+
+## Join Metrics
+When an additional, not provided by default label is needed a [Prometheus matching operator](https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching) 
+can be used to extend metrics output.
+
+This example adds `label_release` to the set of default labels of the `kube_pod_status_ready` metric: 
+
+```
+kube_pod_status_ready * on (namespace, pod) group_left(label_release)  kube_pod_labels
+```
+   

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -66,7 +66,8 @@ Per group of metrics there is one file for each metrics. See each file for speci
 When an additional, not provided by default label is needed, a [Prometheus matching operator](https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching) 
 can be used to extend single metrics output.
 
-This example adds `label_release` to the set of default labels of the `kube_pod_status_ready` metric: 
+This example adds `label_release` to the set of default labels of the `kube_pod_status_ready` metric 
+and allows you select or group the metrics by helm release label: 
 
 ```
 kube_pod_status_ready * on (namespace, pod) group_left(label_release)  kube_pod_labels


### PR DESCRIPTION
This PR adds an example for joining the metrics as per discussion in https://github.com/kubernetes/kube-state-metrics/issues/536

Fix #536 