### PR TITLE
Remove the obsolete metrics code

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,8 +134,6 @@ func main() {
 	collectorBuilder.WithKubeClient(kubeClient)
 
 	ksmMetricsRegistry := prometheus.NewRegistry()
-	ksmMetricsRegistry.Register(kcollectors.ResourcesPerScrapeMetric)
-	ksmMetricsRegistry.Register(kcollectors.ScrapeErrorTotalMetric)
 	ksmMetricsRegistry.Register(prometheus.NewProcessCollector(os.Getpid(), ""))
 	ksmMetricsRegistry.Register(prometheus.NewGoCollector())
 	go telemetryServer(ksmMetricsRegistry, opts.TelemetryHost, opts.TelemetryPort)

--- a/pkg/collectors/utils.go
+++ b/pkg/collectors/utils.go
@@ -20,7 +20,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
 
 	"k8s.io/kube-state-metrics/pkg/metrics"
@@ -28,22 +27,6 @@ import (
 
 var (
 	resyncPeriod = 5 * time.Minute
-
-	ScrapeErrorTotalMetric = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "ksm_scrape_error_total",
-			Help: "Total scrape errors encountered when scraping a resource",
-		},
-		[]string{"resource"},
-	)
-
-	ResourcesPerScrapeMetric = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name: "ksm_resources_per_scrape",
-			Help: "Number of resources returned per scrape",
-		},
-		[]string{"resource"},
-	)
 
 	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 )


### PR DESCRIPTION
These stopped getting populated with 234d788a0d5cfac2b5bf33153afd3b944c39b220, and
cannot be restored easily.

Related-to: #623

_This is intended for after 1.5.0, as per https://github.com/kubernetes/kube-state-metrics/pull/629#issuecomment-453057404_

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

It removes obsolete code that could be misleading when reading this in the future.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


