### PR TITLE
pkg/collectors: Refactor secret and stateful set collector

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -268,7 +268,18 @@ kube_service_spec_type{namespace="default",service="service0",type=""} 1
 # HELP kube_service_labels Kubernetes labels converted to Prometheus labels.
 kube_service_labels{namespace="default",service="service0"} 1
 # HELP kube_service_spec_external_ip Service external ips. One series for each ip
-# HELP kube_service_status_load_balancer_ingress Service load balancer ingress status`
+# HELP kube_service_status_load_balancer_ingress Service load balancer ingress status
+# HELP kube_statefulset_created Unix creation timestamp
+# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
+# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
+# HELP kube_statefulset_status_replicas_ready The number of ready replicas per StatefulSet.
+# HELP kube_statefulset_status_replicas_updated The number of updated replicas per StatefulSet.
+# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
+# HELP kube_statefulset_replicas Number of desired pods for a StatefulSet.
+# HELP kube_statefulset_metadata_generation Sequence number representing a specific generation of the desired state for the StatefulSet.
+# HELP kube_statefulset_labels Kubernetes labels converted to Prometheus labels.
+# HELP kube_statefulset_status_current_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+# HELP kube_statefulset_status_update_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)`
 
 	got := strings.TrimSpace(string(body))
 

--- a/main_test.go
+++ b/main_test.go
@@ -255,6 +255,11 @@ func TestFullScrapeCycle(t *testing.T) {
 # HELP kube_replicaset_spec_replicas Number of desired pods for a ReplicaSet.
 # HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
 # HELP kube_replicaset_owner Information about the ReplicaSet's owner.
+# HELP kube_secret_info Information about secret.
+# HELP kube_secret_type Type about secret.
+# HELP kube_secret_labels Kubernetes labels converted to Prometheus labels.
+# HELP kube_secret_created Unix creation timestamp
+# HELP kube_secret_metadata_resource_version Resource version representing a specific version of secret.
 # HELP kube_service_info Information about service.
 kube_service_info{namespace="default",service="service0",cluster_ip="",external_name="",load_balancer_ip=""} 1
 # HELP kube_service_created Unix creation timestamp

--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -25,7 +25,7 @@ import (
 	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
 	"k8s.io/kube-state-metrics/pkg/options"
 
-	// apps "k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1beta1"
 	// 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -131,14 +131,13 @@ var availableCollectors = map[string]func(f *Builder) *Collector{
 	"replicasets":            func(b *Builder) *Collector { return b.buildReplicaSetCollector() },
 	"secrets":                func(b *Builder) *Collector { return b.buildSecretCollector() },
 	"services":               func(b *Builder) *Collector { return b.buildServiceCollector() },
+	"statefulsets":           func(b *Builder) *Collector { return b.buildStatefulSetCollector() },
 	// 	"configmaps":               func(b *Builder) *Collector { return b.buildConfigMapCollector() },
 	// 	"cronjobs":                 func(b *Builder) *Collector { return b.buildCronJobCollector() },
 	// 	"endpoints":                func(b *Builder) *Collector { return b.buildEndpointsCollector() },
 	// 	"horizontalpodautoscalers": func(b *Builder) *Collector { return b.buildHPACollector() },
-	// 	"jobs":                   func(b *Builder) *Collector { return b.buildJobCollector() },
 	// 	"replicationcontrollers": func(b *Builder) *Collector { return b.buildReplicationControllerCollector() },
 	// 	"resourcequotas":         func(b *Builder) *Collector { return b.buildResourceQuotaCollector() },
-	//  "statefulsets":           func(b *Builder) *Collector { return b.buildStatefulSetCollector() },
 }
 
 func (b *Builder) buildConfigMapCollector() *Collector {
@@ -347,6 +346,21 @@ func (b *Builder) buildServiceCollector() *Collector {
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Service{}, store, b.namespaces, createServiceListWatch)
+
+	return NewCollector(store)
+}
+
+func (b *Builder) buildStatefulSetCollector() *Collector {
+	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, statefulSetMetricFamilies)
+	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
+
+	helpTexts := extractHelpText(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		helpTexts,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, b.kubeClient, &apps.StatefulSet{}, store, b.namespaces, createStatefulSetListWatch)
 
 	return NewCollector(store)
 }

