### PR TITLE
pkg/metrics: Write newline as byte with strings.Builder

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -61,7 +61,7 @@ func NewMetric(name string, labelKeys []string, labelValues []string, value floa
 
 	writeFloat(&m, value)
 
-	m.WriteString("\n")
+	m.WriteByte('\n')
 
 	metric := Metric(m.String())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Write newline with `WriteByte` for higher performance.

Origins from https://github.com/kubernetes/kube-state-metrics/pull/567#discussion_r228943917

//CC @brancz @beorn7 