### PR TITLE
Deduplicate metric name

### DIFF
--- a/internal/collector/configmap.go
+++ b/internal/collector/configmap.go
@@ -37,12 +37,11 @@ var (
 			Help: "Information about configmap.",
 			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metric.Family {
 				return metric.Family{
-					&metric.Metric{
-						Name:        "kube_configmap_info",
+					Metrics: []*metric.Metric{{
 						LabelKeys:   []string{},
 						LabelValues: []string{},
 						Value:       1,
-					},
+					}},
 				}
 			}),
 		},
@@ -51,18 +50,19 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metric.Family {
-				f := metric.Family{}
+				ms := []*metric.Metric{}
 
 				if !c.CreationTimestamp.IsZero() {
-					f = append(f, &metric.Metric{
-						Name:        "kube_configmap_created",
+					ms = append(ms, &metric.Metric{
 						LabelKeys:   []string{},
 						LabelValues: []string{},
 						Value:       float64(c.CreationTimestamp.Unix()),
 					})
 				}
 
-				return f
+				return metric.Family{
+					Metrics: ms,
+				}
 			}),
 		},
 		{
@@ -71,11 +71,12 @@ var (
 			Help: "Resource version representing a specific version of the configmap.",
 			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metric.Family {
 				return metric.Family{
-					&metric.Metric{
-						Name:        "kube_configmap_metadata_resource_version",
-						LabelKeys:   []string{"resource_version"},
-						LabelValues: []string{string(c.ObjectMeta.ResourceVersion)},
-						Value:       1,
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"resource_version"},
+							LabelValues: []string{string(c.ObjectMeta.ResourceVersion)},
+							Value:       1,
+						},
 					},
 				}
 			}),
@@ -100,7 +101,7 @@ func wrapConfigMapFunc(f func(*v1.ConfigMap) metric.Family) func(interface{}) me
 
 		metricFamily := f(configMap)
 
-		for _, m := range metricFamily {
+		for _, m := range metricFamily.Metrics {
 			m.LabelKeys = append(descConfigMapLabelsDefaultLabels, m.LabelKeys...)
 			m.LabelValues = append([]string{configMap.Namespace, configMap.Name}, m.LabelValues...)
 		}

--- a/internal/collector/daemonset.go
+++ b/internal/collector/daemonset.go
@@ -38,18 +38,19 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				f := metric.Family{}
+				ms := []*metric.Metric{}
 
 				if !d.CreationTimestamp.IsZero() {
-					f = append(f, &metric.Metric{
-						Name:        "kube_daemonset_created",
+					ms = append(ms, &metric.Metric{
 						LabelKeys:   []string{},
 						LabelValues: []string{},
 						Value:       float64(d.CreationTimestamp.Unix()),
 					})
 				}
 
-				return f
+				return metric.Family{
+					Metrics: ms,
+				}
 			}),
 		},
 		{
@@ -58,11 +59,12 @@ var (
 			Help: "The number of nodes running at least one daemon pod and are supposed to.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
 				return metric.Family{
-					&metric.Metric{
-						Name:        "kube_daemonset_status_current_number_scheduled",
-						LabelKeys:   []string{},
-						LabelValues: []string{},
-						Value:       float64(d.Status.CurrentNumberScheduled),
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.CurrentNumberScheduled),
+						},
 					},
 				}
 			}),
