### PR TITLE
tests: Add stability notice to lib pkg - back to master

### DIFF
--- a/tests/lib/doc.go
+++ b/tests/lib/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package lib enables other projects to reuse the performance optimized metric
+exposition logic. While this package ensures this use-case is possible, it does
+not give any stability guarantees for the interface.
+*/
+package lib

--- a/tests/lib/lib_test.go
+++ b/tests/lib/lib_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package lib
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

As I can't merge `release-1.5` back into `master` due to the @k8s-merge-robot merge commit that violates the CLA check, this is a follow up pull request to https://github.com/kubernetes/kube-state-metrics/pull/608 at least sharing the base commit.
