### PR TITLE
*: Cut v1.5.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.5.0-beta.0 / 2018-12-11
+
+After a testing period of 11 days, there were no additional bugs found or features introduced.
+
 ## v1.5.0-alpha.0 / 2018-11-30
 
 * [CHANGE] Disable gzip compression of kube-state-metrics responses by default. Can be re-enabled via `--enable-gzip-encoding`. See #563 for more details.


### PR DESCRIPTION
**What this PR does / why we need it**:

Cut v1.5.0-beta.0 of kube-state-metrics. I am not entirely sure what the time between alpha and beta was in the past but given that there are no bug reports so far I would suggest moving on to a beta release.

What are your thoughts?