--- a/pkg/collectors/secret.go
+++ b/pkg/collectors/secret.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metrics"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descSecretLabelsName          = "kube_secret_labels"
+	descSecretLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descSecretLabelsDefaultLabels = []string{"namespace", "secret"}
+
+	secretMetricFamilies = []metrics.FamilyGenerator{
+		metrics.FamilyGenerator{
+			Name: "kube_secret_info",
+			Help: "Information about secret.",
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_secret_info",
+					Value: 1,
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_secret_type",
+			Help: "Type about secret.",
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:        "kube_secret_type",
+					LabelKeys:   []string{"type"},
+					LabelValues: []string{string(s.Type)},
+					Value:       1,
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: descSecretLabelsName,
+			Help: descSecretLabelsHelp,
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metrics.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
+				return metrics.Family{&metrics.Metric{
+					Name:        descSecretLabelsName,
+					LabelKeys:   labelKeys,
+					LabelValues: labelValues,
+					Value:       1,
+				}}
+
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_secret_created",
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metrics.Family {
+				f := metrics.Family{}
+
+				if !s.CreationTimestamp.IsZero() {
+					f = append(f, &metrics.Metric{
+						Name:  "kube_secret_created",
+						Value: float64(s.CreationTimestamp.Unix()),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_secret_metadata_resource_version",
+			Help: "Resource version representing a specific version of secret.",
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:        "kube_secret_metadata_resource_version",
+					LabelKeys:   []string{"resource_version"},
+					LabelValues: []string{string(s.ObjectMeta.ResourceVersion)},
+					Value:       1,
+				}}
+			}),
+		},
+	}
+)
+
+func wrapSecretFunc(f func(*v1.Secret) metrics.Family) func(interface{}) metrics.Family {
+	return func(obj interface{}) metrics.Family {
+		secret := obj.(*v1.Secret)
+
+		metricFamily := f(secret)
+
+		for _, m := range metricFamily {
+			m.LabelKeys = append(descSecretLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{secret.Namespace, secret.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createSecretListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.CoreV1().Secrets(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.CoreV1().Secrets(ns).Watch(opts)
+		},
+	}
+}

--- a/pkg/collectors/secret_test.go
+++ b/pkg/collectors/secret_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSecretCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+
+	startTime := 1501569018
+	metav1StartTime := metav1.Unix(int64(startTime), 0)
+
+	const metadata = `
+        # HELP kube_secret_labels Kubernetes labels converted to Prometheus labels.
+		# TYPE kube_secret_labels gauge
+        # HELP kube_secret_info Information about secret.
+		# TYPE kube_secret_info gauge
+		# HELP kube_secret_type Type about secret.
+		# TYPE kube_secret_type gauge
+		# HELP kube_secret_created Unix creation timestamp
+		# TYPE kube_secret_created gauge
+		# HELP kube_secret_metadata_resource_version Resource version representing a specific version of secret.
+		# TYPE kube_secret_metadata_resource_version gauge
+	`
+	cases := []generateMetricsTestCase{
+		{
+			Obj: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "secret1",
+					Namespace:       "ns1",
+					ResourceVersion: "000000",
+				},
+				Type: v1.SecretTypeOpaque,
+			},
+			Want: `
+				kube_secret_info{namespace="ns1",secret="secret1"} 1
+				kube_secret_type{namespace="ns1",secret="secret1",type="Opaque"} 1
+				kube_secret_metadata_resource_version{namespace="ns1",resource_version="000000",secret="secret1"} 1
+				kube_secret_labels{namespace="ns1",secret="secret1"} 1
+`,
+			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},
+		},
+		{
+			Obj: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "secret2",
+					Namespace:         "ns2",
+					CreationTimestamp: metav1StartTime,
+					ResourceVersion:   "123456",
+				},
+				Type: v1.SecretTypeServiceAccountToken,
+			},
+			Want: `
+				kube_secret_info{namespace="ns2",secret="secret2"} 1
+				kube_secret_type{namespace="ns2",secret="secret2",type="kubernetes.io/service-account-token"} 1
+				kube_secret_created{namespace="ns2",secret="secret2"} 1.501569018e+09
+				kube_secret_metadata_resource_version{namespace="ns2",resource_version="123456",secret="secret2"} 1
+				kube_secret_labels{namespace="ns2",secret="secret2"} 1
+				`,
+			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},
+		},
+		{
+			Obj: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "secret3",
+					Namespace:         "ns3",
+					CreationTimestamp: metav1StartTime,
+					Labels:            map[string]string{"test-3": "test-3"},
+					ResourceVersion:   "abcdef",
+				},
+				Type: v1.SecretTypeDockercfg,
+			},
+			Want: `
+				kube_secret_info{namespace="ns3",secret="secret3"} 1
+				kube_secret_type{namespace="ns3",secret="secret3",type="kubernetes.io/dockercfg"} 1
+				kube_secret_created{namespace="ns3",secret="secret3"} 1.501569018e+09
+				kube_secret_metadata_resource_version{namespace="ns3",resource_version="abcdef",secret="secret3"} 1
+				kube_secret_labels{label_test_3="test-3",namespace="ns3",secret="secret3"} 1
+`,
+			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},
+		},
+	}
+	for i, c := range cases {
+		c.Func = composeMetricGenFuncs(secretMetricFamilies)
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+
+	}
+}

