### PR TITLE
tests: Add stability notice to lib pkg

### DIFF
--- a/tests/lib/doc.go
+++ b/tests/lib/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package lib enables other projects to reuse the performance optimized metric
+exposition logic. While this package ensures this use-case is possible, it does
+not give any stability guarantees for the interface.
+*/
+package lib

--- a/tests/lib/lib_test.go
+++ b/tests/lib/lib_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package lib
 
 import (


### PR DESCRIPTION

**What this PR does / why we need it**:

This patch adds a stability notice to the `tests/lib` package making sure no one depends on kube-state-metrics as a library and expects a stable interface.

While we are already in the package, it also adds a license header to the `lib_test.go` file.

For now this pull request targets the `release-1.5` branch. This can later on be merged back into `master`.
