### PR TITLE
pkg/collectors: Refactor persistent volume & claim collector

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -211,6 +211,9 @@ func TestFullScrapeCycle(t *testing.T) {
 # HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
 # HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
 # HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
+# HELP kube_persistentvolume_labels Kubernetes labels converted to Prometheus labels.
+# HELP kube_persistentvolume_status_phase The phase indicates if a volume is available, bound to a claim, or released by a claim.
+# HELP kube_persistentvolume_info Information about persistentvolume.
 # HELP kube_pod_info Information about pod.
 # HELP kube_pod_start_time Start time in unix timestamp for a pod.
 # HELP kube_pod_completion_time Completion time in unix timestamp for a pod.

--- a/main_test.go
+++ b/main_test.go
@@ -207,6 +207,10 @@ func TestFullScrapeCycle(t *testing.T) {
 # HELP kube_node_status_allocatable_pods The pod resources of a node that are available for scheduling.
 # HELP kube_node_status_allocatable_cpu_cores The CPU resources of a node that are available for scheduling.
 # HELP kube_node_status_allocatable_memory_bytes The memory resources of a node that are available for scheduling.
+# HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
+# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
+# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
+# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
 # HELP kube_pod_info Information about pod.
 # HELP kube_pod_start_time Start time in unix timestamp for a pod.
 # HELP kube_pod_completion_time Completion time in unix timestamp for a pod.

--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -115,22 +115,22 @@ func (b *Builder) Build() []*Collector {
 }
 
 var availableCollectors = map[string]func(f *Builder) *Collector{
-	"configmaps":  func(b *Builder) *Collector { return b.buildConfigMapCollector() },
-	"cronjobs":    func(b *Builder) *Collector { return b.buildCronJobCollector() },
-	"daemonsets":  func(b *Builder) *Collector { return b.buildDaemonSetCollector() },
-	"deployments": func(b *Builder) *Collector { return b.buildDeploymentCollector() },
-	"jobs":        func(b *Builder) *Collector { return b.buildJobCollector() },
-	"limitranges": func(b *Builder) *Collector { return b.buildLimitRangeCollector() },
-	"namespaces":  func(b *Builder) *Collector { return b.buildNamespaceCollector() },
-	"nodes":       func(b *Builder) *Collector { return b.buildNodeCollector() },
-	"pods":        func(b *Builder) *Collector { return b.buildPodCollector() },
-	"services":    func(b *Builder) *Collector { return b.buildServiceCollector() },
+	"configmaps":             func(b *Builder) *Collector { return b.buildConfigMapCollector() },
+	"cronjobs":               func(b *Builder) *Collector { return b.buildCronJobCollector() },
+	"daemonsets":             func(b *Builder) *Collector { return b.buildDaemonSetCollector() },
+	"deployments":            func(b *Builder) *Collector { return b.buildDeploymentCollector() },
+	"jobs":                   func(b *Builder) *Collector { return b.buildJobCollector() },
+	"limitranges":            func(b *Builder) *Collector { return b.buildLimitRangeCollector() },
+	"namespaces":             func(b *Builder) *Collector { return b.buildNamespaceCollector() },
+	"nodes":                  func(b *Builder) *Collector { return b.buildNodeCollector() },
+	"persistentvolumeclaims": func(b *Builder) *Collector { return b.buildPersistentVolumeClaimCollector() },
+	"pods":                   func(b *Builder) *Collector { return b.buildPodCollector() },
+	"services":               func(b *Builder) *Collector { return b.buildServiceCollector() },
 	// 	"configmaps":               func(b *Builder) *Collector { return b.buildConfigMapCollector() },
 	// 	"cronjobs":                 func(b *Builder) *Collector { return b.buildCronJobCollector() },
 	// 	"endpoints":                func(b *Builder) *Collector { return b.buildEndpointsCollector() },
 	// 	"horizontalpodautoscalers": func(b *Builder) *Collector { return b.buildHPACollector() },
 	// 	"jobs":                   func(b *Builder) *Collector { return b.buildJobCollector() },
-	// 	"persistentvolumeclaims": func(b *Builder) *Collector { return b.buildPersistentVolumeClaimCollector() },
 	// 	"persistentvolumes":      func(b *Builder) *Collector { return b.buildPersistentVolumeCollector() },
 	// 	"poddisruptionbudgets":   func(b *Builder) *Collector { return b.buildPodDisruptionBudgetCollector() },
 	// 	"replicasets":            func(b *Builder) *Collector { return b.buildReplicaSetCollector() },
@@ -256,6 +256,21 @@ func (b *Builder) buildNodeCollector() *Collector {
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Node{}, store, b.namespaces, createNodeListWatch)
+
+	return NewCollector(store)
+}
+
+func (b *Builder) buildPersistentVolumeClaimCollector() *Collector {
+	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, persistentVolumeClaimMetricFamilies)
+	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
+
+	helpTexts := extractHelpText(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		helpTexts,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolumeClaim{}, store, b.namespaces, createPersistentVolumeClaimListWatch)
 
 	return NewCollector(store)
 }

--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -124,6 +124,7 @@ var availableCollectors = map[string]func(f *Builder) *Collector{
 	"namespaces":             func(b *Builder) *Collector { return b.buildNamespaceCollector() },
 	"nodes":                  func(b *Builder) *Collector { return b.buildNodeCollector() },
 	"persistentvolumeclaims": func(b *Builder) *Collector { return b.buildPersistentVolumeClaimCollector() },
+	"persistentvolumes":      func(b *Builder) *Collector { return b.buildPersistentVolumeCollector() },
 	"pods":                   func(b *Builder) *Collector { return b.buildPodCollector() },
 	"services":               func(b *Builder) *Collector { return b.buildServiceCollector() },
 	// 	"configmaps":               func(b *Builder) *Collector { return b.buildConfigMapCollector() },
@@ -131,7 +132,6 @@ var availableCollectors = map[string]func(f *Builder) *Collector{
 	// 	"endpoints":                func(b *Builder) *Collector { return b.buildEndpointsCollector() },
 	// 	"horizontalpodautoscalers": func(b *Builder) *Collector { return b.buildHPACollector() },
 	// 	"jobs":                   func(b *Builder) *Collector { return b.buildJobCollector() },
-	// 	"persistentvolumes":      func(b *Builder) *Collector { return b.buildPersistentVolumeCollector() },
 	// 	"poddisruptionbudgets":   func(b *Builder) *Collector { return b.buildPodDisruptionBudgetCollector() },
 	// 	"replicasets":            func(b *Builder) *Collector { return b.buildReplicaSetCollector() },
 	// 	"replicationcontrollers": func(b *Builder) *Collector { return b.buildReplicationControllerCollector() },
@@ -271,6 +271,21 @@ func (b *Builder) buildPersistentVolumeClaimCollector() *Collector {
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolumeClaim{}, store, b.namespaces, createPersistentVolumeClaimListWatch)
+
+	return NewCollector(store)
+}
+
+func (b *Builder) buildPersistentVolumeCollector() *Collector {
+	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, persistentVolumeMetricFamilies)
+	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
+
+	helpTexts := extractHelpText(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		helpTexts,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolume{}, store, b.namespaces, createPersistentVolumeListWatch)
 
 	return NewCollector(store)
 }

--- a/pkg/collectors/persistentvolume.go
+++ b/pkg/collectors/persistentvolume.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metrics"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descPersistentVolumeLabelsName          = "kube_persistentvolume_labels"
+	descPersistentVolumeLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descPersistentVolumeLabelsDefaultLabels = []string{"persistentvolume"}
+
+	persistentVolumeMetricFamilies = []metrics.FamilyGenerator{
+		metrics.FamilyGenerator{
+			Name: descPersistentVolumeLabelsName,
+			Help: descPersistentVolumeLabelsHelp,
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) metrics.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
+				return metrics.Family{&metrics.Metric{
+					Name:        descPersistentVolumeLabelsName,
+					LabelKeys:   labelKeys,
+					LabelValues: labelValues,
+					Value:       1,
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_persistentvolume_status_phase",
+			Help: "The phase indicates if a volume is available, bound to a claim, or released by a claim.",
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) metrics.Family {
+				f := metrics.Family{}
+
+				// Set current phase to 1, others to 0 if it is set.
+				if p := p.Status.Phase; p != "" {
+					f = append(f,
+						&metrics.Metric{
+							LabelValues: []string{string(v1.VolumePending)},
+							Value:       boolFloat64(p == v1.VolumePending),
+						},
+						&metrics.Metric{
+							LabelValues: []string{string(v1.VolumeAvailable)},
+							Value:       boolFloat64(p == v1.VolumeAvailable),
+						},
+						&metrics.Metric{
+							LabelValues: []string{string(v1.VolumeBound)},
+							Value:       boolFloat64(p == v1.VolumeBound),
+						},
+						&metrics.Metric{
+							LabelValues: []string{string(v1.VolumeReleased)},
+							Value:       boolFloat64(p == v1.VolumeReleased),
+						},
+						&metrics.Metric{
+							LabelValues: []string{string(v1.VolumeFailed)},
+							Value:       boolFloat64(p == v1.VolumeFailed),
+						},
+					)
+				}
+
+				for _, m := range f {
+					m.Name = "kube_persistentvolume_status_phase"
+					m.LabelKeys = []string{"phase"}
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_persistentvolume_info",
+			Help: "Information about persistentvolume.",
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:        "kube_persistentvolume_info",
+					LabelKeys:   []string{"storageclass"},
+					LabelValues: []string{p.Spec.StorageClassName},
+					Value:       1,
+				}}
+			}),
+		},
+	}
+)
+
+func wrapPersistentVolumeFunc(f func(*v1.PersistentVolume) metrics.Family) func(interface{}) metrics.Family {
+	return func(obj interface{}) metrics.Family {
+		persistentVolume := obj.(*v1.PersistentVolume)
+
+		metricFamily := f(persistentVolume)
+
+		for _, m := range metricFamily {
+			m.LabelKeys = append(descPersistentVolumeLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{persistentVolume.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createPersistentVolumeListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().PersistentVolumes().List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().PersistentVolumes().Watch(opts)
+		},
+	}
+}

--- a/pkg/collectors/persistentvolume_test.go
+++ b/pkg/collectors/persistentvolume_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPersistentVolumeCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+	const metadata = `
+			# HELP kube_persistentvolume_status_phase The phase indicates if a volume is available, bound to a claim, or released by a claim.
+			# TYPE kube_persistentvolume_status_phase gauge
+			# HELP kube_persistentvolume_labels Kubernetes labels converted to Prometheus labels.
+			# TYPE kube_persistentvolume_labels gauge
+			# HELP kube_persistentvolume_info Information about persistentvolume.
+			# TYPE kube_persistentvolume_info gauge
+	`
+	cases := []generateMetricsTestCase{
+		// Verify phase enumerations.
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv-pending",
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumePending,
+				},
+			},
+			Want: `
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-pending",phase="Available"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-pending",phase="Bound"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-pending",phase="Failed"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-pending",phase="Pending"} 1
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-pending",phase="Released"} 0
+`,
+			MetricNames: []string{
+				"kube_persistentvolume_status_phase",
+			},
+		},
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv-available",
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumeAvailable,
+				},
+			},
+			Want: `
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-available",phase="Available"} 1
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-available",phase="Bound"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-available",phase="Failed"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-available",phase="Pending"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-available",phase="Released"} 0
+`,
+			MetricNames: []string{"kube_persistentvolume_status_phase"},
+		},
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv-bound",
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumeBound,
+				},
+			},
+			Want: `
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-bound",phase="Available"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-bound",phase="Bound"} 1
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-bound",phase="Failed"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-bound",phase="Pending"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-bound",phase="Released"} 0
+`,
+			MetricNames: []string{"kube_persistentvolume_status_phase"},
+		},
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv-released",
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumeReleased,
+				},
+			},
+			Want: `
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-released",phase="Available"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-released",phase="Bound"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-released",phase="Failed"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-released",phase="Pending"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-released",phase="Released"} 1
+`,
+			MetricNames: []string{"kube_persistentvolume_status_phase"},
+		},
+		{
+
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv-failed",
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumeFailed,
+				},
+			},
+			Want: `
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-failed",phase="Available"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-failed",phase="Bound"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-failed",phase="Failed"} 1
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-failed",phase="Pending"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-failed",phase="Released"} 0
+`,
+			MetricNames: []string{"kube_persistentvolume_status_phase"},
+		},
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv-pending",
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumePending,
+				},
+				Spec: v1.PersistentVolumeSpec{
+					StorageClassName: "test",
+				},
+			},
+			Want: `
+				kube_persistentvolume_status_phase{persistentvolume="test-pv-pending",phase="Available"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-pending",phase="Bound"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-pending",phase="Failed"} 0
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-pending",phase="Pending"} 1
+					kube_persistentvolume_status_phase{persistentvolume="test-pv-pending",phase="Released"} 0
+`,
+			MetricNames: []string{
+				"kube_persistentvolume_status_phase",
+			},
+		},
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv-available",
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumeAvailable,
+				},
+			},
+			Want: `
+					kube_persistentvolume_info{persistentvolume="test-pv-available",storageclass=""} 1
+				`,
+			MetricNames: []string{"kube_persistentvolume_info"},
+		},
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-labeled-pv",
+					Labels: map[string]string{
+						"app": "mysql-server",
+					},
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumePending,
+				},
+				Spec: v1.PersistentVolumeSpec{
+					StorageClassName: "test",
+				},
+			},
+			Want: `
+					kube_persistentvolume_labels{label_app="mysql-server",persistentvolume="test-labeled-pv"} 1
+				`,
+			MetricNames: []string{"kube_persistentvolume_labels"},
+		},
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-unlabeled-pv",
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumeAvailable,
+				},
+			},
+			Want: `
+					kube_persistentvolume_labels{persistentvolume="test-unlabeled-pv"} 1
+				`,
+			MetricNames: []string{"kube_persistentvolume_labels"},
+		},
+	}
+	for i, c := range cases {
+		c.Func = composeMetricGenFuncs(persistentVolumeMetricFamilies)
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+	}
+}

