### PR TITLE
*: Reintroduce TYPE text

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http/httptest"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -106,7 +107,7 @@ func TestFullScrapeCycle(t *testing.T) {
 
 	kubeClient := fake.NewSimpleClientset()
 
-	err := service(kubeClient, 0)
+	err := pod(kubeClient, 0)
 	if err != nil {
 		t.Fatalf("failed to insert sample pod %v", err.Error())
 	}
@@ -140,173 +141,152 @@ func TestFullScrapeCycle(t *testing.T) {
 
 	body, _ := ioutil.ReadAll(resp.Body)
 
-	expected := `# HELP kube_configmap_info Information about configmap.
-# HELP kube_configmap_created Unix creation timestamp
-# HELP kube_configmap_metadata_resource_version Resource version representing a specific version of the configmap.
-# HELP kube_cronjob_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_cronjob_info Info about cronjob.
-# HELP kube_cronjob_created Unix creation timestamp
-# HELP kube_cronjob_status_active Active holds pointers to currently running jobs.
-# HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
-# HELP kube_cronjob_spec_suspend Suspend flag tells the controller to suspend subsequent executions.
-# HELP kube_cronjob_spec_starting_deadline_seconds Deadline in seconds for starting the job if it misses scheduled time for any reason.
-# HELP kube_cronjob_next_schedule_time Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.
-# HELP kube_daemonset_created Unix creation timestamp
-# HELP kube_daemonset_status_current_number_scheduled The number of nodes running at least one daemon pod and are supposed to.
-# HELP kube_daemonset_status_desired_number_scheduled The number of nodes that should be running the daemon pod.
-# HELP kube_daemonset_status_number_available The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available
-# HELP kube_daemonset_status_number_misscheduled The number of nodes running a daemon pod but are not supposed to.
-# HELP kube_daemonset_status_number_ready The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-# HELP kube_daemonset_status_number_unavailable The number of nodes that should be running the daemon pod and have none of the daemon pod running and available
-# HELP kube_daemonset_updated_number_scheduled The total number of nodes that are running updated daemon pod
-# HELP kube_daemonset_metadata_generation Sequence number representing a specific generation of the desired state.
-# HELP kube_daemonset_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_deployment_created Unix creation timestamp
-# HELP kube_deployment_status_replicas The number of replicas per deployment.
-# HELP kube_deployment_status_replicas_available The number of available replicas per deployment.
-# HELP kube_deployment_status_replicas_unavailable The number of unavailable replicas per deployment.
-# HELP kube_deployment_status_replicas_updated The number of updated replicas per deployment.
-# HELP kube_deployment_status_observed_generation The generation observed by the deployment controller.
-# HELP kube_deployment_spec_replicas Number of desired pods for a deployment.
-# HELP kube_deployment_spec_paused Whether the deployment is paused and will not be processed by the deployment controller.
-# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable Maximum number of unavailable replicas during a rolling update of a deployment.
-# HELP kube_deployment_spec_strategy_rollingupdate_max_surge Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
-# HELP kube_deployment_metadata_generation Sequence number representing a specific generation of the desired state.
-# HELP kube_deployment_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_endpoint_info Information about endpoint.
-# HELP kube_endpoint_created Unix creation timestamp
-# HELP kube_endpoint_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_endpoint_address_available Number of addresses available in endpoint.
-# HELP kube_endpoint_address_not_ready Number of addresses not ready in endpoint
-# HELP kube_hpa_metadata_generation The generation observed by the HorizontalPodAutoscaler controller.
-# HELP kube_hpa_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
-# HELP kube_hpa_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
-# HELP kube_hpa_status_current_replicas Current number of replicas of pods managed by this autoscaler.
-# HELP kube_hpa_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
-# HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_hpa_status_condition The condition of this autoscaler.
-# HELP kube_job_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_job_info Information about job.
-# HELP kube_job_created Unix creation timestamp
-# HELP kube_job_spec_parallelism The maximum desired number of pods the job should run at any given time.
-# HELP kube_job_spec_completions The desired number of successfully finished pods the job should be run with.
-# HELP kube_job_spec_active_deadline_seconds The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.
-# HELP kube_job_status_succeeded The number of pods which reached Phase Succeeded.
-# HELP kube_job_status_failed The number of pods which reached Phase Failed.
-# HELP kube_job_status_active The number of actively running pods.
-# HELP kube_job_complete The job has completed its execution.
-# HELP kube_job_failed The job has failed its execution.
-# HELP kube_job_status_start_time StartTime represents time when the job was acknowledged by the Job Manager.
-# HELP kube_job_status_completion_time CompletionTime represents time when the job was completed.
-# HELP kube_limitrange Information about limit range.
-# HELP kube_limitrange_created Unix creation timestamp
-# HELP kube_namespace_created Unix creation timestamp
-# HELP kube_namespace_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_namespace_annotations Kubernetes annotations converted to Prometheus labels.
-# HELP kube_namespace_status_phase kubernetes namespace status phase.
-# HELP kube_node_info Information about a cluster node.
-# HELP kube_node_created Unix creation timestamp
-# HELP kube_node_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_node_spec_unschedulable Whether a node can schedule new pods.
-# HELP kube_node_spec_taint The taint of a cluster node.
-# HELP kube_node_status_condition The condition of a cluster node.
-# HELP kube_node_status_phase The phase the node is currently in.
-# HELP kube_node_status_capacity The capacity for different resources of a node.
-# HELP kube_node_status_capacity_pods The total pod resources of the node.
-# HELP kube_node_status_capacity_cpu_cores The total CPU resources of the node.
-# HELP kube_node_status_capacity_memory_bytes The total memory resources of the node.
-# HELP kube_node_status_allocatable The allocatable for different resources of a node that are available for scheduling.
-# HELP kube_node_status_allocatable_pods The pod resources of a node that are available for scheduling.
-# HELP kube_node_status_allocatable_cpu_cores The CPU resources of a node that are available for scheduling.
-# HELP kube_node_status_allocatable_memory_bytes The memory resources of a node that are available for scheduling.
-# HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
-# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
-# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
-# HELP kube_persistentvolume_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_persistentvolume_status_phase The phase indicates if a volume is available, bound to a claim, or released by a claim.
-# HELP kube_persistentvolume_info Information about persistentvolume.
-# HELP kube_poddisruptionbudget_created Unix creation timestamp
-# HELP kube_poddisruptionbudget_status_current_healthy Current number of healthy pods
-# HELP kube_poddisruptionbudget_status_desired_healthy Minimum desired number of healthy pods
-# HELP kube_poddisruptionbudget_status_pod_disruptions_allowed Number of pod disruptions that are currently allowed
-# HELP kube_poddisruptionbudget_status_expected_pods Total number of pods counted by this disruption budget
-# HELP kube_poddisruptionbudget_status_observed_generation Most recent generation observed when updating this PDB status
-# HELP kube_pod_info Information about pod.
+	expected := `# HELP kube_pod_info Information about pod.
+# TYPE kube_pod_info gauge
+kube_pod_info{namespace="default",pod="pod0",host_ip="1.1.1.1",pod_ip="1.2.3.4",uid="abc-123-xxx",node="node1",created_by_kind="<none>",created_by_name="<none>"} 1
 # HELP kube_pod_start_time Start time in unix timestamp for a pod.
+# TYPE kube_pod_start_time gauge
 # HELP kube_pod_completion_time Completion time in unix timestamp for a pod.
+# TYPE kube_pod_completion_time gauge
 # HELP kube_pod_owner Information about the Pod's owner.
+# TYPE kube_pod_owner gauge
+kube_pod_owner{namespace="default",pod="pod0",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
 # HELP kube_pod_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_pod_labels gauge
+kube_pod_labels{namespace="default",pod="pod0"} 1
 # HELP kube_pod_created Unix creation timestamp
+# TYPE kube_pod_created gauge
+kube_pod_created{namespace="default",pod="pod0"} 1.5e+09
 # HELP kube_pod_status_scheduled_time Unix timestamp when pod moved into scheduled status
+# TYPE kube_pod_status_scheduled_time gauge
 # HELP kube_pod_status_phase The pods current phase.
+# TYPE kube_pod_status_phase gauge
+kube_pod_status_phase{namespace="default",pod="pod0",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="pod0",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="pod0",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="pod0",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="pod0",phase="Unknown"} 0
 # HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
+# TYPE kube_pod_status_ready gauge
 # HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
+# TYPE kube_pod_status_scheduled gauge
 # HELP kube_pod_container_info Information about a container in a pod.
+# TYPE kube_pod_container_info gauge
+kube_pod_container_info{namespace="default",pod="pod0",container="container2",image="k8s.gcr.io/hyperkube2",image_id="docker://sha256:bbb",container_id="docker://cd456"} 1
+kube_pod_container_info{namespace="default",pod="pod0",container="container3",image="k8s.gcr.io/hyperkube3",image_id="docker://sha256:ccc",container_id="docker://ef789"} 1
 # HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
+# TYPE kube_pod_container_status_waiting gauge
+kube_pod_container_status_waiting{namespace="default",pod="pod0",container="container2"} 1
+kube_pod_container_status_waiting{namespace="default",pod="pod0",container="container3"} 0
 # HELP kube_pod_container_status_waiting_reason Describes the reason the container is currently in waiting state.
+# TYPE kube_pod_container_status_waiting_reason gauge
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="CrashLoopBackOff"} 1
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="ImagePullBackOff"} 0
 # HELP kube_pod_container_status_running Describes whether the container is currently in running state.
