### PR TITLE
tests: Add check-license script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
 
 jobs:
   include:
-    # Go fmt
-    - script: make gofmtcheck
+    # Format
+    - script: make format
     # Check that all metrics are documented
     - script: make doccheck
     # Unit Test

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ GO_VERSION=1.11.4
 IMAGE = $(REGISTRY)/kube-state-metrics
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
-gofmtcheck:
+format:
 	@go fmt $(PKGS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
+	./tests/check_license.sh
 
 doccheck:
 	@echo "- Checking if documentation is up to date..."

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package metrics
 
 import (

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package metricsstore
 
 import (

--- a/pkg/metrics_store/metrics_store_test.go
+++ b/pkg/metrics_store/metrics_store_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package metricsstore
 
 import (

--- a/pkg/whiteblacklist/whiteblacklist.go
+++ b/pkg/whiteblacklist/whiteblacklist.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package whiteblacklist
 
 import (

--- a/pkg/whiteblacklist/whiteblacklist_test.go
+++ b/pkg/whiteblacklist/whiteblacklist_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package whiteblacklist
 
 import (

--- a/tests/check_license.sh
+++ b/tests/check_license.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+licRes=$(
+    find . -type f -iname '*.go' ! -path '*/vendor/*' -exec \
+         sh -c 'head -n3 $1 | grep -Eq "(Copyright|generated|GENERATED)" || echo -e  $1' {} {} \;
+)
+
+if [ -n "${licRes}" ]; then
+	echo -e "license header checking failed:\\n${licRes}"
+	exit 255
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a script to check, whether each golang file has a license header.