### PR TITLE
pkg/metrics: Tune NewMetrics function

### DIFF
--- a/pkg/collectors/testutils_test.go
+++ b/pkg/collectors/testutils_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+)
+
+func TestSortLabels(t *testing.T) {
+	in := `kube_pod_container_info{container_id="docker://cd456",image="k8s.gcr.io/hyperkube2",container="container2",image_id="docker://sha256:bbb",namespace="ns2",pod="pod2"} 1
+kube_pod_container_info{namespace="ns2",container="container3",container_id="docker://ef789",image="k8s.gcr.io/hyperkube3",image_id="docker://sha256:ccc",pod="pod2"} 1`
+
+	want := `kube_pod_container_info{container="container2",container_id="docker://cd456",image="k8s.gcr.io/hyperkube2",image_id="docker://sha256:bbb",namespace="ns2",pod="pod2"} 1
+kube_pod_container_info{container="container3",container_id="docker://ef789",image="k8s.gcr.io/hyperkube3",image_id="docker://sha256:ccc",namespace="ns2",pod="pod2"} 1`
+
+	out := sortLabels(in)
+
+	if want != out {
+		t.Fatalf("expected:\n%v\nbut got:\n%v", want, out)
+	}
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -135,3 +135,39 @@ func TestFiltererdGathererBlacklist(t *testing.T) {
 		t.Fatalf("Expected `test1` to be filtered and `test2` not. `test1`: %t ; `test2`: %t.", found1, found2)
 	}
 }
+
+func BenchmarkNewMetric(b *testing.B) {
+	tests := []struct {
+		testName    string
+		metricName  string
+		labelKeys   []string
+		labelValues []string
+		value       float64
+	}{
+		{
+			testName:    "value-1",
+			metricName:  "kube_pod_container_info",
+			labelKeys:   []string{"container", "container_id", "image", "image_id", "namespace", "pod"},
+			labelValues: []string{"container2", "docker://cd456", "k8s.gcr.io/hyperkube2", "docker://sha256:bbb", "ns2", "pod2"},
+			value:       float64(1),
+		},
+		{
+			testName:    "value-35.7",
+			metricName:  "kube_pod_container_info",
+			labelKeys:   []string{"container", "container_id", "image", "image_id", "namespace", "pod"},
+			labelValues: []string{"container2", "docker://cd456", "k8s.gcr.io/hyperkube2", "docker://sha256:bbb", "ns2", "pod2"},
+			value:       float64(35.7),
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.testName, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := NewMetric(test.metricName, test.labelKeys, test.labelValues, test.value)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch tunes the `NewMetrics` function based on optimizations discussed in https://github.com/prometheus/common/pull/148 and https://github.com/kubernetes/kube-state-metrics/issues/498#issuecomment-431882415 (//CC @beorn7).

- Use strings.Builder minimizing memory allocations.

- Use strconv to render float64 in combination with a []byte buffer pool
instead of fmt.Sprintf reducing memory allocations.

- Only sort labels of metrics in test framework, not by default (e.g. in
production).

Benchmark patch:

```bash
go get golang.org/x/tools/cmd/benchcmp

git checkout perf-exp~1
go test -v -bench=NewMetric  -run=^$  -benchmem ./pkg/metrics/... > old.txt

git checkout perf-exp
go test -v -bench=NewMetric  -run=^$  -benchmem ./pkg/metrics/... > new.txt

benchcmp old.txt new.txt

benchmark                           old ns/op     new ns/op     delta
BenchmarkNewMetric/value-1-4        2652          612           -76.92%
BenchmarkNewMetric/value-35.7-4     2706          755           -72.10%

benchmark                           old allocs     new allocs     delta
BenchmarkNewMetric/value-1-4        32             6              -81.25%
BenchmarkNewMetric/value-35.7-4     32             6              -81.25%

benchmark                           old bytes     new bytes     delta
BenchmarkNewMetric/value-1-4        1616          528           -67.33%
BenchmarkNewMetric/value-35.7-4     1616          528           -67.33%
```



