### PR TITLE
Added additional labels for pod metrics

### DIFF
--- a/pkg/collectors/pod.go
+++ b/pkg/collectors/pod.go
@@ -259,7 +259,8 @@ var (
 						for _, m := range ms {
 							metric := m
 							metric.Name = "kube_pod_status_ready"
-							metric.LabelKeys = []string{"condition"}
+							metric.LabelKeys = []string{"condition", "host_ip", "pod_ip", "uid", "node"}
+							metric.LabelValues = append(metric.LabelValues, []string{p.Status.HostIP, p.Status.PodIP, string(p.UID), p.Spec.NodeName}...)
 							f = append(f, metric)
 						}
 					}
@@ -283,7 +284,8 @@ var (
 						for _, m := range ms {
 							metric := m
 							metric.Name = "kube_pod_status_scheduled"
-							metric.LabelKeys = []string{"condition"}
+							metric.LabelKeys = []string{"condition", "host_ip", "pod_ip", "uid", "node"}
+							metric.LabelValues = append(metric.LabelValues, []string{p.Status.HostIP, p.Status.PodIP, string(p.UID), p.Spec.NodeName}...)
 							f = append(f, metric)
 						}
 					}

--- a/pkg/collectors/pod_test.go
+++ b/pkg/collectors/pod_test.go
@@ -739,8 +739,14 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod1",
 					Namespace: "ns1",
+					UID:       "abc-123-xxx",
+				},
+				Spec: v1.PodSpec{
+					NodeName: "node1",
 				},
 				Status: v1.PodStatus{
+					HostIP: "1.1.1.1",
+					PodIP:  "1.2.3.4",
 					Conditions: []v1.PodCondition{
 						v1.PodCondition{
 							Type:   v1.PodReady,
@@ -750,9 +756,9 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				},
 			},
 			Want: metadata + `
-				kube_pod_status_ready{condition="false",namespace="ns1",pod="pod1"} 0
-				kube_pod_status_ready{condition="true",namespace="ns1",pod="pod1"} 1
-				kube_pod_status_ready{condition="unknown",namespace="ns1",pod="pod1"} 0
+				kube_pod_status_ready{condition="false",namespace="ns1",pod="pod1",node="node1",host_ip="1.1.1.1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 0
+				kube_pod_status_ready{condition="true",namespace="ns1",pod="pod1",node="node1",host_ip="1.1.1.1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 1
+				kube_pod_status_ready{condition="unknown",namespace="ns1",pod="pod1",node="node1",host_ip="1.1.1.1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 0
 			`,
 			MetricNames: []string{"kube_pod_status_ready"},
 		},
@@ -761,8 +767,14 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod2",
 					Namespace: "ns2",
+					UID:       "abc-123-xxx",
+				},
+				Spec: v1.PodSpec{
+					NodeName: "node1",
 				},
 				Status: v1.PodStatus{
+					HostIP: "1.1.1.1",
+					PodIP:  "1.2.3.4",
 					Conditions: []v1.PodCondition{
 						v1.PodCondition{
 							Type:   v1.PodReady,
@@ -772,9 +784,9 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				},
 			},
 			Want: metadata + `
-				kube_pod_status_ready{condition="false",namespace="ns2",pod="pod2"} 1
-				kube_pod_status_ready{condition="true",namespace="ns2",pod="pod2"} 0
-				kube_pod_status_ready{condition="unknown",namespace="ns2",pod="pod2"} 0
+				kube_pod_status_ready{condition="false",namespace="ns2",pod="pod2",node="node1",host_ip="1.1.1.1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 1
+				kube_pod_status_ready{condition="true",namespace="ns2",pod="pod2",node="node1",host_ip="1.1.1.1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 0
+				kube_pod_status_ready{condition="unknown",namespace="ns2",pod="pod2",node="node1",host_ip="1.1.1.1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 0
 			`,
 			MetricNames: []string{"kube_pod_status_ready"},
 		},
@@ -783,8 +795,14 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod1",
 					Namespace: "ns1",
+					UID:       "abc-123-xxx",
+				},
+				Spec: v1.PodSpec{
+					NodeName: "node1",
 				},
 				Status: v1.PodStatus{
+					HostIP: "1.1.1.1",
+					PodIP:  "1.2.3.4",
 					Conditions: []v1.PodCondition{
 						v1.PodCondition{
 							Type:   v1.PodScheduled,
@@ -798,9 +816,9 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			},
 			Want: metadata + `
 				kube_pod_status_scheduled_time{namespace="ns1",pod="pod1"} 1.501666018e+09
-				kube_pod_status_scheduled{condition="false",namespace="ns1",pod="pod1"} 0
-				kube_pod_status_scheduled{condition="true",namespace="ns1",pod="pod1"} 1
-				kube_pod_status_scheduled{condition="unknown",namespace="ns1",pod="pod1"} 0
+				kube_pod_status_scheduled{condition="false",namespace="ns1",pod="pod1",host_ip="1.1.1.1",node="node1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 0
+				kube_pod_status_scheduled{condition="true",namespace="ns1",pod="pod1",host_ip="1.1.1.1",node="node1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 1
+				kube_pod_status_scheduled{condition="unknown",namespace="ns1",pod="pod1",host_ip="1.1.1.1",node="node1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 0
 			`,
 			MetricNames: []string{"kube_pod_status_scheduled", "kube_pod_status_scheduled_time"},
 		},
@@ -809,8 +827,14 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod2",
 					Namespace: "ns2",
+					UID:       "abc-123-xxx",
+				},
+				Spec: v1.PodSpec{
+					NodeName: "node1",
 				},
 				Status: v1.PodStatus{
+					HostIP: "1.1.1.1",
+					PodIP:  "1.2.3.4",
 					Conditions: []v1.PodCondition{
 						v1.PodCondition{
 							Type:   v1.PodScheduled,
@@ -820,9 +844,9 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				},
 			},
 			Want: metadata + `
-				kube_pod_status_scheduled{condition="false",namespace="ns2",pod="pod2"} 1
-				kube_pod_status_scheduled{condition="true",namespace="ns2",pod="pod2"} 0
-				kube_pod_status_scheduled{condition="unknown",namespace="ns2",pod="pod2"} 0
+				kube_pod_status_scheduled{condition="false",namespace="ns2",pod="pod2",host_ip="1.1.1.1",node="node1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 1
+				kube_pod_status_scheduled{condition="true",namespace="ns2",pod="pod2",host_ip="1.1.1.1",node="node1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 0
+				kube_pod_status_scheduled{condition="unknown",namespace="ns2",pod="pod2",host_ip="1.1.1.1",node="node1",pod_ip="1.2.3.4",uid="abc-123-xxx"} 0
 			`,
 			MetricNames: []string{"kube_pod_status_scheduled", "kube_pod_status_scheduled_time"},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add additional labels to the `kube_pod_status_ready` and `kube_pod_status_scheduled` metrics to provide the `host_ip`, `pod_ip`, `uid` and `node`.

This brings the values more in line with the `kube_pod_info` metric.

**Which issue(s) this PR fixes**:
N/A

