### PR TITLE
Cut 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v1.5.0 / 2019-01-10
+
+After a testing period of 30 days, there were no additional bugs found or features introduced. Due to no bugs being reported over an in total 41 days period, we feel no more pre-releases are necessary for a stable release.
+
+This release's focus was a large architectural change in order to improve performance and resource usage of kube-state-metrics drastically. Special thanks to @mxinden for his hard work on this! See the changelog of the pre-releases for more detailed information and related pull requests.
+
+An additional change has been requested to be listed in the release notes:
+
+* [CHANGE] Due to removal of the surrounding mechanism the `ksm_resources_per_scrape` and `ksm_scrape_error_total` metrics no longer exists.
+
 ## v1.5.0-beta.0 / 2018-12-11
 
 After a testing period of 11 days, there were no additional bugs found or features introduced.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ At most 5 kube-state-metrics releases will be recorded below.
 | **v1.3.0** |  v6.0.0           |         ✓          |         ✓          |         ✓          |         ✓          |
 | **v1.3.1** |  v6.0.0           |         ✓          |         ✓          |         ✓          |         ✓          |
 | **v1.4.0** |  v8.0.0           |         ✓          |         ✓          |         ✓          |         ✓          |
+| **v1.5.0** |  v8.0.0           |         ✓          |         ✓          |         ✓          |         ✓          |
 | **master** |  v8.0.0           |         ✓          |         ✓          |         ✓          |         ✓          |
 - `✓` Fully supported version range.
 - `-` The Kubernetes cluster has features the client-go library can't use (additional API objects, etc).
@@ -72,8 +73,8 @@ release.
 #### Container Image
 
 The latest container image can be found at:
-* `quay.io/coreos/kube-state-metrics:v1.4.0`
-* `k8s.gcr.io/kube-state-metrics:v1.4.0`
+* `quay.io/coreos/kube-state-metrics:v1.5.0`
+* `k8s.gcr.io/kube-state-metrics:v1.5.0`
 
 **Note**:
 The recommended docker registry for kube-state-metrics is `quay.io`. kube-state-metrics on

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.4.0
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION
After an additional testing period of 30 days, there were no additional bugs found or features introduced. Due to no bugs being reported over an in total 41 days period, I feel no more pre-releases are necessary for a stable release.

This release's focus was a large architectural change in order to improve performance and resource usage of kube-state-metrics drastically. Special thanks to @mxinden for his hard work on this! See the changelog of the pre-releases for more detailed information and related pull requests.

@metalmatze @s-urbaniak @mxinden @squat @andyxning @zouyee 

@loburm @piosz @kawych @DirectXMan12 please stand by to publish the gcr.io image.