### PR TITLE
tests: Add benchmark compare script and include in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ language: go
 go:
     - "1.11.5"
 
+git:
+  # Benchmark tests needs to access other branches, thereby we need to fetch all
+  # of the repository.
+  depth: false
+
 env:
   global:
       - E2E_SETUP_MINIKUBE=yes
@@ -25,6 +30,8 @@ jobs:
     - script: make doccheck
     # Unit Test
     - script: make test-unit
+    # Bechmark Test
+    - script: make test-benchmark-compare
     # Build
     - script: make build
     # E2e

--- a/pkg/metric/metric_test.go
+++ b/pkg/metric/metric_test.go
@@ -54,7 +54,7 @@ func BenchmarkMetricWrite(b *testing.B) {
 				LabelValues: []string{"container2", "docker://cd456", "k8s.gcr.io/hyperkube2", "docker://sha256:bbb", "ns2", "pod2"},
 				Value:       float64(1),
 			},
-			expectedLength: 168,
+			expectedLength: 145,
 		},
 		{
 			testName: "value-35.7",
@@ -63,7 +63,7 @@ func BenchmarkMetricWrite(b *testing.B) {
 				LabelValues: []string{"container2", "docker://cd456", "k8s.gcr.io/hyperkube2", "docker://sha256:bbb", "ns2", "pod2"},
 				Value:       float64(35.7),
 			},
-			expectedLength: 171,
+			expectedLength: 148,
 		},
 	}
 

--- a/tests/compare_benchmarks.sh
+++ b/tests/compare_benchmarks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+[ "$#" -eq 1 ] || echo "One argument required, $# provided."
+
+REF_CURRENT="$(git rev-parse --abbrev-ref HEAD)"
+REF_TO_COMPARE=$1
+
+RESULT_CURRENT="$(mktemp)"
+RESULT_TO_COMPARE="$(mktemp)"
+
+echo ""
+echo "### Testing ${REF_CURRENT}"
+
+go test -benchmem -run=NONE -bench=. ./... | tee "${RESULT_CURRENT}"
+
+echo ""
+echo "### Done testing ${REF_CURRENT}"
+
+echo ""
+echo "### Testing ${REF_TO_COMPARE}"
+
+git checkout "$REF_TO_COMPARE"
+
+go test -benchmem -run=NONE -bench=. ./... | tee "$RESULT_TO_COMPARE"
+
+echo ""
+echo "### Done testing ${REF_TO_COMPARE}"
+
+git checkout -
+
+echo ""
+echo "### Result"
+echo "old=${REF_TO_COMPARE} new=${REF_CURRENT}"
+
+benchcmp "$RESULT_TO_COMPARE" "$RESULT_CURRENT"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a script that runs all benchmark tests on the current git ref and
the last release and add it to the Makefile and .travis.yml file.

This does not enforce certain benchmark results, but at least gives people the chance to easily compare their changes performance-wise.

Idea came up here: https://github.com/kubernetes/kube-state-metrics/pull/633#issuecomment-458084905