### PR TITLE
Clear TODO comment in builder.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 		glog.Info("Using default collectors")
 		collectorBuilder.WithEnabledCollectors(options.DefaultCollectors.AsSlice())
 	} else {
+		glog.Infof("Using collectors %s", opts.Collectors.String())
 		collectorBuilder.WithEnabledCollectors(opts.Collectors.AsSlice())
 	}
 
@@ -120,7 +121,7 @@ func main() {
 		})
 	}
 
-	glog.Infof("metric white- blacklisting: %v", whiteBlackList.Status())
+	glog.Infof("metric white-blacklisting: %v", whiteBlackList.Status())
 
 	collectorBuilder.WithWhiteBlackList(whiteBlackList)
 

--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -107,7 +107,6 @@ func (b *Builder) Build() []*Collector {
 			activeCollectorNames = append(activeCollectorNames, c)
 			collectors = append(collectors, collector)
 		}
-		// TODO: What if not ok?
 	}
 
 	glog.Infof("Active collectors: %s", strings.Join(activeCollectorNames, ","))


### PR DESCRIPTION


**What this PR does / why we need it**:
Clear comment --- "TODO : What if not ok?". Because the collector's name has been checked in CollectorSet.Set function. It will exit if collector' name is not in DefaultCollectors. 
As a result, all collectors in Build.enabledCollectors will find its constructor function. 
So I think it doesn't exist "not ok" situation.