--- a/pkg/collectors/persistentvolumeclaim.go
+++ b/pkg/collectors/persistentvolumeclaim.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metrics"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descPersistentVolumeClaimLabelsName          = "kube_persistentvolumeclaim_labels"
+	descPersistentVolumeClaimLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descPersistentVolumeClaimLabelsDefaultLabels = []string{"namespace", "persistentvolumeclaim"}
+
+	persistentVolumeClaimMetricFamilies = []metrics.FamilyGenerator{
+		metrics.FamilyGenerator{
+			Name: descPersistentVolumeClaimLabelsName,
+			Help: descPersistentVolumeClaimLabelsHelp,
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metrics.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
+				return metrics.Family{&metrics.Metric{
+					Name:        descPersistentVolumeClaimLabelsName,
+					LabelKeys:   labelKeys,
+					LabelValues: labelValues,
+					Value:       1,
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_persistentvolumeclaim_info",
+			Help: "Information about persistent volume claim.",
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metrics.Family {
+				storageClassName := getPersistentVolumeClaimClass(p)
+				volumeName := p.Spec.VolumeName
+				return metrics.Family{&metrics.Metric{
+					Name:        "kube_persistentvolumeclaim_info",
+					LabelKeys:   []string{"storageclass", "volumename"},
+					LabelValues: []string{storageClassName, volumeName},
+					Value:       1,
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_persistentvolumeclaim_status_phase",
+			Help: "The phase the persistent volume claim is currently in.",
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metrics.Family {
+				f := metrics.Family{}
+				// Set current phase to 1, others to 0 if it is set.
+				if p := p.Status.Phase; p != "" {
+					f = append(f,
+						&metrics.Metric{
+							LabelValues: []string{string(v1.ClaimLost)},
+							Value:       boolFloat64(p == v1.ClaimLost),
+						},
+						&metrics.Metric{
+							LabelValues: []string{string(v1.ClaimBound)},
+							Value:       boolFloat64(p == v1.ClaimBound),
+						},
+						&metrics.Metric{
+							LabelValues: []string{string(v1.ClaimPending)},
+							Value:       boolFloat64(p == v1.ClaimPending),
+						},
+					)
+				}
+
+				for _, m := range f {
+					m.Name = "kube_persistentvolumeclaim_status_phase"
+					m.LabelKeys = []string{"phase"}
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_persistentvolumeclaim_resource_requests_storage_bytes",
+			Help: "The capacity of storage requested by the persistent volume claim.",
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metrics.Family {
+				f := metrics.Family{}
+				if storage, ok := p.Spec.Resources.Requests[v1.ResourceStorage]; ok {
+					f = append(f, &metrics.Metric{
+						Name:  "kube_persistentvolumeclaim_resource_requests_storage_bytes",
+						Value: float64(storage.Value()),
+					})
+				}
+
+				return f
+			}),
+		},
+	}
+)
+
+func wrapPersistentVolumeClaimFunc(f func(*v1.PersistentVolumeClaim) metrics.Family) func(interface{}) metrics.Family {
+	return func(obj interface{}) metrics.Family {
+		persistentVolumeClaim := obj.(*v1.PersistentVolumeClaim)
+
+		metricFamily := f(persistentVolumeClaim)
+
+		for _, m := range metricFamily {
+			m.LabelKeys = append(descPersistentVolumeClaimLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{persistentVolumeClaim.Namespace, persistentVolumeClaim.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createPersistentVolumeClaimListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().PersistentVolumeClaims(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().PersistentVolumeClaims(ns).Watch(opts)
+		},
+	}
+}
+
+// getPersistentVolumeClaimClass returns StorageClassName. If no storage class was
+// requested, it returns "".
+func getPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
+	// Use beta annotation first
+	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return class
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return *claim.Spec.StorageClassName
+	}
+
+	// Special non-empty string to indicate absence of storage class.
+	return "<none>"
+}

--- a/pkg/collectors/persistentvolumeclaim_test.go
+++ b/pkg/collectors/persistentvolumeclaim_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPersistentVolumeClaimCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+	const metadata = `
+		# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
+		# TYPE kube_persistentvolumeclaim_info gauge
+		# HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
+		# TYPE kube_persistentvolumeclaim_labels gauge
+		# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
+		# TYPE kube_persistentvolumeclaim_status_phase gauge
+		# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
+		# TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
+	`
+	storageClassName := "rbd"
+	cases := []generateMetricsTestCase{
+		// Verify phase enumerations.
+		{
+			Obj: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mysql-data",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "mysql-server",
+					},
+				},
+				Spec: v1.PersistentVolumeClaimSpec{
+					StorageClassName: &storageClassName,
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+					VolumeName: "pvc-mysql-data",
+				},
+				Status: v1.PersistentVolumeClaimStatus{
+					Phase: v1.ClaimBound,
+				},
+			},
+			Want: `
+				kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",volumename="pvc-mysql-data"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Bound"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Lost"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
+				kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
+				kube_persistentvolumeclaim_labels{label_app="mysql-server",namespace="default",persistentvolumeclaim="mysql-data"} 1
+`,
+			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels"},
+		},
+		{
+			Obj: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prometheus-data",
+					Namespace: "default",
+				},
+				Spec: v1.PersistentVolumeClaimSpec{
+					StorageClassName: &storageClassName,
+					VolumeName:       "pvc-prometheus-data",
+				},
+				Status: v1.PersistentVolumeClaimStatus{
+					Phase: v1.ClaimPending,
+				},
+			},
+			Want: `
+				kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="prometheus-data",storageclass="rbd",volumename="pvc-prometheus-data"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Bound"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Lost"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Pending"} 1
+				kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="prometheus-data"} 1
+			`,
+			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels"},
+		},
+		{
+			Obj: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mongo-data",
+				},
+				Status: v1.PersistentVolumeClaimStatus{
+					Phase: v1.ClaimLost,
+				},
+			},
+			Want: `
+				kube_persistentvolumeclaim_info{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",volumename=""} 1
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Bound"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Lost"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Pending"} 0
+				kube_persistentvolumeclaim_labels{namespace="",persistentvolumeclaim="mongo-data"} 1
+`,
+			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels"},
+		},
+	}
+	for i, c := range cases {
+		c.Func = composeMetricGenFuncs(persistentVolumeClaimMetricFamilies)
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+	}
+}


### PR DESCRIPTION


**What this PR does / why we need it**:

This patch refactors the persistent volume and persistent volume claim collector to the format introduced in #577.
