### PR TITLE
Correct readme Deployment -> Development typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the raw metrics.
   - [Building the Docker container](#building-the-docker-container)
 - [Usage](#usage)
   - [Kubernetes Deployment](#kubernetes-deployment)
-  - [Deployment](#deployment)
+  - [Development](#development)
 
 ### Versioning
 


### PR DESCRIPTION


**What this PR does / why we need it**:
This anchor link wasn't working - it was pointing to a non-existent ID.