@@ -72,12 +74,15 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:        "kube_daemonset_status_desired_number_scheduled",
-					LabelKeys:   []string{},
-					LabelValues: []string{},
-					Value:       float64(d.Status.DesiredNumberScheduled),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.DesiredNumberScheduled),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -85,12 +90,15 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:        "kube_daemonset_status_number_available",
-					LabelKeys:   []string{},
-					LabelValues: []string{},
-					Value:       float64(d.Status.NumberAvailable),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.NumberAvailable),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -98,12 +106,15 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes running a daemon pod but are not supposed to.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:        "kube_daemonset_status_number_misscheduled",
-					LabelKeys:   []string{},
-					LabelValues: []string{},
-					Value:       float64(d.Status.NumberMisscheduled),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.NumberMisscheduled),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -111,12 +122,15 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:        "kube_daemonset_status_number_ready",
-					LabelKeys:   []string{},
-					LabelValues: []string{},
-					Value:       float64(d.Status.NumberReady),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.NumberReady),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -124,12 +138,15 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:        "kube_daemonset_status_number_unavailable",
-					LabelKeys:   []string{},
-					LabelValues: []string{},
-					Value:       float64(d.Status.NumberUnavailable),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.NumberUnavailable),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -137,10 +154,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The total number of nodes that are running updated daemon pod",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_daemonset_updated_number_scheduled",
-					Value: float64(d.Status.UpdatedNumberScheduled),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.UpdatedNumberScheduled),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -148,12 +168,15 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:        "kube_daemonset_metadata_generation",
-					LabelKeys:   []string{},
-					LabelValues: []string{},
-					Value:       float64(d.ObjectMeta.Generation),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.ObjectMeta.Generation),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -162,12 +185,15 @@ var (
 			Help: descDaemonSetLabelsHelp,
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.ObjectMeta.Labels)
-				return metric.Family{&metric.Metric{
-					Name:        descDaemonSetLabelsName,
-					LabelKeys:   labelKeys,
-					LabelValues: labelValues,
-					Value:       1,
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
 			}),
 		},
 	}
