### PR TITLE
Fix link href

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ the raw metrics.
 - [Metrics Documentation](#metrics-documentation)
 - [Kube-state-metrics self metrics](#kube-state-metrics-self-metrics)
 - [Resource recommendation](#resource-recommendation)
-- [kube-state-metrics vs. Heapster(metrics-server)](#kube-state-metrics-vs-heapster)
+- [kube-state-metrics vs. Heapster(metrics-server)](#kube-state-metrics-vs-heapstermetrics-server)
 - [Setup](#setup)
   - [Building the Docker container](#building-the-docker-container)
 - [Usage](#usage)


### PR DESCRIPTION
**What this PR does / why we need it**:
One of the hrefs in your README is broken currently. 

This updates with the correct link reference