+# TYPE kube_pod_container_status_running gauge
+kube_pod_container_status_running{namespace="default",pod="pod0",container="container2"} 0
+kube_pod_container_status_running{namespace="default",pod="pod0",container="container3"} 0
 # HELP kube_pod_container_status_terminated Describes whether the container is currently in terminated state.
+# TYPE kube_pod_container_status_terminated gauge
+kube_pod_container_status_terminated{namespace="default",pod="pod0",container="container2"} 0
+kube_pod_container_status_terminated{namespace="default",pod="pod0",container="container3"} 0
 # HELP kube_pod_container_status_terminated_reason Describes the reason the container is currently in terminated state.
+# TYPE kube_pod_container_status_terminated_reason gauge
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="ContainerCannotRun"} 0
 # HELP kube_pod_container_status_last_terminated_reason Describes the last reason the container was in terminated state.
+# TYPE kube_pod_container_status_last_terminated_reason gauge
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="OOMKilled"} 1
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="ContainerCannotRun"} 0
 # HELP kube_pod_container_status_ready Describes whether the containers readiness check succeeded.
+# TYPE kube_pod_container_status_ready gauge
+kube_pod_container_status_ready{namespace="default",pod="pod0",container="container2"} 0
+kube_pod_container_status_ready{namespace="default",pod="pod0",container="container3"} 0
 # HELP kube_pod_container_status_restarts_total The number of container restarts per container.
+# TYPE kube_pod_container_status_restarts_total counter
+kube_pod_container_status_restarts_total{namespace="default",pod="pod0",container="container2"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="pod0",container="container3"} 0
 # HELP kube_pod_container_resource_requests The number of requested request resource by a container.
+# TYPE kube_pod_container_resource_requests gauge
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="nvidia_com_gpu",unit="integer"} 1
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="cpu",unit="core"} 0.2
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="memory",unit="byte"} 1e+08
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="ephemeral_storage",unit="byte"} 3e+08
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="storage",unit="byte"} 4e+08
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="cpu",unit="core"} 0.3
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="memory",unit="byte"} 2e+08
 # HELP kube_pod_container_resource_limits The number of requested limit resource by a container.
+# TYPE kube_pod_container_resource_limits gauge
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="nvidia_com_gpu",unit="integer"} 1
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="cpu",unit="core"} 0.2
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="memory",unit="byte"} 1e+08
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="ephemeral_storage",unit="byte"} 3e+08
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="storage",unit="byte"} 4e+08
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="memory",unit="byte"} 2e+08
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="cpu",unit="core"} 0.3
 # HELP kube_pod_container_resource_requests_cpu_cores The number of requested cpu cores by a container.
