### PR TITLE
Correct typo on new metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ After a testing period of 11 days, there were no additional bugs found or featur
 ## v1.5.0-alpha.0 / 2018-11-30
 
 * [CHANGE] Disable gzip compression of kube-state-metrics responses by default. Can be re-enabled via `--enable-gzip-encoding`. See #563 for more details.
-* [FEATURE] Add `kube_replicatset_owner` metric (#520).
+* [FEATURE] Add `kube_replicaset_owner` metric (#520).
 * [FEATURE] Add `kube_pod_container_status_last_terminated_reason` metric (#535).
 * [FEATURE] Add `stateful_set_status.{current,update}_revision` metric (#545).
 * [FEATURE] Add pod disruption budget collector (#551).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Correct metric name in CHANGELOG.md from kube_replictaset_owner -> kube_replicaset_owner see #520 for reason it's been misnamed