--- a/pkg/collectors/statefulset.go
+++ b/pkg/collectors/statefulset.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"k8s.io/kube-state-metrics/pkg/metrics"
+
+	"k8s.io/api/apps/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descStatefulSetLabelsName          = "kube_statefulset_labels"
+	descStatefulSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descStatefulSetLabelsDefaultLabels = []string{"namespace", "statefulset"}
+
+	statefulSetMetricFamilies = []metrics.FamilyGenerator{
+		metrics.FamilyGenerator{
+			Name: "kube_statefulset_created",
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				f := metrics.Family{}
+
+				if !s.CreationTimestamp.IsZero() {
+					f = append(f, &metrics.Metric{
+						Name:  "kube_statefulset_created",
+						Value: float64(s.CreationTimestamp.Unix()),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_statefulset_status_replicas",
+			Help: "The number of replicas per StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_statefulset_status_replicas",
+					Value: float64(s.Status.Replicas),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_statefulset_status_replicas_current",
+			Help: "The number of current replicas per StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_statefulset_status_replicas_current",
+					Value: float64(s.Status.CurrentReplicas),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_statefulset_status_replicas_ready",
+			Help: "The number of ready replicas per StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_statefulset_status_replicas_ready",
+					Value: float64(s.Status.ReadyReplicas),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_statefulset_status_replicas_updated",
+			Help: "The number of updated replicas per StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_statefulset_status_replicas_updated",
+					Value: float64(s.Status.UpdatedReplicas),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_statefulset_status_observed_generation",
+			Help: "The generation observed by the StatefulSet controller.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				f := metrics.Family{}
+
+				if s.Status.ObservedGeneration != nil {
+					f = append(f, &metrics.Metric{
+						Name:  "kube_statefulset_status_observed_generation",
+						Value: float64(*s.Status.ObservedGeneration),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_statefulset_replicas",
+			Help: "Number of desired pods for a StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				f := metrics.Family{}
+
+				if s.Spec.Replicas != nil {
+					f = append(f, &metrics.Metric{
+						Name:  "kube_statefulset_replicas",
+						Value: float64(*s.Spec.Replicas),
+					})
+				}
+
+				return f
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_statefulset_metadata_generation",
+			Help: "Sequence number representing a specific generation of the desired state for the StatefulSet.",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:  "kube_statefulset_metadata_generation",
+					Value: float64(s.ObjectMeta.Generation),
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: descStatefulSetLabelsName,
+			Help: descStatefulSetLabelsHelp,
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
+				return metrics.Family{&metrics.Metric{
+					Name:        descStatefulSetLabelsName,
+					LabelKeys:   labelKeys,
+					LabelValues: labelValues,
+					Value:       1,
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_statefulset_status_current_revision",
+			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:        "kube_statefulset_status_current_revision",
+					LabelKeys:   []string{"revision"},
+					LabelValues: []string{s.Status.CurrentRevision},
+					Value:       1,
+				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_statefulset_status_update_revision",
+			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
+				return metrics.Family{&metrics.Metric{
+					Name:        "kube_statefulset_status_update_revision",
+					LabelKeys:   []string{"revision"},
+					LabelValues: []string{s.Status.UpdateRevision},
+					Value:       1,
+				}}
+			}),
+		},
+	}
+)
+
+func wrapStatefulSetFunc(f func(*v1beta1.StatefulSet) metrics.Family) func(interface{}) metrics.Family {
+	return func(obj interface{}) metrics.Family {
+		statefulSet := obj.(*v1beta1.StatefulSet)
+
+		metricFamily := f(statefulSet)
+
+		for _, m := range metricFamily {
+			m.LabelKeys = append(descStatefulSetLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{statefulSet.Namespace, statefulSet.Name}, m.LabelValues...)
+		}
+
+		return metricFamily
+	}
+}
+
+func createStatefulSetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.AppsV1beta1().StatefulSets(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.AppsV1beta1().StatefulSets(ns).Watch(opts)
+		},
+	}
+}

--- a/pkg/collectors/statefulset_test.go
+++ b/pkg/collectors/statefulset_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/api/apps/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	statefulSet1Replicas int32 = 3
+	statefulSet2Replicas int32 = 6
+	statefulSet3Replicas int32 = 9
+
+	statefulSet1ObservedGeneration int64 = 1
+	statefulSet2ObservedGeneration int64 = 2
+)
+
+func TestStatefuleSetCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+	const metadata = `
+		# HELP kube_statefulset_created Unix creation timestamp
+		# TYPE kube_statefulset_created gauge
+		# HELP kube_statefulset_status_current_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+		# TYPE kube_statefulset_status_current_revision gauge
+ 		# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
+ 		# TYPE kube_statefulset_status_replicas gauge
+		# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
+		# TYPE kube_statefulset_status_replicas_current gauge
+		# HELP kube_statefulset_status_replicas_ready The number of ready replicas per StatefulSet.
+		# TYPE kube_statefulset_status_replicas_ready gauge
+		# HELP kube_statefulset_status_replicas_updated The number of updated replicas per StatefulSet.
+		# TYPE kube_statefulset_status_replicas_updated gauge
+ 		# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
+ 		# TYPE kube_statefulset_status_observed_generation gauge
+		# HELP kube_statefulset_status_update_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+		# TYPE kube_statefulset_status_update_revision gauge
+ 		# HELP kube_statefulset_replicas Number of desired pods for a StatefulSet.
+ 		# TYPE kube_statefulset_replicas gauge
+ 		# HELP kube_statefulset_metadata_generation Sequence number representing a specific generation of the desired state for the StatefulSet.
+ 		# TYPE kube_statefulset_metadata_generation gauge
+		# HELP kube_statefulset_labels Kubernetes labels converted to Prometheus labels.
+		# TYPE kube_statefulset_labels gauge
+ 	`
+	cases := []generateMetricsTestCase{
+		{
+			Obj: &v1beta1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "statefulset1",
+					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+					Namespace:         "ns1",
+					Labels: map[string]string{
+						"app": "example1",
+					},
+					Generation: 3,
+				},
+				Spec: v1beta1.StatefulSetSpec{
+					Replicas:    &statefulSet1Replicas,
+					ServiceName: "statefulset1service",
+				},
+				Status: v1beta1.StatefulSetStatus{
+					ObservedGeneration: &statefulSet1ObservedGeneration,
+					Replicas:           2,
+					UpdateRevision:     "ur1",
+					CurrentRevision:    "cr1",
+				},
+			},
+			Want: `
+				kube_statefulset_status_update_revision{namespace="ns1",revision="ur1",statefulset="statefulset1"} 1
+				kube_statefulset_created{namespace="ns1",statefulset="statefulset1"} 1.5e+09
+				kube_statefulset_status_current_revision{namespace="ns1",revision="cr1",statefulset="statefulset1"} 1
+ 				kube_statefulset_status_replicas{namespace="ns1",statefulset="statefulset1"} 2
+				kube_statefulset_status_replicas_current{namespace="ns1",statefulset="statefulset1"} 0
+				kube_statefulset_status_replicas_ready{namespace="ns1",statefulset="statefulset1"} 0
+				kube_statefulset_status_replicas_updated{namespace="ns1",statefulset="statefulset1"} 0
+ 				kube_statefulset_status_observed_generation{namespace="ns1",statefulset="statefulset1"} 1
+ 				kube_statefulset_replicas{namespace="ns1",statefulset="statefulset1"} 3
+ 				kube_statefulset_metadata_generation{namespace="ns1",statefulset="statefulset1"} 3
+				kube_statefulset_labels{label_app="example1",namespace="ns1",statefulset="statefulset1"} 1
+`,
+			MetricNames: []string{
+				"kube_statefulset_created",
+				"kube_statefulset_labels",
+				"kube_statefulset_metadata_generation",
+				"kube_statefulset_replicas",
+				"kube_statefulset_status_observed_generation",
+				"kube_statefulset_status_replicas",
+				"kube_statefulset_status_replicas_current",
+				"kube_statefulset_status_replicas_ready",
+				"kube_statefulset_status_replicas_updated",
+				"kube_statefulset_status_update_revision",
+				"kube_statefulset_status_current_revision",
+			},
+		},
+		{
+			Obj: &v1beta1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "statefulset2",
+					Namespace: "ns2",
+					Labels: map[string]string{
+						"app": "example2",
+					},
+					Generation: 21,
+				},
+				Spec: v1beta1.StatefulSetSpec{
+					Replicas:    &statefulSet2Replicas,
+					ServiceName: "statefulset2service",
+				},
+				Status: v1beta1.StatefulSetStatus{
+					CurrentReplicas:    2,
+					ObservedGeneration: &statefulSet2ObservedGeneration,
+					ReadyReplicas:      5,
+					Replicas:           5,
+					UpdatedReplicas:    3,
+					UpdateRevision:     "ur2",
+					CurrentRevision:    "cr2",
+				},
+			},
+			Want: `
+				kube_statefulset_status_update_revision{namespace="ns2",revision="ur2",statefulset="statefulset2"} 1
+ 				kube_statefulset_status_replicas{namespace="ns2",statefulset="statefulset2"} 5
+				kube_statefulset_status_replicas_current{namespace="ns2",statefulset="statefulset2"} 2
+				kube_statefulset_status_replicas_ready{namespace="ns2",statefulset="statefulset2"} 5
+				kube_statefulset_status_replicas_updated{namespace="ns2",statefulset="statefulset2"} 3
+ 				kube_statefulset_status_observed_generation{namespace="ns2",statefulset="statefulset2"} 2
+ 				kube_statefulset_replicas{namespace="ns2",statefulset="statefulset2"} 6
+ 				kube_statefulset_metadata_generation{namespace="ns2",statefulset="statefulset2"} 21
+				kube_statefulset_labels{label_app="example2",namespace="ns2",statefulset="statefulset2"} 1
+				kube_statefulset_status_current_revision{namespace="ns2",revision="cr2",statefulset="statefulset2"} 1
+`,
+			MetricNames: []string{
+				"kube_statefulset_labels",
+				"kube_statefulset_metadata_generation",
+				"kube_statefulset_replicas",
+				"kube_statefulset_status_observed_generation",
+				"kube_statefulset_status_replicas",
+				"kube_statefulset_status_replicas_current",
+				"kube_statefulset_status_replicas_ready",
+				"kube_statefulset_status_replicas_updated",
+				"kube_statefulset_status_update_revision",
+				"kube_statefulset_status_current_revision",
+			},
+		},
+		{
+			Obj: &v1beta1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "statefulset3",
+					Namespace: "ns3",
+					Labels: map[string]string{
+						"app": "example3",
+					},
+					Generation: 36,
+				},
+				Spec: v1beta1.StatefulSetSpec{
+					Replicas:    &statefulSet3Replicas,
+					ServiceName: "statefulset2service",
+				},
+				Status: v1beta1.StatefulSetStatus{
+					ObservedGeneration: nil,
+					Replicas:           7,
+					UpdateRevision:     "ur3",
+					CurrentRevision:    "cr3",
+				},
+			},
+			Want: `
+				kube_statefulset_status_update_revision{namespace="ns3",revision="ur3",statefulset="statefulset3"} 1
+ 				kube_statefulset_status_replicas{namespace="ns3",statefulset="statefulset3"} 7
+				kube_statefulset_status_replicas_current{namespace="ns3",statefulset="statefulset3"} 0
+				kube_statefulset_status_replicas_ready{namespace="ns3",statefulset="statefulset3"} 0
+				kube_statefulset_status_replicas_updated{namespace="ns3",statefulset="statefulset3"} 0
+ 				kube_statefulset_replicas{namespace="ns3",statefulset="statefulset3"} 9
+ 				kube_statefulset_metadata_generation{namespace="ns3",statefulset="statefulset3"} 36
+				kube_statefulset_labels{label_app="example3",namespace="ns3",statefulset="statefulset3"} 1
+				kube_statefulset_status_current_revision{namespace="ns3",revision="cr3",statefulset="statefulset3"} 1
+ 			`,
+			MetricNames: []string{
+				"kube_statefulset_labels",
+				"kube_statefulset_metadata_generation",
+				"kube_statefulset_replicas",
+				"kube_statefulset_status_replicas",
+				"kube_statefulset_status_replicas_current",
+				"kube_statefulset_status_replicas_ready",
+				"kube_statefulset_status_replicas_updated",
+				"kube_statefulset_status_update_revision",
+				"kube_statefulset_status_current_revision",
+			},
+		},
+	}
+	for i, c := range cases {
+		c.Func = composeMetricGenFuncs(statefulSetMetricFamilies)
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This patch refactors the secret and stateful set collector to the format introduced in #577.