+# TYPE kube_pod_container_resource_requests_cpu_cores gauge
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="pod0",container="pod1_con1",node="node1"} 0.2
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="pod0",container="pod1_con2",node="node1"} 0.3
 # HELP kube_pod_container_resource_requests_memory_bytes The number of requested memory bytes by a container.
+# TYPE kube_pod_container_resource_requests_memory_bytes gauge
+kube_pod_container_resource_requests_memory_bytes{namespace="default",pod="pod0",container="pod1_con1",node="node1"} 1e+08
+kube_pod_container_resource_requests_memory_bytes{namespace="default",pod="pod0",container="pod1_con2",node="node1"} 2e+08
 # HELP kube_pod_container_resource_limits_cpu_cores The limit on cpu cores to be used by a container.
+# TYPE kube_pod_container_resource_limits_cpu_cores gauge
+kube_pod_container_resource_limits_cpu_cores{namespace="default",pod="pod0",container="pod1_con1",node="node1"} 0.2
+kube_pod_container_resource_limits_cpu_cores{namespace="default",pod="pod0",container="pod1_con2",node="node1"} 0.3
 # HELP kube_pod_container_resource_limits_memory_bytes The limit on memory to be used by a container in bytes.
+# TYPE kube_pod_container_resource_limits_memory_bytes gauge
+kube_pod_container_resource_limits_memory_bytes{namespace="default",pod="pod0",container="pod1_con1",node="node1"} 1e+08
+kube_pod_container_resource_limits_memory_bytes{namespace="default",pod="pod0",container="pod1_con2",node="node1"} 2e+08
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
+# TYPE kube_pod_spec_volumes_persistentvolumeclaims_info gauge
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_readonly Describes whether a persistentvolumeclaim is mounted read only.
-# HELP kube_replicaset_created Unix creation timestamp
-# HELP kube_replicaset_status_replicas The number of replicas per ReplicaSet.
-# HELP kube_replicaset_status_fully_labeled_replicas The number of fully labeled replicas per ReplicaSet.
-# HELP kube_replicaset_status_ready_replicas The number of ready replicas per ReplicaSet.
-# HELP kube_replicaset_status_observed_generation The generation observed by the ReplicaSet controller.
-# HELP kube_replicaset_spec_replicas Number of desired pods for a ReplicaSet.
-# HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
-# HELP kube_replicaset_owner Information about the ReplicaSet's owner.
-# HELP kube_replicationcontroller_created Unix creation timestamp
-# HELP kube_replicationcontroller_status_replicas The number of replicas per ReplicationController.
-# HELP kube_replicationcontroller_status_fully_labeled_replicas The number of fully labeled replicas per ReplicationController.
-# HELP kube_replicationcontroller_status_ready_replicas The number of ready replicas per ReplicationController.
-# HELP kube_replicationcontroller_status_available_replicas The number of available replicas per ReplicationController.
-# HELP kube_replicationcontroller_status_observed_generation The generation observed by the ReplicationController controller.
-# HELP kube_replicationcontroller_spec_replicas Number of desired pods for a ReplicationController.
-# HELP kube_replicationcontroller_metadata_generation Sequence number representing a specific generation of the desired state.
-# HELP kube_resourcequota_created Unix creation timestamp
-# HELP kube_resourcequota Information about resource quota.
-# HELP kube_secret_info Information about secret.
-# HELP kube_secret_type Type about secret.
-# HELP kube_secret_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_secret_created Unix creation timestamp
-# HELP kube_secret_metadata_resource_version Resource version representing a specific version of secret.
-# HELP kube_service_info Information about service.
-kube_service_info{namespace="default",service="service0",cluster_ip="",external_name="",load_balancer_ip=""} 1
-# HELP kube_service_created Unix creation timestamp
-# HELP kube_service_spec_type Type about service.
-kube_service_spec_type{namespace="default",service="service0",type=""} 1
-# HELP kube_service_labels Kubernetes labels converted to Prometheus labels.
-kube_service_labels{namespace="default",service="service0"} 1
-# HELP kube_service_spec_external_ip Service external ips. One series for each ip
-# HELP kube_service_status_load_balancer_ingress Service load balancer ingress status
-# HELP kube_statefulset_created Unix creation timestamp
-# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
-# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
-# HELP kube_statefulset_status_replicas_ready The number of ready replicas per StatefulSet.
-# HELP kube_statefulset_status_replicas_updated The number of updated replicas per StatefulSet.
-# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
-# HELP kube_statefulset_replicas Number of desired pods for a StatefulSet.
-# HELP kube_statefulset_metadata_generation Sequence number representing a specific generation of the desired state for the StatefulSet.
-# HELP kube_statefulset_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_statefulset_status_current_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
-# HELP kube_statefulset_status_update_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)`
+# TYPE kube_pod_spec_volumes_persistentvolumeclaims_readonly gauge`
 
-	got := strings.TrimSpace(string(body))
+	expectedSplit := strings.Split(strings.TrimSpace(expected), "\n")
+	sort.Strings(expectedSplit)
 
-	if expected != got {
-		t.Fatalf("expected:\n%v\nbut got:\n%v", expected, got)
+	gotSplit := strings.Split(strings.TrimSpace(string(body)), "\n")
+
+	gotFiltered := []string{}
+	for _, l := range gotSplit {
+		if strings.Contains(l, "kube_pod_") {
+			gotFiltered = append(gotFiltered, l)
+		}
+	}
+
+	sort.Strings(gotFiltered)
+
+	if len(expectedSplit) != len(gotFiltered) {
+		t.Fatal("expected different output length")
+	}
+
+	for i := 0; i < len(expectedSplit); i++ {
+		if expectedSplit[i] != gotFiltered[i] {
+			t.Fatalf("expected %v, but got %v", expectedSplit[i], gotFiltered[i])
+		}
 	}
 }
 