@@ -179,7 +205,7 @@ func wrapDaemonSetFunc(f func(*v1beta1.DaemonSet) metric.Family) func(interface{
 
 		metricFamily := f(daemonSet)
 
-		for _, m := range metricFamily {
+		for _, m := range metricFamily.Metrics {
 			m.LabelKeys = append(descDaemonSetLabelsDefaultLabels, m.LabelKeys...)
 			m.LabelValues = append([]string{daemonSet.Namespace, daemonSet.Name}, m.LabelValues...)
 		}

--- a/internal/collector/deployment.go
+++ b/internal/collector/deployment.go
@@ -39,16 +39,17 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metric.Family {
-				f := metric.Family{}
+				ms := []*metric.Metric{}
 
 				if !d.CreationTimestamp.IsZero() {
-					f = append(f, &metric.Metric{
-						Name:  "kube_deployment_created",
+					ms = append(ms, &metric.Metric{
 						Value: float64(d.CreationTimestamp.Unix()),
 					})
 				}
 
-				return f
+				return metric.Family{
+					Metrics: ms,
+				}
 			}),
 		},
 		{
@@ -56,10 +57,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of replicas per deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_deployment_status_replicas",
-					Value: float64(d.Status.Replicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.Replicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -67,10 +71,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of available replicas per deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_deployment_status_replicas_available",
-					Value: float64(d.Status.AvailableReplicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.AvailableReplicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -78,10 +85,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of unavailable replicas per deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_deployment_status_replicas_unavailable",
-					Value: float64(d.Status.UnavailableReplicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.UnavailableReplicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -89,10 +99,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of updated replicas per deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_deployment_status_replicas_updated",
-					Value: float64(d.Status.UpdatedReplicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.UpdatedReplicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -100,10 +113,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The generation observed by the deployment controller.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_deployment_status_observed_generation",
-					Value: float64(d.Status.ObservedGeneration),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.ObservedGeneration),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -111,10 +127,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Number of desired pods for a deployment.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_deployment_spec_replicas",
-					Value: float64(*d.Spec.Replicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(*d.Spec.Replicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -122,10 +141,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Whether the deployment is paused and will not be processed by the deployment controller.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_deployment_spec_paused",
-					Value: boolFloat64(d.Spec.Paused),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: boolFloat64(d.Spec.Paused),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -142,10 +164,13 @@ var (
 					panic(err)
 				}
 
-				return metric.Family{&metric.Metric{
-					Name:  "kube_deployment_spec_strategy_rollingupdate_max_unavailable",
-					Value: float64(maxUnavailable),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(maxUnavailable),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -162,10 +187,13 @@ var (
 					panic(err)
 				}
 
-				return metric.Family{&metric.Metric{
-					Name:  "kube_deployment_spec_strategy_rollingupdate_max_surge",
-					Value: float64(maxSurge),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(maxSurge),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -173,10 +201,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_deployment_metadata_generation",
-					Value: float64(d.ObjectMeta.Generation),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.ObjectMeta.Generation),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -185,12 +216,15 @@ var (
 			Help: descDeploymentLabelsHelp,
 			GenerateFunc: wrapDeploymentFunc(func(d *v1beta1.Deployment) metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
-				return metric.Family{&metric.Metric{
-					Name:        descDeploymentLabelsName,
-					LabelKeys:   labelKeys,
-					LabelValues: labelValues,
-					Value:       1,
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
 			}),
 		},
 	}
@@ -202,7 +236,7 @@ func wrapDeploymentFunc(f func(*v1beta1.Deployment) metric.Family) func(interfac
 
 		metricFamily := f(deployment)
 
-		for _, m := range metricFamily {
+		for _, m := range metricFamily.Metrics {
 			m.LabelKeys = append(descDeploymentLabelsDefaultLabels, m.LabelKeys...)
 			m.LabelValues = append([]string{deployment.Namespace, deployment.Name}, m.LabelValues...)
 		}

--- a/internal/collector/poddisruptionbudget.go
+++ b/internal/collector/poddisruptionbudget.go
@@ -36,16 +36,17 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				f := metric.Family{}
+				ms := []*metric.Metric{}
 
 				if !p.CreationTimestamp.IsZero() {
-					f = append(f, &metric.Metric{
-						Name:  "kube_poddisruptionbudget_created",
+					ms = append(ms, &metric.Metric{
 						Value: float64(p.CreationTimestamp.Unix()),
 					})
 				}
 
-				return f
+				return metric.Family{
+					Metrics: ms,
+				}
 			}),
 		},
 		{
@@ -53,10 +54,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Current number of healthy pods",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_poddisruptionbudget_status_current_healthy",
-					Value: float64(p.Status.CurrentHealthy),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.CurrentHealthy),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -64,10 +68,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Minimum desired number of healthy pods",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_poddisruptionbudget_status_desired_healthy",
-					Value: float64(p.Status.DesiredHealthy),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.DesiredHealthy),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -75,10 +82,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Number of pod disruptions that are currently allowed",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_poddisruptionbudget_status_pod_disruptions_allowed",
-					Value: float64(p.Status.PodDisruptionsAllowed),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.PodDisruptionsAllowed),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -86,10 +96,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Total number of pods counted by this disruption budget",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_poddisruptionbudget_status_expected_pods",
-					Value: float64(p.Status.ExpectedPods),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.ExpectedPods),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -97,10 +110,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Most recent generation observed when updating this PDB status",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_poddisruptionbudget_status_observed_generation",
-					Value: float64(p.Status.ObservedGeneration),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(p.Status.ObservedGeneration),
+						},
+					},
+				}
 			}),
 		},
 	}
@@ -112,7 +128,7 @@ func wrapPodDisruptionBudgetFunc(f func(*v1beta1.PodDisruptionBudget) metric.Fam
 
 		metricFamily := f(podDisruptionBudget)
 
-		for _, m := range metricFamily {
+		for _, m := range metricFamily.Metrics {
 			m.LabelKeys = append(descPodDisruptionBudgetLabelsDefaultLabels, m.LabelKeys...)
 			m.LabelValues = append([]string{podDisruptionBudget.Namespace, podDisruptionBudget.Name}, m.LabelValues...)
 		}

--- a/internal/collector/replicationcontroller.go
+++ b/internal/collector/replicationcontroller.go
@@ -36,16 +36,17 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				f := metric.Family{}
+				ms := []*metric.Metric{}
 
 				if !r.CreationTimestamp.IsZero() {
-					f = append(f, &metric.Metric{
-						Name:  "kube_replicationcontroller_created",
+					ms = append(ms, &metric.Metric{
 						Value: float64(r.CreationTimestamp.Unix()),
 					})
 				}
 
-				return f
+				return metric.Family{
+					Metrics: ms,
+				}
 			}),
 		},
 		{
@@ -53,10 +54,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of replicas per ReplicationController.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_replicationcontroller_status_replicas",
-					Value: float64(r.Status.Replicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.Replicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -64,10 +68,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of fully labeled replicas per ReplicationController.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_replicationcontroller_status_fully_labeled_replicas",
-					Value: float64(r.Status.FullyLabeledReplicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.FullyLabeledReplicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -75,10 +82,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of ready replicas per ReplicationController.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_replicationcontroller_status_ready_replicas",
-					Value: float64(r.Status.ReadyReplicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.ReadyReplicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -86,10 +96,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of available replicas per ReplicationController.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_replicationcontroller_status_available_replicas",
-					Value: float64(r.Status.AvailableReplicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.AvailableReplicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -97,10 +110,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The generation observed by the ReplicationController controller.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_replicationcontroller_status_observed_generation",
-					Value: float64(r.Status.ObservedGeneration),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.Status.ObservedGeneration),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -108,16 +124,17 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Number of desired pods for a ReplicationController.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				f := metric.Family{}
+				ms := []*metric.Metric{}
 
 				if r.Spec.Replicas != nil {
-					f = append(f, &metric.Metric{
-						Name:  "kube_replicationcontroller_spec_replicas",
+					ms = append(ms, &metric.Metric{
 						Value: float64(*r.Spec.Replicas),
 					})
 				}
 
-				return f
+				return metric.Family{
+					Metrics: ms,
+				}
 			}),
 		},
 		{
@@ -125,10 +142,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_replicationcontroller_metadata_generation",
-					Value: float64(r.ObjectMeta.Generation),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(r.ObjectMeta.Generation),
+						},
+					},
+				}
 			}),
 		},
 	}
@@ -140,7 +160,7 @@ func wrapReplicationControllerFunc(f func(*v1.ReplicationController) metric.Fami
 
 		metricFamily := f(replicationController)
 
-		for _, m := range metricFamily {
+		for _, m := range metricFamily.Metrics {
 			m.LabelKeys = append(descReplicationControllerLabelsDefaultLabels, m.LabelKeys...)
 			m.LabelValues = append([]string{replicationController.Namespace, replicationController.Name}, m.LabelValues...)
 		}

--- a/internal/collector/secret.go
+++ b/internal/collector/secret.go
@@ -38,10 +38,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Information about secret.",
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_secret_info",
-					Value: 1,
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: 1,
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -49,12 +52,15 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Type about secret.",
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:        "kube_secret_type",
-					LabelKeys:   []string{"type"},
-					LabelValues: []string{string(s.Type)},
-					Value:       1,
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"type"},
+							LabelValues: []string{string(s.Type)},
+							Value:       1,
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -63,12 +69,15 @@ var (
 			Help: descSecretLabelsHelp,
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
-				return metric.Family{&metric.Metric{
-					Name:        descSecretLabelsName,
-					LabelKeys:   labelKeys,
-					LabelValues: labelValues,
-					Value:       1,
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
 
 			}),
 		},
@@ -77,16 +86,17 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metric.Family {
-				f := metric.Family{}
+				ms := []*metric.Metric{}
 
 				if !s.CreationTimestamp.IsZero() {
-					f = append(f, &metric.Metric{
-						Name:  "kube_secret_created",
+					ms = append(ms, &metric.Metric{
 						Value: float64(s.CreationTimestamp.Unix()),
 					})
 				}
 
-				return f
+				return metric.Family{
+					Metrics: ms,
+				}
 			}),
 		},
 		{
@@ -94,12 +104,15 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Resource version representing a specific version of secret.",
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:        "kube_secret_metadata_resource_version",
-					LabelKeys:   []string{"resource_version"},
-					LabelValues: []string{string(s.ObjectMeta.ResourceVersion)},
-					Value:       1,
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"resource_version"},
+							LabelValues: []string{string(s.ObjectMeta.ResourceVersion)},
+							Value:       1,
+						},
+					},
+				}
 			}),
 		},
 	}
