### PR TITLE
Pre-allocate the metrics slice in `GetAll`

### DIFF
--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -104,10 +104,10 @@ func (s *MetricsStore) Resync() error {
 }
 
 func (s *MetricsStore) GetAll() []*metrics.Metric {
-	m := []*metrics.Metric{}
-
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
+
+	m := make([]*metrics.Metric, 0, len(s.metrics))
 
 	for _, metrics := range s.metrics {
 		m = append(m, metrics...)


### PR DESCRIPTION
**What this PR does / why we need it**:

This method is the heaviest allocator. Pre-allocation will not help a
lot, but I guess every little helps... (Plus, it's really easy.)

**Which issue(s) this PR fixes**

It's related to #498 . See analysis there.

@mxinden 