--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -142,10 +142,10 @@ func (b *Builder) buildConfigMapCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, configMapMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ConfigMap{}, store, b.namespaces, createConfigMapListWatch)
@@ -157,10 +157,10 @@ func (b *Builder) buildCronJobCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, cronJobMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &batchv1beta1.CronJob{}, store, b.namespaces, createCronJobListWatch)
@@ -172,10 +172,10 @@ func (b *Builder) buildDaemonSetCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, daemonSetMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.DaemonSet{}, store, b.namespaces, createDaemonSetListWatch)
@@ -187,10 +187,10 @@ func (b *Builder) buildDeploymentCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, deploymentMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.Deployment{}, store, b.namespaces, createDeploymentListWatch)
@@ -202,10 +202,10 @@ func (b *Builder) buildEndpointsCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, endpointMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Endpoints{}, store, b.namespaces, createEndpointsListWatch)
@@ -217,10 +217,10 @@ func (b *Builder) buildHPACollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, hpaMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &autoscaling.HorizontalPodAutoscaler{}, store, b.namespaces, createHPAListWatch)
@@ -232,10 +232,10 @@ func (b *Builder) buildJobCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, jobMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &batchv1.Job{}, store, b.namespaces, createJobListWatch)
@@ -247,10 +247,10 @@ func (b *Builder) buildLimitRangeCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, limitRangeMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.LimitRange{}, store, b.namespaces, createLimitRangeListWatch)
@@ -262,10 +262,10 @@ func (b *Builder) buildNamespaceCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, namespaceMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Namespace{}, store, b.namespaces, createNamespaceListWatch)
@@ -277,10 +277,10 @@ func (b *Builder) buildNodeCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, nodeMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Node{}, store, b.namespaces, createNodeListWatch)
@@ -292,10 +292,10 @@ func (b *Builder) buildPersistentVolumeClaimCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, persistentVolumeClaimMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolumeClaim{}, store, b.namespaces, createPersistentVolumeClaimListWatch)
@@ -307,10 +307,10 @@ func (b *Builder) buildPersistentVolumeCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, persistentVolumeMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolume{}, store, b.namespaces, createPersistentVolumeListWatch)
@@ -322,10 +322,10 @@ func (b *Builder) buildPodDisruptionBudgetCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, podDisruptionBudgetMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &policy.PodDisruptionBudget{}, store, b.namespaces, createPodDisruptionBudgetListWatch)
@@ -337,10 +337,10 @@ func (b *Builder) buildReplicaSetCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, replicaSetMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.ReplicaSet{}, store, b.namespaces, createReplicaSetListWatch)
@@ -352,10 +352,10 @@ func (b *Builder) buildReplicationControllerCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, replicationControllerMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ReplicationController{}, store, b.namespaces, createReplicationControllerListWatch)
@@ -367,10 +367,10 @@ func (b *Builder) buildResourceQuotaCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, resourceQuotaMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ResourceQuota{}, store, b.namespaces, createResourceQuotaListWatch)
@@ -382,10 +382,10 @@ func (b *Builder) buildSecretCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, secretMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Secret{}, store, b.namespaces, createSecretListWatch)
@@ -397,10 +397,10 @@ func (b *Builder) buildServiceCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, serviceMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Service{}, store, b.namespaces, createServiceListWatch)
@@ -412,10 +412,10 @@ func (b *Builder) buildStatefulSetCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, statefulSetMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &apps.StatefulSet{}, store, b.namespaces, createStatefulSetListWatch)
@@ -427,10 +427,10 @@ func (b *Builder) buildPodCollector() *Collector {
 	filteredMetricFamilies := filterMetricFamilies(b.whiteBlackList, podMetricFamilies)
 	composedMetricGenFuncs := composeMetricGenFuncs(filteredMetricFamilies)
 
-	helpTexts := extractHelpText(filteredMetricFamilies)
+	familyHeaders := extractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
-		helpTexts,
+		familyHeaders,
 		composedMetricGenFuncs,
 	)
 	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Pod{}, store, b.namespaces, createPodListWatch)
@@ -438,13 +438,26 @@ func (b *Builder) buildPodCollector() *Collector {
 	return NewCollector(store)
 }
 
