### PR TITLE
Add changelog note for breaking change in #371

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ After a testing period of 12 days, there were no additional bugs found or featur
 
 ## v1.3.0-rc.0 / 2018-03-23
 
+* [CHANGE] Removed `--in-cluster` flag in [#371](https://github.com/kubernetes/kube-state-metrics/pull/371).
+  Users can no longer specify `--apiserver` with `--in-cluster=true`. To
+  emulate this behaviour in future releases, set the `KUBERNETES_SERVICE_HOST`
+  environment variable to the value of the `--apiserver` argument.
 * [FEATURE] Allow to specify multiple namespace.
 * [FEATURE] Add `kube_pod_completion_time`, `kube_pod_spec_volumes_persistentvolumeclaims_info`, and `kube_pod_spec_volumes_persistentvolumeclaims_readonly` metrics to the Pod collector.
 * [FEATURE] Add `kube_node_spec_taint` metric.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adds a note about breaking changes to the CHANGELOG for the 1.2.0 -> 1.3.0 upgrade.

The changelog does not currently warn about the deprecation of the `--in-cluster` flag, meaning that users on 1.2.0 releases and earlier who use `--apiserver` with the default `--in-cluster=true` flag have authentication break on upgrade.

**Which issue(s) this PR fixes**:

Fixes #543.

**Other notes:**

The behaviour from 1.2.0 can be emulated on upgrade by removing the `--apiserver` flag and setting the environment variable `KUBERNETES_SERVICE_HOST` to the API server value.
