### PR TITLE
pkg/collectors: Remove leftover commented code

### DIFF
--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -493,14 +493,6 @@ func filterMetricFamilies(l whiteBlackLister, families []metrics.FamilyGenerator
 	return filtered
 }
 
-//
-// func (b *Builder) buildStatefulSetCollector() *Collector {
-// 	store := metricsstore.NewMetricsStore(generateStatefulSetMetrics)
-// 	reflectorPerNamespace(b.ctx, b.kubeClient, &apps.StatefulSet{}, store, b.namespaces, createStatefulSetListWatch)
-//
-// 	return newCollector(store)
-// }
-
 // reflectorPerNamespace creates a Kubernetes client-go reflector with the given
 // listWatchFunc for each given namespace and registers it with the given store.
 func reflectorPerNamespace(


### PR DESCRIPTION
**What this PR does / why we need it**:
As the `buildStatefulSetCollector` function has been refactored this code
can be removed.

cc @mxinden 


