### PR TITLE
Update add on resizer

### DIFF
--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -31,14 +31,14 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: addon-resizer
-        image: k8s.gcr.io/addon-resizer:1.7
+        image: k8s.gcr.io/addon-resizer:1.8.3
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 150m
+            memory: 50Mi
           requests:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 150m
+            memory: 50Mi
         env:
           - name: MY_POD_NAME
             valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
• Update addon-resizer with latest changes
• Bump minimum requests & limits as I have observed that kube-state-metrics pods often get killed on our kubernetes clusters with the minimum resources.