@@ -111,7 +124,7 @@ func wrapSecretFunc(f func(*v1.Secret) metric.Family) func(interface{}) metric.F
 
 		metricFamily := f(secret)
 
-		for _, m := range metricFamily {
+		for _, m := range metricFamily.Metrics {
 			m.LabelKeys = append(descSecretLabelsDefaultLabels, m.LabelKeys...)
 			m.LabelValues = append([]string{secret.Namespace, secret.Name}, m.LabelValues...)
 		}

--- a/internal/collector/statefulset.go
+++ b/internal/collector/statefulset.go
@@ -38,16 +38,17 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				f := metric.Family{}
+				ms := []*metric.Metric{}
 
 				if !s.CreationTimestamp.IsZero() {
-					f = append(f, &metric.Metric{
-						Name:  "kube_statefulset_created",
+					ms = append(ms, &metric.Metric{
 						Value: float64(s.CreationTimestamp.Unix()),
 					})
 				}
 
-				return f
+				return metric.Family{
+					Metrics: ms,
+				}
 			}),
 		},
 		{
@@ -55,10 +56,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of replicas per StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_statefulset_status_replicas",
-					Value: float64(s.Status.Replicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.Status.Replicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -66,10 +70,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of current replicas per StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_statefulset_status_replicas_current",
-					Value: float64(s.Status.CurrentReplicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.Status.CurrentReplicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -77,10 +84,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of ready replicas per StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_statefulset_status_replicas_ready",
-					Value: float64(s.Status.ReadyReplicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.Status.ReadyReplicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -88,10 +98,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The number of updated replicas per StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_statefulset_status_replicas_updated",
-					Value: float64(s.Status.UpdatedReplicas),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.Status.UpdatedReplicas),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -99,16 +112,17 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "The generation observed by the StatefulSet controller.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				f := metric.Family{}
+				ms := []*metric.Metric{}
 
 				if s.Status.ObservedGeneration != nil {
-					f = append(f, &metric.Metric{
-						Name:  "kube_statefulset_status_observed_generation",
+					ms = append(ms, &metric.Metric{
 						Value: float64(*s.Status.ObservedGeneration),
 					})
 				}
 
-				return f
+				return metric.Family{
+					Metrics: ms,
+				}
 			}),
 		},
 		{
@@ -116,16 +130,17 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Number of desired pods for a StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				f := metric.Family{}
+				ms := []*metric.Metric{}
 
 				if s.Spec.Replicas != nil {
-					f = append(f, &metric.Metric{
-						Name:  "kube_statefulset_replicas",
+					ms = append(ms, &metric.Metric{
 						Value: float64(*s.Spec.Replicas),
 					})
 				}
 
-				return f
+				return metric.Family{
+					Metrics: ms,
+				}
 			}),
 		},
 		{
@@ -133,10 +148,13 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state for the StatefulSet.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:  "kube_statefulset_metadata_generation",
-					Value: float64(s.ObjectMeta.Generation),
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.ObjectMeta.Generation),
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -145,12 +163,15 @@ var (
 			Help: descStatefulSetLabelsHelp,
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
-				return metric.Family{&metric.Metric{
-					Name:        descStatefulSetLabelsName,
-					LabelKeys:   labelKeys,
-					LabelValues: labelValues,
-					Value:       1,
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -158,12 +179,15 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:        "kube_statefulset_status_current_revision",
-					LabelKeys:   []string{"revision"},
-					LabelValues: []string{s.Status.CurrentRevision},
-					Value:       1,
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"revision"},
+							LabelValues: []string{s.Status.CurrentRevision},
+							Value:       1,
+						},
+					},
+				}
 			}),
 		},
 		{
@@ -171,12 +195,15 @@ var (
 			Type: metric.MetricTypeGauge,
 			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{&metric.Metric{
-					Name:        "kube_statefulset_status_update_revision",
-					LabelKeys:   []string{"revision"},
-					LabelValues: []string{s.Status.UpdateRevision},
-					Value:       1,
-				}}
+				return metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"revision"},
+							LabelValues: []string{s.Status.UpdateRevision},
+							Value:       1,
+						},
+					},
+				}
 			}),
 		},
 	}
