### PR TITLE
pkg/builder: Make collector order deterministic

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,9 +79,9 @@ func main() {
 
 	if len(opts.Collectors) == 0 {
 		glog.Info("Using default collectors")
-		collectorBuilder.WithEnabledCollectors(options.DefaultCollectors)
+		collectorBuilder.WithEnabledCollectors(options.DefaultCollectors.AsSlice())
 	} else {
-		collectorBuilder.WithEnabledCollectors(opts.Collectors)
+		collectorBuilder.WithEnabledCollectors(opts.Collectors.AsSlice())
 	}
 
 	if len(opts.Namespaces) == 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -54,7 +54,7 @@ func BenchmarkKubeStateMetrics(b *testing.B) {
 	opts := options.NewOptions()
 
 	builder := kcollectors.NewBuilder(context.TODO(), opts)
-	builder.WithEnabledCollectors(options.DefaultCollectors)
+	builder.WithEnabledCollectors(options.DefaultCollectors.AsSlice())
 	builder.WithKubeClient(kubeClient)
 	builder.WithNamespaces(options.DefaultNamespaces)
 
@@ -113,7 +113,7 @@ func TestFullScrapeCycle(t *testing.T) {
 	opts := options.NewOptions()
 
 	builder := kcollectors.NewBuilder(context.TODO(), opts)
-	builder.WithEnabledCollectors(options.DefaultCollectors)
+	builder.WithEnabledCollectors(options.DefaultCollectors.AsSlice())
 	builder.WithKubeClient(kubeClient)
 	builder.WithNamespaces(options.DefaultNamespaces)
 

--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -18,6 +18,7 @@ limitations under the License.
 package collectors
 
 import (
+	"sort"
 	"strings"
 
 	// 	apps "k8s.io/api/apps/v1beta1"
@@ -50,7 +51,7 @@ type Builder struct {
 	// TODO: Are opts still needed anywhere?
 	opts              *options.Options
 	ctx               context.Context
-	enabledCollectors options.CollectorSet
+	enabledCollectors []string
 	whiteBlackList    whiteBlackLister
 }
 
@@ -66,8 +67,15 @@ func NewBuilder(
 }
 
 // WithEnabledCollectors sets the enabledCollectors property of a Builder.
-func (b *Builder) WithEnabledCollectors(c options.CollectorSet) {
-	b.enabledCollectors = c
+func (b *Builder) WithEnabledCollectors(c []string) {
+	copy := []string{}
+	for _, s := range c {
+		copy = append(copy, s)
+	}
+
+	sort.Strings(copy)
+
+	b.enabledCollectors = copy
 }
 
 // WithNamespaces sets the namespaces property of a Builder.
@@ -95,7 +103,7 @@ func (b *Builder) Build() []*Collector {
 	collectors := []*Collector{}
 	activeCollectorNames := []string{}
 
-	for c := range b.enabledCollectors {
+	for _, c := range b.enabledCollectors {
 		constructor, ok := availableCollectors[c]
 		if ok {
 			collector := constructor(b)

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -66,7 +66,7 @@ type CollectorSet map[string]struct{}
 
 func (c *CollectorSet) String() string {
 	s := *c
-	ss := s.asSlice()
+	ss := s.AsSlice()
 	sort.Strings(ss)
 	return strings.Join(ss, ",")
 }
@@ -87,7 +87,7 @@ func (c *CollectorSet) Set(value string) error {
 	return nil
 }
 
-func (c CollectorSet) asSlice() []string {
+func (c CollectorSet) AsSlice() []string {
 	cols := []string{}
 	for col := range c {
 		cols = append(cols, col)
@@ -96,7 +96,7 @@ func (c CollectorSet) asSlice() []string {
 }
 
 func (c CollectorSet) isEmpty() bool {
-	return len(c.asSlice()) == 0
+	return len(c.AsSlice()) == 0
 }
 
 func (c *CollectorSet) Type() string {


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of iterating a map of enabled collectors, iterate a sorted
slice to achieve determinism across scrapes.

Having a consistent order in the metrics output enables Proemetheus to
apply optimizations during metric parsing and ingestion.
