### PR TITLE
Adding CreateContainerConfigError as possible reason for container no…

### DIFF
--- a/pkg/collectors/pod.go
+++ b/pkg/collectors/pod.go
@@ -37,7 +37,7 @@ var (
 	descPodLabelsName          = "kube_pod_labels"
 	descPodLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descPodLabelsDefaultLabels = []string{"namespace", "pod"}
-	containerWaitingReasons    = []string{"ContainerCreating", "CrashLoopBackOff", "ErrImagePull", "ImagePullBackOff"}
+	containerWaitingReasons    = []string{"ContainerCreating", "CrashLoopBackOff", "CreateContainerConfigError", "ErrImagePull", "ImagePullBackOff"}
 	containerTerminatedReasons = []string{"OOMKilled", "Completed", "Error", "ContainerCannotRun"}
 
 	descPodInfo = metrics.NewMetricFamilyDef(

--- a/pkg/collectors/pod_test.go
+++ b/pkg/collectors/pod_test.go
@@ -256,6 +256,8 @@ func TestPodCollector(t *testing.T) {
 				kube_pod_container_status_waiting_reason{container="container1",namespace="ns1",pod="pod1",reason="ImagePullBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container1",namespace="ns1",pod="pod1",reason="CrashLoopBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container1",namespace="ns1",pod="pod1",reason="ErrImagePull"} 0
+				kube_pod_container_status_waiting_reason{container="container1",namespace="ns1",pod="pod1",reason="CreateContainerConfigError"} 0
+
 `,
 
 			MetricNames: []string{
@@ -312,10 +314,13 @@ func TestPodCollector(t *testing.T) {
 				kube_pod_container_status_waiting_reason{container="container2",namespace="ns2",pod="pod2",reason="ImagePullBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container2",namespace="ns2",pod="pod2",reason="CrashLoopBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container2",namespace="ns2",pod="pod2",reason="ErrImagePull"} 0
+				kube_pod_container_status_waiting_reason{container="container2",namespace="ns2",pod="pod2",reason="CreateContainerConfigError"} 0
                 kube_pod_container_status_waiting_reason{container="container3",namespace="ns2",pod="pod2",reason="ContainerCreating"} 1
                 kube_pod_container_status_waiting_reason{container="container3",namespace="ns2",pod="pod2",reason="CrashLoopBackOff"} 0
                 kube_pod_container_status_waiting_reason{container="container3",namespace="ns2",pod="pod2",reason="ErrImagePull"} 0
-                kube_pod_container_status_waiting_reason{container="container3",namespace="ns2",pod="pod2",reason="ImagePullBackOff"} 0
+				kube_pod_container_status_waiting_reason{container="container3",namespace="ns2",pod="pod2",reason="ImagePullBackOff"} 0
+				kube_pod_container_status_waiting_reason{container="container3",namespace="ns2",pod="pod2",reason="CreateContainerConfigError"} 0
+
 `,
 			MetricNames: []string{
 				"kube_pod_container_status_running",
@@ -356,6 +361,7 @@ kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",
 				kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="ImagePullBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="CrashLoopBackOff"} 1
 				kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="ErrImagePull"} 0
+				kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="CreateContainerConfigError"} 0
 kube_pod_container_status_last_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="Completed"} 0
 				kube_pod_container_status_last_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="ContainerCannotRun"} 0
 				kube_pod_container_status_last_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="Error"} 0