@@ -188,7 +215,7 @@ func wrapStatefulSetFunc(f func(*v1beta1.StatefulSet) metric.Family) func(interf
 
 		metricFamily := f(statefulSet)
 
-		for _, m := range metricFamily {
+		for _, m := range metricFamily.Metrics {
 			m.LabelKeys = append(descStatefulSetLabelsDefaultLabels, m.LabelKeys...)
 			m.LabelValues = append([]string{statefulSet.Namespace, statefulSet.Name}, m.LabelValues...)
 		}

--- a/pkg/metric/family.go
+++ b/pkg/metric/family.go
@@ -21,12 +21,16 @@ import (
 )
 
 // Family represents a set of metrics with the same name and help text.
-type Family []*Metric
+type Family struct {
+	Name    string
+	Metrics []*Metric
+}
 
 // String returns the given Family in its string representation.
 func (f Family) String() string {
 	b := strings.Builder{}
-	for _, m := range f {
+	for _, m := range f.Metrics {
+		b.WriteString(f.Name)
 		m.Write(&b)
 	}
 

--- a/pkg/metric/generator.go
+++ b/pkg/metric/generator.go
@@ -60,18 +60,15 @@ func ExtractMetricFamilyHeaders(families []FamilyGenerator) []string {
 
 // ComposeMetricGenFuncs takes a slice of metric families and returns a function
 // that composes their metric generation functions into a single one.
-func ComposeMetricGenFuncs(families []FamilyGenerator) func(obj interface{}) []metricsstore.FamilyStringer {
-	funcs := []func(obj interface{}) Family{}
-
-	for _, f := range families {
-		funcs = append(funcs, f.GenerateFunc)
-	}
-
+func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []metricsstore.FamilyStringer {
 	return func(obj interface{}) []metricsstore.FamilyStringer {
-		families := make([]metricsstore.FamilyStringer, len(funcs))
+		families := make([]metricsstore.FamilyStringer, len(familyGens))
 
-		for i, f := range funcs {
-			families[i] = f(obj)
+		for i, gen := range familyGens {
+			family := gen.GenerateFunc(obj)
+			// Make family aware of its name.
+			family.Name = gen.Name
+			families[i] = &family
 		}
 
 		return families

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -48,7 +48,7 @@ var MetricTypeCounter MetricType = "counter"
 
 // Metric represents a single time series.
 type Metric struct {
-	Name        string
+	// The name of a metric is injected by its family to reduce duplication.
 	LabelKeys   []string
 	LabelValues []string
 	Value       float64
@@ -59,7 +59,6 @@ func (m *Metric) Write(s *strings.Builder) {
 		panic("expected labelKeys to be of same length as labelValues")
 	}
 
-	s.WriteString(m.Name)
 	labelsToString(s, m.LabelKeys, m.LabelValues)
 	s.WriteByte(' ')
 	writeFloat(s, m.Value)

--- a/pkg/metric/metric_test.go
+++ b/pkg/metric/metric_test.go
@@ -23,13 +23,15 @@ import (
 
 func TestFamilyString(t *testing.T) {
 	m := Metric{
-		Name:        "kube_pod_info",
 		LabelKeys:   []string{"namespace"},
 		LabelValues: []string{"default"},
 		Value:       1,
 	}
 
-	f := Family{&m}
+	f := Family{
+		Name:    "kube_pod_info",
+		Metrics: []*Metric{&m},
+	}
 
 	expected := "kube_pod_info{namespace=\"default\"} 1"
 	got := strings.TrimSpace(f.String())
@@ -48,7 +50,6 @@ func BenchmarkMetricWrite(b *testing.B) {
 		{
 			testName: "value-1",
 			metric: Metric{
-				Name:        "kube_pod_container_info",
 				LabelKeys:   []string{"container", "container_id", "image", "image_id", "namespace", "pod"},
 				LabelValues: []string{"container2", "docker://cd456", "k8s.gcr.io/hyperkube2", "docker://sha256:bbb", "ns2", "pod2"},
 				Value:       float64(1),
@@ -58,7 +59,6 @@ func BenchmarkMetricWrite(b *testing.B) {
 		{
 			testName: "value-35.7",
 			metric: Metric{
-				Name:        "kube_pod_container_info",
 				LabelKeys:   []string{"container", "container_id", "image", "image_id", "namespace", "pod"},
 				LabelValues: []string{"container2", "docker://cd456", "k8s.gcr.io/hyperkube2", "docker://sha256:bbb", "ns2", "pod2"},
 				Value:       float64(35.7),

--- a/tests/lib/lib_test.go
+++ b/tests/lib/lib_test.go
@@ -87,13 +87,15 @@ func generateServiceMetrics(obj interface{}) []metricsstore.FamilyStringer {
 	s := *sPointer
 
 	m := metric.Metric{
-		Name:        "test_metric",
 		LabelKeys:   []string{"name"},
 		LabelValues: []string{s.Name},
 		Value:       1,
 	}
 
-	family := metric.Family{&m}
+	family := metric.Family{
+		Name:    "test_metric",
+		Metrics: []*metric.Metric{&m},
+	}
 
-	return []metricsstore.FamilyStringer{family}
+	return []metricsstore.FamilyStringer{&family}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of defining the metric name both in the metric family generator
as well as the metric itself, with this patch the metric name is
injected into the metric family by the metric family generator.
