### PR TITLE
Making kube-state-metrics a library

### DIFF
--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -124,70 +124,70 @@ func (b *Builder) buildPodCollector() *Collector {
 	store := metricsstore.NewMetricsStore(genFunc)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Pod{}, store, b.namespaces, createPodListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildCronJobCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateCronJobMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &batchv1beta1.CronJob{}, store, b.namespaces, createCronJobListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildConfigMapCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateConfigMapMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ConfigMap{}, store, b.namespaces, createConfigMapListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildDaemonSetCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateDaemonSetMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.DaemonSet{}, store, b.namespaces, createDaemonSetListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildDeploymentCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateDeploymentMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.Deployment{}, store, b.namespaces, createDeploymentListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildEndpointsCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateEndpointsMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Endpoints{}, store, b.namespaces, createEndpointsListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildHPACollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateHPAMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &autoscaling.HorizontalPodAutoscaler{}, store, b.namespaces, createHPAListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildJobCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateJobMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &batchv1.Job{}, store, b.namespaces, createJobListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildLimitRangeCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateLimitRangeMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.LimitRange{}, store, b.namespaces, createLimitRangeListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildNamespaceCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateNamespaceMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Namespace{}, store, b.namespaces, createNamespaceListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildNodeCollector() *Collector {
@@ -197,70 +197,70 @@ func (b *Builder) buildNodeCollector() *Collector {
 	store := metricsstore.NewMetricsStore(genFunc)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Node{}, store, b.namespaces, createNodeListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildPersistentVolumeCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generatePersistentVolumeMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolume{}, store, b.namespaces, createPersistentVolumeListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildPersistentVolumeClaimCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generatePersistentVolumeClaimMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolumeClaim{}, store, b.namespaces, createPersistentVolumeClaimListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildPodDisruptionBudgetCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generatePodDisruptionBudgetMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1beta1.PodDisruptionBudget{}, store, b.namespaces, createPodDisruptionBudgetListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildReplicaSetCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateReplicaSetMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.ReplicaSet{}, store, b.namespaces, createReplicaSetListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildReplicationControllerCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateReplicationControllerMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ReplicationController{}, store, b.namespaces, createReplicationControllerListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildResourceQuotaCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateResourceQuotaMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ResourceQuota{}, store, b.namespaces, createResourceQuotaListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildSecretCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateSecretMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Secret{}, store, b.namespaces, createSecretListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildServiceCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateServiceMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Service{}, store, b.namespaces, createServiceListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func (b *Builder) buildStatefulSetCollector() *Collector {
 	store := metricsstore.NewMetricsStore(generateStatefulSetMetrics)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &apps.StatefulSet{}, store, b.namespaces, createStatefulSetListWatch)
 
-	return newCollector(store)
+	return NewCollector(store)
 }
 
 func reflectorPerNamespace(

--- a/pkg/collectors/collectors.go
+++ b/pkg/collectors/collectors.go
@@ -26,53 +26,31 @@ import (
 	"k8s.io/kube-state-metrics/pkg/metrics"
 )
 
-var (
-	resyncPeriod = 5 * time.Minute
-
-	ScrapeErrorTotalMetric = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "ksm_scrape_error_total",
-			Help: "Total scrape errors encountered when scraping a resource",
-		},
-		[]string{"resource"},
-	)
-
-	ResourcesPerScrapeMetric = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name: "ksm_resources_per_scrape",
-			Help: "Number of resources returned per scrape",
-		},
-		[]string{"resource"},
-	)
-
-	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
-)
-
-type store interface {
+type Store interface {
 	GetAll() []*metrics.Metric
 }
 
 // Collector represents a kube-state-metrics metric collector. It is stripped
 // down version of the Prometheus client_golang collector.
 type Collector struct {
-	store store
+	Store Store
 }
 
-func newCollector(s store) *Collector {
+func NewCollector(s Store) *Collector {
 	return &Collector{s}
 }
 
 // Collect returns all metrics of the underlying store of the collector.
 func (c *Collector) Collect() []*metrics.Metric {
-	return c.store.GetAll()
+	return c.Store.GetAll()
 }
 
-func newMetricFamilyDef(name, help string, labelKeys []string, constLabels prometheus.Labels) *metricFamilyDef {
-	return &metricFamilyDef{name, help, labelKeys, constLabels}
+func NewMetricFamilyDef(name, help string, labelKeys []string, constLabels prometheus.Labels) *MetricFamilyDef {
+	return &MetricFamilyDef{name, help, labelKeys, constLabels}
 }
 
-// metricFamilyDef represents a metric family definition
-type metricFamilyDef struct {
+// MetricFamilyDef represents a metric family definition
+type MetricFamilyDef struct {
 	Name        string
 	Help        string
 	LabelKeys   []string

--- a/pkg/collectors/collectors.go
+++ b/pkg/collectors/collectors.go
@@ -17,7 +17,6 @@ limitations under the License.
 package collectors
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/kube-state-metrics/pkg/metrics"
 )
 
@@ -38,16 +37,4 @@ func NewCollector(s Store) *Collector {
 // Collect returns all metrics of the underlying store of the collector.
 func (c *Collector) Collect() []*metrics.Metric {
 	return c.Store.GetAll()
-}
-
-func NewMetricFamilyDef(name, help string, labelKeys []string, constLabels prometheus.Labels) *MetricFamilyDef {
-	return &MetricFamilyDef{name, help, labelKeys, constLabels}
-}
-
-// MetricFamilyDef represents a metric family definition
-type MetricFamilyDef struct {
-	Name        string
-	Help        string
-	LabelKeys   []string
-	ConstLabels prometheus.Labels
 }

--- a/pkg/collectors/collectors.go
+++ b/pkg/collectors/collectors.go
@@ -17,12 +17,7 @@ limitations under the License.
 package collectors
 
 import (
-	"time"
-
-	"regexp"
-
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/api/core/v1"
 	"k8s.io/kube-state-metrics/pkg/metrics"
 )
 
@@ -55,63 +50,4 @@ type MetricFamilyDef struct {
 	Help        string
 	LabelKeys   []string
 	ConstLabels prometheus.Labels
-}
-
-func boolFloat64(b bool) float64 {
-	if b {
-		return 1
-	}
-	return 0
-}
-
-// addConditionMetrics generates one metric for each possible node condition
-// status. For this function to work properly, the last label in the metric
-// description must be the condition.
-func addConditionMetrics(desc *metricFamilyDef, cs v1.ConditionStatus, lv ...string) []*metrics.Metric {
-	ms := []*metrics.Metric{}
-	m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, append(lv, "true"), boolFloat64(cs == v1.ConditionTrue))
-	if err != nil {
-		panic(err)
-	}
-	ms = append(ms, m)
-	m, err = metrics.NewMetric(desc.Name, desc.LabelKeys, append(lv, "false"), boolFloat64(cs == v1.ConditionFalse))
-	if err != nil {
-		panic(err)
-	}
-	ms = append(ms, m)
-	m, err = metrics.NewMetric(desc.Name, desc.LabelKeys, append(lv, "unknown"), boolFloat64(cs == v1.ConditionUnknown))
-	if err != nil {
-		panic(err)
-	}
-	ms = append(ms, m)
-
-	return ms
-}
-
-func kubeLabelsToPrometheusLabels(labels map[string]string) ([]string, []string) {
-	labelKeys := make([]string, len(labels))
-	labelValues := make([]string, len(labels))
-	i := 0
-	for k, v := range labels {
-		labelKeys[i] = "label_" + sanitizeLabelName(k)
-		labelValues[i] = v
-		i++
-	}
-	return labelKeys, labelValues
-}
-
-func kubeAnnotationsToPrometheusAnnotations(annotations map[string]string) ([]string, []string) {
-	annotationKeys := make([]string, len(annotations))
-	annotationValues := make([]string, len(annotations))
-	i := 0
-	for k, v := range annotations {
-		annotationKeys[i] = "annotation_" + sanitizeLabelName(k)
-		annotationValues[i] = v
-		i++
-	}
-	return annotationKeys, annotationValues
-}
-
-func sanitizeLabelName(s string) string {
-	return invalidLabelCharRE.ReplaceAllString(s, "_")
 }

--- a/pkg/collectors/configmap.go
+++ b/pkg/collectors/configmap.go
@@ -30,21 +30,21 @@ import (
 var (
 	descConfigMapLabelsDefaultLabels = []string{"namespace", "configmap"}
 
-	descConfigMapInfo = NewMetricFamilyDef(
+	descConfigMapInfo = metrics.NewMetricFamilyDef(
 		"kube_configmap_info",
 		"Information about configmap.",
 		descConfigMapLabelsDefaultLabels,
 		nil,
 	)
 
-	descConfigMapCreated = NewMetricFamilyDef(
+	descConfigMapCreated = metrics.NewMetricFamilyDef(
 		"kube_configmap_created",
 		"Unix creation timestamp",
 		descConfigMapLabelsDefaultLabels,
 		nil,
 	)
 
-	descConfigMapMetadataResourceVersion = NewMetricFamilyDef(
+	descConfigMapMetadataResourceVersion = metrics.NewMetricFamilyDef(
 		"kube_configmap_metadata_resource_version",
 		"Resource version representing a specific version of the configmap.",
 		append(descConfigMapLabelsDefaultLabels, "resource_version"),
@@ -70,7 +70,7 @@ func generateConfigMapMetrics(obj interface{}) []*metrics.Metric {
 	mPointer := obj.(*v1.ConfigMap)
 	m := *mPointer
 
-	addConstMetric := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addConstMetric := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{m.Namespace, m.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -80,7 +80,7 @@ func generateConfigMapMetrics(obj interface{}) []*metrics.Metric {
 
 		ms = append(ms, m)
 	}
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
 	addGauge(descConfigMapInfo, 1)

--- a/pkg/collectors/configmap.go
+++ b/pkg/collectors/configmap.go
@@ -70,7 +70,7 @@ func generateConfigMapMetrics(obj interface{}) []*metrics.Metric {
 	mPointer := obj.(*v1.ConfigMap)
 	m := *mPointer
 
-	addConstMetric := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addConstMetric := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{m.Namespace, m.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -80,7 +80,7 @@ func generateConfigMapMetrics(obj interface{}) []*metrics.Metric {
 
 		ms = append(ms, m)
 	}
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
 	addGauge(descConfigMapInfo, 1)

--- a/pkg/collectors/configmap.go
+++ b/pkg/collectors/configmap.go
@@ -30,21 +30,21 @@ import (
 var (
 	descConfigMapLabelsDefaultLabels = []string{"namespace", "configmap"}
 
-	descConfigMapInfo = newMetricFamilyDef(
+	descConfigMapInfo = NewMetricFamilyDef(
 		"kube_configmap_info",
 		"Information about configmap.",
 		descConfigMapLabelsDefaultLabels,
 		nil,
 	)
 
-	descConfigMapCreated = newMetricFamilyDef(
+	descConfigMapCreated = NewMetricFamilyDef(
 		"kube_configmap_created",
 		"Unix creation timestamp",
 		descConfigMapLabelsDefaultLabels,
 		nil,
 	)
 
-	descConfigMapMetadataResourceVersion = newMetricFamilyDef(
+	descConfigMapMetadataResourceVersion = NewMetricFamilyDef(
 		"kube_configmap_metadata_resource_version",
 		"Resource version representing a specific version of the configmap.",
 		append(descConfigMapLabelsDefaultLabels, "resource_version"),

--- a/pkg/collectors/cronjob.go
+++ b/pkg/collectors/cronjob.go
@@ -37,49 +37,49 @@ var (
 	descCronJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descCronJobLabelsDefaultLabels = []string{"namespace", "cronjob"}
 
-	descCronJobLabels = newMetricFamilyDef(
+	descCronJobLabels = NewMetricFamilyDef(
 		descCronJobLabelsName,
 		descCronJobLabelsHelp,
 		descCronJobLabelsDefaultLabels, nil,
 	)
 
-	descCronJobInfo = newMetricFamilyDef(
+	descCronJobInfo = NewMetricFamilyDef(
 		"kube_cronjob_info",
 		"Info about cronjob.",
 		append(descCronJobLabelsDefaultLabels, "schedule", "concurrency_policy"),
 		nil,
 	)
-	descCronJobCreated = newMetricFamilyDef(
+	descCronJobCreated = NewMetricFamilyDef(
 		"kube_cronjob_created",
 		"Unix creation timestamp",
 		descCronJobLabelsDefaultLabels,
 		nil,
 	)
-	descCronJobStatusActive = newMetricFamilyDef(
+	descCronJobStatusActive = NewMetricFamilyDef(
 		"kube_cronjob_status_active",
 		"Active holds pointers to currently running jobs.",
 		descCronJobLabelsDefaultLabels,
 		nil,
 	)
-	descCronJobStatusLastScheduleTime = newMetricFamilyDef(
+	descCronJobStatusLastScheduleTime = NewMetricFamilyDef(
 		"kube_cronjob_status_last_schedule_time",
 		"LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
 		descCronJobLabelsDefaultLabels,
 		nil,
 	)
-	descCronJobSpecSuspend = newMetricFamilyDef(
+	descCronJobSpecSuspend = NewMetricFamilyDef(
 		"kube_cronjob_spec_suspend",
 		"Suspend flag tells the controller to suspend subsequent executions.",
 		descCronJobLabelsDefaultLabels,
 		nil,
 	)
-	descCronJobSpecStartingDeadlineSeconds = newMetricFamilyDef(
+	descCronJobSpecStartingDeadlineSeconds = NewMetricFamilyDef(
 		"kube_cronjob_spec_starting_deadline_seconds",
 		"Deadline in seconds for starting the job if it misses scheduled time for any reason.",
 		descCronJobLabelsDefaultLabels,
 		nil,
 	)
-	descCronJobNextScheduledTime = newMetricFamilyDef(
+	descCronJobNextScheduledTime = NewMetricFamilyDef(
 		"kube_cronjob_next_schedule_time",
 		"Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
 		descCronJobLabelsDefaultLabels,
@@ -113,7 +113,7 @@ func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, create
 }
 
 func cronJobLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descCronJobLabelsName,
 		descCronJobLabelsHelp,
 		append(descCronJobLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/cronjob.go
+++ b/pkg/collectors/cronjob.go
@@ -37,49 +37,49 @@ var (
 	descCronJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descCronJobLabelsDefaultLabels = []string{"namespace", "cronjob"}
 
-	descCronJobLabels = NewMetricFamilyDef(
+	descCronJobLabels = metrics.NewMetricFamilyDef(
 		descCronJobLabelsName,
 		descCronJobLabelsHelp,
 		descCronJobLabelsDefaultLabels, nil,
 	)
 
-	descCronJobInfo = NewMetricFamilyDef(
+	descCronJobInfo = metrics.NewMetricFamilyDef(
 		"kube_cronjob_info",
 		"Info about cronjob.",
 		append(descCronJobLabelsDefaultLabels, "schedule", "concurrency_policy"),
 		nil,
 	)
-	descCronJobCreated = NewMetricFamilyDef(
+	descCronJobCreated = metrics.NewMetricFamilyDef(
 		"kube_cronjob_created",
 		"Unix creation timestamp",
 		descCronJobLabelsDefaultLabels,
 		nil,
 	)
-	descCronJobStatusActive = NewMetricFamilyDef(
+	descCronJobStatusActive = metrics.NewMetricFamilyDef(
 		"kube_cronjob_status_active",
 		"Active holds pointers to currently running jobs.",
 		descCronJobLabelsDefaultLabels,
 		nil,
 	)
-	descCronJobStatusLastScheduleTime = NewMetricFamilyDef(
+	descCronJobStatusLastScheduleTime = metrics.NewMetricFamilyDef(
 		"kube_cronjob_status_last_schedule_time",
 		"LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
 		descCronJobLabelsDefaultLabels,
 		nil,
 	)
-	descCronJobSpecSuspend = NewMetricFamilyDef(
+	descCronJobSpecSuspend = metrics.NewMetricFamilyDef(
 		"kube_cronjob_spec_suspend",
 		"Suspend flag tells the controller to suspend subsequent executions.",
 		descCronJobLabelsDefaultLabels,
 		nil,
 	)
-	descCronJobSpecStartingDeadlineSeconds = NewMetricFamilyDef(
+	descCronJobSpecStartingDeadlineSeconds = metrics.NewMetricFamilyDef(
 		"kube_cronjob_spec_starting_deadline_seconds",
 		"Deadline in seconds for starting the job if it misses scheduled time for any reason.",
 		descCronJobLabelsDefaultLabels,
 		nil,
 	)
-	descCronJobNextScheduledTime = NewMetricFamilyDef(
+	descCronJobNextScheduledTime = metrics.NewMetricFamilyDef(
 		"kube_cronjob_next_schedule_time",
 		"Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
 		descCronJobLabelsDefaultLabels,
@@ -112,8 +112,8 @@ func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, create
 	return time.Time{}, fmt.Errorf("Created time and lastScheduleTime are both zero")
 }
 
-func cronJobLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func cronJobLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descCronJobLabelsName,
 		descCronJobLabelsHelp,
 		append(descCronJobLabelsDefaultLabels, labelKeys...),
@@ -128,7 +128,7 @@ func generateCronJobMetrics(obj interface{}) []*metrics.Metric {
 	jPointer := obj.(*batchv1beta1.CronJob)
 	j := *jPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{j.Namespace, j.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/cronjob.go
+++ b/pkg/collectors/cronjob.go
@@ -112,7 +112,7 @@ func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, create
 	return time.Time{}, fmt.Errorf("Created time and lastScheduleTime are both zero")
 }
 
-func cronJobLabelsDesc(labelKeys []string) *metricFamilyDef {
+func cronJobLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descCronJobLabelsName,
 		descCronJobLabelsHelp,
@@ -128,7 +128,7 @@ func generateCronJobMetrics(obj interface{}) []*metrics.Metric {
 	jPointer := obj.(*batchv1beta1.CronJob)
 	j := *jPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{j.Namespace, j.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/daemonset.go
+++ b/pkg/collectors/daemonset.go
@@ -96,7 +96,7 @@ var (
 
 // TODO: Not necessary without HELP and TYPE line
 // // Describe implements the prometheus.Collector interface.
-// func (dc *daemonsetCollector) Describe(ch chan<- *metricFamilyDef) {
+// func (dc *daemonsetCollector) Describe(ch chan<- *MetricFamilyDef) {
 // 	ch <- descDaemonSetCreated
 // 	ch <- descDaemonSetCurrentNumberScheduled
 // 	ch <- descDaemonSetNumberAvailable
@@ -120,7 +120,7 @@ func createDaemonSetListWatch(kubeClient clientset.Interface, ns string) cache.L
 	}
 }
 
-func DaemonSetLabelsDesc(labelKeys []string) *metricFamilyDef {
+func DaemonSetLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descDaemonSetLabelsName,
 		descDaemonSetLabelsHelp,
@@ -136,7 +136,7 @@ func generateDaemonSetMetrics(obj interface{}) []*metrics.Metric {
 	dPointer := obj.(*v1beta1.DaemonSet)
 	d := *dPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{d.Namespace, d.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/daemonset.go
+++ b/pkg/collectors/daemonset.go
@@ -32,61 +32,61 @@ var (
 	descDaemonSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descDaemonSetLabelsDefaultLabels = []string{"namespace", "daemonset"}
 
-	descDaemonSetCreated = newMetricFamilyDef(
+	descDaemonSetCreated = NewMetricFamilyDef(
 		"kube_daemonset_created",
 		"Unix creation timestamp",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetCurrentNumberScheduled = newMetricFamilyDef(
+	descDaemonSetCurrentNumberScheduled = NewMetricFamilyDef(
 		"kube_daemonset_status_current_number_scheduled",
 		"The number of nodes running at least one daemon pod and are supposed to.",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetDesiredNumberScheduled = newMetricFamilyDef(
+	descDaemonSetDesiredNumberScheduled = NewMetricFamilyDef(
 		"kube_daemonset_status_desired_number_scheduled",
 		"The number of nodes that should be running the daemon pod.",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetNumberAvailable = newMetricFamilyDef(
+	descDaemonSetNumberAvailable = NewMetricFamilyDef(
 		"kube_daemonset_status_number_available",
 		"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetNumberMisscheduled = newMetricFamilyDef(
+	descDaemonSetNumberMisscheduled = NewMetricFamilyDef(
 		"kube_daemonset_status_number_misscheduled",
 		"The number of nodes running a daemon pod but are not supposed to.",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetNumberReady = newMetricFamilyDef(
+	descDaemonSetNumberReady = NewMetricFamilyDef(
 		"kube_daemonset_status_number_ready",
 		"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetNumberUnavailable = newMetricFamilyDef(
+	descDaemonSetNumberUnavailable = NewMetricFamilyDef(
 		"kube_daemonset_status_number_unavailable",
 		"The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetUpdatedNumberScheduled = newMetricFamilyDef(
+	descDaemonSetUpdatedNumberScheduled = NewMetricFamilyDef(
 		"kube_daemonset_updated_number_scheduled",
 		"The total number of nodes that are running updated daemon pod",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetMetadataGeneration = newMetricFamilyDef(
+	descDaemonSetMetadataGeneration = NewMetricFamilyDef(
 		"kube_daemonset_metadata_generation",
 		"Sequence number representing a specific generation of the desired state.",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetLabels = newMetricFamilyDef(
+	descDaemonSetLabels = NewMetricFamilyDef(
 		descDaemonSetLabelsName,
 		descDaemonSetLabelsHelp,
 		descDaemonSetLabelsDefaultLabels,
@@ -121,7 +121,7 @@ func createDaemonSetListWatch(kubeClient clientset.Interface, ns string) cache.L
 }
 
 func DaemonSetLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descDaemonSetLabelsName,
 		descDaemonSetLabelsHelp,
 		append(descDaemonSetLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/daemonset.go
+++ b/pkg/collectors/daemonset.go
@@ -32,61 +32,61 @@ var (
 	descDaemonSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descDaemonSetLabelsDefaultLabels = []string{"namespace", "daemonset"}
 
-	descDaemonSetCreated = NewMetricFamilyDef(
+	descDaemonSetCreated = metrics.NewMetricFamilyDef(
 		"kube_daemonset_created",
 		"Unix creation timestamp",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetCurrentNumberScheduled = NewMetricFamilyDef(
+	descDaemonSetCurrentNumberScheduled = metrics.NewMetricFamilyDef(
 		"kube_daemonset_status_current_number_scheduled",
 		"The number of nodes running at least one daemon pod and are supposed to.",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetDesiredNumberScheduled = NewMetricFamilyDef(
+	descDaemonSetDesiredNumberScheduled = metrics.NewMetricFamilyDef(
 		"kube_daemonset_status_desired_number_scheduled",
 		"The number of nodes that should be running the daemon pod.",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetNumberAvailable = NewMetricFamilyDef(
+	descDaemonSetNumberAvailable = metrics.NewMetricFamilyDef(
 		"kube_daemonset_status_number_available",
 		"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetNumberMisscheduled = NewMetricFamilyDef(
+	descDaemonSetNumberMisscheduled = metrics.NewMetricFamilyDef(
 		"kube_daemonset_status_number_misscheduled",
 		"The number of nodes running a daemon pod but are not supposed to.",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetNumberReady = NewMetricFamilyDef(
+	descDaemonSetNumberReady = metrics.NewMetricFamilyDef(
 		"kube_daemonset_status_number_ready",
 		"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetNumberUnavailable = NewMetricFamilyDef(
+	descDaemonSetNumberUnavailable = metrics.NewMetricFamilyDef(
 		"kube_daemonset_status_number_unavailable",
 		"The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetUpdatedNumberScheduled = NewMetricFamilyDef(
+	descDaemonSetUpdatedNumberScheduled = metrics.NewMetricFamilyDef(
 		"kube_daemonset_updated_number_scheduled",
 		"The total number of nodes that are running updated daemon pod",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetMetadataGeneration = NewMetricFamilyDef(
+	descDaemonSetMetadataGeneration = metrics.NewMetricFamilyDef(
 		"kube_daemonset_metadata_generation",
 		"Sequence number representing a specific generation of the desired state.",
 		descDaemonSetLabelsDefaultLabels,
 		nil,
 	)
-	descDaemonSetLabels = NewMetricFamilyDef(
+	descDaemonSetLabels = metrics.NewMetricFamilyDef(
 		descDaemonSetLabelsName,
 		descDaemonSetLabelsHelp,
 		descDaemonSetLabelsDefaultLabels,
@@ -96,7 +96,7 @@ var (
 
 // TODO: Not necessary without HELP and TYPE line
 // // Describe implements the prometheus.Collector interface.
-// func (dc *daemonsetCollector) Describe(ch chan<- *MetricFamilyDef) {
+// func (dc *daemonsetCollector) Describe(ch chan<- *metrics.MetricFamilyDef) {
 // 	ch <- descDaemonSetCreated
 // 	ch <- descDaemonSetCurrentNumberScheduled
 // 	ch <- descDaemonSetNumberAvailable
@@ -120,8 +120,8 @@ func createDaemonSetListWatch(kubeClient clientset.Interface, ns string) cache.L
 	}
 }
 
-func DaemonSetLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func DaemonSetLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descDaemonSetLabelsName,
 		descDaemonSetLabelsHelp,
 		append(descDaemonSetLabelsDefaultLabels, labelKeys...),
@@ -136,7 +136,7 @@ func generateDaemonSetMetrics(obj interface{}) []*metrics.Metric {
 	dPointer := obj.(*v1beta1.DaemonSet)
 	d := *dPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{d.Namespace, d.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/deployment.go
+++ b/pkg/collectors/deployment.go
@@ -33,81 +33,81 @@ var (
 	descDeploymentLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
 
-	descDeploymentCreated = newMetricFamilyDef(
+	descDeploymentCreated = NewMetricFamilyDef(
 		"kube_deployment_created",
 		"Unix creation timestamp",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentStatusReplicas = newMetricFamilyDef(
+	descDeploymentStatusReplicas = NewMetricFamilyDef(
 		"kube_deployment_status_replicas",
 		"The number of replicas per deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
-	descDeploymentStatusReplicasAvailable = newMetricFamilyDef(
+	descDeploymentStatusReplicasAvailable = NewMetricFamilyDef(
 		"kube_deployment_status_replicas_available",
 		"The number of available replicas per deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
-	descDeploymentStatusReplicasUnavailable = newMetricFamilyDef(
+	descDeploymentStatusReplicasUnavailable = NewMetricFamilyDef(
 		"kube_deployment_status_replicas_unavailable",
 		"The number of unavailable replicas per deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
-	descDeploymentStatusReplicasUpdated = newMetricFamilyDef(
+	descDeploymentStatusReplicasUpdated = NewMetricFamilyDef(
 		"kube_deployment_status_replicas_updated",
 		"The number of updated replicas per deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentStatusObservedGeneration = newMetricFamilyDef(
+	descDeploymentStatusObservedGeneration = NewMetricFamilyDef(
 		"kube_deployment_status_observed_generation",
 		"The generation observed by the deployment controller.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentSpecReplicas = newMetricFamilyDef(
+	descDeploymentSpecReplicas = NewMetricFamilyDef(
 		"kube_deployment_spec_replicas",
 		"Number of desired pods for a deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentSpecPaused = newMetricFamilyDef(
+	descDeploymentSpecPaused = NewMetricFamilyDef(
 		"kube_deployment_spec_paused",
 		"Whether the deployment is paused and will not be processed by the deployment controller.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentStrategyRollingUpdateMaxUnavailable = newMetricFamilyDef(
+	descDeploymentStrategyRollingUpdateMaxUnavailable = NewMetricFamilyDef(
 		"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
 		"Maximum number of unavailable replicas during a rolling update of a deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentStrategyRollingUpdateMaxSurge = newMetricFamilyDef(
+	descDeploymentStrategyRollingUpdateMaxSurge = NewMetricFamilyDef(
 		"kube_deployment_spec_strategy_rollingupdate_max_surge",
 		"Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentMetadataGeneration = newMetricFamilyDef(
+	descDeploymentMetadataGeneration = NewMetricFamilyDef(
 		"kube_deployment_metadata_generation",
 		"Sequence number representing a specific generation of the desired state.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentLabels = newMetricFamilyDef(
+	descDeploymentLabels = NewMetricFamilyDef(
 		descDeploymentLabelsName,
 		descDeploymentLabelsHelp,
 		descDeploymentLabelsDefaultLabels, nil,
@@ -126,7 +126,7 @@ func createDeploymentListWatch(kubeClient clientset.Interface, ns string) cache.
 }
 
 func deploymentLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descDeploymentLabelsName,
 		descDeploymentLabelsHelp,
 		append(descDeploymentLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/deployment.go
+++ b/pkg/collectors/deployment.go
@@ -125,7 +125,7 @@ func createDeploymentListWatch(kubeClient clientset.Interface, ns string) cache.
 	}
 }
 
-func deploymentLabelsDesc(labelKeys []string) *metricFamilyDef {
+func deploymentLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descDeploymentLabelsName,
 		descDeploymentLabelsHelp,
@@ -141,7 +141,7 @@ func generateDeploymentMetrics(obj interface{}) []*metrics.Metric {
 	dPointer := obj.(*v1beta1.Deployment)
 	d := *dPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{d.Namespace, d.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/deployment.go
+++ b/pkg/collectors/deployment.go
@@ -33,81 +33,81 @@ var (
 	descDeploymentLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
 
-	descDeploymentCreated = NewMetricFamilyDef(
+	descDeploymentCreated = metrics.NewMetricFamilyDef(
 		"kube_deployment_created",
 		"Unix creation timestamp",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentStatusReplicas = NewMetricFamilyDef(
+	descDeploymentStatusReplicas = metrics.NewMetricFamilyDef(
 		"kube_deployment_status_replicas",
 		"The number of replicas per deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
-	descDeploymentStatusReplicasAvailable = NewMetricFamilyDef(
+	descDeploymentStatusReplicasAvailable = metrics.NewMetricFamilyDef(
 		"kube_deployment_status_replicas_available",
 		"The number of available replicas per deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
-	descDeploymentStatusReplicasUnavailable = NewMetricFamilyDef(
+	descDeploymentStatusReplicasUnavailable = metrics.NewMetricFamilyDef(
 		"kube_deployment_status_replicas_unavailable",
 		"The number of unavailable replicas per deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
-	descDeploymentStatusReplicasUpdated = NewMetricFamilyDef(
+	descDeploymentStatusReplicasUpdated = metrics.NewMetricFamilyDef(
 		"kube_deployment_status_replicas_updated",
 		"The number of updated replicas per deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentStatusObservedGeneration = NewMetricFamilyDef(
+	descDeploymentStatusObservedGeneration = metrics.NewMetricFamilyDef(
 		"kube_deployment_status_observed_generation",
 		"The generation observed by the deployment controller.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentSpecReplicas = NewMetricFamilyDef(
+	descDeploymentSpecReplicas = metrics.NewMetricFamilyDef(
 		"kube_deployment_spec_replicas",
 		"Number of desired pods for a deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentSpecPaused = NewMetricFamilyDef(
+	descDeploymentSpecPaused = metrics.NewMetricFamilyDef(
 		"kube_deployment_spec_paused",
 		"Whether the deployment is paused and will not be processed by the deployment controller.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentStrategyRollingUpdateMaxUnavailable = NewMetricFamilyDef(
+	descDeploymentStrategyRollingUpdateMaxUnavailable = metrics.NewMetricFamilyDef(
 		"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
 		"Maximum number of unavailable replicas during a rolling update of a deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentStrategyRollingUpdateMaxSurge = NewMetricFamilyDef(
+	descDeploymentStrategyRollingUpdateMaxSurge = metrics.NewMetricFamilyDef(
 		"kube_deployment_spec_strategy_rollingupdate_max_surge",
 		"Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentMetadataGeneration = NewMetricFamilyDef(
+	descDeploymentMetadataGeneration = metrics.NewMetricFamilyDef(
 		"kube_deployment_metadata_generation",
 		"Sequence number representing a specific generation of the desired state.",
 		descDeploymentLabelsDefaultLabels,
 		nil,
 	)
 
-	descDeploymentLabels = NewMetricFamilyDef(
+	descDeploymentLabels = metrics.NewMetricFamilyDef(
 		descDeploymentLabelsName,
 		descDeploymentLabelsHelp,
 		descDeploymentLabelsDefaultLabels, nil,
@@ -125,8 +125,8 @@ func createDeploymentListWatch(kubeClient clientset.Interface, ns string) cache.
 	}
 }
 
-func deploymentLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func deploymentLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descDeploymentLabelsName,
 		descDeploymentLabelsHelp,
 		append(descDeploymentLabelsDefaultLabels, labelKeys...),
@@ -141,7 +141,7 @@ func generateDeploymentMetrics(obj interface{}) []*metrics.Metric {
 	dPointer := obj.(*v1beta1.Deployment)
 	d := *dPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{d.Namespace, d.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/endpoint.go
+++ b/pkg/collectors/endpoint.go
@@ -86,7 +86,7 @@ func generateEndpointsMetrics(obj interface{}) []*metrics.Metric {
 	ePointer := obj.(*v1.Endpoints)
 	e := *ePointer
 
-	addConstMetric := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addConstMetric := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{e.Namespace, e.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -96,7 +96,7 @@ func generateEndpointsMetrics(obj interface{}) []*metrics.Metric {
 
 		ms = append(ms, m)
 	}
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
 
@@ -122,7 +122,7 @@ func generateEndpointsMetrics(obj interface{}) []*metrics.Metric {
 	return ms
 }
 
-func endpointLabelsDesc(labelKeys []string) *metricFamilyDef {
+func endpointLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descEndpointLabelsName,
 		descEndpointLabelsHelp,

--- a/pkg/collectors/endpoint.go
+++ b/pkg/collectors/endpoint.go
@@ -32,35 +32,35 @@ var (
 	descEndpointLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descEndpointLabelsDefaultLabels = []string{"namespace", "endpoint"}
 
-	descEndpointInfo = NewMetricFamilyDef(
+	descEndpointInfo = metrics.NewMetricFamilyDef(
 		"kube_endpoint_info",
 		"Information about endpoint.",
 		descEndpointLabelsDefaultLabels,
 		nil,
 	)
 
-	descEndpointCreated = NewMetricFamilyDef(
+	descEndpointCreated = metrics.NewMetricFamilyDef(
 		"kube_endpoint_created",
 		"Unix creation timestamp",
 		descEndpointLabelsDefaultLabels,
 		nil,
 	)
 
-	descEndpointLabels = NewMetricFamilyDef(
+	descEndpointLabels = metrics.NewMetricFamilyDef(
 		descEndpointLabelsName,
 		descEndpointLabelsHelp,
 		descEndpointLabelsDefaultLabels,
 		nil,
 	)
 
-	descEndpointAddressAvailable = NewMetricFamilyDef(
+	descEndpointAddressAvailable = metrics.NewMetricFamilyDef(
 		"kube_endpoint_address_available",
 		"Number of addresses available in endpoint.",
 		descEndpointLabelsDefaultLabels,
 		nil,
 	)
 
-	descEndpointAddressNotReady = NewMetricFamilyDef(
+	descEndpointAddressNotReady = metrics.NewMetricFamilyDef(
 		"kube_endpoint_address_not_ready",
 		"Number of addresses not ready in endpoint",
 		descEndpointLabelsDefaultLabels,
@@ -86,7 +86,7 @@ func generateEndpointsMetrics(obj interface{}) []*metrics.Metric {
 	ePointer := obj.(*v1.Endpoints)
 	e := *ePointer
 
-	addConstMetric := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addConstMetric := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{e.Namespace, e.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -96,7 +96,7 @@ func generateEndpointsMetrics(obj interface{}) []*metrics.Metric {
 
 		ms = append(ms, m)
 	}
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
 
@@ -122,8 +122,8 @@ func generateEndpointsMetrics(obj interface{}) []*metrics.Metric {
 	return ms
 }
 
-func endpointLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func endpointLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descEndpointLabelsName,
 		descEndpointLabelsHelp,
 		append(descEndpointLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/endpoint.go
+++ b/pkg/collectors/endpoint.go
@@ -32,35 +32,35 @@ var (
 	descEndpointLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descEndpointLabelsDefaultLabels = []string{"namespace", "endpoint"}
 
-	descEndpointInfo = newMetricFamilyDef(
+	descEndpointInfo = NewMetricFamilyDef(
 		"kube_endpoint_info",
 		"Information about endpoint.",
 		descEndpointLabelsDefaultLabels,
 		nil,
 	)
 
-	descEndpointCreated = newMetricFamilyDef(
+	descEndpointCreated = NewMetricFamilyDef(
 		"kube_endpoint_created",
 		"Unix creation timestamp",
 		descEndpointLabelsDefaultLabels,
 		nil,
 	)
 
-	descEndpointLabels = newMetricFamilyDef(
+	descEndpointLabels = NewMetricFamilyDef(
 		descEndpointLabelsName,
 		descEndpointLabelsHelp,
 		descEndpointLabelsDefaultLabels,
 		nil,
 	)
 
-	descEndpointAddressAvailable = newMetricFamilyDef(
+	descEndpointAddressAvailable = NewMetricFamilyDef(
 		"kube_endpoint_address_available",
 		"Number of addresses available in endpoint.",
 		descEndpointLabelsDefaultLabels,
 		nil,
 	)
 
-	descEndpointAddressNotReady = newMetricFamilyDef(
+	descEndpointAddressNotReady = NewMetricFamilyDef(
 		"kube_endpoint_address_not_ready",
 		"Number of addresses not ready in endpoint",
 		descEndpointLabelsDefaultLabels,
@@ -123,7 +123,7 @@ func generateEndpointsMetrics(obj interface{}) []*metrics.Metric {
 }
 
 func endpointLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descEndpointLabelsName,
 		descEndpointLabelsHelp,
 		append(descEndpointLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/hpa.go
+++ b/pkg/collectors/hpa.go
@@ -87,7 +87,7 @@ func createHPAListWatch(kubeClient clientset.Interface, ns string) cache.ListWat
 	}
 }
 
-func hpaLabelsDesc(labelKeys []string) *metricFamilyDef {
+func hpaLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descHorizontalPodAutoscalerLabelsName,
 		descHorizontalPodAutoscalerLabelsHelp,
@@ -104,7 +104,7 @@ func generateHPAMetrics(obj interface{}) []*metrics.Metric {
 	hPointer := obj.(*autoscaling.HorizontalPodAutoscaler)
 	h := *hPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{h.Namespace, h.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/hpa.go
+++ b/pkg/collectors/hpa.go
@@ -32,43 +32,43 @@ var (
 	descHorizontalPodAutoscalerLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descHorizontalPodAutoscalerLabelsDefaultLabels = []string{"namespace", "hpa"}
 
-	descHorizontalPodAutoscalerMetadataGeneration = newMetricFamilyDef(
+	descHorizontalPodAutoscalerMetadataGeneration = NewMetricFamilyDef(
 		"kube_hpa_metadata_generation",
 		"The generation observed by the HorizontalPodAutoscaler controller.",
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerSpecMaxReplicas = newMetricFamilyDef(
+	descHorizontalPodAutoscalerSpecMaxReplicas = NewMetricFamilyDef(
 		"kube_hpa_spec_max_replicas",
 		"Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerSpecMinReplicas = newMetricFamilyDef(
+	descHorizontalPodAutoscalerSpecMinReplicas = NewMetricFamilyDef(
 		"kube_hpa_spec_min_replicas",
 		"Lower limit for the number of pods that can be set by the autoscaler, default 1.",
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerStatusCurrentReplicas = newMetricFamilyDef(
+	descHorizontalPodAutoscalerStatusCurrentReplicas = NewMetricFamilyDef(
 		"kube_hpa_status_current_replicas",
 		"Current number of replicas of pods managed by this autoscaler.",
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerStatusDesiredReplicas = newMetricFamilyDef(
+	descHorizontalPodAutoscalerStatusDesiredReplicas = NewMetricFamilyDef(
 		"kube_hpa_status_desired_replicas",
 		"Desired number of replicas of pods managed by this autoscaler.",
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerLabels = newMetricFamilyDef(
+	descHorizontalPodAutoscalerLabels = NewMetricFamilyDef(
 		descHorizontalPodAutoscalerLabelsName,
 		descHorizontalPodAutoscalerLabelsHelp,
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerCondition = newMetricFamilyDef(
+	descHorizontalPodAutoscalerCondition = NewMetricFamilyDef(
 		"kube_hpa_status_condition",
 		"The condition of this autoscaler.",
 		append(descHorizontalPodAutoscalerLabelsDefaultLabels, "condition", "status"),
@@ -88,7 +88,7 @@ func createHPAListWatch(kubeClient clientset.Interface, ns string) cache.ListWat
 }
 
 func hpaLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descHorizontalPodAutoscalerLabelsName,
 		descHorizontalPodAutoscalerLabelsHelp,
 		append(descHorizontalPodAutoscalerLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/hpa.go
+++ b/pkg/collectors/hpa.go
@@ -32,43 +32,43 @@ var (
 	descHorizontalPodAutoscalerLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descHorizontalPodAutoscalerLabelsDefaultLabels = []string{"namespace", "hpa"}
 
-	descHorizontalPodAutoscalerMetadataGeneration = NewMetricFamilyDef(
+	descHorizontalPodAutoscalerMetadataGeneration = metrics.NewMetricFamilyDef(
 		"kube_hpa_metadata_generation",
 		"The generation observed by the HorizontalPodAutoscaler controller.",
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerSpecMaxReplicas = NewMetricFamilyDef(
+	descHorizontalPodAutoscalerSpecMaxReplicas = metrics.NewMetricFamilyDef(
 		"kube_hpa_spec_max_replicas",
 		"Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerSpecMinReplicas = NewMetricFamilyDef(
+	descHorizontalPodAutoscalerSpecMinReplicas = metrics.NewMetricFamilyDef(
 		"kube_hpa_spec_min_replicas",
 		"Lower limit for the number of pods that can be set by the autoscaler, default 1.",
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerStatusCurrentReplicas = NewMetricFamilyDef(
+	descHorizontalPodAutoscalerStatusCurrentReplicas = metrics.NewMetricFamilyDef(
 		"kube_hpa_status_current_replicas",
 		"Current number of replicas of pods managed by this autoscaler.",
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerStatusDesiredReplicas = NewMetricFamilyDef(
+	descHorizontalPodAutoscalerStatusDesiredReplicas = metrics.NewMetricFamilyDef(
 		"kube_hpa_status_desired_replicas",
 		"Desired number of replicas of pods managed by this autoscaler.",
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerLabels = NewMetricFamilyDef(
+	descHorizontalPodAutoscalerLabels = metrics.NewMetricFamilyDef(
 		descHorizontalPodAutoscalerLabelsName,
 		descHorizontalPodAutoscalerLabelsHelp,
 		descHorizontalPodAutoscalerLabelsDefaultLabels,
 		nil,
 	)
-	descHorizontalPodAutoscalerCondition = NewMetricFamilyDef(
+	descHorizontalPodAutoscalerCondition = metrics.NewMetricFamilyDef(
 		"kube_hpa_status_condition",
 		"The condition of this autoscaler.",
 		append(descHorizontalPodAutoscalerLabelsDefaultLabels, "condition", "status"),
@@ -87,8 +87,8 @@ func createHPAListWatch(kubeClient clientset.Interface, ns string) cache.ListWat
 	}
 }
 
-func hpaLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func hpaLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descHorizontalPodAutoscalerLabelsName,
 		descHorizontalPodAutoscalerLabelsHelp,
 		append(descHorizontalPodAutoscalerLabelsDefaultLabels, labelKeys...),
@@ -104,7 +104,7 @@ func generateHPAMetrics(obj interface{}) []*metrics.Metric {
 	hPointer := obj.(*autoscaling.HorizontalPodAutoscaler)
 	h := *hPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{h.Namespace, h.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/job.go
+++ b/pkg/collectors/job.go
@@ -124,7 +124,7 @@ func createJobListWatch(kubeClient clientset.Interface, ns string) cache.ListWat
 	}
 }
 
-func jobLabelsDesc(labelKeys []string) *metricFamilyDef {
+func jobLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descJobLabelsName,
 		descJobLabelsHelp,
@@ -140,7 +140,7 @@ func generateJobMetrics(obj interface{}) []*metrics.Metric {
 	jPointer := obj.(*v1batch.Job)
 	j := *jPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{j.Namespace, j.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/job.go
+++ b/pkg/collectors/job.go
@@ -32,80 +32,80 @@ var (
 	descJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descJobLabelsDefaultLabels = []string{"namespace", "job_name"}
 
-	descJobLabels = newMetricFamilyDef(
+	descJobLabels = NewMetricFamilyDef(
 		descJobLabelsName,
 		descJobLabelsHelp,
 		descJobLabelsDefaultLabels,
 		nil,
 	)
 
-	descJobInfo = newMetricFamilyDef(
+	descJobInfo = NewMetricFamilyDef(
 		"kube_job_info",
 		"Information about job.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobCreated = newMetricFamilyDef(
+	descJobCreated = NewMetricFamilyDef(
 		"kube_job_created",
 		"Unix creation timestamp",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobSpecParallelism = newMetricFamilyDef(
+	descJobSpecParallelism = NewMetricFamilyDef(
 		"kube_job_spec_parallelism",
 		"The maximum desired number of pods the job should run at any given time.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobSpecCompletions = newMetricFamilyDef(
+	descJobSpecCompletions = NewMetricFamilyDef(
 		"kube_job_spec_completions",
 		"The desired number of successfully finished pods the job should be run with.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobSpecActiveDeadlineSeconds = newMetricFamilyDef(
+	descJobSpecActiveDeadlineSeconds = NewMetricFamilyDef(
 		"kube_job_spec_active_deadline_seconds",
 		"The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobStatusSucceeded = newMetricFamilyDef(
+	descJobStatusSucceeded = NewMetricFamilyDef(
 		"kube_job_status_succeeded",
 		"The number of pods which reached Phase Succeeded.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobStatusFailed = newMetricFamilyDef(
+	descJobStatusFailed = NewMetricFamilyDef(
 		"kube_job_status_failed",
 		"The number of pods which reached Phase Failed.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobStatusActive = newMetricFamilyDef(
+	descJobStatusActive = NewMetricFamilyDef(
 		"kube_job_status_active",
 		"The number of actively running pods.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobConditionComplete = newMetricFamilyDef(
+	descJobConditionComplete = NewMetricFamilyDef(
 		"kube_job_complete",
 		"The job has completed its execution.",
 		append(descJobLabelsDefaultLabels, "condition"),
 		nil,
 	)
-	descJobConditionFailed = newMetricFamilyDef(
+	descJobConditionFailed = NewMetricFamilyDef(
 		"kube_job_failed",
 		"The job has failed its execution.",
 		append(descJobLabelsDefaultLabels, "condition"),
 		nil,
 	)
-	descJobStatusStartTime = newMetricFamilyDef(
+	descJobStatusStartTime = NewMetricFamilyDef(
 		"kube_job_status_start_time",
 		"StartTime represents time when the job was acknowledged by the Job Manager.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobStatusCompletionTime = newMetricFamilyDef(
+	descJobStatusCompletionTime = NewMetricFamilyDef(
 		"kube_job_status_completion_time",
 		"CompletionTime represents time when the job was completed.",
 		descJobLabelsDefaultLabels,
@@ -125,7 +125,7 @@ func createJobListWatch(kubeClient clientset.Interface, ns string) cache.ListWat
 }
 
 func jobLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descJobLabelsName,
 		descJobLabelsHelp,
 		append(descJobLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/job.go
+++ b/pkg/collectors/job.go
@@ -32,80 +32,80 @@ var (
 	descJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descJobLabelsDefaultLabels = []string{"namespace", "job_name"}
 
-	descJobLabels = NewMetricFamilyDef(
+	descJobLabels = metrics.NewMetricFamilyDef(
 		descJobLabelsName,
 		descJobLabelsHelp,
 		descJobLabelsDefaultLabels,
 		nil,
 	)
 
-	descJobInfo = NewMetricFamilyDef(
+	descJobInfo = metrics.NewMetricFamilyDef(
 		"kube_job_info",
 		"Information about job.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobCreated = NewMetricFamilyDef(
+	descJobCreated = metrics.NewMetricFamilyDef(
 		"kube_job_created",
 		"Unix creation timestamp",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobSpecParallelism = NewMetricFamilyDef(
+	descJobSpecParallelism = metrics.NewMetricFamilyDef(
 		"kube_job_spec_parallelism",
 		"The maximum desired number of pods the job should run at any given time.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobSpecCompletions = NewMetricFamilyDef(
+	descJobSpecCompletions = metrics.NewMetricFamilyDef(
 		"kube_job_spec_completions",
 		"The desired number of successfully finished pods the job should be run with.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobSpecActiveDeadlineSeconds = NewMetricFamilyDef(
+	descJobSpecActiveDeadlineSeconds = metrics.NewMetricFamilyDef(
 		"kube_job_spec_active_deadline_seconds",
 		"The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobStatusSucceeded = NewMetricFamilyDef(
+	descJobStatusSucceeded = metrics.NewMetricFamilyDef(
 		"kube_job_status_succeeded",
 		"The number of pods which reached Phase Succeeded.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobStatusFailed = NewMetricFamilyDef(
+	descJobStatusFailed = metrics.NewMetricFamilyDef(
 		"kube_job_status_failed",
 		"The number of pods which reached Phase Failed.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobStatusActive = NewMetricFamilyDef(
+	descJobStatusActive = metrics.NewMetricFamilyDef(
 		"kube_job_status_active",
 		"The number of actively running pods.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobConditionComplete = NewMetricFamilyDef(
+	descJobConditionComplete = metrics.NewMetricFamilyDef(
 		"kube_job_complete",
 		"The job has completed its execution.",
 		append(descJobLabelsDefaultLabels, "condition"),
 		nil,
 	)
-	descJobConditionFailed = NewMetricFamilyDef(
+	descJobConditionFailed = metrics.NewMetricFamilyDef(
 		"kube_job_failed",
 		"The job has failed its execution.",
 		append(descJobLabelsDefaultLabels, "condition"),
 		nil,
 	)
-	descJobStatusStartTime = NewMetricFamilyDef(
+	descJobStatusStartTime = metrics.NewMetricFamilyDef(
 		"kube_job_status_start_time",
 		"StartTime represents time when the job was acknowledged by the Job Manager.",
 		descJobLabelsDefaultLabels,
 		nil,
 	)
-	descJobStatusCompletionTime = NewMetricFamilyDef(
+	descJobStatusCompletionTime = metrics.NewMetricFamilyDef(
 		"kube_job_status_completion_time",
 		"CompletionTime represents time when the job was completed.",
 		descJobLabelsDefaultLabels,
@@ -124,8 +124,8 @@ func createJobListWatch(kubeClient clientset.Interface, ns string) cache.ListWat
 	}
 }
 
-func jobLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func jobLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descJobLabelsName,
 		descJobLabelsHelp,
 		append(descJobLabelsDefaultLabels, labelKeys...),
@@ -140,7 +140,7 @@ func generateJobMetrics(obj interface{}) []*metrics.Metric {
 	jPointer := obj.(*v1batch.Job)
 	j := *jPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{j.Namespace, j.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/limitrange.go
+++ b/pkg/collectors/limitrange.go
@@ -29,14 +29,14 @@ import (
 
 var (
 	descLimitRangeLabelsDefaultLabels = []string{"limitrange", "namespace"}
-	descLimitRange                    = NewMetricFamilyDef(
+	descLimitRange                    = metrics.NewMetricFamilyDef(
 		"kube_limitrange",
 		"Information about limit range.",
 		append(descLimitRangeLabelsDefaultLabels, "resource", "type", "constraint"),
 		nil,
 	)
 
-	descLimitRangeCreated = NewMetricFamilyDef(
+	descLimitRangeCreated = metrics.NewMetricFamilyDef(
 		"kube_limitrange_created",
 		"Unix creation timestamp",
 		descLimitRangeLabelsDefaultLabels,
@@ -61,7 +61,7 @@ func generateLimitRangeMetrics(obj interface{}) []*metrics.Metric {
 	lPointer := obj.(*v1.LimitRange)
 	l := *lPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{l.Name, l.Namespace}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/limitrange.go
+++ b/pkg/collectors/limitrange.go
@@ -61,7 +61,7 @@ func generateLimitRangeMetrics(obj interface{}) []*metrics.Metric {
 	lPointer := obj.(*v1.LimitRange)
 	l := *lPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{l.Name, l.Namespace}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/limitrange.go
+++ b/pkg/collectors/limitrange.go
@@ -29,14 +29,14 @@ import (
 
 var (
 	descLimitRangeLabelsDefaultLabels = []string{"limitrange", "namespace"}
-	descLimitRange                    = newMetricFamilyDef(
+	descLimitRange                    = NewMetricFamilyDef(
 		"kube_limitrange",
 		"Information about limit range.",
 		append(descLimitRangeLabelsDefaultLabels, "resource", "type", "constraint"),
 		nil,
 	)
 
-	descLimitRangeCreated = newMetricFamilyDef(
+	descLimitRangeCreated = NewMetricFamilyDef(
 		"kube_limitrange_created",
 		"Unix creation timestamp",
 		descLimitRangeLabelsDefaultLabels,

--- a/pkg/collectors/namespace.go
+++ b/pkg/collectors/namespace.go
@@ -36,25 +36,25 @@ var (
 	descNamespaceAnnotationsHelp          = "Kubernetes annotations converted to Prometheus labels."
 	descNamespaceAnnotationsDefaultLabels = []string{"namespace"}
 
-	descNamespaceCreated = NewMetricFamilyDef(
+	descNamespaceCreated = metrics.NewMetricFamilyDef(
 		"kube_namespace_created",
 		"Unix creation timestamp",
 		descNamespaceLabelsDefaultLabels,
 		nil,
 	)
-	descNamespaceLabels = NewMetricFamilyDef(
+	descNamespaceLabels = metrics.NewMetricFamilyDef(
 		descNamespaceLabelsName,
 		descNamespaceLabelsHelp,
 		descNamespaceLabelsDefaultLabels,
 		nil,
 	)
-	descNamespaceAnnotations = NewMetricFamilyDef(
+	descNamespaceAnnotations = metrics.NewMetricFamilyDef(
 		descNamespaceAnnotationsName,
 		descNamespaceAnnotationsHelp,
 		descNamespaceAnnotationsDefaultLabels,
 		nil,
 	)
-	descNamespacePhase = NewMetricFamilyDef(
+	descNamespacePhase = metrics.NewMetricFamilyDef(
 		"kube_namespace_status_phase",
 		"kubernetes namespace status phase.",
 		append(descNamespaceLabelsDefaultLabels, "phase"),
@@ -80,7 +80,7 @@ func generateNamespaceMetrics(obj interface{}) []*metrics.Metric {
 	nPointer := obj.(*v1.Namespace)
 	n := *nPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{n.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -107,8 +107,8 @@ func generateNamespaceMetrics(obj interface{}) []*metrics.Metric {
 	return ms
 }
 
-func namespaceLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func namespaceLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descNamespaceLabelsName,
 		descNamespaceLabelsHelp,
 		append(descNamespaceLabelsDefaultLabels, labelKeys...),
@@ -116,8 +116,8 @@ func namespaceLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	)
 }
 
-func namespaceAnnotationsDesc(annotationKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func namespaceAnnotationsDesc(annotationKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descNamespaceAnnotationsName,
 		descNamespaceAnnotationsHelp,
 		append(descNamespaceAnnotationsDefaultLabels, annotationKeys...),

--- a/pkg/collectors/namespace.go
+++ b/pkg/collectors/namespace.go
@@ -80,7 +80,7 @@ func generateNamespaceMetrics(obj interface{}) []*metrics.Metric {
 	nPointer := obj.(*v1.Namespace)
 	n := *nPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{n.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -107,7 +107,7 @@ func generateNamespaceMetrics(obj interface{}) []*metrics.Metric {
 	return ms
 }
 
-func namespaceLabelsDesc(labelKeys []string) *metricFamilyDef {
+func namespaceLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descNamespaceLabelsName,
 		descNamespaceLabelsHelp,
@@ -116,7 +116,7 @@ func namespaceLabelsDesc(labelKeys []string) *metricFamilyDef {
 	)
 }
 
-func namespaceAnnotationsDesc(annotationKeys []string) *metricFamilyDef {
+func namespaceAnnotationsDesc(annotationKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descNamespaceAnnotationsName,
 		descNamespaceAnnotationsHelp,

--- a/pkg/collectors/namespace.go
+++ b/pkg/collectors/namespace.go
@@ -36,25 +36,25 @@ var (
 	descNamespaceAnnotationsHelp          = "Kubernetes annotations converted to Prometheus labels."
 	descNamespaceAnnotationsDefaultLabels = []string{"namespace"}
 
-	descNamespaceCreated = newMetricFamilyDef(
+	descNamespaceCreated = NewMetricFamilyDef(
 		"kube_namespace_created",
 		"Unix creation timestamp",
 		descNamespaceLabelsDefaultLabels,
 		nil,
 	)
-	descNamespaceLabels = newMetricFamilyDef(
+	descNamespaceLabels = NewMetricFamilyDef(
 		descNamespaceLabelsName,
 		descNamespaceLabelsHelp,
 		descNamespaceLabelsDefaultLabels,
 		nil,
 	)
-	descNamespaceAnnotations = newMetricFamilyDef(
+	descNamespaceAnnotations = NewMetricFamilyDef(
 		descNamespaceAnnotationsName,
 		descNamespaceAnnotationsHelp,
 		descNamespaceAnnotationsDefaultLabels,
 		nil,
 	)
-	descNamespacePhase = newMetricFamilyDef(
+	descNamespacePhase = NewMetricFamilyDef(
 		"kube_namespace_status_phase",
 		"kubernetes namespace status phase.",
 		append(descNamespaceLabelsDefaultLabels, "phase"),
@@ -108,7 +108,7 @@ func generateNamespaceMetrics(obj interface{}) []*metrics.Metric {
 }
 
 func namespaceLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descNamespaceLabelsName,
 		descNamespaceLabelsHelp,
 		append(descNamespaceLabelsDefaultLabels, labelKeys...),
@@ -117,7 +117,7 @@ func namespaceLabelsDesc(labelKeys []string) *MetricFamilyDef {
 }
 
 func namespaceAnnotationsDesc(annotationKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descNamespaceAnnotationsName,
 		descNamespaceAnnotationsHelp,
 		append(descNamespaceAnnotationsDefaultLabels, annotationKeys...),

--- a/pkg/collectors/node.go
+++ b/pkg/collectors/node.go
@@ -34,7 +34,7 @@ var (
 	descNodeLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descNodeLabelsDefaultLabels = []string{"node"}
 
-	descNodeInfo = NewMetricFamilyDef(
+	descNodeInfo = metrics.NewMetricFamilyDef(
 		"kube_node_info",
 		"Information about a cluster node.",
 		append(descNodeLabelsDefaultLabels,
@@ -46,85 +46,85 @@ var (
 			"provider_id"),
 		nil,
 	)
-	descNodeCreated = NewMetricFamilyDef(
+	descNodeCreated = metrics.NewMetricFamilyDef(
 		"kube_node_created",
 		"Unix creation timestamp",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeLabels = NewMetricFamilyDef(
+	descNodeLabels = metrics.NewMetricFamilyDef(
 		descNodeLabelsName,
 		descNodeLabelsHelp,
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeSpecUnschedulable = NewMetricFamilyDef(
+	descNodeSpecUnschedulable = metrics.NewMetricFamilyDef(
 		"kube_node_spec_unschedulable",
 		"Whether a node can schedule new pods.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeSpecTaint = NewMetricFamilyDef(
+	descNodeSpecTaint = metrics.NewMetricFamilyDef(
 		"kube_node_spec_taint",
 		"The taint of a cluster node.",
 		append(descNodeLabelsDefaultLabels, "key", "value", "effect"),
 		nil,
 	)
-	descNodeStatusCondition = NewMetricFamilyDef(
+	descNodeStatusCondition = metrics.NewMetricFamilyDef(
 		"kube_node_status_condition",
 		"The condition of a cluster node.",
 		append(descNodeLabelsDefaultLabels, "condition", "status"),
 		nil,
 	)
-	descNodeStatusPhase = NewMetricFamilyDef(
+	descNodeStatusPhase = metrics.NewMetricFamilyDef(
 		"kube_node_status_phase",
 		"The phase the node is currently in.",
 		append(descNodeLabelsDefaultLabels, "phase"),
 		nil,
 	)
-	descNodeStatusCapacity = NewMetricFamilyDef(
+	descNodeStatusCapacity = metrics.NewMetricFamilyDef(
 		"kube_node_status_capacity",
 		"The capacity for different resources of a node.",
 		append(descNodeLabelsDefaultLabels, "resource", "unit"),
 		nil,
 	)
-	descNodeStatusCapacityPods = NewMetricFamilyDef(
+	descNodeStatusCapacityPods = metrics.NewMetricFamilyDef(
 		"kube_node_status_capacity_pods",
 		"The total pod resources of the node.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeStatusCapacityCPU = NewMetricFamilyDef(
+	descNodeStatusCapacityCPU = metrics.NewMetricFamilyDef(
 		"kube_node_status_capacity_cpu_cores",
 		"The total CPU resources of the node.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeStatusCapacityMemory = NewMetricFamilyDef(
+	descNodeStatusCapacityMemory = metrics.NewMetricFamilyDef(
 		"kube_node_status_capacity_memory_bytes",
 		"The total memory resources of the node.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeStatusAllocatable = NewMetricFamilyDef(
+	descNodeStatusAllocatable = metrics.NewMetricFamilyDef(
 		"kube_node_status_allocatable",
 		"The allocatable for different resources of a node that are available for scheduling.",
 		append(descNodeLabelsDefaultLabels, "resource", "unit"),
 		nil,
 	)
-	descNodeStatusAllocatablePods = NewMetricFamilyDef(
+	descNodeStatusAllocatablePods = metrics.NewMetricFamilyDef(
 		"kube_node_status_allocatable_pods",
 		"The pod resources of a node that are available for scheduling.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeStatusAllocatableCPU = NewMetricFamilyDef(
+	descNodeStatusAllocatableCPU = metrics.NewMetricFamilyDef(
 		"kube_node_status_allocatable_cpu_cores",
 		"The CPU resources of a node that are available for scheduling.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeStatusAllocatableMemory = NewMetricFamilyDef(
+	descNodeStatusAllocatableMemory = metrics.NewMetricFamilyDef(
 		"kube_node_status_allocatable_memory_bytes",
 		"The memory resources of a node that are available for scheduling.",
 		descNodeLabelsDefaultLabels,
@@ -143,8 +143,8 @@ func createNodeListWatch(kubeClient clientset.Interface, ns string) cache.ListWa
 	}
 }
 
-func nodeLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func nodeLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descNodeLabelsName,
 		descNodeLabelsHelp,
 		append(descNodeLabelsDefaultLabels, labelKeys...),
@@ -159,7 +159,7 @@ func generateNodeMetrics(disableNodeNonGenericResourceMetrics bool, obj interfac
 	nPointer := obj.(*v1.Node)
 	n := *nPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{n.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -213,7 +213,7 @@ func generateNodeMetrics(disableNodeNonGenericResourceMetrics bool, obj interfac
 
 	if !disableNodeNonGenericResourceMetrics {
 		// Add capacity and allocatable resources if they are set.
-		addResource := func(d *MetricFamilyDef, res v1.ResourceList, n v1.ResourceName) {
+		addResource := func(d *metrics.MetricFamilyDef, res v1.ResourceList, n v1.ResourceName) {
 			if v, ok := res[n]; ok {
 				addGauge(d, float64(v.MilliValue())/1000)
 			}

--- a/pkg/collectors/node.go
+++ b/pkg/collectors/node.go
@@ -143,7 +143,7 @@ func createNodeListWatch(kubeClient clientset.Interface, ns string) cache.ListWa
 	}
 }
 
-func nodeLabelsDesc(labelKeys []string) *metricFamilyDef {
+func nodeLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descNodeLabelsName,
 		descNodeLabelsHelp,
@@ -159,7 +159,7 @@ func generateNodeMetrics(disableNodeNonGenericResourceMetrics bool, obj interfac
 	nPointer := obj.(*v1.Node)
 	n := *nPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{n.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -213,7 +213,7 @@ func generateNodeMetrics(disableNodeNonGenericResourceMetrics bool, obj interfac
 
 	if !disableNodeNonGenericResourceMetrics {
 		// Add capacity and allocatable resources if they are set.
-		addResource := func(d *metricFamilyDef, res v1.ResourceList, n v1.ResourceName) {
+		addResource := func(d *MetricFamilyDef, res v1.ResourceList, n v1.ResourceName) {
 			if v, ok := res[n]; ok {
 				addGauge(d, float64(v.MilliValue())/1000)
 			}

--- a/pkg/collectors/node.go
+++ b/pkg/collectors/node.go
@@ -34,7 +34,7 @@ var (
 	descNodeLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descNodeLabelsDefaultLabels = []string{"node"}
 
-	descNodeInfo = newMetricFamilyDef(
+	descNodeInfo = NewMetricFamilyDef(
 		"kube_node_info",
 		"Information about a cluster node.",
 		append(descNodeLabelsDefaultLabels,
@@ -46,85 +46,85 @@ var (
 			"provider_id"),
 		nil,
 	)
-	descNodeCreated = newMetricFamilyDef(
+	descNodeCreated = NewMetricFamilyDef(
 		"kube_node_created",
 		"Unix creation timestamp",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeLabels = newMetricFamilyDef(
+	descNodeLabels = NewMetricFamilyDef(
 		descNodeLabelsName,
 		descNodeLabelsHelp,
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeSpecUnschedulable = newMetricFamilyDef(
+	descNodeSpecUnschedulable = NewMetricFamilyDef(
 		"kube_node_spec_unschedulable",
 		"Whether a node can schedule new pods.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeSpecTaint = newMetricFamilyDef(
+	descNodeSpecTaint = NewMetricFamilyDef(
 		"kube_node_spec_taint",
 		"The taint of a cluster node.",
 		append(descNodeLabelsDefaultLabels, "key", "value", "effect"),
 		nil,
 	)
-	descNodeStatusCondition = newMetricFamilyDef(
+	descNodeStatusCondition = NewMetricFamilyDef(
 		"kube_node_status_condition",
 		"The condition of a cluster node.",
 		append(descNodeLabelsDefaultLabels, "condition", "status"),
 		nil,
 	)
-	descNodeStatusPhase = newMetricFamilyDef(
+	descNodeStatusPhase = NewMetricFamilyDef(
 		"kube_node_status_phase",
 		"The phase the node is currently in.",
 		append(descNodeLabelsDefaultLabels, "phase"),
 		nil,
 	)
-	descNodeStatusCapacity = newMetricFamilyDef(
+	descNodeStatusCapacity = NewMetricFamilyDef(
 		"kube_node_status_capacity",
 		"The capacity for different resources of a node.",
 		append(descNodeLabelsDefaultLabels, "resource", "unit"),
 		nil,
 	)
-	descNodeStatusCapacityPods = newMetricFamilyDef(
+	descNodeStatusCapacityPods = NewMetricFamilyDef(
 		"kube_node_status_capacity_pods",
 		"The total pod resources of the node.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeStatusCapacityCPU = newMetricFamilyDef(
+	descNodeStatusCapacityCPU = NewMetricFamilyDef(
 		"kube_node_status_capacity_cpu_cores",
 		"The total CPU resources of the node.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeStatusCapacityMemory = newMetricFamilyDef(
+	descNodeStatusCapacityMemory = NewMetricFamilyDef(
 		"kube_node_status_capacity_memory_bytes",
 		"The total memory resources of the node.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeStatusAllocatable = newMetricFamilyDef(
+	descNodeStatusAllocatable = NewMetricFamilyDef(
 		"kube_node_status_allocatable",
 		"The allocatable for different resources of a node that are available for scheduling.",
 		append(descNodeLabelsDefaultLabels, "resource", "unit"),
 		nil,
 	)
-	descNodeStatusAllocatablePods = newMetricFamilyDef(
+	descNodeStatusAllocatablePods = NewMetricFamilyDef(
 		"kube_node_status_allocatable_pods",
 		"The pod resources of a node that are available for scheduling.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeStatusAllocatableCPU = newMetricFamilyDef(
+	descNodeStatusAllocatableCPU = NewMetricFamilyDef(
 		"kube_node_status_allocatable_cpu_cores",
 		"The CPU resources of a node that are available for scheduling.",
 		descNodeLabelsDefaultLabels,
 		nil,
 	)
-	descNodeStatusAllocatableMemory = newMetricFamilyDef(
+	descNodeStatusAllocatableMemory = NewMetricFamilyDef(
 		"kube_node_status_allocatable_memory_bytes",
 		"The memory resources of a node that are available for scheduling.",
 		descNodeLabelsDefaultLabels,
@@ -144,7 +144,7 @@ func createNodeListWatch(kubeClient clientset.Interface, ns string) cache.ListWa
 }
 
 func nodeLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descNodeLabelsName,
 		descNodeLabelsHelp,
 		append(descNodeLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/persistentvolume.go
+++ b/pkg/collectors/persistentvolume.go
@@ -32,19 +32,19 @@ var (
 	descPersistentVolumeLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descPersistentVolumeLabelsDefaultLabels = []string{"persistentvolume"}
 
-	descPersistentVolumeLabels = NewMetricFamilyDef(
+	descPersistentVolumeLabels = metrics.NewMetricFamilyDef(
 		descPersistentVolumeLabelsName,
 		descPersistentVolumeLabelsHelp,
 		descPersistentVolumeLabelsDefaultLabels,
 		nil,
 	)
-	descPersistentVolumeStatusPhase = NewMetricFamilyDef(
+	descPersistentVolumeStatusPhase = metrics.NewMetricFamilyDef(
 		"kube_persistentvolume_status_phase",
 		"The phase indicates if a volume is available, bound to a claim, or released by a claim.",
 		append(descPersistentVolumeLabelsDefaultLabels, "phase"),
 		nil,
 	)
-	descPersistentVolumeInfo = NewMetricFamilyDef(
+	descPersistentVolumeInfo = metrics.NewMetricFamilyDef(
 		"kube_persistentvolume_info",
 		"Information about persistentvolume.",
 		append(descPersistentVolumeLabelsDefaultLabels, "storageclass"),
@@ -63,8 +63,8 @@ func createPersistentVolumeListWatch(kubeClient clientset.Interface, ns string) 
 	}
 }
 
-func persistentVolumeLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func persistentVolumeLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descPersistentVolumeLabelsName,
 		descPersistentVolumeLabelsHelp,
 		append(descPersistentVolumeLabelsDefaultLabels, labelKeys...),
@@ -79,7 +79,7 @@ func generatePersistentVolumeMetrics(obj interface{}) []*metrics.Metric {
 	pPointer := obj.(*v1.PersistentVolume)
 	p := *pPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{p.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/persistentvolume.go
+++ b/pkg/collectors/persistentvolume.go
@@ -63,7 +63,7 @@ func createPersistentVolumeListWatch(kubeClient clientset.Interface, ns string) 
 	}
 }
 
-func persistentVolumeLabelsDesc(labelKeys []string) *metricFamilyDef {
+func persistentVolumeLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descPersistentVolumeLabelsName,
 		descPersistentVolumeLabelsHelp,
@@ -79,7 +79,7 @@ func generatePersistentVolumeMetrics(obj interface{}) []*metrics.Metric {
 	pPointer := obj.(*v1.PersistentVolume)
 	p := *pPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{p.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/persistentvolume.go
+++ b/pkg/collectors/persistentvolume.go
@@ -32,19 +32,19 @@ var (
 	descPersistentVolumeLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descPersistentVolumeLabelsDefaultLabels = []string{"persistentvolume"}
 
-	descPersistentVolumeLabels = newMetricFamilyDef(
+	descPersistentVolumeLabels = NewMetricFamilyDef(
 		descPersistentVolumeLabelsName,
 		descPersistentVolumeLabelsHelp,
 		descPersistentVolumeLabelsDefaultLabels,
 		nil,
 	)
-	descPersistentVolumeStatusPhase = newMetricFamilyDef(
+	descPersistentVolumeStatusPhase = NewMetricFamilyDef(
 		"kube_persistentvolume_status_phase",
 		"The phase indicates if a volume is available, bound to a claim, or released by a claim.",
 		append(descPersistentVolumeLabelsDefaultLabels, "phase"),
 		nil,
 	)
-	descPersistentVolumeInfo = newMetricFamilyDef(
+	descPersistentVolumeInfo = NewMetricFamilyDef(
 		"kube_persistentvolume_info",
 		"Information about persistentvolume.",
 		append(descPersistentVolumeLabelsDefaultLabels, "storageclass"),
@@ -64,7 +64,7 @@ func createPersistentVolumeListWatch(kubeClient clientset.Interface, ns string) 
 }
 
 func persistentVolumeLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descPersistentVolumeLabelsName,
 		descPersistentVolumeLabelsHelp,
 		append(descPersistentVolumeLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/persistentvolumeclaim.go
+++ b/pkg/collectors/persistentvolumeclaim.go
@@ -32,25 +32,25 @@ var (
 	descPersistentVolumeClaimLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descPersistentVolumeClaimLabelsDefaultLabels = []string{"namespace", "persistentvolumeclaim"}
 
-	descPersistentVolumeClaimLabels = NewMetricFamilyDef(
+	descPersistentVolumeClaimLabels = metrics.NewMetricFamilyDef(
 		descPersistentVolumeClaimLabelsName,
 		descPersistentVolumeClaimLabelsHelp,
 		descPersistentVolumeClaimLabelsDefaultLabels,
 		nil,
 	)
-	descPersistentVolumeClaimInfo = NewMetricFamilyDef(
+	descPersistentVolumeClaimInfo = metrics.NewMetricFamilyDef(
 		"kube_persistentvolumeclaim_info",
 		"Information about persistent volume claim.",
 		append(descPersistentVolumeClaimLabelsDefaultLabels, "storageclass", "volumename"),
 		nil,
 	)
-	descPersistentVolumeClaimStatusPhase = NewMetricFamilyDef(
+	descPersistentVolumeClaimStatusPhase = metrics.NewMetricFamilyDef(
 		"kube_persistentvolumeclaim_status_phase",
 		"The phase the persistent volume claim is currently in.",
 		append(descPersistentVolumeClaimLabelsDefaultLabels, "phase"),
 		nil,
 	)
-	descPersistentVolumeClaimResourceRequestsStorage = NewMetricFamilyDef(
+	descPersistentVolumeClaimResourceRequestsStorage = metrics.NewMetricFamilyDef(
 		"kube_persistentvolumeclaim_resource_requests_storage_bytes",
 		"The capacity of storage requested by the persistent volume claim.",
 		descPersistentVolumeClaimLabelsDefaultLabels,
@@ -68,8 +68,8 @@ func createPersistentVolumeClaimListWatch(kubeClient clientset.Interface, ns str
 		},
 	}
 }
-func persistentVolumeClaimLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func persistentVolumeClaimLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descPersistentVolumeClaimLabelsName,
 		descPersistentVolumeClaimLabelsHelp,
 		append(descPersistentVolumeClaimLabelsDefaultLabels, labelKeys...),
@@ -100,7 +100,7 @@ func generatePersistentVolumeClaimMetrics(obj interface{}) []*metrics.Metric {
 	pPointer := obj.(*v1.PersistentVolumeClaim)
 	p := *pPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{p.Namespace, p.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/persistentvolumeclaim.go
+++ b/pkg/collectors/persistentvolumeclaim.go
@@ -32,25 +32,25 @@ var (
 	descPersistentVolumeClaimLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descPersistentVolumeClaimLabelsDefaultLabels = []string{"namespace", "persistentvolumeclaim"}
 
-	descPersistentVolumeClaimLabels = newMetricFamilyDef(
+	descPersistentVolumeClaimLabels = NewMetricFamilyDef(
 		descPersistentVolumeClaimLabelsName,
 		descPersistentVolumeClaimLabelsHelp,
 		descPersistentVolumeClaimLabelsDefaultLabels,
 		nil,
 	)
-	descPersistentVolumeClaimInfo = newMetricFamilyDef(
+	descPersistentVolumeClaimInfo = NewMetricFamilyDef(
 		"kube_persistentvolumeclaim_info",
 		"Information about persistent volume claim.",
 		append(descPersistentVolumeClaimLabelsDefaultLabels, "storageclass", "volumename"),
 		nil,
 	)
-	descPersistentVolumeClaimStatusPhase = newMetricFamilyDef(
+	descPersistentVolumeClaimStatusPhase = NewMetricFamilyDef(
 		"kube_persistentvolumeclaim_status_phase",
 		"The phase the persistent volume claim is currently in.",
 		append(descPersistentVolumeClaimLabelsDefaultLabels, "phase"),
 		nil,
 	)
-	descPersistentVolumeClaimResourceRequestsStorage = newMetricFamilyDef(
+	descPersistentVolumeClaimResourceRequestsStorage = NewMetricFamilyDef(
 		"kube_persistentvolumeclaim_resource_requests_storage_bytes",
 		"The capacity of storage requested by the persistent volume claim.",
 		descPersistentVolumeClaimLabelsDefaultLabels,
@@ -69,7 +69,7 @@ func createPersistentVolumeClaimListWatch(kubeClient clientset.Interface, ns str
 	}
 }
 func persistentVolumeClaimLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descPersistentVolumeClaimLabelsName,
 		descPersistentVolumeClaimLabelsHelp,
 		append(descPersistentVolumeClaimLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/persistentvolumeclaim.go
+++ b/pkg/collectors/persistentvolumeclaim.go
@@ -68,7 +68,7 @@ func createPersistentVolumeClaimListWatch(kubeClient clientset.Interface, ns str
 		},
 	}
 }
-func persistentVolumeClaimLabelsDesc(labelKeys []string) *metricFamilyDef {
+func persistentVolumeClaimLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descPersistentVolumeClaimLabelsName,
 		descPersistentVolumeClaimLabelsHelp,
@@ -100,7 +100,7 @@ func generatePersistentVolumeClaimMetrics(obj interface{}) []*metrics.Metric {
 	pPointer := obj.(*v1.PersistentVolumeClaim)
 	p := *pPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{p.Namespace, p.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/pod.go
+++ b/pkg/collectors/pod.go
@@ -40,164 +40,164 @@ var (
 	containerWaitingReasons    = []string{"ContainerCreating", "CrashLoopBackOff", "ErrImagePull", "ImagePullBackOff"}
 	containerTerminatedReasons = []string{"OOMKilled", "Completed", "Error", "ContainerCannotRun"}
 
-	descPodInfo = NewMetricFamilyDef(
+	descPodInfo = metrics.NewMetricFamilyDef(
 		"kube_pod_info",
 		"Information about pod.",
 		append(descPodLabelsDefaultLabels, "host_ip", "pod_ip", "uid", "node", "created_by_kind", "created_by_name"),
 		nil,
 	)
-	descPodStartTime = NewMetricFamilyDef(
+	descPodStartTime = metrics.NewMetricFamilyDef(
 		"kube_pod_start_time",
 		"Start time in unix timestamp for a pod.",
 		descPodLabelsDefaultLabels,
 		nil,
 	)
-	descPodCompletionTime = NewMetricFamilyDef(
+	descPodCompletionTime = metrics.NewMetricFamilyDef(
 		"kube_pod_completion_time",
 		"Completion time in unix timestamp for a pod.",
 		descPodLabelsDefaultLabels,
 		nil,
 	)
-	descPodOwner = NewMetricFamilyDef(
+	descPodOwner = metrics.NewMetricFamilyDef(
 		"kube_pod_owner",
 		"Information about the Pod's owner.",
 		append(descPodLabelsDefaultLabels, "owner_kind", "owner_name", "owner_is_controller"),
 		nil,
 	)
-	descPodLabels = NewMetricFamilyDef(
+	descPodLabels = metrics.NewMetricFamilyDef(
 		descPodLabelsName,
 		descPodLabelsHelp,
 		descPodLabelsDefaultLabels,
 		nil,
 	)
-	descPodCreated = NewMetricFamilyDef(
+	descPodCreated = metrics.NewMetricFamilyDef(
 		"kube_pod_created",
 		"Unix creation timestamp",
 		descPodLabelsDefaultLabels,
 		nil,
 	)
-	descPodStatusScheduledTime = NewMetricFamilyDef(
+	descPodStatusScheduledTime = metrics.NewMetricFamilyDef(
 		"kube_pod_status_scheduled_time",
 		"Unix timestamp when pod moved into scheduled status",
 		descPodLabelsDefaultLabels,
 		nil,
 	)
-	descPodStatusPhase = NewMetricFamilyDef(
+	descPodStatusPhase = metrics.NewMetricFamilyDef(
 		"kube_pod_status_phase",
 		"The pods current phase.",
 		append(descPodLabelsDefaultLabels, "phase"),
 		nil,
 	)
-	descPodStatusReady = NewMetricFamilyDef(
+	descPodStatusReady = metrics.NewMetricFamilyDef(
 		"kube_pod_status_ready",
 		"Describes whether the pod is ready to serve requests.",
 		append(descPodLabelsDefaultLabels, "condition"),
 		nil,
 	)
-	descPodStatusScheduled = NewMetricFamilyDef(
+	descPodStatusScheduled = metrics.NewMetricFamilyDef(
 		"kube_pod_status_scheduled",
 		"Describes the status of the scheduling process for the pod.",
 		append(descPodLabelsDefaultLabels, "condition"),
 		nil,
 	)
-	descPodContainerInfo = NewMetricFamilyDef(
+	descPodContainerInfo = metrics.NewMetricFamilyDef(
 		"kube_pod_container_info",
 		"Information about a container in a pod.",
 		append(descPodLabelsDefaultLabels, "container", "image", "image_id", "container_id"),
 		nil,
 	)
-	descPodContainerStatusWaiting = NewMetricFamilyDef(
+	descPodContainerStatusWaiting = metrics.NewMetricFamilyDef(
 		"kube_pod_container_status_waiting",
 		"Describes whether the container is currently in waiting state.",
 		append(descPodLabelsDefaultLabels, "container"),
 		nil,
 	)
-	descPodContainerStatusWaitingReason = NewMetricFamilyDef(
+	descPodContainerStatusWaitingReason = metrics.NewMetricFamilyDef(
 		"kube_pod_container_status_waiting_reason",
 		"Describes the reason the container is currently in waiting state.",
 		append(descPodLabelsDefaultLabels, "container", "reason"),
 		nil,
 	)
-	descPodContainerStatusRunning = NewMetricFamilyDef(
+	descPodContainerStatusRunning = metrics.NewMetricFamilyDef(
 		"kube_pod_container_status_running",
 		"Describes whether the container is currently in running state.",
 		append(descPodLabelsDefaultLabels, "container"),
 		nil,
 	)
-	descPodContainerStatusTerminated = NewMetricFamilyDef(
+	descPodContainerStatusTerminated = metrics.NewMetricFamilyDef(
 		"kube_pod_container_status_terminated",
 		"Describes whether the container is currently in terminated state.",
 		append(descPodLabelsDefaultLabels, "container"),
 		nil,
 	)
-	descPodContainerStatusTerminatedReason = NewMetricFamilyDef(
+	descPodContainerStatusTerminatedReason = metrics.NewMetricFamilyDef(
 		"kube_pod_container_status_terminated_reason",
 		"Describes the reason the container is currently in terminated state.",
 		append(descPodLabelsDefaultLabels, "container", "reason"),
 		nil,
 	)
-	descPodContainerStatusLastTerminatedReason = NewMetricFamilyDef(
+	descPodContainerStatusLastTerminatedReason = metrics.NewMetricFamilyDef(
 		"kube_pod_container_status_last_terminated_reason",
 		"Describes the last reason the container was in terminated state.",
 		append(descPodLabelsDefaultLabels, "container", "reason"),
 		nil,
 	)
 
-	descPodContainerStatusReady = NewMetricFamilyDef(
+	descPodContainerStatusReady = metrics.NewMetricFamilyDef(
 		"kube_pod_container_status_ready",
 		"Describes whether the containers readiness check succeeded.",
 		append(descPodLabelsDefaultLabels, "container"),
 		nil,
 	)
-	descPodContainerStatusRestarts = NewMetricFamilyDef(
+	descPodContainerStatusRestarts = metrics.NewMetricFamilyDef(
 		"kube_pod_container_status_restarts_total",
 		"The number of container restarts per container.",
 		append(descPodLabelsDefaultLabels, "container"),
 		nil,
 	)
-	descPodContainerResourceRequests = NewMetricFamilyDef(
+	descPodContainerResourceRequests = metrics.NewMetricFamilyDef(
 		"kube_pod_container_resource_requests",
 		"The number of requested request resource by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node", "resource", "unit"),
 		nil,
 	)
-	descPodContainerResourceLimits = NewMetricFamilyDef(
+	descPodContainerResourceLimits = metrics.NewMetricFamilyDef(
 		"kube_pod_container_resource_limits",
 		"The number of requested limit resource by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node", "resource", "unit"),
 		nil,
 	)
-	descPodContainerResourceRequestsCPUCores = NewMetricFamilyDef(
+	descPodContainerResourceRequestsCPUCores = metrics.NewMetricFamilyDef(
 		"kube_pod_container_resource_requests_cpu_cores",
 		"The number of requested cpu cores by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node"),
 		nil,
 	)
-	descPodContainerResourceRequestsMemoryBytes = NewMetricFamilyDef(
+	descPodContainerResourceRequestsMemoryBytes = metrics.NewMetricFamilyDef(
 		"kube_pod_container_resource_requests_memory_bytes",
 		"The number of requested memory bytes by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node"),
 		nil,
 	)
-	descPodContainerResourceLimitsCPUCores = NewMetricFamilyDef(
+	descPodContainerResourceLimitsCPUCores = metrics.NewMetricFamilyDef(
 		"kube_pod_container_resource_limits_cpu_cores",
 		"The limit on cpu cores to be used by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node"),
 		nil,
 	)
-	descPodContainerResourceLimitsMemoryBytes = NewMetricFamilyDef(
+	descPodContainerResourceLimitsMemoryBytes = metrics.NewMetricFamilyDef(
 		"kube_pod_container_resource_limits_memory_bytes",
 		"The limit on memory to be used by a container in bytes.",
 		append(descPodLabelsDefaultLabels, "container", "node"),
 		nil,
 	)
-	descPodSpecVolumesPersistentVolumeClaimsInfo = NewMetricFamilyDef(
+	descPodSpecVolumesPersistentVolumeClaimsInfo = metrics.NewMetricFamilyDef(
 		"kube_pod_spec_volumes_persistentvolumeclaims_info",
 		"Information about persistentvolumeclaim volumes in a pod.",
 		append(descPodLabelsDefaultLabels, "volume", "persistentvolumeclaim"),
 		nil,
 	)
-	descPodSpecVolumesPersistentVolumeClaimsReadOnly = NewMetricFamilyDef(
+	descPodSpecVolumesPersistentVolumeClaimsReadOnly = metrics.NewMetricFamilyDef(
 		"kube_pod_spec_volumes_persistentvolumeclaims_readonly",
 		"Describes whether a persistentvolumeclaim is mounted read only.",
 		append(descPodLabelsDefaultLabels, "volume", "persistentvolumeclaim"),
@@ -251,8 +251,8 @@ func createPodListWatch(kubeClient clientset.Interface, ns string) cache.ListWat
 // 	}
 // }
 
-func podLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func podLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descPodLabelsName,
 		descPodLabelsHelp,
 		append(descPodLabelsDefaultLabels, labelKeys...),
@@ -268,7 +268,7 @@ func generatePodMetrics(disablePodNonGenericResourceMetrics bool, obj interface{
 	p := *pPointer
 
 	nodeName := p.Spec.NodeName
-	addConstMetric := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addConstMetric := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{p.Namespace, p.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -278,10 +278,10 @@ func generatePodMetrics(disablePodNonGenericResourceMetrics bool, obj interface{
 
 		ms = append(ms, m)
 	}
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
-	addCounter := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addCounter := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
 

--- a/pkg/collectors/pod.go
+++ b/pkg/collectors/pod.go
@@ -40,164 +40,164 @@ var (
 	containerWaitingReasons    = []string{"ContainerCreating", "CrashLoopBackOff", "ErrImagePull", "ImagePullBackOff"}
 	containerTerminatedReasons = []string{"OOMKilled", "Completed", "Error", "ContainerCannotRun"}
 
-	descPodInfo = newMetricFamilyDef(
+	descPodInfo = NewMetricFamilyDef(
 		"kube_pod_info",
 		"Information about pod.",
 		append(descPodLabelsDefaultLabels, "host_ip", "pod_ip", "uid", "node", "created_by_kind", "created_by_name"),
 		nil,
 	)
-	descPodStartTime = newMetricFamilyDef(
+	descPodStartTime = NewMetricFamilyDef(
 		"kube_pod_start_time",
 		"Start time in unix timestamp for a pod.",
 		descPodLabelsDefaultLabels,
 		nil,
 	)
-	descPodCompletionTime = newMetricFamilyDef(
+	descPodCompletionTime = NewMetricFamilyDef(
 		"kube_pod_completion_time",
 		"Completion time in unix timestamp for a pod.",
 		descPodLabelsDefaultLabels,
 		nil,
 	)
-	descPodOwner = newMetricFamilyDef(
+	descPodOwner = NewMetricFamilyDef(
 		"kube_pod_owner",
 		"Information about the Pod's owner.",
 		append(descPodLabelsDefaultLabels, "owner_kind", "owner_name", "owner_is_controller"),
 		nil,
 	)
-	descPodLabels = newMetricFamilyDef(
+	descPodLabels = NewMetricFamilyDef(
 		descPodLabelsName,
 		descPodLabelsHelp,
 		descPodLabelsDefaultLabels,
 		nil,
 	)
-	descPodCreated = newMetricFamilyDef(
+	descPodCreated = NewMetricFamilyDef(
 		"kube_pod_created",
 		"Unix creation timestamp",
 		descPodLabelsDefaultLabels,
 		nil,
 	)
-	descPodStatusScheduledTime = newMetricFamilyDef(
+	descPodStatusScheduledTime = NewMetricFamilyDef(
 		"kube_pod_status_scheduled_time",
 		"Unix timestamp when pod moved into scheduled status",
 		descPodLabelsDefaultLabels,
 		nil,
 	)
-	descPodStatusPhase = newMetricFamilyDef(
+	descPodStatusPhase = NewMetricFamilyDef(
 		"kube_pod_status_phase",
 		"The pods current phase.",
 		append(descPodLabelsDefaultLabels, "phase"),
 		nil,
 	)
-	descPodStatusReady = newMetricFamilyDef(
+	descPodStatusReady = NewMetricFamilyDef(
 		"kube_pod_status_ready",
 		"Describes whether the pod is ready to serve requests.",
 		append(descPodLabelsDefaultLabels, "condition"),
 		nil,
 	)
-	descPodStatusScheduled = newMetricFamilyDef(
+	descPodStatusScheduled = NewMetricFamilyDef(
 		"kube_pod_status_scheduled",
 		"Describes the status of the scheduling process for the pod.",
 		append(descPodLabelsDefaultLabels, "condition"),
 		nil,
 	)
-	descPodContainerInfo = newMetricFamilyDef(
+	descPodContainerInfo = NewMetricFamilyDef(
 		"kube_pod_container_info",
 		"Information about a container in a pod.",
 		append(descPodLabelsDefaultLabels, "container", "image", "image_id", "container_id"),
 		nil,
 	)
-	descPodContainerStatusWaiting = newMetricFamilyDef(
+	descPodContainerStatusWaiting = NewMetricFamilyDef(
 		"kube_pod_container_status_waiting",
 		"Describes whether the container is currently in waiting state.",
 		append(descPodLabelsDefaultLabels, "container"),
 		nil,
 	)
-	descPodContainerStatusWaitingReason = newMetricFamilyDef(
+	descPodContainerStatusWaitingReason = NewMetricFamilyDef(
 		"kube_pod_container_status_waiting_reason",
 		"Describes the reason the container is currently in waiting state.",
 		append(descPodLabelsDefaultLabels, "container", "reason"),
 		nil,
 	)
-	descPodContainerStatusRunning = newMetricFamilyDef(
+	descPodContainerStatusRunning = NewMetricFamilyDef(
 		"kube_pod_container_status_running",
 		"Describes whether the container is currently in running state.",
 		append(descPodLabelsDefaultLabels, "container"),
 		nil,
 	)
-	descPodContainerStatusTerminated = newMetricFamilyDef(
+	descPodContainerStatusTerminated = NewMetricFamilyDef(
 		"kube_pod_container_status_terminated",
 		"Describes whether the container is currently in terminated state.",
 		append(descPodLabelsDefaultLabels, "container"),
 		nil,
 	)
-	descPodContainerStatusTerminatedReason = newMetricFamilyDef(
+	descPodContainerStatusTerminatedReason = NewMetricFamilyDef(
 		"kube_pod_container_status_terminated_reason",
 		"Describes the reason the container is currently in terminated state.",
 		append(descPodLabelsDefaultLabels, "container", "reason"),
 		nil,
 	)
-	descPodContainerStatusLastTerminatedReason = newMetricFamilyDef(
+	descPodContainerStatusLastTerminatedReason = NewMetricFamilyDef(
 		"kube_pod_container_status_last_terminated_reason",
 		"Describes the last reason the container was in terminated state.",
 		append(descPodLabelsDefaultLabels, "container", "reason"),
 		nil,
 	)
 
-	descPodContainerStatusReady = newMetricFamilyDef(
+	descPodContainerStatusReady = NewMetricFamilyDef(
 		"kube_pod_container_status_ready",
 		"Describes whether the containers readiness check succeeded.",
 		append(descPodLabelsDefaultLabels, "container"),
 		nil,
 	)
-	descPodContainerStatusRestarts = newMetricFamilyDef(
+	descPodContainerStatusRestarts = NewMetricFamilyDef(
 		"kube_pod_container_status_restarts_total",
 		"The number of container restarts per container.",
 		append(descPodLabelsDefaultLabels, "container"),
 		nil,
 	)
-	descPodContainerResourceRequests = newMetricFamilyDef(
+	descPodContainerResourceRequests = NewMetricFamilyDef(
 		"kube_pod_container_resource_requests",
 		"The number of requested request resource by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node", "resource", "unit"),
 		nil,
 	)
-	descPodContainerResourceLimits = newMetricFamilyDef(
+	descPodContainerResourceLimits = NewMetricFamilyDef(
 		"kube_pod_container_resource_limits",
 		"The number of requested limit resource by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node", "resource", "unit"),
 		nil,
 	)
-	descPodContainerResourceRequestsCPUCores = newMetricFamilyDef(
+	descPodContainerResourceRequestsCPUCores = NewMetricFamilyDef(
 		"kube_pod_container_resource_requests_cpu_cores",
 		"The number of requested cpu cores by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node"),
 		nil,
 	)
-	descPodContainerResourceRequestsMemoryBytes = newMetricFamilyDef(
+	descPodContainerResourceRequestsMemoryBytes = NewMetricFamilyDef(
 		"kube_pod_container_resource_requests_memory_bytes",
 		"The number of requested memory bytes by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node"),
 		nil,
 	)
-	descPodContainerResourceLimitsCPUCores = newMetricFamilyDef(
+	descPodContainerResourceLimitsCPUCores = NewMetricFamilyDef(
 		"kube_pod_container_resource_limits_cpu_cores",
 		"The limit on cpu cores to be used by a container.",
 		append(descPodLabelsDefaultLabels, "container", "node"),
 		nil,
 	)
-	descPodContainerResourceLimitsMemoryBytes = newMetricFamilyDef(
+	descPodContainerResourceLimitsMemoryBytes = NewMetricFamilyDef(
 		"kube_pod_container_resource_limits_memory_bytes",
 		"The limit on memory to be used by a container in bytes.",
 		append(descPodLabelsDefaultLabels, "container", "node"),
 		nil,
 	)
-	descPodSpecVolumesPersistentVolumeClaimsInfo = newMetricFamilyDef(
+	descPodSpecVolumesPersistentVolumeClaimsInfo = NewMetricFamilyDef(
 		"kube_pod_spec_volumes_persistentvolumeclaims_info",
 		"Information about persistentvolumeclaim volumes in a pod.",
 		append(descPodLabelsDefaultLabels, "volume", "persistentvolumeclaim"),
 		nil,
 	)
-	descPodSpecVolumesPersistentVolumeClaimsReadOnly = newMetricFamilyDef(
+	descPodSpecVolumesPersistentVolumeClaimsReadOnly = NewMetricFamilyDef(
 		"kube_pod_spec_volumes_persistentvolumeclaims_readonly",
 		"Describes whether a persistentvolumeclaim is mounted read only.",
 		append(descPodLabelsDefaultLabels, "volume", "persistentvolumeclaim"),
@@ -252,7 +252,7 @@ func createPodListWatch(kubeClient clientset.Interface, ns string) cache.ListWat
 // }
 
 func podLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descPodLabelsName,
 		descPodLabelsHelp,
 		append(descPodLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/pod.go
+++ b/pkg/collectors/pod.go
@@ -251,7 +251,7 @@ func createPodListWatch(kubeClient clientset.Interface, ns string) cache.ListWat
 // 	}
 // }
 
-func podLabelsDesc(labelKeys []string) *metricFamilyDef {
+func podLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descPodLabelsName,
 		descPodLabelsHelp,
@@ -268,7 +268,7 @@ func generatePodMetrics(disablePodNonGenericResourceMetrics bool, obj interface{
 	p := *pPointer
 
 	nodeName := p.Spec.NodeName
-	addConstMetric := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addConstMetric := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{p.Namespace, p.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -278,10 +278,10 @@ func generatePodMetrics(disablePodNonGenericResourceMetrics bool, obj interface{
 
 		ms = append(ms, m)
 	}
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
-	addCounter := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addCounter := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
 

--- a/pkg/collectors/poddisruptionbudget.go
+++ b/pkg/collectors/poddisruptionbudget.go
@@ -87,7 +87,7 @@ func generatePodDisruptionBudgetMetrics(obj interface{}) []*metrics.Metric {
 	pPointer := obj.(*v1beta1.PodDisruptionBudget)
 	p := *pPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{p.Name, p.Namespace}, lv...)
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
 		if err != nil {

--- a/pkg/collectors/poddisruptionbudget.go
+++ b/pkg/collectors/poddisruptionbudget.go
@@ -30,38 +30,38 @@ import (
 var (
 	descPodDisruptionBudgetLabelsDefaultLabels = []string{"poddisruptionbudget", "namespace"}
 
-	descPodDisruptionBudgetCreated = NewMetricFamilyDef(
+	descPodDisruptionBudgetCreated = metrics.NewMetricFamilyDef(
 		"kube_poddisruptionbudget_created",
 		"Unix creation timestamp",
 		descPodDisruptionBudgetLabelsDefaultLabels,
 		nil,
 	)
 
-	descPodDisruptionBudgetStatusCurrentHealthy = NewMetricFamilyDef(
+	descPodDisruptionBudgetStatusCurrentHealthy = metrics.NewMetricFamilyDef(
 		"kube_poddisruptionbudget_status_current_healthy",
 		"Current number of healthy pods",
 		descPodDisruptionBudgetLabelsDefaultLabels,
 		nil,
 	)
-	descPodDisruptionBudgetStatusDesiredHealthy = NewMetricFamilyDef(
+	descPodDisruptionBudgetStatusDesiredHealthy = metrics.NewMetricFamilyDef(
 		"kube_poddisruptionbudget_status_desired_healthy",
 		"Minimum desired number of healthy pods",
 		descPodDisruptionBudgetLabelsDefaultLabels,
 		nil,
 	)
-	descPodDisruptionBudgetStatusPodDisruptionsAllowed = NewMetricFamilyDef(
+	descPodDisruptionBudgetStatusPodDisruptionsAllowed = metrics.NewMetricFamilyDef(
 		"kube_poddisruptionbudget_status_pod_disruptions_allowed",
 		"Number of pod disruptions that are currently allowed",
 		descPodDisruptionBudgetLabelsDefaultLabels,
 		nil,
 	)
-	descPodDisruptionBudgetStatusExpectedPods = NewMetricFamilyDef(
+	descPodDisruptionBudgetStatusExpectedPods = metrics.NewMetricFamilyDef(
 		"kube_poddisruptionbudget_status_expected_pods",
 		"Total number of pods counted by this disruption budget",
 		descPodDisruptionBudgetLabelsDefaultLabels,
 		nil,
 	)
-	descPodDisruptionBudgetStatusObservedGeneration = NewMetricFamilyDef(
+	descPodDisruptionBudgetStatusObservedGeneration = metrics.NewMetricFamilyDef(
 		"kube_poddisruptionbudget_status_observed_generation",
 		"Most recent generation observed when updating this PDB status",
 		descPodDisruptionBudgetLabelsDefaultLabels,
@@ -87,7 +87,7 @@ func generatePodDisruptionBudgetMetrics(obj interface{}) []*metrics.Metric {
 	pPointer := obj.(*v1beta1.PodDisruptionBudget)
 	p := *pPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{p.Name, p.Namespace}, lv...)
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
 		if err != nil {

--- a/pkg/collectors/poddisruptionbudget.go
+++ b/pkg/collectors/poddisruptionbudget.go
@@ -30,38 +30,38 @@ import (
 var (
 	descPodDisruptionBudgetLabelsDefaultLabels = []string{"poddisruptionbudget", "namespace"}
 
-	descPodDisruptionBudgetCreated = newMetricFamilyDef(
+	descPodDisruptionBudgetCreated = NewMetricFamilyDef(
 		"kube_poddisruptionbudget_created",
 		"Unix creation timestamp",
 		descPodDisruptionBudgetLabelsDefaultLabels,
 		nil,
 	)
 
-	descPodDisruptionBudgetStatusCurrentHealthy = newMetricFamilyDef(
+	descPodDisruptionBudgetStatusCurrentHealthy = NewMetricFamilyDef(
 		"kube_poddisruptionbudget_status_current_healthy",
 		"Current number of healthy pods",
 		descPodDisruptionBudgetLabelsDefaultLabels,
 		nil,
 	)
-	descPodDisruptionBudgetStatusDesiredHealthy = newMetricFamilyDef(
+	descPodDisruptionBudgetStatusDesiredHealthy = NewMetricFamilyDef(
 		"kube_poddisruptionbudget_status_desired_healthy",
 		"Minimum desired number of healthy pods",
 		descPodDisruptionBudgetLabelsDefaultLabels,
 		nil,
 	)
-	descPodDisruptionBudgetStatusPodDisruptionsAllowed = newMetricFamilyDef(
+	descPodDisruptionBudgetStatusPodDisruptionsAllowed = NewMetricFamilyDef(
 		"kube_poddisruptionbudget_status_pod_disruptions_allowed",
 		"Number of pod disruptions that are currently allowed",
 		descPodDisruptionBudgetLabelsDefaultLabels,
 		nil,
 	)
-	descPodDisruptionBudgetStatusExpectedPods = newMetricFamilyDef(
+	descPodDisruptionBudgetStatusExpectedPods = NewMetricFamilyDef(
 		"kube_poddisruptionbudget_status_expected_pods",
 		"Total number of pods counted by this disruption budget",
 		descPodDisruptionBudgetLabelsDefaultLabels,
 		nil,
 	)
-	descPodDisruptionBudgetStatusObservedGeneration = newMetricFamilyDef(
+	descPodDisruptionBudgetStatusObservedGeneration = NewMetricFamilyDef(
 		"kube_poddisruptionbudget_status_observed_generation",
 		"Most recent generation observed when updating this PDB status",
 		descPodDisruptionBudgetLabelsDefaultLabels,

--- a/pkg/collectors/replicaset.go
+++ b/pkg/collectors/replicaset.go
@@ -31,49 +31,49 @@ import (
 
 var (
 	descReplicaSetLabelsDefaultLabels = []string{"namespace", "replicaset"}
-	descReplicaSetCreated             = NewMetricFamilyDef(
+	descReplicaSetCreated             = metrics.NewMetricFamilyDef(
 		"kube_replicaset_created",
 		"Unix creation timestamp",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetStatusReplicas = NewMetricFamilyDef(
+	descReplicaSetStatusReplicas = metrics.NewMetricFamilyDef(
 		"kube_replicaset_status_replicas",
 		"The number of replicas per ReplicaSet.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetStatusFullyLabeledReplicas = NewMetricFamilyDef(
+	descReplicaSetStatusFullyLabeledReplicas = metrics.NewMetricFamilyDef(
 		"kube_replicaset_status_fully_labeled_replicas",
 		"The number of fully labeled replicas per ReplicaSet.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetStatusReadyReplicas = NewMetricFamilyDef(
+	descReplicaSetStatusReadyReplicas = metrics.NewMetricFamilyDef(
 		"kube_replicaset_status_ready_replicas",
 		"The number of ready replicas per ReplicaSet.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetStatusObservedGeneration = NewMetricFamilyDef(
+	descReplicaSetStatusObservedGeneration = metrics.NewMetricFamilyDef(
 		"kube_replicaset_status_observed_generation",
 		"The generation observed by the ReplicaSet controller.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetSpecReplicas = NewMetricFamilyDef(
+	descReplicaSetSpecReplicas = metrics.NewMetricFamilyDef(
 		"kube_replicaset_spec_replicas",
 		"Number of desired pods for a ReplicaSet.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetMetadataGeneration = NewMetricFamilyDef(
+	descReplicaSetMetadataGeneration = metrics.NewMetricFamilyDef(
 		"kube_replicaset_metadata_generation",
 		"Sequence number representing a specific generation of the desired state.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetOwner = NewMetricFamilyDef(
+	descReplicaSetOwner = metrics.NewMetricFamilyDef(
 		"kube_replicaset_owner",
 		"Information about the ReplicaSet's owner.",
 		append(descReplicaSetLabelsDefaultLabels, "owner_kind", "owner_name", "owner_is_controller"),
@@ -99,7 +99,7 @@ func generateReplicaSetMetrics(obj interface{}) []*metrics.Metric {
 	rPointer := obj.(*v1beta1.ReplicaSet)
 	r := *rPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{r.Namespace, r.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/replicaset.go
+++ b/pkg/collectors/replicaset.go
@@ -99,7 +99,7 @@ func generateReplicaSetMetrics(obj interface{}) []*metrics.Metric {
 	rPointer := obj.(*v1beta1.ReplicaSet)
 	r := *rPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{r.Namespace, r.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/replicaset.go
+++ b/pkg/collectors/replicaset.go
@@ -31,49 +31,49 @@ import (
 
 var (
 	descReplicaSetLabelsDefaultLabels = []string{"namespace", "replicaset"}
-	descReplicaSetCreated             = newMetricFamilyDef(
+	descReplicaSetCreated             = NewMetricFamilyDef(
 		"kube_replicaset_created",
 		"Unix creation timestamp",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetStatusReplicas = newMetricFamilyDef(
+	descReplicaSetStatusReplicas = NewMetricFamilyDef(
 		"kube_replicaset_status_replicas",
 		"The number of replicas per ReplicaSet.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetStatusFullyLabeledReplicas = newMetricFamilyDef(
+	descReplicaSetStatusFullyLabeledReplicas = NewMetricFamilyDef(
 		"kube_replicaset_status_fully_labeled_replicas",
 		"The number of fully labeled replicas per ReplicaSet.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetStatusReadyReplicas = newMetricFamilyDef(
+	descReplicaSetStatusReadyReplicas = NewMetricFamilyDef(
 		"kube_replicaset_status_ready_replicas",
 		"The number of ready replicas per ReplicaSet.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetStatusObservedGeneration = newMetricFamilyDef(
+	descReplicaSetStatusObservedGeneration = NewMetricFamilyDef(
 		"kube_replicaset_status_observed_generation",
 		"The generation observed by the ReplicaSet controller.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetSpecReplicas = newMetricFamilyDef(
+	descReplicaSetSpecReplicas = NewMetricFamilyDef(
 		"kube_replicaset_spec_replicas",
 		"Number of desired pods for a ReplicaSet.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetMetadataGeneration = newMetricFamilyDef(
+	descReplicaSetMetadataGeneration = NewMetricFamilyDef(
 		"kube_replicaset_metadata_generation",
 		"Sequence number representing a specific generation of the desired state.",
 		descReplicaSetLabelsDefaultLabels,
 		nil,
 	)
-	descReplicaSetOwner = newMetricFamilyDef(
+	descReplicaSetOwner = NewMetricFamilyDef(
 		"kube_replicaset_owner",
 		"Information about the ReplicaSet's owner.",
 		append(descReplicaSetLabelsDefaultLabels, "owner_kind", "owner_name", "owner_is_controller"),

--- a/pkg/collectors/replicationcontroller.go
+++ b/pkg/collectors/replicationcontroller.go
@@ -97,7 +97,7 @@ func generateReplicationControllerMetrics(obj interface{}) []*metrics.Metric {
 	rPointer := obj.(*v1.ReplicationController)
 	r := *rPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{r.Namespace, r.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/replicationcontroller.go
+++ b/pkg/collectors/replicationcontroller.go
@@ -30,49 +30,49 @@ import (
 var (
 	descReplicationControllerLabelsDefaultLabels = []string{"namespace", "replicationcontroller"}
 
-	descReplicationControllerCreated = NewMetricFamilyDef(
+	descReplicationControllerCreated = metrics.NewMetricFamilyDef(
 		"kube_replicationcontroller_created",
 		"Unix creation timestamp",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerStatusReplicas = NewMetricFamilyDef(
+	descReplicationControllerStatusReplicas = metrics.NewMetricFamilyDef(
 		"kube_replicationcontroller_status_replicas",
 		"The number of replicas per ReplicationController.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerStatusFullyLabeledReplicas = NewMetricFamilyDef(
+	descReplicationControllerStatusFullyLabeledReplicas = metrics.NewMetricFamilyDef(
 		"kube_replicationcontroller_status_fully_labeled_replicas",
 		"The number of fully labeled replicas per ReplicationController.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerStatusReadyReplicas = NewMetricFamilyDef(
+	descReplicationControllerStatusReadyReplicas = metrics.NewMetricFamilyDef(
 		"kube_replicationcontroller_status_ready_replicas",
 		"The number of ready replicas per ReplicationController.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerStatusAvailableReplicas = NewMetricFamilyDef(
+	descReplicationControllerStatusAvailableReplicas = metrics.NewMetricFamilyDef(
 		"kube_replicationcontroller_status_available_replicas",
 		"The number of available replicas per ReplicationController.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerStatusObservedGeneration = NewMetricFamilyDef(
+	descReplicationControllerStatusObservedGeneration = metrics.NewMetricFamilyDef(
 		"kube_replicationcontroller_status_observed_generation",
 		"The generation observed by the ReplicationController controller.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerSpecReplicas = NewMetricFamilyDef(
+	descReplicationControllerSpecReplicas = metrics.NewMetricFamilyDef(
 		"kube_replicationcontroller_spec_replicas",
 		"Number of desired pods for a ReplicationController.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerMetadataGeneration = NewMetricFamilyDef(
+	descReplicationControllerMetadataGeneration = metrics.NewMetricFamilyDef(
 		"kube_replicationcontroller_metadata_generation",
 		"Sequence number representing a specific generation of the desired state.",
 		descReplicationControllerLabelsDefaultLabels,
@@ -97,7 +97,7 @@ func generateReplicationControllerMetrics(obj interface{}) []*metrics.Metric {
 	rPointer := obj.(*v1.ReplicationController)
 	r := *rPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{r.Namespace, r.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)

--- a/pkg/collectors/replicationcontroller.go
+++ b/pkg/collectors/replicationcontroller.go
@@ -30,49 +30,49 @@ import (
 var (
 	descReplicationControllerLabelsDefaultLabels = []string{"namespace", "replicationcontroller"}
 
-	descReplicationControllerCreated = newMetricFamilyDef(
+	descReplicationControllerCreated = NewMetricFamilyDef(
 		"kube_replicationcontroller_created",
 		"Unix creation timestamp",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerStatusReplicas = newMetricFamilyDef(
+	descReplicationControllerStatusReplicas = NewMetricFamilyDef(
 		"kube_replicationcontroller_status_replicas",
 		"The number of replicas per ReplicationController.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerStatusFullyLabeledReplicas = newMetricFamilyDef(
+	descReplicationControllerStatusFullyLabeledReplicas = NewMetricFamilyDef(
 		"kube_replicationcontroller_status_fully_labeled_replicas",
 		"The number of fully labeled replicas per ReplicationController.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerStatusReadyReplicas = newMetricFamilyDef(
+	descReplicationControllerStatusReadyReplicas = NewMetricFamilyDef(
 		"kube_replicationcontroller_status_ready_replicas",
 		"The number of ready replicas per ReplicationController.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerStatusAvailableReplicas = newMetricFamilyDef(
+	descReplicationControllerStatusAvailableReplicas = NewMetricFamilyDef(
 		"kube_replicationcontroller_status_available_replicas",
 		"The number of available replicas per ReplicationController.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerStatusObservedGeneration = newMetricFamilyDef(
+	descReplicationControllerStatusObservedGeneration = NewMetricFamilyDef(
 		"kube_replicationcontroller_status_observed_generation",
 		"The generation observed by the ReplicationController controller.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerSpecReplicas = newMetricFamilyDef(
+	descReplicationControllerSpecReplicas = NewMetricFamilyDef(
 		"kube_replicationcontroller_spec_replicas",
 		"Number of desired pods for a ReplicationController.",
 		descReplicationControllerLabelsDefaultLabels,
 		nil,
 	)
-	descReplicationControllerMetadataGeneration = newMetricFamilyDef(
+	descReplicationControllerMetadataGeneration = NewMetricFamilyDef(
 		"kube_replicationcontroller_metadata_generation",
 		"Sequence number representing a specific generation of the desired state.",
 		descReplicationControllerLabelsDefaultLabels,

--- a/pkg/collectors/resourcequota.go
+++ b/pkg/collectors/resourcequota.go
@@ -30,13 +30,13 @@ import (
 var (
 	descResourceQuotaLabelsDefaultLabels = []string{"resourcequota", "namespace"}
 
-	descResourceQuotaCreated = NewMetricFamilyDef(
+	descResourceQuotaCreated = metrics.NewMetricFamilyDef(
 		"kube_resourcequota_created",
 		"Unix creation timestamp",
 		descResourceQuotaLabelsDefaultLabels,
 		nil,
 	)
-	descResourceQuota = NewMetricFamilyDef(
+	descResourceQuota = metrics.NewMetricFamilyDef(
 		"kube_resourcequota",
 		"Information about resource quota.",
 		append(descResourceQuotaLabelsDefaultLabels,
@@ -64,7 +64,7 @@ func generateResourceQuotaMetrics(obj interface{}) []*metrics.Metric {
 	rPointer := obj.(*v1.ResourceQuota)
 	r := *rPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{r.Name, r.Namespace}, lv...)
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
 		if err != nil {

--- a/pkg/collectors/resourcequota.go
+++ b/pkg/collectors/resourcequota.go
@@ -30,13 +30,13 @@ import (
 var (
 	descResourceQuotaLabelsDefaultLabels = []string{"resourcequota", "namespace"}
 
-	descResourceQuotaCreated = newMetricFamilyDef(
+	descResourceQuotaCreated = NewMetricFamilyDef(
 		"kube_resourcequota_created",
 		"Unix creation timestamp",
 		descResourceQuotaLabelsDefaultLabels,
 		nil,
 	)
-	descResourceQuota = newMetricFamilyDef(
+	descResourceQuota = NewMetricFamilyDef(
 		"kube_resourcequota",
 		"Information about resource quota.",
 		append(descResourceQuotaLabelsDefaultLabels,

--- a/pkg/collectors/resourcequota.go
+++ b/pkg/collectors/resourcequota.go
@@ -64,7 +64,7 @@ func generateResourceQuotaMetrics(obj interface{}) []*metrics.Metric {
 	rPointer := obj.(*v1.ResourceQuota)
 	r := *rPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{r.Name, r.Namespace}, lv...)
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
 		if err != nil {

--- a/pkg/collectors/secret.go
+++ b/pkg/collectors/secret.go
@@ -32,35 +32,35 @@ var (
 	descSecretLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descSecretLabelsDefaultLabels = []string{"namespace", "secret"}
 
-	descSecretInfo = NewMetricFamilyDef(
+	descSecretInfo = metrics.NewMetricFamilyDef(
 		"kube_secret_info",
 		"Information about secret.",
 		descSecretLabelsDefaultLabels,
 		nil,
 	)
 
-	descSecretType = NewMetricFamilyDef(
+	descSecretType = metrics.NewMetricFamilyDef(
 		"kube_secret_type",
 		"Type about secret.",
 		append(descSecretLabelsDefaultLabels, "type"),
 		nil,
 	)
 
-	descSecretLabels = NewMetricFamilyDef(
+	descSecretLabels = metrics.NewMetricFamilyDef(
 		descSecretLabelsName,
 		descSecretLabelsHelp,
 		descSecretLabelsDefaultLabels,
 		nil,
 	)
 
-	descSecretCreated = NewMetricFamilyDef(
+	descSecretCreated = metrics.NewMetricFamilyDef(
 		"kube_secret_created",
 		"Unix creation timestamp",
 		descSecretLabelsDefaultLabels,
 		nil,
 	)
 
-	descSecretMetadataResourceVersion = NewMetricFamilyDef(
+	descSecretMetadataResourceVersion = metrics.NewMetricFamilyDef(
 		"kube_secret_metadata_resource_version",
 		"Resource version representing a specific version of secret.",
 		append(descSecretLabelsDefaultLabels, "resource_version"),
@@ -78,8 +78,8 @@ func createSecretListWatch(kubeClient clientset.Interface, ns string) cache.List
 		},
 	}
 }
-func secretLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func secretLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descSecretLabelsName,
 		descSecretLabelsHelp,
 		append(descSecretLabelsDefaultLabels, labelKeys...),
@@ -94,7 +94,7 @@ func generateSecretMetrics(obj interface{}) []*metrics.Metric {
 	sPointer := obj.(*v1.Secret)
 	s := *sPointer
 
-	addConstMetric := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addConstMetric := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{s.Namespace, s.Name}, lv...)
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
 		if err != nil {
@@ -103,7 +103,7 @@ func generateSecretMetrics(obj interface{}) []*metrics.Metric {
 
 		ms = append(ms, m)
 	}
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
 	addGauge(descSecretInfo, 1)

--- a/pkg/collectors/secret.go
+++ b/pkg/collectors/secret.go
@@ -78,7 +78,7 @@ func createSecretListWatch(kubeClient clientset.Interface, ns string) cache.List
 		},
 	}
 }
-func secretLabelsDesc(labelKeys []string) *metricFamilyDef {
+func secretLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descSecretLabelsName,
 		descSecretLabelsHelp,
@@ -94,7 +94,7 @@ func generateSecretMetrics(obj interface{}) []*metrics.Metric {
 	sPointer := obj.(*v1.Secret)
 	s := *sPointer
 
-	addConstMetric := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addConstMetric := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{s.Namespace, s.Name}, lv...)
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
 		if err != nil {
@@ -103,7 +103,7 @@ func generateSecretMetrics(obj interface{}) []*metrics.Metric {
 
 		ms = append(ms, m)
 	}
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
 	addGauge(descSecretInfo, 1)

--- a/pkg/collectors/secret.go
+++ b/pkg/collectors/secret.go
@@ -32,35 +32,35 @@ var (
 	descSecretLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descSecretLabelsDefaultLabels = []string{"namespace", "secret"}
 
-	descSecretInfo = newMetricFamilyDef(
+	descSecretInfo = NewMetricFamilyDef(
 		"kube_secret_info",
 		"Information about secret.",
 		descSecretLabelsDefaultLabels,
 		nil,
 	)
 
-	descSecretType = newMetricFamilyDef(
+	descSecretType = NewMetricFamilyDef(
 		"kube_secret_type",
 		"Type about secret.",
 		append(descSecretLabelsDefaultLabels, "type"),
 		nil,
 	)
 
-	descSecretLabels = newMetricFamilyDef(
+	descSecretLabels = NewMetricFamilyDef(
 		descSecretLabelsName,
 		descSecretLabelsHelp,
 		descSecretLabelsDefaultLabels,
 		nil,
 	)
 
-	descSecretCreated = newMetricFamilyDef(
+	descSecretCreated = NewMetricFamilyDef(
 		"kube_secret_created",
 		"Unix creation timestamp",
 		descSecretLabelsDefaultLabels,
 		nil,
 	)
 
-	descSecretMetadataResourceVersion = newMetricFamilyDef(
+	descSecretMetadataResourceVersion = NewMetricFamilyDef(
 		"kube_secret_metadata_resource_version",
 		"Resource version representing a specific version of secret.",
 		append(descSecretLabelsDefaultLabels, "resource_version"),
@@ -79,7 +79,7 @@ func createSecretListWatch(kubeClient clientset.Interface, ns string) cache.List
 	}
 }
 func secretLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descSecretLabelsName,
 		descSecretLabelsHelp,
 		append(descSecretLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/service.go
+++ b/pkg/collectors/service.go
@@ -72,7 +72,7 @@ func createServiceListWatch(kubeClient clientset.Interface, ns string) cache.Lis
 	}
 }
 
-func serviceLabelsDesc(labelKeys []string) *metricFamilyDef {
+func serviceLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descServiceLabelsName,
 		descServiceLabelsHelp,
@@ -88,7 +88,7 @@ func generateServiceMetrics(obj interface{}) []*metrics.Metric {
 	sPointer := obj.(*v1.Service)
 	s := *sPointer
 
-	addConstMetric := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addConstMetric := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{s.Namespace, s.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -98,7 +98,7 @@ func generateServiceMetrics(obj interface{}) []*metrics.Metric {
 
 		ms = append(ms, m)
 	}
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
 	addGauge(descServiceSpecType, 1, string(s.Spec.Type))

--- a/pkg/collectors/service.go
+++ b/pkg/collectors/service.go
@@ -32,28 +32,28 @@ var (
 	descServiceLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descServiceLabelsDefaultLabels = []string{"namespace", "service"}
 
-	descServiceInfo = newMetricFamilyDef(
+	descServiceInfo = NewMetricFamilyDef(
 		"kube_service_info",
 		"Information about service.",
 		append(descServiceLabelsDefaultLabels, "cluster_ip"),
 		nil,
 	)
 
-	descServiceCreated = newMetricFamilyDef(
+	descServiceCreated = NewMetricFamilyDef(
 		"kube_service_created",
 		"Unix creation timestamp",
 		descServiceLabelsDefaultLabels,
 		nil,
 	)
 
-	descServiceSpecType = newMetricFamilyDef(
+	descServiceSpecType = NewMetricFamilyDef(
 		"kube_service_spec_type",
 		"Type about service.",
 		append(descServiceLabelsDefaultLabels, "type"),
 		nil,
 	)
 
-	descServiceLabels = newMetricFamilyDef(
+	descServiceLabels = NewMetricFamilyDef(
 		descServiceLabelsName,
 		descServiceLabelsHelp,
 		descServiceLabelsDefaultLabels,
@@ -73,7 +73,7 @@ func createServiceListWatch(kubeClient clientset.Interface, ns string) cache.Lis
 }
 
 func serviceLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descServiceLabelsName,
 		descServiceLabelsHelp,
 		append(descServiceLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/service.go
+++ b/pkg/collectors/service.go
@@ -32,28 +32,28 @@ var (
 	descServiceLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descServiceLabelsDefaultLabels = []string{"namespace", "service"}
 
-	descServiceInfo = NewMetricFamilyDef(
+	descServiceInfo = metrics.NewMetricFamilyDef(
 		"kube_service_info",
 		"Information about service.",
 		append(descServiceLabelsDefaultLabels, "cluster_ip"),
 		nil,
 	)
 
-	descServiceCreated = NewMetricFamilyDef(
+	descServiceCreated = metrics.NewMetricFamilyDef(
 		"kube_service_created",
 		"Unix creation timestamp",
 		descServiceLabelsDefaultLabels,
 		nil,
 	)
 
-	descServiceSpecType = NewMetricFamilyDef(
+	descServiceSpecType = metrics.NewMetricFamilyDef(
 		"kube_service_spec_type",
 		"Type about service.",
 		append(descServiceLabelsDefaultLabels, "type"),
 		nil,
 	)
 
-	descServiceLabels = NewMetricFamilyDef(
+	descServiceLabels = metrics.NewMetricFamilyDef(
 		descServiceLabelsName,
 		descServiceLabelsHelp,
 		descServiceLabelsDefaultLabels,
@@ -72,8 +72,8 @@ func createServiceListWatch(kubeClient clientset.Interface, ns string) cache.Lis
 	}
 }
 
-func serviceLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func serviceLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descServiceLabelsName,
 		descServiceLabelsHelp,
 		append(descServiceLabelsDefaultLabels, labelKeys...),
@@ -88,7 +88,7 @@ func generateServiceMetrics(obj interface{}) []*metrics.Metric {
 	sPointer := obj.(*v1.Service)
 	s := *sPointer
 
-	addConstMetric := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addConstMetric := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{s.Namespace, s.Name}, lv...)
 
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
@@ -98,7 +98,7 @@ func generateServiceMetrics(obj interface{}) []*metrics.Metric {
 
 		ms = append(ms, m)
 	}
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		addConstMetric(desc, v, lv...)
 	}
 	addGauge(descServiceSpecType, 1, string(s.Spec.Type))

--- a/pkg/collectors/statefulset.go
+++ b/pkg/collectors/statefulset.go
@@ -32,67 +32,67 @@ var (
 	descStatefulSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descStatefulSetLabelsDefaultLabels = []string{"namespace", "statefulset"}
 
-	descStatefulSetCreated = NewMetricFamilyDef(
+	descStatefulSetCreated = metrics.NewMetricFamilyDef(
 		"kube_statefulset_created",
 		"Unix creation timestamp",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetStatusReplicas = NewMetricFamilyDef(
+	descStatefulSetStatusReplicas = metrics.NewMetricFamilyDef(
 		"kube_statefulset_status_replicas",
 		"The number of replicas per StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetStatusReplicasCurrent = NewMetricFamilyDef(
+	descStatefulSetStatusReplicasCurrent = metrics.NewMetricFamilyDef(
 		"kube_statefulset_status_replicas_current",
 		"The number of current replicas per StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetStatusReplicasReady = NewMetricFamilyDef(
+	descStatefulSetStatusReplicasReady = metrics.NewMetricFamilyDef(
 		"kube_statefulset_status_replicas_ready",
 		"The number of ready replicas per StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetStatusReplicasUpdated = NewMetricFamilyDef(
+	descStatefulSetStatusReplicasUpdated = metrics.NewMetricFamilyDef(
 		"kube_statefulset_status_replicas_updated",
 		"The number of updated replicas per StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetStatusObservedGeneration = NewMetricFamilyDef(
+	descStatefulSetStatusObservedGeneration = metrics.NewMetricFamilyDef(
 		"kube_statefulset_status_observed_generation",
 		"The generation observed by the StatefulSet controller.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetSpecReplicas = NewMetricFamilyDef(
+	descStatefulSetSpecReplicas = metrics.NewMetricFamilyDef(
 		"kube_statefulset_replicas",
 		"Number of desired pods for a StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetMetadataGeneration = NewMetricFamilyDef(
+	descStatefulSetMetadataGeneration = metrics.NewMetricFamilyDef(
 		"kube_statefulset_metadata_generation",
 		"Sequence number representing a specific generation of the desired state for the StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetLabels = NewMetricFamilyDef(
+	descStatefulSetLabels = metrics.NewMetricFamilyDef(
 		descStatefulSetLabelsName,
 		descStatefulSetLabelsHelp,
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetCurrentRevision = NewMetricFamilyDef(
+	descStatefulSetCurrentRevision = metrics.NewMetricFamilyDef(
 		"kube_statefulset_status_current_revision",
 		"Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
 		append(descStatefulSetLabelsDefaultLabels, "revision"),
 		nil,
 	)
-	descStatefulSetUpdateRevision = NewMetricFamilyDef(
+	descStatefulSetUpdateRevision = metrics.NewMetricFamilyDef(
 		"kube_statefulset_status_update_revision",
 		"Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
 		append(descStatefulSetLabelsDefaultLabels, "revision"),
@@ -111,8 +111,8 @@ func createStatefulSetListWatch(kubeClient clientset.Interface, ns string) cache
 	}
 }
 
-func statefulSetLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return NewMetricFamilyDef(
+func statefulSetLabelsDesc(labelKeys []string) *metrics.MetricFamilyDef {
+	return metrics.NewMetricFamilyDef(
 		descStatefulSetLabelsName,
 		descStatefulSetLabelsHelp,
 		append(descStatefulSetLabelsDefaultLabels, labelKeys...),
@@ -127,7 +127,7 @@ func generateStatefulSetMetrics(obj interface{}) []*metrics.Metric {
 	sPointer := obj.(*v1beta1.StatefulSet)
 	s := *sPointer
 
-	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *metrics.MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{s.Namespace, s.Name}, lv...)
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
 		if err != nil {

--- a/pkg/collectors/statefulset.go
+++ b/pkg/collectors/statefulset.go
@@ -111,7 +111,7 @@ func createStatefulSetListWatch(kubeClient clientset.Interface, ns string) cache
 	}
 }
 
-func statefulSetLabelsDesc(labelKeys []string) *metricFamilyDef {
+func statefulSetLabelsDesc(labelKeys []string) *MetricFamilyDef {
 	return newMetricFamilyDef(
 		descStatefulSetLabelsName,
 		descStatefulSetLabelsHelp,
@@ -127,7 +127,7 @@ func generateStatefulSetMetrics(obj interface{}) []*metrics.Metric {
 	sPointer := obj.(*v1beta1.StatefulSet)
 	s := *sPointer
 
-	addGauge := func(desc *metricFamilyDef, v float64, lv ...string) {
+	addGauge := func(desc *MetricFamilyDef, v float64, lv ...string) {
 		lv = append([]string{s.Namespace, s.Name}, lv...)
 		m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, lv, v)
 		if err != nil {

--- a/pkg/collectors/statefulset.go
+++ b/pkg/collectors/statefulset.go
@@ -32,67 +32,67 @@ var (
 	descStatefulSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descStatefulSetLabelsDefaultLabels = []string{"namespace", "statefulset"}
 
-	descStatefulSetCreated = newMetricFamilyDef(
+	descStatefulSetCreated = NewMetricFamilyDef(
 		"kube_statefulset_created",
 		"Unix creation timestamp",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetStatusReplicas = newMetricFamilyDef(
+	descStatefulSetStatusReplicas = NewMetricFamilyDef(
 		"kube_statefulset_status_replicas",
 		"The number of replicas per StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetStatusReplicasCurrent = newMetricFamilyDef(
+	descStatefulSetStatusReplicasCurrent = NewMetricFamilyDef(
 		"kube_statefulset_status_replicas_current",
 		"The number of current replicas per StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetStatusReplicasReady = newMetricFamilyDef(
+	descStatefulSetStatusReplicasReady = NewMetricFamilyDef(
 		"kube_statefulset_status_replicas_ready",
 		"The number of ready replicas per StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetStatusReplicasUpdated = newMetricFamilyDef(
+	descStatefulSetStatusReplicasUpdated = NewMetricFamilyDef(
 		"kube_statefulset_status_replicas_updated",
 		"The number of updated replicas per StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetStatusObservedGeneration = newMetricFamilyDef(
+	descStatefulSetStatusObservedGeneration = NewMetricFamilyDef(
 		"kube_statefulset_status_observed_generation",
 		"The generation observed by the StatefulSet controller.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetSpecReplicas = newMetricFamilyDef(
+	descStatefulSetSpecReplicas = NewMetricFamilyDef(
 		"kube_statefulset_replicas",
 		"Number of desired pods for a StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetMetadataGeneration = newMetricFamilyDef(
+	descStatefulSetMetadataGeneration = NewMetricFamilyDef(
 		"kube_statefulset_metadata_generation",
 		"Sequence number representing a specific generation of the desired state for the StatefulSet.",
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetLabels = newMetricFamilyDef(
+	descStatefulSetLabels = NewMetricFamilyDef(
 		descStatefulSetLabelsName,
 		descStatefulSetLabelsHelp,
 		descStatefulSetLabelsDefaultLabels,
 		nil,
 	)
-	descStatefulSetCurrentRevision = newMetricFamilyDef(
+	descStatefulSetCurrentRevision = NewMetricFamilyDef(
 		"kube_statefulset_status_current_revision",
 		"Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
 		append(descStatefulSetLabelsDefaultLabels, "revision"),
 		nil,
 	)
-	descStatefulSetUpdateRevision = newMetricFamilyDef(
+	descStatefulSetUpdateRevision = NewMetricFamilyDef(
 		"kube_statefulset_status_update_revision",
 		"Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
 		append(descStatefulSetLabelsDefaultLabels, "revision"),
@@ -112,7 +112,7 @@ func createStatefulSetListWatch(kubeClient clientset.Interface, ns string) cache
 }
 
 func statefulSetLabelsDesc(labelKeys []string) *MetricFamilyDef {
-	return newMetricFamilyDef(
+	return NewMetricFamilyDef(
 		descStatefulSetLabelsName,
 		descStatefulSetLabelsHelp,
 		append(descStatefulSetLabelsDefaultLabels, labelKeys...),

--- a/pkg/collectors/utils.go
+++ b/pkg/collectors/utils.go
@@ -58,7 +58,7 @@ func boolFloat64(b bool) float64 {
 // addConditionMetrics generates one metric for each possible node condition
 // status. For this function to work properly, the last label in the metric
 // description must be the condition.
-func addConditionMetrics(desc *metricFamilyDef, cs v1.ConditionStatus, lv ...string) []*metrics.Metric {
+func addConditionMetrics(desc *MetricFamilyDef, cs v1.ConditionStatus, lv ...string) []*metrics.Metric {
 	ms := []*metrics.Metric{}
 	m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, append(lv, "true"), boolFloat64(cs == v1.ConditionTrue))
 	if err != nil {

--- a/pkg/collectors/utils.go
+++ b/pkg/collectors/utils.go
@@ -58,7 +58,7 @@ func boolFloat64(b bool) float64 {
 // addConditionMetrics generates one metric for each possible node condition
 // status. For this function to work properly, the last label in the metric
 // description must be the condition.
-func addConditionMetrics(desc *MetricFamilyDef, cs v1.ConditionStatus, lv ...string) []*metrics.Metric {
+func addConditionMetrics(desc *metrics.MetricFamilyDef, cs v1.ConditionStatus, lv ...string) []*metrics.Metric {
 	ms := []*metrics.Metric{}
 	m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, append(lv, "true"), boolFloat64(cs == v1.ConditionTrue))
 	if err != nil {

--- a/pkg/collectors/utils.go
+++ b/pkg/collectors/utils.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/api/core/v1"
+
+	"k8s.io/kube-state-metrics/pkg/metrics"
+)
+
+var (
+	resyncPeriod = 5 * time.Minute
+
+	ScrapeErrorTotalMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ksm_scrape_error_total",
+			Help: "Total scrape errors encountered when scraping a resource",
+		},
+		[]string{"resource"},
+	)
+
+	ResourcesPerScrapeMetric = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "ksm_resources_per_scrape",
+			Help: "Number of resources returned per scrape",
+		},
+		[]string{"resource"},
+	)
+
+	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+)
+
+func boolFloat64(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// addConditionMetrics generates one metric for each possible node condition
+// status. For this function to work properly, the last label in the metric
+// description must be the condition.
+func addConditionMetrics(desc *metricFamilyDef, cs v1.ConditionStatus, lv ...string) []*metrics.Metric {
+	ms := []*metrics.Metric{}
+	m, err := metrics.NewMetric(desc.Name, desc.LabelKeys, append(lv, "true"), boolFloat64(cs == v1.ConditionTrue))
+	if err != nil {
+		panic(err)
+	}
+	ms = append(ms, m)
+	m, err = metrics.NewMetric(desc.Name, desc.LabelKeys, append(lv, "false"), boolFloat64(cs == v1.ConditionFalse))
+	if err != nil {
+		panic(err)
+	}
+	ms = append(ms, m)
+	m, err = metrics.NewMetric(desc.Name, desc.LabelKeys, append(lv, "unknown"), boolFloat64(cs == v1.ConditionUnknown))
+	if err != nil {
+		panic(err)
+	}
+	ms = append(ms, m)
+
+	return ms
+}
+
+func kubeLabelsToPrometheusLabels(labels map[string]string) ([]string, []string) {
+	labelKeys := make([]string, len(labels))
+	labelValues := make([]string, len(labels))
+	i := 0
+	for k, v := range labels {
+		labelKeys[i] = "label_" + sanitizeLabelName(k)
+		labelValues[i] = v
+		i++
+	}
+	return labelKeys, labelValues
+}
+
+func kubeAnnotationsToPrometheusAnnotations(annotations map[string]string) ([]string, []string) {
+	annotationKeys := make([]string, len(annotations))
+	annotationValues := make([]string, len(annotations))
+	i := 0
+	for k, v := range annotations {
+		annotationKeys[i] = "annotation_" + sanitizeLabelName(k)
+		annotationValues[i] = v
+		i++
+	}
+	return annotationKeys, annotationValues
+}
+
+func sanitizeLabelName(s string) string {
+	return invalidLabelCharRE.ReplaceAllString(s, "_")
+}

--- a/pkg/metrics/metric_family.go
+++ b/pkg/metrics/metric_family.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func NewMetricFamilyDef(name, help string, labelKeys []string, constLabels prometheus.Labels) *MetricFamilyDef {
+	return &MetricFamilyDef{name, help, labelKeys, constLabels}
+}
+
+// MetricFamilyDef represents a metric family definition
+type MetricFamilyDef struct {
+	Name        string
+	Help        string
+	LabelKeys   []string
+	ConstLabels prometheus.Labels
+}

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -175,7 +175,7 @@ set +o pipefail
 ! cat $KUBE_STATE_METRICS_LOG_DIR/metrics | promtool check metrics 2>&1 | grep -v "no help text"
 set -o pipefail
 
-collectors=$(find pkg/collectors/ -maxdepth 1 -name "*.go" -not -name "*_test.go" -not -name "collectors.go" -not -name "builder.go" -not -name "testutils.go" | xargs -n1 basename | awk -F. '{print $1}')
+collectors=$(find pkg/collectors/ -maxdepth 1 -name "*.go" -not -name "*_test.go" -not -name "collectors.go" -not -name "builder.go" -not -name "testutils.go" -not -name "utils.go" | xargs -n1 basename | awk -F. '{print $1}')
 echo "available collectors: $collectors"
 for collector in $collectors; do
     echo "checking that kube_${collector}* metrics exists"

--- a/tests/lib/lib_test.go
+++ b/tests/lib/lib_test.go
@@ -1,0 +1,81 @@
+package lib
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-state-metrics/pkg/collectors"
+	"k8s.io/kube-state-metrics/pkg/metrics"
+	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
+)
+
+func TestAsLibrary(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+
+	service := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-service",
+			ResourceVersion: "123456",
+		},
+	}
+
+	_, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Create(&service)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := serviceCollector(kubeClient)
+
+	// Wait for informers to sync
+	time.Sleep(time.Second)
+
+	m := c.Collect()
+
+	if len(m) != 1 {
+		t.Fatalf("expected one metric to be returned but got %v", len(m))
+	}
+
+	if !strings.Contains(string(*m[0]), service.ObjectMeta.Name) {
+		t.Fatal("expected string to contain service name")
+	}
+}
+
+func serviceCollector(kubeClient clientset.Interface) *collectors.Collector {
+	store := metricsstore.NewMetricsStore(generateServiceMetrics)
+
+	lw := cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().Services(metav1.NamespaceDefault).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().Services(metav1.NamespaceDefault).Watch(opts)
+		},
+	}
+
+	r := cache.NewReflector(&lw, &v1.Service{}, store, 0)
+
+	go r.Run(context.TODO().Done())
+
+	return collectors.NewCollector(store)
+}
+
+func generateServiceMetrics(obj interface{}) []*metrics.Metric {
+	sPointer := obj.(*v1.Service)
+	s := *sPointer
+
+	m, err := metrics.NewMetric("test_metric", []string{"name"}, []string{s.Name}, 1)
+	if err != nil {
+		panic(err)
+	}
+
+	return []*metrics.Metric{m}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`kube-state-metrics` has many useful parts which could be used as library, this is the first step towards that.

For now only the functions are exposed and some helper functions moved to a different place. In the long term I would prefer to end with the following structure:
```
pkg
├── collector // functions needed to create a collector, this would be used in the builder pkg and externally 
├── internal
│   └── builder // content of the current upstream resource collectors which would consume the collector pkg
├── metrics // what is currently there but also move the utils/helper functions from collectors. Also the metricHandler interface as that would be useful to expose and reuse elsewhere.

```
Any thoughts on the above are welcome, I can also open an issue to discuss it?