-func extractHelpText(families []metrics.FamilyGenerator) []string {
-	help := make([]string, len(families))
+func extractMetricFamilyHeaders(families []metrics.FamilyGenerator) []string {
+	headers := make([]string, len(families))
+
 	for i, f := range families {
-		help[i] = f.Name + " " + f.Help
+		header := strings.Builder{}
+
+		header.WriteString("# HELP ")
+		header.WriteString(f.Name)
+		header.WriteByte(' ')
+		header.WriteString(f.Help)
+		header.WriteByte('\n')
+		header.WriteString("# TYPE ")
+		header.WriteString(f.Name)
+		header.WriteByte(' ')
+		header.WriteString(string(f.Type))
+
+		headers[i] = header.String()
 	}
 
-	return help
+	return headers
 }
 
 // composeMetricGenFuncs takes a slice of metric families and returns a function

--- a/pkg/collectors/configmap.go
+++ b/pkg/collectors/configmap.go
@@ -33,6 +33,7 @@ var (
 	configMapMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_configmap_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about configmap.",
 			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metrics.Family {
 				return metrics.Family{
@@ -47,6 +48,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_configmap_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metrics.Family {
 				f := metrics.Family{}
@@ -65,6 +67,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_configmap_metadata_resource_version",
+			Type: metrics.MetricTypeGauge,
 			Help: "Resource version representing a specific version of the configmap.",
 			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metrics.Family {
 				return metrics.Family{

--- a/pkg/collectors/cronjob.go
+++ b/pkg/collectors/cronjob.go
@@ -40,6 +40,7 @@ var (
 	cronJobMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: descCronJobLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descCronJobLabelsHelp,
 			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
@@ -55,6 +56,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_cronjob_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Info about cronjob.",
 			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
 				return metrics.Family{
@@ -69,6 +71,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_cronjob_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
 				f := metrics.Family{}
@@ -86,6 +89,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_cronjob_status_active",
+			Type: metrics.MetricTypeGauge,
 			Help: "Active holds pointers to currently running jobs.",
 			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
 				return metrics.Family{
@@ -100,6 +104,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_cronjob_status_last_schedule_time",
+			Type: metrics.MetricTypeGauge,
 			Help: "LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
 			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
 				f := metrics.Family{}
@@ -118,6 +123,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_cronjob_spec_suspend",
+			Type: metrics.MetricTypeGauge,
 			Help: "Suspend flag tells the controller to suspend subsequent executions.",
 			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
 				f := metrics.Family{}
@@ -136,6 +142,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_cronjob_spec_starting_deadline_seconds",
+			Type: metrics.MetricTypeGauge,
 			Help: "Deadline in seconds for starting the job if it misses scheduled time for any reason.",
 			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
 				f := metrics.Family{}
@@ -155,6 +162,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_cronjob_next_schedule_time",
+			Type: metrics.MetricTypeGauge,
 			Help: "Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
 			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metrics.Family {
 				f := metrics.Family{}

--- a/pkg/collectors/daemonset.go
+++ b/pkg/collectors/daemonset.go
@@ -35,6 +35,7 @@ var (
 	daemonSetMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_daemonset_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metrics.Family {
 				f := metrics.Family{}
@@ -53,6 +54,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_daemonset_status_current_number_scheduled",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of nodes running at least one daemon pod and are supposed to.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metrics.Family {
 				return metrics.Family{
@@ -67,6 +69,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_daemonset_status_desired_number_scheduled",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -79,6 +82,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_daemonset_status_number_available",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -91,6 +95,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_daemonset_status_number_misscheduled",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of nodes running a daemon pod but are not supposed to.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -103,6 +108,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_daemonset_status_number_ready",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -115,6 +121,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_daemonset_status_number_unavailable",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -127,6 +134,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_daemonset_updated_number_scheduled",
+			Type: metrics.MetricTypeGauge,
 			Help: "The total number of nodes that are running updated daemon pod",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -137,6 +145,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_daemonset_metadata_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -149,6 +158,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: descDaemonSetLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descDaemonSetLabelsHelp,
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.ObjectMeta.Labels)

--- a/pkg/collectors/deployment.go
+++ b/pkg/collectors/deployment.go
@@ -36,6 +36,7 @@ var (
 	deploymentMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				f := metrics.Family{}
@@ -52,6 +53,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_status_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of replicas per deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -62,6 +64,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_status_replicas_available",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of available replicas per deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -72,6 +75,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_status_replicas_unavailable",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of unavailable replicas per deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -82,6 +86,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_status_replicas_updated",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of updated replicas per deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -92,6 +97,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_status_observed_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "The generation observed by the deployment controller.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -102,6 +108,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_spec_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "Number of desired pods for a deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -112,6 +119,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_spec_paused",
+			Type: metrics.MetricTypeGauge,
 			Help: "Whether the deployment is paused and will not be processed by the deployment controller.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -122,6 +130,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_spec_strategy_rollingupdate_max_unavailable",
+			Type: metrics.MetricTypeGauge,
 			Help: "Maximum number of unavailable replicas during a rolling update of a deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				if d.Spec.Strategy.RollingUpdate == nil {
@@ -141,6 +150,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_spec_strategy_rollingupdate_max_surge",
+			Type: metrics.MetricTypeGauge,
 			Help: "Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				if d.Spec.Strategy.RollingUpdate == nil {
@@ -160,6 +170,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_deployment_metadata_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -170,6 +181,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: descDeploymentLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descDeploymentLabelsHelp,
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)

--- a/pkg/collectors/endpoint.go
+++ b/pkg/collectors/endpoint.go
@@ -35,6 +35,7 @@ var (
 	endpointMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_endpoint_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about endpoint.",
 			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -45,6 +46,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_endpoint_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) metrics.Family {
 				f := metrics.Family{}
@@ -61,6 +63,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: descEndpointLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descEndpointLabelsHelp,
 			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(e.Labels)
@@ -74,6 +77,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_endpoint_address_available",
+			Type: metrics.MetricTypeGauge,
 			Help: "Number of addresses available in endpoint.",
 			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) metrics.Family {
 				var available int
@@ -89,6 +93,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_endpoint_address_not_ready",
+			Type: metrics.MetricTypeGauge,
 			Help: "Number of addresses not ready in endpoint",
 			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) metrics.Family {
 				var notReady int

--- a/pkg/collectors/hpa.go
+++ b/pkg/collectors/hpa.go
@@ -35,6 +35,7 @@ var (
 	hpaMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_hpa_metadata_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "The generation observed by the HorizontalPodAutoscaler controller.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -45,6 +46,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_hpa_spec_max_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -55,6 +57,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_hpa_spec_min_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "Lower limit for the number of pods that can be set by the autoscaler, default 1.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -65,6 +68,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_hpa_status_current_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "Current number of replicas of pods managed by this autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -75,6 +79,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_hpa_status_desired_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "Desired number of replicas of pods managed by this autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -85,6 +90,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: descHorizontalPodAutoscalerLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descHorizontalPodAutoscalerLabelsHelp,
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(a.Labels)
@@ -98,6 +104,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_hpa_status_condition",
+			Type: metrics.MetricTypeGauge,
 			Help: "The condition of this autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metrics.Family {
 				f := metrics.Family{}

--- a/pkg/collectors/job.go
+++ b/pkg/collectors/job.go
@@ -35,6 +35,7 @@ var (
 	jobMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: descJobLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descJobLabelsHelp,
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
@@ -48,6 +49,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about job.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -58,6 +60,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				f := metrics.Family{}
@@ -74,6 +77,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_spec_parallelism",
+			Type: metrics.MetricTypeGauge,
 			Help: "The maximum desired number of pods the job should run at any given time.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				f := metrics.Family{}
@@ -90,6 +94,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_spec_completions",
+			Type: metrics.MetricTypeGauge,
 			Help: "The desired number of successfully finished pods the job should be run with.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				f := metrics.Family{}
@@ -106,6 +111,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_spec_active_deadline_seconds",
+			Type: metrics.MetricTypeGauge,
 			Help: "The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				f := metrics.Family{}
@@ -122,6 +128,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_status_succeeded",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of pods which reached Phase Succeeded.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -132,6 +139,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_status_failed",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of pods which reached Phase Failed.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -142,6 +150,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_status_active",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of actively running pods.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -152,6 +161,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_complete",
+			Type: metrics.MetricTypeGauge,
 			Help: "The job has completed its execution.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				f := metrics.Family{}
@@ -172,6 +182,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_failed",
+			Type: metrics.MetricTypeGauge,
 			Help: "The job has failed its execution.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				f := metrics.Family{}
@@ -193,6 +204,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_status_start_time",
+			Type: metrics.MetricTypeGauge,
 			Help: "StartTime represents time when the job was acknowledged by the Job Manager.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				f := metrics.Family{}
@@ -209,6 +221,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_job_status_completion_time",
+			Type: metrics.MetricTypeGauge,
 			Help: "CompletionTime represents time when the job was completed.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metrics.Family {
 				f := metrics.Family{}

--- a/pkg/collectors/limitrange.go
+++ b/pkg/collectors/limitrange.go
@@ -33,6 +33,7 @@ var (
 	limitRangeMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_limitrange",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about limit range.",
 			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) metrics.Family {
 				f := metrics.Family{}
@@ -85,6 +86,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_limitrange_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) metrics.Family {
 				f := metrics.Family{}

--- a/pkg/collectors/namespace.go
+++ b/pkg/collectors/namespace.go
@@ -39,6 +39,7 @@ var (
 	namespaceMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_namespace_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) metrics.Family {
 				f := metrics.Family{}
@@ -54,6 +55,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: descNamespaceLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descNamespaceLabelsHelp,
 			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
@@ -67,6 +69,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: descNamespaceAnnotationsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descNamespaceAnnotationsHelp,
 			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) metrics.Family {
 				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(n.Annotations)
@@ -80,6 +83,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_namespace_status_phase",
+			Type: metrics.MetricTypeGauge,
 			Help: "kubernetes namespace status phase.",
 			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) metrics.Family {
 				families := metrics.Family{

--- a/pkg/collectors/node.go
+++ b/pkg/collectors/node.go
@@ -37,6 +37,7 @@ var (
 	nodeMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_node_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about a cluster node.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -63,6 +64,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -79,6 +81,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: descNodeLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descNodeLabelsHelp,
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
@@ -92,6 +95,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_spec_unschedulable",
+			Type: metrics.MetricTypeGauge,
 			Help: "Whether a node can schedule new pods.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -102,6 +106,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_spec_taint",
+			Type: metrics.MetricTypeGauge,
 			Help: "The taint of a cluster node.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -127,6 +132,7 @@ var (
 		// conditions in future.
 		metrics.FamilyGenerator{
 			Name: "kube_node_status_condition",
+			Type: metrics.MetricTypeGauge,
 			Help: "The condition of a cluster node.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -147,6 +153,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_status_phase",
+			Type: metrics.MetricTypeGauge,
 			Help: "The phase the node is currently in.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -179,6 +186,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_status_capacity",
+			Type: metrics.MetricTypeGauge,
 			Help: "The capacity for different resources of a node.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -255,6 +263,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_status_capacity_pods",
+			Type: metrics.MetricTypeGauge,
 			Help: "The total pod resources of the node.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -272,6 +281,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_status_capacity_cpu_cores",
+			Type: metrics.MetricTypeGauge,
 			Help: "The total CPU resources of the node.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -289,6 +299,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_status_capacity_memory_bytes",
+			Type: metrics.MetricTypeGauge,
 			Help: "The total memory resources of the node.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -306,6 +317,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_status_allocatable",
+			Type: metrics.MetricTypeGauge,
 			Help: "The allocatable for different resources of a node that are available for scheduling.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -383,6 +395,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_status_allocatable_pods",
+			Type: metrics.MetricTypeGauge,
 			Help: "The pod resources of a node that are available for scheduling.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -400,6 +413,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_status_allocatable_cpu_cores",
+			Type: metrics.MetricTypeGauge,
 			Help: "The CPU resources of a node that are available for scheduling.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}
@@ -417,6 +431,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_node_status_allocatable_memory_bytes",
+			Type: metrics.MetricTypeGauge,
 			Help: "The memory resources of a node that are available for scheduling.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
 				f := metrics.Family{}

--- a/pkg/collectors/persistentvolume.go
+++ b/pkg/collectors/persistentvolume.go
@@ -35,6 +35,7 @@ var (
 	persistentVolumeMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: descPersistentVolumeLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descPersistentVolumeLabelsHelp,
 			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
@@ -48,6 +49,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_persistentvolume_status_phase",
+			Type: metrics.MetricTypeGauge,
 			Help: "The phase indicates if a volume is available, bound to a claim, or released by a claim.",
 			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) metrics.Family {
 				f := metrics.Family{}
@@ -88,6 +90,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_persistentvolume_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about persistentvolume.",
 			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) metrics.Family {
 				return metrics.Family{&metrics.Metric{

--- a/pkg/collectors/persistentvolumeclaim.go
+++ b/pkg/collectors/persistentvolumeclaim.go
@@ -35,6 +35,7 @@ var (
 	persistentVolumeClaimMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: descPersistentVolumeClaimLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descPersistentVolumeClaimLabelsHelp,
 			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
@@ -48,6 +49,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_persistentvolumeclaim_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about persistent volume claim.",
 			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metrics.Family {
 				storageClassName := getPersistentVolumeClaimClass(p)
@@ -62,6 +64,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_persistentvolumeclaim_status_phase",
+			Type: metrics.MetricTypeGauge,
 			Help: "The phase the persistent volume claim is currently in.",
 			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metrics.Family {
 				f := metrics.Family{}
@@ -93,6 +96,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_persistentvolumeclaim_resource_requests_storage_bytes",
+			Type: metrics.MetricTypeGauge,
 			Help: "The capacity of storage requested by the persistent volume claim.",
 			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metrics.Family {
 				f := metrics.Family{}

--- a/pkg/collectors/pod.go
+++ b/pkg/collectors/pod.go
@@ -40,6 +40,7 @@ var (
 	podMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_pod_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about pod.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				createdBy := metav1.GetControllerOf(p)
@@ -66,6 +67,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_start_time",
+			Type: metrics.MetricTypeGauge,
 			Help: "Start time in unix timestamp for a pod.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -84,6 +86,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_completion_time",
+			Type: metrics.MetricTypeGauge,
 			Help: "Completion time in unix timestamp for a pod.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -111,6 +114,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_owner",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about the Pod's owner.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
@@ -149,6 +153,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_labels",
+			Type: metrics.MetricTypeGauge,
 			Help: "Kubernetes labels converted to Prometheus labels.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
@@ -163,6 +168,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -179,6 +185,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_status_scheduled_time",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix timestamp when pod moved into scheduled status",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -202,6 +209,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_status_phase",
+			Type: metrics.MetricTypeGauge,
 			Help: "The pods current phase.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -238,6 +246,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_status_ready",
+			Type: metrics.MetricTypeGauge,
 			Help: "Describes whether the pod is ready to serve requests.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -261,6 +270,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_status_scheduled",
+			Type: metrics.MetricTypeGauge,
 			Help: "Describes the status of the scheduling process for the pod.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -284,6 +294,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about a container in a pod.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -303,6 +314,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_status_waiting",
+			Type: metrics.MetricTypeGauge,
 			Help: "Describes whether the container is currently in waiting state.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -321,6 +333,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_status_waiting_reason",
+			Type: metrics.MetricTypeGauge,
 			Help: "Describes the reason the container is currently in waiting state.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -341,6 +354,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_status_running",
+			Type: metrics.MetricTypeGauge,
 			Help: "Describes whether the container is currently in running state.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -359,6 +373,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_status_terminated",
+			Type: metrics.MetricTypeGauge,
 			Help: "Describes whether the container is currently in terminated state.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -377,6 +392,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_status_terminated_reason",
+			Type: metrics.MetricTypeGauge,
 			Help: "Describes the reason the container is currently in terminated state.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -397,6 +413,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_status_last_terminated_reason",
+			Type: metrics.MetricTypeGauge,
 			Help: "Describes the last reason the container was in terminated state.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -417,6 +434,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_status_ready",
+			Type: metrics.MetricTypeGauge,
 			Help: "Describes whether the containers readiness check succeeded.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -435,6 +453,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_status_restarts_total",
+			Type: metrics.MetricTypeCounter,
 			Help: "The number of container restarts per container.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -453,6 +472,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_resource_requests",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of requested request resource by a container.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -509,6 +529,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_resource_limits",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of requested limit resource by a container.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -565,6 +586,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_resource_requests_cpu_cores",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of requested cpu cores by a container.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -586,6 +608,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_resource_requests_memory_bytes",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of requested memory bytes by a container.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -607,6 +630,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_resource_limits_cpu_cores",
+			Type: metrics.MetricTypeGauge,
 			Help: "The limit on cpu cores to be used by a container.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -628,6 +652,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_container_resource_limits_memory_bytes",
+			Type: metrics.MetricTypeGauge,
 			Help: "The limit on memory to be used by a container in bytes.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -650,6 +675,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_spec_volumes_persistentvolumeclaims_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about persistentvolumeclaim volumes in a pod.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}
@@ -670,6 +696,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_pod_spec_volumes_persistentvolumeclaims_readonly",
+			Type: metrics.MetricTypeGauge,
 			Help: "Describes whether a persistentvolumeclaim is mounted read only.",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metrics.Family {
 				f := metrics.Family{}

--- a/pkg/collectors/poddisruptionbudget.go
+++ b/pkg/collectors/poddisruptionbudget.go
@@ -33,6 +33,7 @@ var (
 	podDisruptionBudgetMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_poddisruptionbudget_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
 				f := metrics.Family{}
@@ -49,6 +50,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_poddisruptionbudget_status_current_healthy",
+			Type: metrics.MetricTypeGauge,
 			Help: "Current number of healthy pods",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -59,6 +61,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_poddisruptionbudget_status_desired_healthy",
+			Type: metrics.MetricTypeGauge,
 			Help: "Minimum desired number of healthy pods",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -69,6 +72,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_poddisruptionbudget_status_pod_disruptions_allowed",
+			Type: metrics.MetricTypeGauge,
 			Help: "Number of pod disruptions that are currently allowed",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -79,6 +83,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_poddisruptionbudget_status_expected_pods",
+			Type: metrics.MetricTypeGauge,
 			Help: "Total number of pods counted by this disruption budget",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -89,6 +94,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_poddisruptionbudget_status_observed_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "Most recent generation observed when updating this PDB status",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metrics.Family {
 				return metrics.Family{&metrics.Metric{

--- a/pkg/collectors/replicaset.go
+++ b/pkg/collectors/replicaset.go
@@ -35,6 +35,7 @@ var (
 	replicaSetMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_replicaset_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
 				f := metrics.Family{}
@@ -51,6 +52,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicaset_status_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of replicas per ReplicaSet.",
 			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -61,6 +63,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicaset_status_fully_labeled_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of fully labeled replicas per ReplicaSet.",
 			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -71,6 +74,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicaset_status_ready_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of ready replicas per ReplicaSet.",
 			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -81,6 +85,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicaset_status_observed_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "The generation observed by the ReplicaSet controller.",
 			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -91,6 +96,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicaset_spec_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "Number of desired pods for a ReplicaSet.",
 			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
 				f := metrics.Family{}
@@ -107,6 +113,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicaset_metadata_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
 			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -117,6 +124,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicaset_owner",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about the ReplicaSet's owner.",
 			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metrics.Family {
 				f := metrics.Family{}

--- a/pkg/collectors/replicationcontroller.go
+++ b/pkg/collectors/replicationcontroller.go
@@ -33,6 +33,7 @@ var (
 	replicationControllerMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_replicationcontroller_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metrics.Family {
 				f := metrics.Family{}
@@ -49,6 +50,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicationcontroller_status_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of replicas per ReplicationController.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -59,6 +61,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicationcontroller_status_fully_labeled_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of fully labeled replicas per ReplicationController.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -69,6 +72,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicationcontroller_status_ready_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of ready replicas per ReplicationController.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -79,6 +83,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicationcontroller_status_available_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of available replicas per ReplicationController.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -89,6 +94,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicationcontroller_status_observed_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "The generation observed by the ReplicationController controller.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -99,6 +105,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicationcontroller_spec_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "Number of desired pods for a ReplicationController.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metrics.Family {
 				f := metrics.Family{}
@@ -115,6 +122,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_replicationcontroller_metadata_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metrics.Family {
 				return metrics.Family{&metrics.Metric{

--- a/pkg/collectors/resourcequota.go
+++ b/pkg/collectors/resourcequota.go
@@ -33,6 +33,7 @@ var (
 	resourceQuotaMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_resourcequota_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) metrics.Family {
 				f := metrics.Family{}
@@ -49,6 +50,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_resourcequota",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about resource quota.",
 			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) metrics.Family {
 				f := metrics.Family{}

--- a/pkg/collectors/secret.go
+++ b/pkg/collectors/secret.go
@@ -35,6 +35,7 @@ var (
 	secretMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_secret_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about secret.",
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -45,6 +46,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_secret_type",
+			Type: metrics.MetricTypeGauge,
 			Help: "Type about secret.",
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -57,6 +59,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: descSecretLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descSecretLabelsHelp,
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
@@ -71,6 +74,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_secret_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metrics.Family {
 				f := metrics.Family{}
@@ -87,6 +91,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_secret_metadata_resource_version",
+			Type: metrics.MetricTypeGauge,
 			Help: "Resource version representing a specific version of secret.",
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metrics.Family {
 				return metrics.Family{&metrics.Metric{

--- a/pkg/collectors/service.go
+++ b/pkg/collectors/service.go
@@ -35,6 +35,7 @@ var (
 	serviceMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_service_info",
+			Type: metrics.MetricTypeGauge,
 			Help: "Information about service.",
 			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metrics.Family {
 				m := metrics.Metric{
@@ -48,6 +49,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_service_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metrics.Family {
 				if !s.CreationTimestamp.IsZero() {
@@ -64,6 +66,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_service_spec_type",
+			Type: metrics.MetricTypeGauge,
 			Help: "Type about service.",
 			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metrics.Family {
 				m := metrics.Metric{
@@ -77,6 +80,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: descServiceLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descServiceLabelsHelp,
 			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
@@ -91,6 +95,7 @@ var (
 		},
 		{
 			Name: "kube_service_spec_external_ip",
+			Type: metrics.MetricTypeGauge,
 			Help: "Service external ips. One series for each ip",
 			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metrics.Family {
 				family := metrics.Family{}
@@ -111,6 +116,7 @@ var (
 		},
 		{
 			Name: "kube_service_status_load_balancer_ingress",
+			Type: metrics.MetricTypeGauge,
 			Help: "Service load balancer ingress status",
 			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metrics.Family {
 				family := metrics.Family{}

--- a/pkg/collectors/statefulset.go
+++ b/pkg/collectors/statefulset.go
@@ -35,6 +35,7 @@ var (
 	statefulSetMetricFamilies = []metrics.FamilyGenerator{
 		metrics.FamilyGenerator{
 			Name: "kube_statefulset_created",
+			Type: metrics.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				f := metrics.Family{}
@@ -51,6 +52,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_statefulset_status_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of replicas per StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -61,6 +63,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_statefulset_status_replicas_current",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of current replicas per StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -71,6 +74,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_statefulset_status_replicas_ready",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of ready replicas per StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -81,6 +85,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_statefulset_status_replicas_updated",
+			Type: metrics.MetricTypeGauge,
 			Help: "The number of updated replicas per StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -91,6 +96,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_statefulset_status_observed_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "The generation observed by the StatefulSet controller.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				f := metrics.Family{}
@@ -107,6 +113,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_statefulset_replicas",
+			Type: metrics.MetricTypeGauge,
 			Help: "Number of desired pods for a StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				f := metrics.Family{}
@@ -123,6 +130,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_statefulset_metadata_generation",
+			Type: metrics.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state for the StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -133,6 +141,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: descStatefulSetLabelsName,
+			Type: metrics.MetricTypeGauge,
 			Help: descStatefulSetLabelsHelp,
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
@@ -146,6 +155,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_statefulset_status_current_revision",
+			Type: metrics.MetricTypeGauge,
 			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{
@@ -158,6 +168,7 @@ var (
 		},
 		metrics.FamilyGenerator{
 			Name: "kube_statefulset_status_update_revision",
+			Type: metrics.MetricTypeGauge,
 			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metrics.Family {
 				return metrics.Family{&metrics.Metric{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -41,6 +41,7 @@ var (
 type FamilyGenerator struct {
 	Name         string
 	Help         string
+	Type         MetricType
 	GenerateFunc func(obj interface{}) Family
 }
 
@@ -56,6 +57,16 @@ func (f Family) String() string {
 
 	return b.String()
 }
+
+// MetricType represents the type of a metric e.g. a counter. See
+// https://prometheus.io/docs/concepts/metric_types/.
+type MetricType string
+
+// MetricTypeGauge defines a Prometheus gauge.
+var MetricTypeGauge MetricType = "gauge"
+
+// MetricTypeCounter defines a Prometheus counter.
+var MetricTypeCounter MetricType = "counter"
 
 // Metric represents a single time series.
 type Metric struct {

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -166,14 +166,7 @@ curl -s "http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state
 
 echo "check metrics format with promtool"
 [ -n "$E2E_SETUP_PROMTOOL" ] && setup_promtool
-# kube-state-metrics does not expose the HELP lines for each metric family on
-# its /metrics endpoint. In order to still check for other issues raised by
-# promtool, filter out the HELP text warnings.
-# `grep -v` fails when it returns an empty string. This is inverted at the
-# beginning via `!`.
-set +o pipefail
-! cat $KUBE_STATE_METRICS_LOG_DIR/metrics | promtool check metrics 2>&1 | grep -v "no help text"
-set -o pipefail
+cat $KUBE_STATE_METRICS_LOG_DIR/metrics | promtool check metrics
 
 collectors=$(find pkg/collectors/ -maxdepth 1 -name "*.go" -not -name "*_test.go" -not -name "collectors.go" -not -name "builder.go" -not -name "testutils.go" -not -name "utils.go" | xargs -n1 basename | awk -F. '{print $1}')
 echo "available collectors: $collectors"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Prometheus exposes the [type](https://prometheus.io/docs/concepts/metric_types/) of a metric family as a header line. This patch reintroduces this feature to the performance optimized version.

This patch is based on https://github.com/kubernetes/kube-state-metrics/pull/591. Once that is merged, this can follow along.

