### PR TITLE
pkg/collectors: Refactor Cron Job and Config Map collector

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -144,7 +144,10 @@ func TestFullScrapeCycle(t *testing.T) {
 
 	body, _ := ioutil.ReadAll(resp.Body)
 
-	expected := `# HELP kube_daemonset_created Unix creation timestamp
+	expected := `# HELP kube_configmap_info Information about configmap.
+# HELP kube_configmap_created Unix creation timestamp
+# HELP kube_configmap_metadata_resource_version Resource version representing a specific version of the configmap.
+# HELP kube_daemonset_created Unix creation timestamp
 # HELP kube_daemonset_status_current_number_scheduled The number of nodes running at least one daemon pod and are supposed to.
 # HELP kube_daemonset_status_desired_number_scheduled The number of nodes that should be running the daemon pod.
 # HELP kube_daemonset_status_number_available The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available

--- a/main_test.go
+++ b/main_test.go
@@ -147,6 +147,14 @@ func TestFullScrapeCycle(t *testing.T) {
 	expected := `# HELP kube_configmap_info Information about configmap.
 # HELP kube_configmap_created Unix creation timestamp
 # HELP kube_configmap_metadata_resource_version Resource version representing a specific version of the configmap.
+# HELP kube_cronjob_labels Kubernetes labels converted to Prometheus labels.
+# HELP kube_cronjob_info Info about cronjob.
+# HELP kube_cronjob_created Unix creation timestamp
+# HELP kube_cronjob_status_active Active holds pointers to currently running jobs.
+# HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
+# HELP kube_cronjob_spec_suspend Suspend flag tells the controller to suspend subsequent executions.
+# HELP kube_cronjob_spec_starting_deadline_seconds Deadline in seconds for starting the job if it misses scheduled time for any reason.
+# HELP kube_cronjob_next_schedule_time Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.
 # HELP kube_daemonset_created Unix creation timestamp
 # HELP kube_daemonset_status_current_number_scheduled The number of nodes running at least one daemon pod and are supposed to.
 # HELP kube_daemonset_status_desired_number_scheduled The number of nodes that should be running the daemon pod.

--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -27,11 +27,10 @@ import (
 
 	// apps "k8s.io/api/apps/v1beta1"
 	// 	autoscaling "k8s.io/api/autoscaling/v2beta1"
-	// 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
-	// "k8s.io/api/policy/v1beta1"
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
@@ -121,6 +120,7 @@ func (b *Builder) Build() []*Collector {
 
 var availableCollectors = map[string]func(f *Builder) *Collector{
 	"configmaps":  func(b *Builder) *Collector { return b.buildConfigMapCollector() },
+	"cronjobs":    func(b *Builder) *Collector { return b.buildCronJobCollector() },
 	"daemonsets":  func(b *Builder) *Collector { return b.buildDaemonSetCollector() },
 	"deployments": func(b *Builder) *Collector { return b.buildDeploymentCollector() },
 	"jobs":        func(b *Builder) *Collector { return b.buildJobCollector() },
@@ -156,6 +156,21 @@ func (b *Builder) buildConfigMapCollector() *Collector {
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ConfigMap{}, store, b.namespaces, createConfigMapListWatch)
+
+	return NewCollector(store)
+}
+
+func (b *Builder) buildCronJobCollector() *Collector {
+	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, cronJobMetricFamilies)
+	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
+
+	helpTexts := extractHelpText(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		helpTexts,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &batchv1beta1.CronJob{}, store, b.namespaces, createCronJobListWatch)
 
 	return NewCollector(store)
 }

--- a/pkg/collectors/configmap.go
+++ b/pkg/collectors/configmap.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metrics"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descConfigMapLabelsDefaultLabels = []string{"namespace", "configmap"}
+
+	configMapMetricFamilies = []metrics.FamilyGenerator{
+		metrics.FamilyGenerator{
+			Name: "kube_configmap_info",
+			Help: "Information about configmap.",
+			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metrics.Family {
+				return metrics.Family{
+					&metrics.Metric{
+						Name:        "kube_configmap_info",
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       1,
+					},
+				}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_configmap_created",
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metrics.Family {
+				f := metrics.Family{}
+
+				if !c.CreationTimestamp.IsZero() {
+					f = append(f, &metrics.Metric{
+						Name:        "kube_configmap_created",
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(c.CreationTimestamp.Unix()),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_configmap_metadata_resource_version",
+			Help: "Resource version representing a specific version of the configmap.",
+			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metrics.Family {
+				return metrics.Family{
+					&metrics.Metric{
+						Name:        "kube_configmap_metadata_resource_version",
+						LabelKeys:   []string{"resource_version"},
+						LabelValues: []string{string(c.ObjectMeta.ResourceVersion)},
+						Value:       1,
+					},
+				}
+			}),
+		},
+	}
+)
+
+func createConfigMapListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().ConfigMaps(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().ConfigMaps(ns).Watch(opts)
+		},
+	}
+}
+
+func wrapConfigMapFunc(f func(*v1.ConfigMap) metrics.Family) func(interface{}) metrics.Family {
+	return func(obj interface{}) metrics.Family {
+		configMap := obj.(*v1.ConfigMap)
+
+		metricFamily := f(configMap)
+
+		for _, m := range metricFamily {
+			m.LabelKeys = append(descConfigMapLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{configMap.Namespace, configMap.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}

--- a/pkg/collectors/configmap_test.go
+++ b/pkg/collectors/configmap_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConfigMapCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+
+	startTime := 1501569018
+	metav1StartTime := metav1.Unix(int64(startTime), 0)
+
+	const metadata = `
+        # HELP kube_configmap_info Information about configmap.
+		# TYPE kube_configmap_info gauge
+		# HELP kube_configmap_created Unix creation timestamp
+		# TYPE kube_configmap_created gauge
+		# HELP kube_configmap_metadata_resource_version Resource version representing a specific version of the configmap.
+		# TYPE kube_configmap_metadata_resource_version gauge
+	`
+	cases := []generateMetricsTestCase{
+		{
+			Obj: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "configmap1",
+					Namespace:       "ns1",
+					ResourceVersion: "123456",
+				},
+			},
+			Want: `
+				kube_configmap_info{configmap="configmap1",namespace="ns1"} 1
+				kube_configmap_metadata_resource_version{configmap="configmap1",namespace="ns1",resource_version="123456"} 1
+`,
+			MetricNames: []string{"kube_configmap_info", "kube_configmap_metadata_resource_version"},
+		},
+		{
+			Obj: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "configmap2",
+					Namespace:         "ns2",
+					CreationTimestamp: metav1StartTime,
+					ResourceVersion:   "abcdef",
+				},
+			},
+			Want: `
+				kube_configmap_info{configmap="configmap2",namespace="ns2"} 1
+				kube_configmap_created{configmap="configmap2",namespace="ns2"} 1.501569018e+09
+				kube_configmap_metadata_resource_version{configmap="configmap2",namespace="ns2",resource_version="abcdef"} 1
+				`,
+			MetricNames: []string{"kube_configmap_info", "kube_configmap_created", "kube_configmap_metadata_resource_version"},
+		},
+	}
+	for i, c := range cases {
+		c.Func = composeMetricGenFuncs(configMapMetricFamilies)
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+	}
+}

--- a/pkg/collectors/cronjob.go
+++ b/pkg/collectors/cronjob.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/kube-state-metrics/pkg/metrics"
+
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/robfig/cron"
+)
+
+var (
+	descCronJobLabelsName          = "kube_cronjob_labels"
+	descCronJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descCronJobLabelsDefaultLabels = []string{"namespace", "cronjob"}
+
+	cronJobMetricFamilies = []metrics.FamilyGenerator{
+		metrics.FamilyGenerator{
+			Name: descCronJobLabelsName,
+			Help: descCronJobLabelsHelp,
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
+				return metrics.Family{
+					&metrics.Metric{
+						Name:        descCronJobLabelsName,
+						LabelKeys:   labelKeys,
+						LabelValues: labelValues,
+						Value:       1,
+					},
+				}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_cronjob_info",
+			Help: "Info about cronjob.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
+				return metrics.Family{
+					&metrics.Metric{
+						Name:        "kube_cronjob_info",
+						LabelKeys:   []string{"schedule", "concurrency_policy"},
+						LabelValues: []string{j.Spec.Schedule, string(j.Spec.ConcurrencyPolicy)},
+						Value:       1,
+					},
+				}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_cronjob_created",
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
+				f := metrics.Family{}
+				if !j.CreationTimestamp.IsZero() {
+					f = append(f, &metrics.Metric{
+						Name:        "kube_cronjob_created",
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(j.CreationTimestamp.Unix()),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_cronjob_status_active",
+			Help: "Active holds pointers to currently running jobs.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
+				return metrics.Family{
+					&metrics.Metric{
+						Name:        "kube_cronjob_status_active",
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(len(j.Status.Active)),
+					},
+				}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_cronjob_status_last_schedule_time",
+			Help: "LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
+				f := metrics.Family{}
+
+				if j.Status.LastScheduleTime != nil {
+					f = append(f, &metrics.Metric{
+						Name:        "kube_cronjob_status_last_schedule_time",
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(j.Status.LastScheduleTime.Unix()),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_cronjob_spec_suspend",
+			Help: "Suspend flag tells the controller to suspend subsequent executions.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
+				f := metrics.Family{}
+
+				if j.Spec.Suspend != nil {
+					f = append(f, &metrics.Metric{
+						Name:        "kube_cronjob_spec_suspend",
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       boolFloat64(*j.Spec.Suspend),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_cronjob_spec_starting_deadline_seconds",
+			Help: "Deadline in seconds for starting the job if it misses scheduled time for any reason.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
+				f := metrics.Family{}
+
+				if j.Spec.StartingDeadlineSeconds != nil {
+					f = append(f, &metrics.Metric{
+						Name:        "kube_cronjob_spec_starting_deadline_seconds",
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(*j.Spec.StartingDeadlineSeconds),
+					})
+
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_cronjob_next_schedule_time",
+			Help: "Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
+				f := metrics.Family{}
+
+				// If the cron job is suspended, don't track the next scheduled time
+				nextScheduledTime, err := getNextScheduledTime(j.Spec.Schedule, j.Status.LastScheduleTime, j.CreationTimestamp)
+				if err != nil {
+					panic(err)
+				} else if !*j.Spec.Suspend {
+					f = append(f, &metrics.Metric{
+						Name:        "kube_cronjob_next_schedule_time",
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(nextScheduledTime.Unix()),
+					})
+				}
+
+				return f
+			}),
+		},
+	}
+)
+
+func wrapCronJobFunc(f func(*batchv1beta1.CronJob) metrics.Family) func(interface{}) metrics.Family {
+	return func(obj interface{}) metrics.Family {
+		cronJob := obj.(*batchv1beta1.CronJob)
+
+		metricFamily := f(cronJob)
+
+		for _, m := range metricFamily {
+			m.LabelKeys = append(descCronJobLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{cronJob.Namespace, cronJob.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createCronJobListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.BatchV1beta1().CronJobs(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.BatchV1beta1().CronJobs(ns).Watch(opts)
+		},
+	}
+}
+
+func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, createdTime metav1.Time) (time.Time, error) {
+	sched, err := cron.ParseStandard(schedule)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("Failed to parse cron job schedule '%s': %s", schedule, err)
+	}
+	if !lastScheduleTime.IsZero() {
+		return sched.Next((*lastScheduleTime).Time), nil
+	}
+	if !createdTime.IsZero() {
+		return sched.Next(createdTime.Time), nil
+	}
+	return time.Time{}, fmt.Errorf("Created time and lastScheduleTime are both zero")
+}

--- a/pkg/collectors/cronjob_test.go
+++ b/pkg/collectors/cronjob_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	SuspendTrue                      = true
+	SuspendFalse                     = false
+	StartingDeadlineSeconds300 int64 = 300
+
+	// "1520742896" is "2018/3/11 12:34:56" in "Asia/Shanghai".
+	ActiveRunningCronJob1LastScheduleTime          = time.Unix(1520742896, 0)
+	SuspendedCronJob1LastScheduleTime              = time.Unix(1520742896+5.5*3600, 0) // 5.5 hours later
+	ActiveCronJob1NoLastScheduledCreationTimestamp = time.Unix(1520742896+6.5*3600, 0)
+)
+
+func TestCronJobCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+
+	hour := ActiveRunningCronJob1LastScheduleTime.Hour()
+	ActiveRunningCronJob1NextScheduleTime := time.Time{}
+	switch {
+	case hour < 6:
+		ActiveRunningCronJob1NextScheduleTime = time.Date(
+			ActiveRunningCronJob1LastScheduleTime.Year(),
+			ActiveRunningCronJob1LastScheduleTime.Month(),
+			ActiveRunningCronJob1LastScheduleTime.Day(),
+			6,
+			0,
+			0, 0, time.Local)
+	case hour < 12:
+		ActiveRunningCronJob1NextScheduleTime = time.Date(
+			ActiveRunningCronJob1LastScheduleTime.Year(),
+			ActiveRunningCronJob1LastScheduleTime.Month(),
+			ActiveRunningCronJob1LastScheduleTime.Day(),
+			12,
+			0,
+			0, 0, time.Local)
+	case hour < 18:
+		ActiveRunningCronJob1NextScheduleTime = time.Date(
+			ActiveRunningCronJob1LastScheduleTime.Year(),
+			ActiveRunningCronJob1LastScheduleTime.Month(),
+			ActiveRunningCronJob1LastScheduleTime.Day(),
+			18,
+			0,
+			0, 0, time.Local)
+	case hour < 24:
+		ActiveRunningCronJob1NextScheduleTime = time.Date(
+			ActiveRunningCronJob1LastScheduleTime.Year(),
+			ActiveRunningCronJob1LastScheduleTime.Month(),
+			ActiveRunningCronJob1LastScheduleTime.Day(),
+			24,
+			0,
+			0, 0, time.Local)
+	}
+
+	minute := ActiveCronJob1NoLastScheduledCreationTimestamp.Minute()
+	ActiveCronJob1NoLastScheduledNextScheduleTime := time.Time{}
+	switch {
+	case minute < 25:
+		ActiveCronJob1NoLastScheduledNextScheduleTime = time.Date(
+			ActiveCronJob1NoLastScheduledCreationTimestamp.Year(),
+			ActiveCronJob1NoLastScheduledCreationTimestamp.Month(),
+			ActiveCronJob1NoLastScheduledCreationTimestamp.Day(),
+			ActiveCronJob1NoLastScheduledCreationTimestamp.Hour(),
+			25,
+			0, 0, time.Local)
+	default:
+		ActiveCronJob1NoLastScheduledNextScheduleTime = time.Date(
+			ActiveCronJob1NoLastScheduledNextScheduleTime.Year(),
+			ActiveCronJob1NoLastScheduledNextScheduleTime.Month(),
+			ActiveCronJob1NoLastScheduledNextScheduleTime.Day(),
+			ActiveCronJob1NoLastScheduledNextScheduleTime.Hour()+1,
+			25,
+			0, 0, time.Local)
+	}
+
+	const metadata = `
+		# HELP kube_cronjob_labels Kubernetes labels converted to Prometheus labels.
+		# TYPE kube_cronjob_labels gauge
+		# HELP kube_cronjob_info Info about cronjob.
+		# TYPE kube_cronjob_info gauge
+		# HELP kube_cronjob_created Unix creation timestamp
+		# TYPE kube_cronjob_created gauge
+		# HELP kube_cronjob_spec_starting_deadline_seconds Deadline in seconds for starting the job if it misses scheduled time for any reason.
+		# TYPE kube_cronjob_spec_starting_deadline_seconds gauge
+		# HELP kube_cronjob_spec_suspend Suspend flag tells the controller to suspend subsequent executions.
+		# TYPE kube_cronjob_spec_suspend gauge
+		# HELP kube_cronjob_status_active Active holds pointers to currently running jobs.
+		# TYPE kube_cronjob_status_active gauge
+		# HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
+		# TYPE kube_cronjob_status_last_schedule_time gauge
+		# HELP kube_cronjob_next_schedule_time Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.
+		# TYPE kube_cronjob_next_schedule_time gauge
+	`
+	cases := []generateMetricsTestCase{
+		{
+			Obj: &batchv1beta1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "ActiveRunningCronJob1",
+					Namespace:  "ns1",
+					Generation: 1,
+					Labels: map[string]string{
+						"app": "example-active-running-1",
+					},
+				},
+				Status: batchv1beta1.CronJobStatus{
+					Active:           []v1.ObjectReference{{Name: "FakeJob1"}, {Name: "FakeJob2"}},
+					LastScheduleTime: &metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
+				},
+				Spec: batchv1beta1.CronJobSpec{
+					StartingDeadlineSeconds: &StartingDeadlineSeconds300,
+					ConcurrencyPolicy:       "Forbid",
+					Suspend:                 &SuspendFalse,
+					Schedule:                "0 */6 * * *",
+				},
+			},
+			Want: `
+				kube_cronjob_info{concurrency_policy="Forbid",cronjob="ActiveRunningCronJob1",namespace="ns1",schedule="0 */6 * * *"} 1
+				kube_cronjob_labels{cronjob="ActiveRunningCronJob1",label_app="example-active-running-1",namespace="ns1"} 1
+				kube_cronjob_spec_starting_deadline_seconds{cronjob="ActiveRunningCronJob1",namespace="ns1"} 300
+				kube_cronjob_spec_suspend{cronjob="ActiveRunningCronJob1",namespace="ns1"} 0
+				kube_cronjob_status_active{cronjob="ActiveRunningCronJob1",namespace="ns1"} 2
+				kube_cronjob_status_last_schedule_time{cronjob="ActiveRunningCronJob1",namespace="ns1"} 1.520742896e+09
+` + fmt.Sprintf("kube_cronjob_next_schedule_time{cronjob=\"ActiveRunningCronJob1\",namespace=\"ns1\"} %ve+09\n",
+				float64(ActiveRunningCronJob1NextScheduleTime.Unix())/math.Pow10(9)),
+			MetricNames: []string{"kube_cronjob_next_schedule_time", "kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels", "kube_cronjob_status_last_schedule_time"},
+		},
+		{
+			Obj: &batchv1beta1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "SuspendedCronJob1",
+					Namespace:  "ns1",
+					Generation: 1,
+					Labels: map[string]string{
+						"app": "example-suspended-1",
+					},
+				},
+				Status: batchv1beta1.CronJobStatus{
+					Active:           []v1.ObjectReference{},
+					LastScheduleTime: &metav1.Time{Time: SuspendedCronJob1LastScheduleTime},
+				},
+				Spec: batchv1beta1.CronJobSpec{
+					StartingDeadlineSeconds: &StartingDeadlineSeconds300,
+					ConcurrencyPolicy:       "Forbid",
+					Suspend:                 &SuspendTrue,
+					Schedule:                "0 */3 * * *",
+				},
+			},
+			Want: `
+				kube_cronjob_info{concurrency_policy="Forbid",cronjob="SuspendedCronJob1",namespace="ns1",schedule="0 */3 * * *"} 1
+				kube_cronjob_labels{cronjob="SuspendedCronJob1",label_app="example-suspended-1",namespace="ns1"} 1
+				kube_cronjob_spec_starting_deadline_seconds{cronjob="SuspendedCronJob1",namespace="ns1"} 300
+				kube_cronjob_spec_suspend{cronjob="SuspendedCronJob1",namespace="ns1"} 1
+				kube_cronjob_status_active{cronjob="SuspendedCronJob1",namespace="ns1"} 0
+				kube_cronjob_status_last_schedule_time{cronjob="SuspendedCronJob1",namespace="ns1"} 1.520762696e+09
+`,
+			MetricNames: []string{"kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels", "kube_cronjob_status_last_schedule_time"},
+		},
+		{
+			Obj: &batchv1beta1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "ActiveCronJob1NoLastScheduled",
+					CreationTimestamp: metav1.Time{Time: ActiveCronJob1NoLastScheduledCreationTimestamp},
+					Namespace:         "ns1",
+					Generation:        1,
+					Labels: map[string]string{
+						"app": "example-active-no-last-scheduled-1",
+					},
+				},
+				Status: batchv1beta1.CronJobStatus{
+					Active:           []v1.ObjectReference{},
+					LastScheduleTime: nil,
+				},
+				Spec: batchv1beta1.CronJobSpec{
+					StartingDeadlineSeconds: &StartingDeadlineSeconds300,
+					ConcurrencyPolicy:       "Forbid",
+					Suspend:                 &SuspendFalse,
+					Schedule:                "25 * * * *",
+				},
+			},
+			Want: `
+				kube_cronjob_spec_starting_deadline_seconds{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 300
+				kube_cronjob_status_active{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 0
+				kube_cronjob_spec_suspend{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 0
+				kube_cronjob_info{concurrency_policy="Forbid",cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1",schedule="25 * * * *"} 1
+				kube_cronjob_created{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 1.520766296e+09
+				kube_cronjob_labels{cronjob="ActiveCronJob1NoLastScheduled",label_app="example-active-no-last-scheduled-1",namespace="ns1"} 1
+` +
+				fmt.Sprintf("kube_cronjob_next_schedule_time{cronjob=\"ActiveCronJob1NoLastScheduled\",namespace=\"ns1\"} %ve+09\n",
+					float64(ActiveCronJob1NoLastScheduledNextScheduleTime.Unix())/math.Pow10(9)),
+			// TODO: Do we need to specify metricnames?
+			MetricNames: []string{"kube_cronjob_next_schedule_time", "kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels"},
+		},
+	}
+	for i, c := range cases {
+		c.Func = composeMetricGenFuncs(cronJobMetricFamilies)
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This patch refactors the cron job and config map collector to the format introduced in https://github.com/kubernetes/kube-state-metrics/pull/577.
