### PR TITLE
pkg/collectors: Refactor pod disruption budget and replica set collector

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -214,6 +214,12 @@ func TestFullScrapeCycle(t *testing.T) {
 # HELP kube_persistentvolume_labels Kubernetes labels converted to Prometheus labels.
 # HELP kube_persistentvolume_status_phase The phase indicates if a volume is available, bound to a claim, or released by a claim.
 # HELP kube_persistentvolume_info Information about persistentvolume.
+# HELP kube_poddisruptionbudget_created Unix creation timestamp
+# HELP kube_poddisruptionbudget_status_current_healthy Current number of healthy pods
+# HELP kube_poddisruptionbudget_status_desired_healthy Minimum desired number of healthy pods
+# HELP kube_poddisruptionbudget_status_pod_disruptions_allowed Number of pod disruptions that are currently allowed
+# HELP kube_poddisruptionbudget_status_expected_pods Total number of pods counted by this disruption budget
+# HELP kube_poddisruptionbudget_status_observed_generation Most recent generation observed when updating this PDB status
 # HELP kube_pod_info Information about pod.
 # HELP kube_pod_start_time Start time in unix timestamp for a pod.
 # HELP kube_pod_completion_time Completion time in unix timestamp for a pod.

--- a/main_test.go
+++ b/main_test.go
@@ -247,6 +247,14 @@ func TestFullScrapeCycle(t *testing.T) {
 # HELP kube_pod_container_resource_limits_memory_bytes The limit on memory to be used by a container in bytes.
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_readonly Describes whether a persistentvolumeclaim is mounted read only.
+# HELP kube_replicaset_created Unix creation timestamp
+# HELP kube_replicaset_status_replicas The number of replicas per ReplicaSet.
+# HELP kube_replicaset_status_fully_labeled_replicas The number of fully labeled replicas per ReplicaSet.
+# HELP kube_replicaset_status_ready_replicas The number of ready replicas per ReplicaSet.
+# HELP kube_replicaset_status_observed_generation The generation observed by the ReplicaSet controller.
+# HELP kube_replicaset_spec_replicas Number of desired pods for a ReplicaSet.
+# HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
+# HELP kube_replicaset_owner Information about the ReplicaSet's owner.
 # HELP kube_service_info Information about service.
 kube_service_info{namespace="default",service="service0",cluster_ip="",external_name="",load_balancer_ip=""} 1
 # HELP kube_service_created Unix creation timestamp

--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -128,13 +128,13 @@ var availableCollectors = map[string]func(f *Builder) *Collector{
 	"persistentvolumes":      func(b *Builder) *Collector { return b.buildPersistentVolumeCollector() },
 	"poddisruptionbudgets":   func(b *Builder) *Collector { return b.buildPodDisruptionBudgetCollector() },
 	"pods":                   func(b *Builder) *Collector { return b.buildPodCollector() },
+	"replicasets":            func(b *Builder) *Collector { return b.buildReplicaSetCollector() },
 	"services":               func(b *Builder) *Collector { return b.buildServiceCollector() },
 	// 	"configmaps":               func(b *Builder) *Collector { return b.buildConfigMapCollector() },
 	// 	"cronjobs":                 func(b *Builder) *Collector { return b.buildCronJobCollector() },
 	// 	"endpoints":                func(b *Builder) *Collector { return b.buildEndpointsCollector() },
 	// 	"horizontalpodautoscalers": func(b *Builder) *Collector { return b.buildHPACollector() },
 	// 	"jobs":                   func(b *Builder) *Collector { return b.buildJobCollector() },
-	// 	"replicasets":            func(b *Builder) *Collector { return b.buildReplicaSetCollector() },
 	// 	"replicationcontrollers": func(b *Builder) *Collector { return b.buildReplicationControllerCollector() },
 	// 	"resourcequotas":         func(b *Builder) *Collector { return b.buildResourceQuotaCollector() },
 	// 	"secrets":                func(b *Builder) *Collector { return b.buildSecretCollector() },
@@ -290,6 +290,7 @@ func (b *Builder) buildPersistentVolumeCollector() *Collector {
 
 	return NewCollector(store)
 }
+
 func (b *Builder) buildPodDisruptionBudgetCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, podDisruptionBudgetMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
@@ -301,6 +302,21 @@ func (b *Builder) buildPodDisruptionBudgetCollector() *Collector {
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &policy.PodDisruptionBudget{}, store, b.namespaces, createPodDisruptionBudgetListWatch)
+
+	return NewCollector(store)
+}
+
+func (b *Builder) buildReplicaSetCollector() *Collector {
+	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, replicaSetMetricFamilies)
+	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
+
+	helpTexts := extractHelpText(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		helpTexts,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.ReplicaSet{}, store, b.namespaces, createReplicaSetListWatch)
 
 	return NewCollector(store)
 }

--- a/pkg/collectors/poddisruptionbudget.go
+++ b/pkg/collectors/poddisruptionbudget.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-state-metrics/pkg/metrics"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+var (
+	descPodDisruptionBudgetLabelsDefaultLabels = []string{"namespace", "poddisruptionbudget"}
+
+	podDisruptionBudgetMetricFamilies = []metrics.FamilyGenerator{
+		metrics.FamilyGenerator{
+			Name: "kube_poddisruptionbudget_created",
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
+				f := metrics.Family{}
+
+				if !p.CreationTimestamp.IsZero() {
+					f = append(f, &metrics.Metric{
+						Name:  "kube_poddisruptionbudget_created",
+						Value: float64(p.CreationTimestamp.Unix()),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_poddisruptionbudget_status_current_healthy",
+			Help: "Current number of healthy pods",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_poddisruptionbudget_status_current_healthy",
+					Value: float64(p.Status.CurrentHealthy),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_poddisruptionbudget_status_desired_healthy",
+			Help: "Minimum desired number of healthy pods",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_poddisruptionbudget_status_desired_healthy",
+					Value: float64(p.Status.DesiredHealthy),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_poddisruptionbudget_status_pod_disruptions_allowed",
+			Help: "Number of pod disruptions that are currently allowed",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_poddisruptionbudget_status_pod_disruptions_allowed",
+					Value: float64(p.Status.PodDisruptionsAllowed),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_poddisruptionbudget_status_expected_pods",
+			Help: "Total number of pods counted by this disruption budget",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_poddisruptionbudget_status_expected_pods",
+					Value: float64(p.Status.ExpectedPods),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_poddisruptionbudget_status_observed_generation",
+			Help: "Most recent generation observed when updating this PDB status",
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_poddisruptionbudget_status_observed_generation",
+					Value: float64(p.Status.ObservedGeneration),
+				}}
+			}),
+		},
+	}
+)
+
+func wrapPodDisruptionBudgetFunc(f func(*v1beta1.PodDisruptionBudget) metrics.Family) func(interface{}) metrics.Family {
+	return func(obj interface{}) metrics.Family {
+		podDisruptionBudget := obj.(*v1beta1.PodDisruptionBudget)
+
+		metricFamily := f(podDisruptionBudget)
+
+		for _, m := range metricFamily {
+			m.LabelKeys = append(descPodDisruptionBudgetLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{podDisruptionBudget.Namespace, podDisruptionBudget.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createPodDisruptionBudgetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.PolicyV1beta1().PodDisruptionBudgets(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.PolicyV1beta1().PodDisruptionBudgets(ns).Watch(opts)
+		},
+	}
+}

--- a/pkg/collectors/poddisruptionbudget_test.go
+++ b/pkg/collectors/poddisruptionbudget_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodDisruptionBudgetCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+	const metadata = `
+	# HELP kube_poddisruptionbudget_created Unix creation timestamp
+	# TYPE kube_poddisruptionbudget_created gauge
+	# HELP kube_poddisruptionbudget_status_current_healthy Current number of healthy pods
+	# TYPE kube_poddisruptionbudget_status_current_healthy gauge
+	# HELP kube_poddisruptionbudget_status_desired_healthy Minimum desired number of healthy pods
+	# TYPE kube_poddisruptionbudget_status_desired_healthy gauge
+	# HELP kube_poddisruptionbudget_status_pod_disruptions_allowed Number of pod disruptions that are currently allowed
+	# TYPE kube_poddisruptionbudget_status_pod_disruptions_allowed gauge
+	# HELP kube_poddisruptionbudget_status_expected_pods Total number of pods counted by this disruption budget
+	# TYPE kube_poddisruptionbudget_status_expected_pods gauge
+	# HELP kube_poddisruptionbudget_status_observed_generation Most recent generation observed when updating this PDB status
+	# TYPE kube_poddisruptionbudget_status_observed_generation gauge
+	`
+	cases := []generateMetricsTestCase{
+		{
+			Obj: &v1beta1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "pdb1",
+					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+					Namespace:         "ns1",
+					Generation:        21,
+				},
+				Status: v1beta1.PodDisruptionBudgetStatus{
+					CurrentHealthy:        12,
+					DesiredHealthy:        10,
+					PodDisruptionsAllowed: 2,
+					ExpectedPods:          15,
+					ObservedGeneration:    111,
+				},
+			},
+			Want: `
+			kube_poddisruptionbudget_created{namespace="ns1",poddisruptionbudget="pdb1"} 1.5e+09
+			kube_poddisruptionbudget_status_current_healthy{namespace="ns1",poddisruptionbudget="pdb1"} 12
+			kube_poddisruptionbudget_status_desired_healthy{namespace="ns1",poddisruptionbudget="pdb1"} 10
+			kube_poddisruptionbudget_status_pod_disruptions_allowed{namespace="ns1",poddisruptionbudget="pdb1"} 2
+			kube_poddisruptionbudget_status_expected_pods{namespace="ns1",poddisruptionbudget="pdb1"} 15
+			kube_poddisruptionbudget_status_observed_generation{namespace="ns1",poddisruptionbudget="pdb1"} 111
+			`,
+		},
+		{
+			Obj: &v1beta1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "pdb2",
+					Namespace:  "ns2",
+					Generation: 14,
+				},
+				Status: v1beta1.PodDisruptionBudgetStatus{
+					CurrentHealthy:        8,
+					DesiredHealthy:        9,
+					PodDisruptionsAllowed: 0,
+					ExpectedPods:          10,
+					ObservedGeneration:    1111,
+				},
+			},
+			Want: `
+				kube_poddisruptionbudget_status_current_healthy{namespace="ns2",poddisruptionbudget="pdb2"} 8
+				kube_poddisruptionbudget_status_desired_healthy{namespace="ns2",poddisruptionbudget="pdb2"} 9
+				kube_poddisruptionbudget_status_pod_disruptions_allowed{namespace="ns2",poddisruptionbudget="pdb2"} 0
+				kube_poddisruptionbudget_status_expected_pods{namespace="ns2",poddisruptionbudget="pdb2"} 10
+				kube_poddisruptionbudget_status_observed_generation{namespace="ns2",poddisruptionbudget="pdb2"} 1111
+			`,
+		},
+	}
+	for i, c := range cases {
+		c.Func = composeMetricGenFuncs(podDisruptionBudgetMetricFamilies)
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+	}
+}