@@ -369,6 +375,7 @@ kube_pod_container_status_last_terminated_reason{container="container4",namespac
 				"kube_pod_container_status_terminated_reason",
 				"kube_pod_container_status_terminated_reason",
 				"kube_pod_container_status_waiting",
+				"kube_pod_container_status_waiting_reason",
 				"kube_pod_container_status_waiting_reason",
 				"kube_pod_container_status_waiting_reason",
 				"kube_pod_container_status_waiting_reason",
@@ -414,6 +421,7 @@ kube_pod_container_status_waiting_reason{container="container7",namespace="ns6",
 				kube_pod_container_status_waiting_reason{container="container7",namespace="ns6",pod="pod6",reason="ImagePullBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container7",namespace="ns6",pod="pod6",reason="CrashLoopBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container7",namespace="ns6",pod="pod6",reason="ErrImagePull"} 0
+				kube_pod_container_status_waiting_reason{container="container7",namespace="ns6",pod="pod6",reason="CreateContainerConfigError"} 0
 kube_pod_container_status_last_terminated_reason{container="container7",namespace="ns6",pod="pod6",reason="Completed"} 0
 				kube_pod_container_status_last_terminated_reason{container="container7",namespace="ns6",pod="pod6",reason="ContainerCannotRun"} 0
 				kube_pod_container_status_last_terminated_reason{container="container7",namespace="ns6",pod="pod6",reason="Error"} 0
@@ -459,6 +467,7 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				kube_pod_container_status_waiting_reason{container="container5",namespace="ns4",pod="pod4",reason="ImagePullBackOff"} 1
 				kube_pod_container_status_waiting_reason{container="container5",namespace="ns4",pod="pod4",reason="CrashLoopBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container5",namespace="ns4",pod="pod4",reason="ErrImagePull"} 0
+				kube_pod_container_status_waiting_reason{container="container5",namespace="ns4",pod="pod4",reason="CreateContainerConfigError"} 0
 `,
 			MetricNames: []string{
 				"kube_pod_container_status_running",
@@ -499,7 +508,49 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				kube_pod_container_status_waiting_reason{container="container6",namespace="ns5",pod="pod5",reason="ImagePullBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container6",namespace="ns5",pod="pod5",reason="CrashLoopBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container6",namespace="ns5",pod="pod5",reason="ErrImagePull"} 1
-				`,
+				kube_pod_container_status_waiting_reason{container="container6",namespace="ns5",pod="pod5",reason="CreateContainerConfigError"} 0
+`,
+				MetricNames: []string{
+					"kube_pod_container_status_running",
+					"kube_pod_container_status_waiting",
+					"kube_pod_container_status_waiting_reason",
+					"kube_pod_container_status_terminated",
+					"kube_pod_container_status_terminated_reason",
+				},
+			},
+			{
+				Obj: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod7",
+						Namespace: "ns7",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							v1.ContainerStatus{
+								Name: "container8",
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "CreateContainerConfigError",
+									},
+								},
+							},
+						},
+					},
+				},
+				Want: `
+					kube_pod_container_status_running{container="container8",namespace="ns7",pod="pod7"} 0
+					kube_pod_container_status_terminated{container="container8",namespace="ns7",pod="pod7"} 0
+					kube_pod_container_status_terminated_reason{container="container8",namespace="ns7",pod="pod7",reason="Completed"} 0
+					kube_pod_container_status_terminated_reason{container="container8",namespace="ns7",pod="pod7",reason="ContainerCannotRun"} 0
+					kube_pod_container_status_terminated_reason{container="container8",namespace="ns7",pod="pod7",reason="Error"} 0
+					kube_pod_container_status_terminated_reason{container="container8",namespace="ns7",pod="pod7",reason="OOMKilled"} 0
+					kube_pod_container_status_waiting{container="container8",namespace="ns7",pod="pod7"} 1
+					kube_pod_container_status_waiting_reason{container="container8",namespace="ns7",pod="pod7",reason="ContainerCreating"} 0
+					kube_pod_container_status_waiting_reason{container="container8",namespace="ns7",pod="pod7",reason="ImagePullBackOff"} 0
+					kube_pod_container_status_waiting_reason{container="container8",namespace="ns7",pod="pod7",reason="CrashLoopBackOff"} 0
+					kube_pod_container_status_waiting_reason{container="container8",namespace="ns7",pod="pod7",reason="ErrImagePull"} 0
+					kube_pod_container_status_waiting_reason{container="container8",namespace="ns7",pod="pod7",reason="CreateContainerConfigError"} 1
+`,
 			MetricNames: []string{
 				"kube_pod_container_status_running",
 				"kube_pod_container_status_terminated",

--- a/pkg/collectors/pod_test.go
+++ b/pkg/collectors/pod_test.go
@@ -510,34 +510,34 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				kube_pod_container_status_waiting_reason{container="container6",namespace="ns5",pod="pod5",reason="ErrImagePull"} 1
 				kube_pod_container_status_waiting_reason{container="container6",namespace="ns5",pod="pod5",reason="CreateContainerConfigError"} 0
 `,
-				MetricNames: []string{
-					"kube_pod_container_status_running",
-					"kube_pod_container_status_waiting",
-					"kube_pod_container_status_waiting_reason",
-					"kube_pod_container_status_terminated",
-					"kube_pod_container_status_terminated_reason",
-				},
+			MetricNames: []string{
+				"kube_pod_container_status_running",
+				"kube_pod_container_status_waiting",
+				"kube_pod_container_status_waiting_reason",
+				"kube_pod_container_status_terminated",
+				"kube_pod_container_status_terminated_reason",
 			},
-			{
-				Obj: &v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod7",
-						Namespace: "ns7",
-					},
-					Status: v1.PodStatus{
-						ContainerStatuses: []v1.ContainerStatus{
-							v1.ContainerStatus{
-								Name: "container8",
-								State: v1.ContainerState{
-									Waiting: &v1.ContainerStateWaiting{
-										Reason: "CreateContainerConfigError",
-									},
+		},
+		{
+			Obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod7",
+					Namespace: "ns7",
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						v1.ContainerStatus{
+							Name: "container8",
+							State: v1.ContainerState{
+								Waiting: &v1.ContainerStateWaiting{
+									Reason: "CreateContainerConfigError",
 								},
 							},
 						},
 					},
 				},
-				Want: `
+			},
+			Want: `
 					kube_pod_container_status_running{container="container8",namespace="ns7",pod="pod7"} 0
 					kube_pod_container_status_terminated{container="container8",namespace="ns7",pod="pod7"} 0
 					kube_pod_container_status_terminated_reason{container="container8",namespace="ns7",pod="pod7",reason="Completed"} 0


### PR DESCRIPTION


**What this PR does / why we need it**:

For alerts based off `kube_pod_container_status_waiting_reason` metric to go off in event of `CreateContainerConfigError`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/prometheus/prometheus/issues/4815

