### PR TITLE
Export stateful sets status.{current_revision,update_revision}

### DIFF
--- a/Documentation/statefulset-metrics.md
+++ b/Documentation/statefulset-metrics.md
@@ -11,3 +11,5 @@
 | kube_statefulset_metadata_generation | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_created | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_labels | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt; <br> `label_STATEFULSET_LABEL`=&lt;STATEFULSET_LABEL&gt; | STABLE |
+| kube_statefulset_status_current_revision | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt; <br> `revision`=&lt;statefulset-current-revision&gt; | STABLE |
+| kube_statefulset_status_update_revision | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt; <br> `revision`=&lt;statefulset-update-revision&gt | STABLE |

--- a/pkg/collectors/statefulset.go
+++ b/pkg/collectors/statefulset.go
@@ -85,6 +85,18 @@ var (
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
+	descStatefulSetCurrentRevision = prometheus.NewDesc(
+		"kube_statefulset_status_current_revision",
+		"Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
+		append(descStatefulSetLabelsDefaultLabels, "revision"),
+		nil,
+	)
+	descStatefulSetUpdateRevision = prometheus.NewDesc(
+		"kube_statefulset_status_update_revision",
+		"Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
+		append(descStatefulSetLabelsDefaultLabels, "revision"),
+		nil,
+	)
 )
 
 type StatefulSetLister func() ([]v1beta1.StatefulSet, error)
@@ -133,6 +145,8 @@ func (dc *statefulSetCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descStatefulSetSpecReplicas
 	ch <- descStatefulSetMetadataGeneration
 	ch <- descStatefulSetLabels
+	ch <- descStatefulSetCurrentRevision
+	ch <- descStatefulSetUpdateRevision
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -185,4 +199,7 @@ func (dc *statefulSetCollector) collectStatefulSet(ch chan<- prometheus.Metric, 
 
 	labelKeys, labelValues := kubeLabelsToPrometheusLabels(statefulSet.Labels)
 	addGauge(statefulSetLabelsDesc(labelKeys), 1, labelValues...)
+
+	addGauge(descStatefulSetCurrentRevision, 1, statefulSet.Status.CurrentRevision)
+	addGauge(descStatefulSetUpdateRevision, 1, statefulSet.Status.UpdateRevision)
 }

--- a/pkg/collectors/statefulset_test.go
+++ b/pkg/collectors/statefulset_test.go
@@ -49,6 +49,8 @@ func TestStatefuleSetCollector(t *testing.T) {
 	const metadata = `
 		# HELP kube_statefulset_created Unix creation timestamp
 		# TYPE kube_statefulset_created gauge
+		# HELP kube_statefulset_status_current_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+		# TYPE kube_statefulset_status_current_revision gauge
  		# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
  		# TYPE kube_statefulset_status_replicas gauge
 		# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
@@ -59,6 +61,8 @@ func TestStatefuleSetCollector(t *testing.T) {
 		# TYPE kube_statefulset_status_replicas_updated gauge
  		# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
  		# TYPE kube_statefulset_status_observed_generation gauge
+		# HELP kube_statefulset_status_update_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+		# TYPE kube_statefulset_status_update_revision gauge
  		# HELP kube_statefulset_replicas Number of desired pods for a StatefulSet.
  		# TYPE kube_statefulset_replicas gauge
  		# HELP kube_statefulset_metadata_generation Sequence number representing a specific generation of the desired state for the StatefulSet.
@@ -89,6 +93,8 @@ func TestStatefuleSetCollector(t *testing.T) {
 					Status: v1beta1.StatefulSetStatus{
 						ObservedGeneration: &statefulSet1ObservedGeneration,
 						Replicas:           2,
+						CurrentRevision:    "cr1",
+						UpdateRevision:     "ur1",
 					},
 				}, {
 					ObjectMeta: metav1.ObjectMeta{
@@ -109,6 +115,8 @@ func TestStatefuleSetCollector(t *testing.T) {
 						ReadyReplicas:      5,
 						Replicas:           5,
 						UpdatedReplicas:    3,
+						CurrentRevision:    "cr2",
+						UpdateRevision:     "ur2",
 					},
 				}, {
 					ObjectMeta: metav1.ObjectMeta{
@@ -126,11 +134,16 @@ func TestStatefuleSetCollector(t *testing.T) {
 					Status: v1beta1.StatefulSetStatus{
 						ObservedGeneration: nil,
 						Replicas:           7,
+						CurrentRevision:    "cr3",
+						UpdateRevision:     "ur3",
 					},
 				},
 			},
 			want: metadata + `
 				kube_statefulset_created{namespace="ns1",statefulset="statefulset1"} 1.5e+09
+				kube_statefulset_status_current_revision{namespace="ns1",revision="cr1",statefulset="statefulset1"} 1
+				kube_statefulset_status_current_revision{namespace="ns2",revision="cr2",statefulset="statefulset2"} 1
+				kube_statefulset_status_current_revision{namespace="ns3",revision="cr3",statefulset="statefulset3"} 1
  				kube_statefulset_status_replicas{namespace="ns1",statefulset="statefulset1"} 2
  				kube_statefulset_status_replicas{namespace="ns2",statefulset="statefulset2"} 5
  				kube_statefulset_status_replicas{namespace="ns3",statefulset="statefulset3"} 7
@@ -145,6 +158,9 @@ func TestStatefuleSetCollector(t *testing.T) {
 				kube_statefulset_status_replicas_updated{namespace="ns3",statefulset="statefulset3"} 0
  				kube_statefulset_status_observed_generation{namespace="ns1",statefulset="statefulset1"} 1
  				kube_statefulset_status_observed_generation{namespace="ns2",statefulset="statefulset2"} 2
+				kube_statefulset_status_update_revision{namespace="ns1",revision="ur1",statefulset="statefulset1"} 1
+				kube_statefulset_status_update_revision{namespace="ns2",revision="ur2",statefulset="statefulset2"} 1
+				kube_statefulset_status_update_revision{namespace="ns3",revision="ur3",statefulset="statefulset3"} 1
  				kube_statefulset_replicas{namespace="ns1",statefulset="statefulset1"} 3
  				kube_statefulset_replicas{namespace="ns2",statefulset="statefulset2"} 6
  				kube_statefulset_replicas{namespace="ns3",statefulset="statefulset3"} 9


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>

**What this PR does / why we need it**:

~Turns out probably not necessary, was looking to build an alert for non-updated pods, `kube_statefulset_status_replicas_updated != kube_statefulset_replicas`.~

Nope, above query only works for statefulsets with updated.  You need `max without (revision) (kube_statefulset_status_current_revision unless kube_statefulset_status_update_revision) * (kube_statefulset_replicas != kube_statefulset_status_replicas_updated)` to find stateful sets with updates that haven't been rolled out.

