### PR TITLE
Add replicaset label metrics

### DIFF
--- a/Documentation/replicaset-metrics.md
+++ b/Documentation/replicaset-metrics.md
@@ -8,5 +8,6 @@
 | kube_replicaset_status_observed_generation | Gauge | `replicaset`=&lt;replicaset-name&gt; <br> `namespace`=&lt;replicaset-namespace&gt; | STABLE |
 | kube_replicaset_spec_replicas | Gauge | `replicaset`=&lt;replicaset-name&gt; <br> `namespace`=&lt;replicaset-namespace&gt; | STABLE |
 | kube_replicaset_metadata_generation | Gauge | `replicaset`=&lt;replicaset-name&gt; <br> `namespace`=&lt;replicaset-namespace&gt; | STABLE |
+| kube_replicaset_labels | Gauge | `replicaset`=&lt;replicaset-name&gt; <br> `namespace`=&lt;replicaset-namespace&gt; | STABLE |
 | kube_replicaset_created | Gauge | `replicaset`=&lt;replicaset-name&gt; <br> `namespace`=&lt;replicaset-namespace&gt; | STABLE |
 | kube_replicaset_owner | Gauge | `replicaset`=&lt;replicaset-name&gt; <br> `namespace`=&lt;replicaset-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  | STABLE |

--- a/pkg/collectors/replicaset.go
+++ b/pkg/collectors/replicaset.go
@@ -30,6 +30,8 @@ import (
 )
 
 var (
+	descReplicaSetLabelsName          = "kube_replicaset_labels"
+	descReplicaSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descReplicaSetLabelsDefaultLabels = []string{"namespace", "replicaset"}
 
 	replicaSetMetricFamilies = []metrics.FamilyGenerator{
@@ -155,6 +157,20 @@ var (
 				}
 
 				return f
+			}),
+		},
+		{
+			Name: descReplicaSetLabelsName,
+			Type: metrics.MetricTypeGauge,
+			Help: descReplicaSetLabelsHelp,
+			GenerateFunc: wrapReplicaSetFunc(func(d *v1beta1.ReplicaSet) metrics.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
+				return metrics.Family{&metrics.Metric{
+					Name:        descReplicaSetLabelsName,
+					LabelKeys:   labelKeys,
+					LabelValues: labelValues,
+					Value:       1,
+				}}
 			}),
 		},
 	}

--- a/pkg/collectors/replicaset_test.go
+++ b/pkg/collectors/replicaset_test.go
@@ -84,7 +84,7 @@ func TestReplicaSetCollector(t *testing.T) {
 				},
 			},
 			Want: `
-				kube_replicaset_labels{replicaset="rs1",label_app="example1"} 1
+				kube_replicaset_labels{replicaset="rs1",namespace="ns1",label_app="example1"} 1
 				kube_replicaset_created{namespace="ns1",replicaset="rs1"} 1.5e+09
 				kube_replicaset_metadata_generation{namespace="ns1",replicaset="rs1"} 21
 				kube_replicaset_status_replicas{namespace="ns1",replicaset="rs1"} 5

--- a/pkg/collectors/replicaset_test.go
+++ b/pkg/collectors/replicaset_test.go
@@ -117,7 +117,7 @@ func TestReplicaSetCollector(t *testing.T) {
 				},
 			},
 			Want: `
-				kube_replicaset_labels{replicaset="rs2",label_app="example2",label_env="ex"} 1
+				kube_replicaset_labels{replicaset="rs2",namespace="ns2",label_app="example2",label_env="ex"} 1
 				kube_replicaset_metadata_generation{namespace="ns2",replicaset="rs2"} 14
 				kube_replicaset_status_replicas{namespace="ns2",replicaset="rs2"} 0
 				kube_replicaset_status_observed_generation{namespace="ns2",replicaset="rs2"} 5

--- a/pkg/collectors/replicaset_test.go
+++ b/pkg/collectors/replicaset_test.go
@@ -51,6 +51,8 @@ func TestReplicaSetCollector(t *testing.T) {
 		# TYPE kube_replicaset_spec_replicas gauge
 		# HELP kube_replicaset_owner Information about the ReplicaSet's owner.
 		# TYPE kube_replicaset_owner gauge
+		# HELP kube_replicaset_labels Kubernetes labels converted to Prometheus labels.
+		# TYPE kube_replicaset_labels gauge
 	`
 	cases := []generateMetricsTestCase{
 		{
@@ -67,6 +69,9 @@ func TestReplicaSetCollector(t *testing.T) {
 							Controller: &test,
 						},
 					},
+					Labels: map[string]string{
+						"app": "example1",
+					},
 				},
 				Status: v1beta1.ReplicaSetStatus{
 					Replicas:             5,
@@ -79,6 +84,7 @@ func TestReplicaSetCollector(t *testing.T) {
 				},
 			},
 			Want: `
+				kube_replicaset_labels{replicaset="rs1",label_app="example1"} 1
 				kube_replicaset_created{namespace="ns1",replicaset="rs1"} 1.5e+09
 				kube_replicaset_metadata_generation{namespace="ns1",replicaset="rs1"} 21
 				kube_replicaset_status_replicas{namespace="ns1",replicaset="rs1"} 5
@@ -95,6 +101,10 @@ func TestReplicaSetCollector(t *testing.T) {
 					Name:       "rs2",
 					Namespace:  "ns2",
 					Generation: 14,
+					Labels: map[string]string{
+						"app": "example2",
+						"env": "ex",
+					},
 				},
 				Status: v1beta1.ReplicaSetStatus{
 					Replicas:             0,
@@ -107,6 +117,7 @@ func TestReplicaSetCollector(t *testing.T) {
 				},
 			},
 			Want: `
+				kube_replicaset_labels{replicaset="rs2",label_app="example2",label_env="ex"} 1
 				kube_replicaset_metadata_generation{namespace="ns2",replicaset="rs2"} 14
 				kube_replicaset_status_replicas{namespace="ns2",replicaset="rs2"} 0
 				kube_replicaset_status_observed_generation{namespace="ns2",replicaset="rs2"} 5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This PR adds the `kube_replicaset_labels` metric. In some edge case scenarios this can be useful.

In our environment, we heavily use labels for tenancy. Developers want to be able to see how often they "deploy" an update; this can normally be done using `kube_deployment_created`, unless the deployment is updated. When the deployment is updated, a new replicaset is created, so we use `kube_replicaset_created`, but we can not determine what team owns the replicaset without being able to access its labels

I'm having minikube issues so I'm unable to run the e2e tests locally :sweat_smile: 