--- a/pkg/collectors/replicaset.go
+++ b/pkg/collectors/replicaset.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"strconv"
+
+	"k8s.io/kube-state-metrics/pkg/metrics"
+
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descReplicaSetLabelsDefaultLabels = []string{"namespace", "replicaset"}
+
+	replicaSetMetricFamilies = []metrics.FamilyGenerator{
+		metrics.FamilyGenerator{
+			Name: "kube_replicaset_created",
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
+				f := metrics.Family{}
+
+				if !r.CreationTimestamp.IsZero() {
+					f = append(f, &metrics.Metric{
+						Name:  "kube_replicaset_created",
+						Value: float64(r.CreationTimestamp.Unix()),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_replicaset_status_replicas",
+			Help: "The number of replicas per ReplicaSet.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_replicaset_status_replicas",
+					Value: float64(r.Status.Replicas),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_replicaset_status_fully_labeled_replicas",
+			Help: "The number of fully labeled replicas per ReplicaSet.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_replicaset_status_fully_labeled_replicas",
+					Value: float64(r.Status.FullyLabeledReplicas),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_replicaset_status_ready_replicas",
+			Help: "The number of ready replicas per ReplicaSet.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_replicaset_status_ready_replicas",
+					Value: float64(r.Status.ReadyReplicas),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_replicaset_status_observed_generation",
+			Help: "The generation observed by the ReplicaSet controller.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_replicaset_status_observed_generation",
+					Value: float64(r.Status.ObservedGeneration),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_replicaset_spec_replicas",
+			Help: "Number of desired pods for a ReplicaSet.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
+				f := metrics.Family{}
+
+				if r.Spec.Replicas != nil {
+					f = append(f, &metrics.Metric{
+						Name:  "kube_replicaset_spec_replicas",
+						Value: float64(*r.Spec.Replicas),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_replicaset_metadata_generation",
+			Help: "Sequence number representing a specific generation of the desired state.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_replicaset_metadata_generation",
+					Value: float64(r.ObjectMeta.Generation),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_replicaset_owner",
+			Help: "Information about the ReplicaSet's owner.",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
+				f := metrics.Family{}
+
+				owners := r.GetOwnerReferences()
+				if len(owners) == 0 {
+					f = append(f, &metrics.Metric{
+						LabelValues: []string{"<none>", "<none>", "<none>"},
+					})
+				} else {
+					for _, owner := range owners {
+						if owner.Controller != nil {
+							f = append(f, &metrics.Metric{
+								LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
+							})
+						} else {
+							f = append(f, &metrics.Metric{
+								LabelValues: []string{owner.Kind, owner.Name, "false"},
+							})
+						}
+					}
+				}
+
+				for _, m := range f {
+					m.Name = "kube_replicaset_owner"
+					m.LabelKeys = []string{"owner_kind", "owner_name", "owner_is_controller"}
+					m.Value = 1
+				}
+
+				return f
+			}),
+		},
+	}
+)
+
+func wrapReplicaSetFunc(f func(*v1beta1.ReplicaSet) metrics.Family) func(interface{}) metrics.Family {
+	return func(obj interface{}) metrics.Family {
+		replicaSet := obj.(*v1beta1.ReplicaSet)
+
+		metricFamily := f(replicaSet)
+
+		for _, m := range metricFamily {
+			m.LabelKeys = append(descReplicaSetLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{replicaSet.Namespace, replicaSet.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createReplicaSetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.ExtensionsV1beta1().ReplicaSets(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.ExtensionsV1beta1().ReplicaSets(ns).Watch(opts)
+		},
+	}
+}

--- a/pkg/collectors/replicaset_test.go
+++ b/pkg/collectors/replicaset_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	rs1Replicas int32 = 5
+	rs2Replicas int32 = 0
+)
+
+func TestReplicaSetCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+	var test = true
+
+	const metadata = `
+		# HELP kube_replicaset_created Unix creation timestamp
+		# TYPE kube_replicaset_created gauge
+	  # HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
+		# TYPE kube_replicaset_metadata_generation gauge
+		# HELP kube_replicaset_status_replicas The number of replicas per ReplicaSet.
+		# TYPE kube_replicaset_status_replicas gauge
+		# HELP kube_replicaset_status_fully_labeled_replicas The number of fully labeled replicas per ReplicaSet.
+		# TYPE kube_replicaset_status_fully_labeled_replicas gauge
+		# HELP kube_replicaset_status_ready_replicas The number of ready replicas per ReplicaSet.
+		# TYPE kube_replicaset_status_ready_replicas gauge
+		# HELP kube_replicaset_status_observed_generation The generation observed by the ReplicaSet controller.
+		# TYPE kube_replicaset_status_observed_generation gauge
+		# HELP kube_replicaset_spec_replicas Number of desired pods for a ReplicaSet.
+		# TYPE kube_replicaset_spec_replicas gauge
+		# HELP kube_replicaset_owner Information about the ReplicaSet's owner.
+		# TYPE kube_replicaset_owner gauge
+	`
+	cases := []generateMetricsTestCase{
+		{
+			Obj: &v1beta1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rs1",
+					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+					Namespace:         "ns1",
+					Generation:        21,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "Deployment",
+							Name:       "dp-name",
+							Controller: &test,
+						},
+					},
+				},
+				Status: v1beta1.ReplicaSetStatus{
+					Replicas:             5,
+					FullyLabeledReplicas: 10,
+					ReadyReplicas:        5,
+					ObservedGeneration:   1,
+				},
+				Spec: v1beta1.ReplicaSetSpec{
+					Replicas: &rs1Replicas,
+				},
+			},
+			Want: `
+				kube_replicaset_created{namespace="ns1",replicaset="rs1"} 1.5e+09
+				kube_replicaset_metadata_generation{namespace="ns1",replicaset="rs1"} 21
+				kube_replicaset_status_replicas{namespace="ns1",replicaset="rs1"} 5
+				kube_replicaset_status_observed_generation{namespace="ns1",replicaset="rs1"} 1
+				kube_replicaset_status_fully_labeled_replicas{namespace="ns1",replicaset="rs1"} 10
+				kube_replicaset_status_ready_replicas{namespace="ns1",replicaset="rs1"} 5
+				kube_replicaset_spec_replicas{namespace="ns1",replicaset="rs1"} 5
+				kube_replicaset_owner{namespace="ns1",owner_is_controller="true",owner_kind="Deployment",owner_name="dp-name",replicaset="rs1"} 1
+`,
+		},
+		{
+			Obj: &v1beta1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "rs2",
+					Namespace:  "ns2",
+					Generation: 14,
+				},
+				Status: v1beta1.ReplicaSetStatus{
+					Replicas:             0,
+					FullyLabeledReplicas: 5,
+					ReadyReplicas:        0,
+					ObservedGeneration:   5,
+				},
+				Spec: v1beta1.ReplicaSetSpec{
+					Replicas: &rs2Replicas,
+				},
+			},
+			Want: `
+				kube_replicaset_metadata_generation{namespace="ns2",replicaset="rs2"} 14
+				kube_replicaset_status_replicas{namespace="ns2",replicaset="rs2"} 0
+				kube_replicaset_status_observed_generation{namespace="ns2",replicaset="rs2"} 5
+				kube_replicaset_status_fully_labeled_replicas{namespace="ns2",replicaset="rs2"} 5
+				kube_replicaset_status_ready_replicas{namespace="ns2",replicaset="rs2"} 0
+				kube_replicaset_spec_replicas{namespace="ns2",replicaset="rs2"} 0
+				kube_replicaset_owner{namespace="ns2",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>",replicaset="rs2"} 1
+			`,
+		},
+	}
+	for i, c := range cases {
+		c.Func = composeMetricGenFuncs(replicaSetMetricFamilies)
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This patch refactors the pod disruption budget and replica set collector to the format introduced in #577.
