### PR TITLE
pkg/metric/generator: Refactor GenerateFunc call and return pointer

### DIFF
--- a/internal/collector/configmap.go
+++ b/internal/collector/configmap.go
@@ -35,8 +35,8 @@ var (
 			Name: "kube_configmap_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about configmap.",
-			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{{
 						LabelKeys:   []string{},
 						LabelValues: []string{},
@@ -49,7 +49,7 @@ var (
 			Name: "kube_configmap_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metric.Family {
+			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !c.CreationTimestamp.IsZero() {
@@ -60,7 +60,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -69,8 +69,8 @@ var (
 			Name: "kube_configmap_metadata_resource_version",
 			Type: metric.MetricTypeGauge,
 			Help: "Resource version representing a specific version of the configmap.",
-			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"resource_version"},
@@ -95,8 +95,8 @@ func createConfigMapListWatch(kubeClient clientset.Interface, ns string) cache.L
 	}
 }
 
-func wrapConfigMapFunc(f func(*v1.ConfigMap) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapConfigMapFunc(f func(*v1.ConfigMap) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		configMap := obj.(*v1.ConfigMap)
 
 		metricFamily := f(configMap)

--- a/internal/collector/cronjob.go
+++ b/internal/collector/cronjob.go
@@ -42,9 +42,9 @@ var (
 			Name: descCronJobLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descCronJobLabelsHelp,
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metric.Family {
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -59,8 +59,8 @@ var (
 			Name: "kube_cronjob_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Info about cronjob.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"schedule", "concurrency_policy"},
@@ -75,7 +75,7 @@ var (
 			Name: "kube_cronjob_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metric.Family {
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 				if !j.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
@@ -85,7 +85,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -94,8 +94,8 @@ var (
 			Name: "kube_cronjob_status_active",
 			Type: metric.MetricTypeGauge,
 			Help: "Active holds pointers to currently running jobs.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{},
@@ -110,7 +110,7 @@ var (
 			Name: "kube_cronjob_status_last_schedule_time",
 			Type: metric.MetricTypeGauge,
 			Help: "LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metric.Family {
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Status.LastScheduleTime != nil {
@@ -121,7 +121,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -130,7 +130,7 @@ var (
 			Name: "kube_cronjob_spec_suspend",
 			Type: metric.MetricTypeGauge,
 			Help: "Suspend flag tells the controller to suspend subsequent executions.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metric.Family {
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.Suspend != nil {
@@ -141,7 +141,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -150,7 +150,7 @@ var (
 			Name: "kube_cronjob_spec_starting_deadline_seconds",
 			Type: metric.MetricTypeGauge,
 			Help: "Deadline in seconds for starting the job if it misses scheduled time for any reason.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metric.Family {
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.StartingDeadlineSeconds != nil {
@@ -162,7 +162,7 @@ var (
 
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -171,7 +171,7 @@ var (
 			Name: "kube_cronjob_next_schedule_time",
 			Type: metric.MetricTypeGauge,
 			Help: "Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) metric.Family {
+			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// If the cron job is suspended, don't track the next scheduled time
@@ -186,7 +186,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -194,8 +194,8 @@ var (
 	}
 )
 
-func wrapCronJobFunc(f func(*batchv1beta1.CronJob) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapCronJobFunc(f func(*batchv1beta1.CronJob) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		cronJob := obj.(*batchv1beta1.CronJob)
 
 		metricFamily := f(cronJob)

--- a/internal/collector/daemonset.go
+++ b/internal/collector/daemonset.go
@@ -37,7 +37,7 @@ var (
 			Name: "kube_daemonset_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !d.CreationTimestamp.IsZero() {
@@ -48,7 +48,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -57,8 +57,8 @@ var (
 			Name: "kube_daemonset_status_current_number_scheduled",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes running at least one daemon pod and are supposed to.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{},
@@ -73,8 +73,8 @@ var (
 			Name: "kube_daemonset_status_desired_number_scheduled",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{},
@@ -89,8 +89,8 @@ var (
 			Name: "kube_daemonset_status_number_available",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{},
@@ -105,8 +105,8 @@ var (
 			Name: "kube_daemonset_status_number_misscheduled",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes running a daemon pod but are not supposed to.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{},
@@ -121,8 +121,8 @@ var (
 			Name: "kube_daemonset_status_number_ready",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{},
@@ -137,8 +137,8 @@ var (
 			Name: "kube_daemonset_status_number_unavailable",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{},
@@ -153,8 +153,8 @@ var (
 			Name: "kube_daemonset_updated_number_scheduled",
 			Type: metric.MetricTypeGauge,
 			Help: "The total number of nodes that are running updated daemon pod",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(d.Status.UpdatedNumberScheduled),
@@ -167,8 +167,8 @@ var (
 			Name: "kube_daemonset_metadata_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{},
@@ -183,9 +183,9 @@ var (
 			Name: descDaemonSetLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descDaemonSetLabelsHelp,
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) metric.Family {
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1beta1.DaemonSet) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.ObjectMeta.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -199,8 +199,8 @@ var (
 	}
 )
 
-func wrapDaemonSetFunc(f func(*v1beta1.DaemonSet) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapDaemonSetFunc(f func(*v1beta1.DaemonSet) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		daemonSet := obj.(*v1beta1.DaemonSet)
 
 		metricFamily := f(daemonSet)

--- a/internal/collector/deployment.go
+++ b/internal/collector/deployment.go
@@ -38,7 +38,7 @@ var (
 			Name: "kube_deployment_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !d.CreationTimestamp.IsZero() {
@@ -47,7 +47,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -56,8 +56,8 @@ var (
 			Name: "kube_deployment_status_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of replicas per deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(d.Status.Replicas),
@@ -70,8 +70,8 @@ var (
 			Name: "kube_deployment_status_replicas_available",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of available replicas per deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(d.Status.AvailableReplicas),
@@ -84,8 +84,8 @@ var (
 			Name: "kube_deployment_status_replicas_unavailable",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of unavailable replicas per deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(d.Status.UnavailableReplicas),
@@ -98,8 +98,8 @@ var (
 			Name: "kube_deployment_status_replicas_updated",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of updated replicas per deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(d.Status.UpdatedReplicas),
@@ -112,8 +112,8 @@ var (
 			Name: "kube_deployment_status_observed_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "The generation observed by the deployment controller.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(d.Status.ObservedGeneration),
@@ -126,8 +126,8 @@ var (
 			Name: "kube_deployment_spec_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "Number of desired pods for a deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(*d.Spec.Replicas),
@@ -140,8 +140,8 @@ var (
 			Name: "kube_deployment_spec_paused",
 			Type: metric.MetricTypeGauge,
 			Help: "Whether the deployment is paused and will not be processed by the deployment controller.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: boolFloat64(d.Spec.Paused),
@@ -154,9 +154,9 @@ var (
 			Name: "kube_deployment_spec_strategy_rollingupdate_max_unavailable",
 			Type: metric.MetricTypeGauge,
 			Help: "Maximum number of unavailable replicas during a rolling update of a deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.Spec.Strategy.RollingUpdate == nil {
-					return metric.Family{}
+					return &metric.Family{}
 				}
 
 				maxUnavailable, err := intstr.GetValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*d.Spec.Replicas), true)
@@ -164,7 +164,7 @@ var (
 					panic(err)
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(maxUnavailable),
@@ -177,9 +177,9 @@ var (
 			Name: "kube_deployment_spec_strategy_rollingupdate_max_surge",
 			Type: metric.MetricTypeGauge,
 			Help: "Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.Spec.Strategy.RollingUpdate == nil {
-					return metric.Family{}
+					return &metric.Family{}
 				}
 
 				maxSurge, err := intstr.GetValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxSurge, int(*d.Spec.Replicas), true)
@@ -187,7 +187,7 @@ var (
 					panic(err)
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(maxSurge),
@@ -200,8 +200,8 @@ var (
 			Name: "kube_deployment_metadata_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(d.ObjectMeta.Generation),
@@ -214,9 +214,9 @@ var (
 			Name: descDeploymentLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descDeploymentLabelsHelp,
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) metric.Family {
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -230,8 +230,8 @@ var (
 	}
 )
 
-func wrapDeploymentFunc(f func(*v1.Deployment) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapDeploymentFunc(f func(*v1.Deployment) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		deployment := obj.(*v1.Deployment)
 
 		metricFamily := f(deployment)

--- a/internal/collector/endpoint.go
+++ b/internal/collector/endpoint.go
@@ -37,8 +37,8 @@ var (
 			Name: "kube_endpoint_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about endpoint.",
-			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: 1,
@@ -51,7 +51,7 @@ var (
 			Name: "kube_endpoint_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) metric.Family {
+			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !e.CreationTimestamp.IsZero() {
@@ -61,7 +61,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -70,9 +70,9 @@ var (
 			Name: descEndpointLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descEndpointLabelsHelp,
-			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) metric.Family {
+			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(e.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -87,13 +87,13 @@ var (
 			Name: "kube_endpoint_address_available",
 			Type: metric.MetricTypeGauge,
 			Help: "Number of addresses available in endpoint.",
-			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) metric.Family {
+			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				var available int
 				for _, s := range e.Subsets {
 					available += len(s.Addresses) * len(s.Ports)
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(available),
@@ -106,12 +106,12 @@ var (
 			Name: "kube_endpoint_address_not_ready",
 			Type: metric.MetricTypeGauge,
 			Help: "Number of addresses not ready in endpoint",
-			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) metric.Family {
+			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				var notReady int
 				for _, s := range e.Subsets {
 					notReady += len(s.NotReadyAddresses) * len(s.Ports)
 				}
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(notReady),
@@ -123,8 +123,8 @@ var (
 	}
 )
 
-func wrapEndpointFunc(f func(*v1.Endpoints) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapEndpointFunc(f func(*v1.Endpoints) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		endpoint := obj.(*v1.Endpoints)
 
 		metricFamily := f(endpoint)

--- a/internal/collector/hpa.go
+++ b/internal/collector/hpa.go
@@ -37,8 +37,8 @@ var (
 			Name: "kube_hpa_metadata_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "The generation observed by the HorizontalPodAutoscaler controller.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(a.ObjectMeta.Generation),
@@ -51,8 +51,8 @@ var (
 			Name: "kube_hpa_spec_max_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(a.Spec.MaxReplicas),
@@ -65,8 +65,8 @@ var (
 			Name: "kube_hpa_spec_min_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "Lower limit for the number of pods that can be set by the autoscaler, default 1.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(*a.Spec.MinReplicas),
@@ -79,8 +79,8 @@ var (
 			Name: "kube_hpa_status_current_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "Current number of replicas of pods managed by this autoscaler.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(a.Status.CurrentReplicas),
@@ -93,8 +93,8 @@ var (
 			Name: "kube_hpa_status_desired_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "Desired number of replicas of pods managed by this autoscaler.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(a.Status.DesiredReplicas),
@@ -107,9 +107,9 @@ var (
 			Name: descHorizontalPodAutoscalerLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descHorizontalPodAutoscalerLabelsHelp,
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metric.Family {
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(a.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -124,7 +124,7 @@ var (
 			Name: "kube_hpa_status_condition",
 			Type: metric.MetricTypeGauge,
 			Help: "The condition of this autoscaler.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) metric.Family {
+			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range a.Status.Conditions {
@@ -138,7 +138,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -146,8 +146,8 @@ var (
 	}
 )
 
-func wrapHPAFunc(f func(*autoscaling.HorizontalPodAutoscaler) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapHPAFunc(f func(*autoscaling.HorizontalPodAutoscaler) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		hpa := obj.(*autoscaling.HorizontalPodAutoscaler)
 
 		metricFamily := f(hpa)

--- a/internal/collector/job.go
+++ b/internal/collector/job.go
@@ -37,9 +37,9 @@ var (
 			Name: descJobLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descJobLabelsHelp,
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -54,8 +54,8 @@ var (
 			Name: "kube_job_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about job.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: 1,
@@ -68,7 +68,7 @@ var (
 			Name: "kube_job_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !j.CreationTimestamp.IsZero() {
@@ -77,7 +77,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -86,7 +86,7 @@ var (
 			Name: "kube_job_spec_parallelism",
 			Type: metric.MetricTypeGauge,
 			Help: "The maximum desired number of pods the job should run at any given time.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.Parallelism != nil {
@@ -95,7 +95,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -104,7 +104,7 @@ var (
 			Name: "kube_job_spec_completions",
 			Type: metric.MetricTypeGauge,
 			Help: "The desired number of successfully finished pods the job should be run with.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.Completions != nil {
@@ -113,7 +113,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -122,7 +122,7 @@ var (
 			Name: "kube_job_spec_active_deadline_seconds",
 			Type: metric.MetricTypeGauge,
 			Help: "The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.ActiveDeadlineSeconds != nil {
@@ -131,7 +131,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -140,8 +140,8 @@ var (
 			Name: "kube_job_status_succeeded",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of pods which reached Phase Succeeded.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(j.Status.Succeeded),
@@ -154,8 +154,8 @@ var (
 			Name: "kube_job_status_failed",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of pods which reached Phase Failed.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(j.Status.Failed),
@@ -168,8 +168,8 @@ var (
 			Name: "kube_job_status_active",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of actively running pods.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(j.Status.Active),
@@ -182,7 +182,7 @@ var (
 			Name: "kube_job_complete",
 			Type: metric.MetricTypeGauge,
 			Help: "The job has completed its execution.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 				for _, c := range j.Status.Conditions {
 					if c.Type == v1batch.JobComplete {
@@ -195,7 +195,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -204,7 +204,7 @@ var (
 			Name: "kube_job_failed",
 			Type: metric.MetricTypeGauge,
 			Help: "The job has failed its execution.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range j.Status.Conditions {
@@ -218,7 +218,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -227,7 +227,7 @@ var (
 			Name: "kube_job_status_start_time",
 			Type: metric.MetricTypeGauge,
 			Help: "StartTime represents time when the job was acknowledged by the Job Manager.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Status.StartTime != nil {
@@ -237,7 +237,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -246,7 +246,7 @@ var (
 			Name: "kube_job_status_completion_time",
 			Type: metric.MetricTypeGauge,
 			Help: "CompletionTime represents time when the job was completed.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) metric.Family {
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 				if j.Status.CompletionTime != nil {
 					ms = append(ms, &metric.Metric{
@@ -255,7 +255,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -263,8 +263,8 @@ var (
 	}
 )
 
-func wrapJobFunc(f func(*v1batch.Job) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapJobFunc(f func(*v1batch.Job) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		job := obj.(*v1batch.Job)
 
 		metricFamily := f(job)

--- a/internal/collector/limitrange.go
+++ b/internal/collector/limitrange.go
@@ -35,7 +35,7 @@ var (
 			Name: "kube_limitrange",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about limit range.",
-			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) metric.Family {
+			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
 				ms := []*metric.Metric{}
 
 				rawLimitRanges := r.Spec.Limits
@@ -80,7 +80,7 @@ var (
 					m.LabelKeys = []string{"resource", "type", "constraint"}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -89,7 +89,7 @@ var (
 			Name: "kube_limitrange_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) metric.Family {
+			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !r.CreationTimestamp.IsZero() {
@@ -99,7 +99,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -107,8 +107,8 @@ var (
 	}
 )
 
-func wrapLimitRangeFunc(f func(*v1.LimitRange) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapLimitRangeFunc(f func(*v1.LimitRange) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		limitRange := obj.(*v1.LimitRange)
 
 		metricFamily := f(limitRange)

--- a/internal/collector/namespace.go
+++ b/internal/collector/namespace.go
@@ -41,7 +41,7 @@ var (
 			Name: "kube_namespace_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) metric.Family {
+			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := []*metric.Metric{}
 				if !n.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
@@ -49,7 +49,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -58,9 +58,9 @@ var (
 			Name: descNamespaceLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descNamespaceLabelsHelp,
-			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) metric.Family {
+			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -75,9 +75,9 @@ var (
 			Name: descNamespaceAnnotationsName,
 			Type: metric.MetricTypeGauge,
 			Help: descNamespaceAnnotationsHelp,
-			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) metric.Family {
+			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(n.Annotations)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   annotationKeys,
@@ -92,7 +92,7 @@ var (
 			Name: "kube_namespace_status_phase",
 			Type: metric.MetricTypeGauge,
 			Help: "kubernetes namespace status phase.",
-			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) metric.Family {
+			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := []*metric.Metric{
 					{
 						LabelValues: []string{string(v1.NamespaceActive)},
@@ -108,7 +108,7 @@ var (
 					metric.LabelKeys = []string{"phase"}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -116,8 +116,8 @@ var (
 	}
 )
 
-func wrapNamespaceFunc(f func(*v1.Namespace) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapNamespaceFunc(f func(*v1.Namespace) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		namespace := obj.(*v1.Namespace)
 
 		metricFamily := f(namespace)

--- a/internal/collector/node.go
+++ b/internal/collector/node.go
@@ -38,8 +38,8 @@ var (
 			Name: "kube_node_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about a cluster node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys: []string{
@@ -68,7 +68,7 @@ var (
 			Name: "kube_node_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !n.CreationTimestamp.IsZero() {
@@ -78,7 +78,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -87,9 +87,9 @@ var (
 			Name: descNodeLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descNodeLabelsHelp,
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -104,8 +104,8 @@ var (
 			Name: "kube_node_spec_unschedulable",
 			Type: metric.MetricTypeGauge,
 			Help: "Whether a node can schedule new pods.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: boolFloat64(n.Spec.Unschedulable),
@@ -118,7 +118,7 @@ var (
 			Name: "kube_node_spec_taint",
 			Type: metric.MetricTypeGauge,
 			Help: "The taint of a cluster node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, taint := range n.Spec.Taints {
@@ -132,7 +132,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -145,7 +145,7 @@ var (
 			Name: "kube_node_status_condition",
 			Type: metric.MetricTypeGauge,
 			Help: "The condition of a cluster node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// Collect node conditions and while default to false.
@@ -158,7 +158,7 @@ var (
 					ms = append(ms, conditionMetrics...)
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -167,7 +167,7 @@ var (
 			Name: "kube_node_status_phase",
 			Type: metric.MetricTypeGauge,
 			Help: "The phase the node is currently in.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// Set current phase to 1, others to 0 if it is set.
@@ -192,7 +192,7 @@ var (
 					metric.LabelKeys = []string{"phase"}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -201,7 +201,7 @@ var (
 			Name: "kube_node_status_capacity",
 			Type: metric.MetricTypeGauge,
 			Help: "The capacity for different resources of a node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				capacity := n.Status.Capacity
@@ -270,7 +270,7 @@ var (
 					metric.LabelKeys = []string{"resource", "unit"}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -279,7 +279,7 @@ var (
 			Name: "kube_node_status_capacity_pods",
 			Type: metric.MetricTypeGauge,
 			Help: "The total pod resources of the node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// Add capacity and allocatable resources if they are set.
@@ -290,7 +290,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -299,7 +299,7 @@ var (
 			Name: "kube_node_status_capacity_cpu_cores",
 			Type: metric.MetricTypeGauge,
 			Help: "The total CPU resources of the node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// Add capacity and allocatable resources if they are set.
@@ -309,7 +309,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -318,7 +318,7 @@ var (
 			Name: "kube_node_status_capacity_memory_bytes",
 			Type: metric.MetricTypeGauge,
 			Help: "The total memory resources of the node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// Add capacity and allocatable resources if they are set.
@@ -328,7 +328,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -337,7 +337,7 @@ var (
 			Name: "kube_node_status_allocatable",
 			Type: metric.MetricTypeGauge,
 			Help: "The allocatable for different resources of a node that are available for scheduling.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				allocatable := n.Status.Allocatable
@@ -407,7 +407,7 @@ var (
 					m.LabelKeys = []string{"resource", "unit"}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -416,7 +416,7 @@ var (
 			Name: "kube_node_status_allocatable_pods",
 			Type: metric.MetricTypeGauge,
 			Help: "The pod resources of a node that are available for scheduling.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// Add capacity and allocatable resources if they are set.
@@ -426,7 +426,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -435,7 +435,7 @@ var (
 			Name: "kube_node_status_allocatable_cpu_cores",
 			Type: metric.MetricTypeGauge,
 			Help: "The CPU resources of a node that are available for scheduling.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// Add capacity and allocatable resources if they are set.
@@ -445,7 +445,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -454,7 +454,7 @@ var (
 			Name: "kube_node_status_allocatable_memory_bytes",
 			Type: metric.MetricTypeGauge,
 			Help: "The memory resources of a node that are available for scheduling.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metric.Family {
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// Add capacity and allocatable resources if they are set.
@@ -465,7 +465,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -473,8 +473,8 @@ var (
 	}
 )
 
-func wrapNodeFunc(f func(*v1.Node) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapNodeFunc(f func(*v1.Node) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		node := obj.(*v1.Node)
 
 		metricFamily := f(node)

--- a/internal/collector/persistentvolume.go
+++ b/internal/collector/persistentvolume.go
@@ -37,9 +37,9 @@ var (
 			Name: descPersistentVolumeLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descPersistentVolumeLabelsHelp,
-			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) metric.Family {
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -54,7 +54,7 @@ var (
 			Name: "kube_persistentvolume_status_phase",
 			Type: metric.MetricTypeGauge,
 			Help: "The phase indicates if a volume is available, bound to a claim, or released by a claim.",
-			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) metric.Family {
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// Set current phase to 1, others to 0 if it is set.
@@ -87,7 +87,7 @@ var (
 					m.LabelKeys = []string{"phase"}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -96,8 +96,8 @@ var (
 			Name: "kube_persistentvolume_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about persistentvolume.",
-			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"storageclass"},
@@ -111,8 +111,8 @@ var (
 	}
 )
 
-func wrapPersistentVolumeFunc(f func(*v1.PersistentVolume) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapPersistentVolumeFunc(f func(*v1.PersistentVolume) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		persistentVolume := obj.(*v1.PersistentVolume)
 
 		metricFamily := f(persistentVolume)

--- a/internal/collector/persistentvolumeclaim.go
+++ b/internal/collector/persistentvolumeclaim.go
@@ -37,9 +37,9 @@ var (
 			Name: descPersistentVolumeClaimLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descPersistentVolumeClaimLabelsHelp,
-			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metric.Family {
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -54,10 +54,10 @@ var (
 			Name: "kube_persistentvolumeclaim_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about persistent volume claim.",
-			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metric.Family {
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				storageClassName := getPersistentVolumeClaimClass(p)
 				volumeName := p.Spec.VolumeName
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"storageclass", "volumename"},
@@ -72,7 +72,7 @@ var (
 			Name: "kube_persistentvolumeclaim_status_phase",
 			Type: metric.MetricTypeGauge,
 			Help: "The phase the persistent volume claim is currently in.",
-			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metric.Family {
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// Set current phase to 1, others to 0 if it is set.
@@ -97,7 +97,7 @@ var (
 					m.LabelKeys = []string{"phase"}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -106,7 +106,7 @@ var (
 			Name: "kube_persistentvolumeclaim_resource_requests_storage_bytes",
 			Type: metric.MetricTypeGauge,
 			Help: "The capacity of storage requested by the persistent volume claim.",
-			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) metric.Family {
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if storage, ok := p.Spec.Resources.Requests[v1.ResourceStorage]; ok {
@@ -115,7 +115,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -123,8 +123,8 @@ var (
 	}
 )
 
-func wrapPersistentVolumeClaimFunc(f func(*v1.PersistentVolumeClaim) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapPersistentVolumeClaimFunc(f func(*v1.PersistentVolumeClaim) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		persistentVolumeClaim := obj.(*v1.PersistentVolumeClaim)
 
 		metricFamily := f(persistentVolumeClaim)

--- a/internal/collector/pod.go
+++ b/internal/collector/pod.go
@@ -42,7 +42,7 @@ var (
 			Name: "kube_pod_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				createdBy := metav1.GetControllerOf(p)
 				createdByKind := "<none>"
 				createdByName := "<none>"
@@ -62,7 +62,7 @@ var (
 					Value:       1,
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{&m},
 				}
 			}),
@@ -71,7 +71,7 @@ var (
 			Name: "kube_pod_start_time",
 			Type: metric.MetricTypeGauge,
 			Help: "Start time in unix timestamp for a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if p.Status.StartTime != nil {
@@ -82,7 +82,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -91,7 +91,7 @@ var (
 			Name: "kube_pod_completion_time",
 			Type: metric.MetricTypeGauge,
 			Help: "Completion time in unix timestamp for a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				var lastFinishTime float64
@@ -112,7 +112,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -121,7 +121,7 @@ var (
 			Name: "kube_pod_owner",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about the Pod's owner.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
 				ms := []*metric.Metric{}
 
@@ -150,7 +150,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -159,14 +159,14 @@ var (
 			Name: "kube_pod_labels",
 			Type: metric.MetricTypeGauge,
 			Help: "Kubernetes labels converted to Prometheus labels.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
 				m := metric.Metric{
 					LabelKeys:   labelKeys,
 					LabelValues: labelValues,
 					Value:       1,
 				}
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{&m},
 				}
 			}),
@@ -175,7 +175,7 @@ var (
 			Name: "kube_pod_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !p.CreationTimestamp.IsZero() {
@@ -186,7 +186,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -195,7 +195,7 @@ var (
 			Name: "kube_pod_status_scheduled_time",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix timestamp when pod moved into scheduled status",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Status.Conditions {
@@ -211,7 +211,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -220,12 +220,12 @@ var (
 			Name: "kube_pod_status_phase",
 			Type: metric.MetricTypeGauge,
 			Help: "The pods current phase.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				phase := p.Status.Phase
 				if phase == "" {
-					return metric.Family{
+					return &metric.Family{
 						Metrics: []*metric.Metric{},
 					}
 				}
@@ -252,7 +252,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -261,7 +261,7 @@ var (
 			Name: "kube_pod_status_ready",
 			Type: metric.MetricTypeGauge,
 			Help: "Describes whether the pod is ready to serve requests.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Status.Conditions {
@@ -277,7 +277,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -286,7 +286,7 @@ var (
 			Name: "kube_pod_status_scheduled",
 			Type: metric.MetricTypeGauge,
 			Help: "Describes the status of the scheduling process for the pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Status.Conditions {
@@ -302,7 +302,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -311,7 +311,7 @@ var (
 			Name: "kube_pod_container_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about a container in a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 				labelKeys := []string{"container", "image", "image_id", "container_id"}
 
@@ -323,7 +323,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -332,7 +332,7 @@ var (
 			Name: "kube_pod_container_status_waiting",
 			Type: metric.MetricTypeGauge,
 			Help: "Describes whether the container is currently in waiting state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, cs := range p.Status.ContainerStatuses {
@@ -343,7 +343,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -352,7 +352,7 @@ var (
 			Name: "kube_pod_container_status_waiting_reason",
 			Type: metric.MetricTypeGauge,
 			Help: "Describes the reason the container is currently in waiting state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, cs := range p.Status.ContainerStatuses {
@@ -365,7 +365,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -374,7 +374,7 @@ var (
 			Name: "kube_pod_container_status_running",
 			Type: metric.MetricTypeGauge,
 			Help: "Describes whether the container is currently in running state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, cs := range p.Status.ContainerStatuses {
@@ -385,7 +385,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -394,7 +394,7 @@ var (
 			Name: "kube_pod_container_status_terminated",
 			Type: metric.MetricTypeGauge,
 			Help: "Describes whether the container is currently in terminated state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, cs := range p.Status.ContainerStatuses {
@@ -405,7 +405,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -414,7 +414,7 @@ var (
 			Name: "kube_pod_container_status_terminated_reason",
 			Type: metric.MetricTypeGauge,
 			Help: "Describes the reason the container is currently in terminated state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, cs := range p.Status.ContainerStatuses {
@@ -427,7 +427,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -436,7 +436,7 @@ var (
 			Name: "kube_pod_container_status_last_terminated_reason",
 			Type: metric.MetricTypeGauge,
 			Help: "Describes the last reason the container was in terminated state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, cs := range p.Status.ContainerStatuses {
@@ -449,7 +449,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -458,7 +458,7 @@ var (
 			Name: "kube_pod_container_status_ready",
 			Type: metric.MetricTypeGauge,
 			Help: "Describes whether the containers readiness check succeeded.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, cs := range p.Status.ContainerStatuses {
@@ -469,7 +469,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -478,7 +478,7 @@ var (
 			Name: "kube_pod_container_status_restarts_total",
 			Type: metric.MetricTypeCounter,
 			Help: "The number of container restarts per container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, cs := range p.Status.ContainerStatuses {
@@ -489,7 +489,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -498,7 +498,7 @@ var (
 			Name: "kube_pod_container_resource_requests",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of requested request resource by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -547,7 +547,7 @@ var (
 					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -556,7 +556,7 @@ var (
 			Name: "kube_pod_container_resource_limits",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of requested limit resource by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -605,7 +605,7 @@ var (
 					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -614,7 +614,7 @@ var (
 			Name: "kube_pod_container_resource_requests_cpu_cores",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of requested cpu cores by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -628,7 +628,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -637,7 +637,7 @@ var (
 			Name: "kube_pod_container_resource_requests_memory_bytes",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of requested memory bytes by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -651,7 +651,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -660,7 +660,7 @@ var (
 			Name: "kube_pod_container_resource_limits_cpu_cores",
 			Type: metric.MetricTypeGauge,
 			Help: "The limit on cpu cores to be used by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -674,7 +674,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -683,7 +683,7 @@ var (
 			Name: "kube_pod_container_resource_limits_memory_bytes",
 			Type: metric.MetricTypeGauge,
 			Help: "The limit on memory to be used by a container in bytes.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -698,7 +698,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -707,7 +707,7 @@ var (
 			Name: "kube_pod_spec_volumes_persistentvolumeclaims_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about persistentvolumeclaim volumes in a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, v := range p.Spec.Volumes {
@@ -720,7 +720,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -729,7 +729,7 @@ var (
 			Name: "kube_pod_spec_volumes_persistentvolumeclaims_readonly",
 			Type: metric.MetricTypeGauge,
 			Help: "Describes whether a persistentvolumeclaim is mounted read only.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) metric.Family {
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, v := range p.Spec.Volumes {
@@ -742,7 +742,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -750,8 +750,8 @@ var (
 	}
 )
 
-func wrapPodFunc(f func(*v1.Pod) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapPodFunc(f func(*v1.Pod) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		pod := obj.(*v1.Pod)
 
 		metricFamily := f(pod)

--- a/internal/collector/poddisruptionbudget.go
+++ b/internal/collector/poddisruptionbudget.go
@@ -35,7 +35,7 @@ var (
 			Name: "kube_poddisruptionbudget_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !p.CreationTimestamp.IsZero() {
@@ -44,7 +44,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -53,8 +53,8 @@ var (
 			Name: "kube_poddisruptionbudget_status_current_healthy",
 			Type: metric.MetricTypeGauge,
 			Help: "Current number of healthy pods",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(p.Status.CurrentHealthy),
@@ -67,8 +67,8 @@ var (
 			Name: "kube_poddisruptionbudget_status_desired_healthy",
 			Type: metric.MetricTypeGauge,
 			Help: "Minimum desired number of healthy pods",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(p.Status.DesiredHealthy),
@@ -81,8 +81,8 @@ var (
 			Name: "kube_poddisruptionbudget_status_pod_disruptions_allowed",
 			Type: metric.MetricTypeGauge,
 			Help: "Number of pod disruptions that are currently allowed",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(p.Status.PodDisruptionsAllowed),
@@ -95,8 +95,8 @@ var (
 			Name: "kube_poddisruptionbudget_status_expected_pods",
 			Type: metric.MetricTypeGauge,
 			Help: "Total number of pods counted by this disruption budget",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(p.Status.ExpectedPods),
@@ -109,8 +109,8 @@ var (
 			Name: "kube_poddisruptionbudget_status_observed_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "Most recent generation observed when updating this PDB status",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(p.Status.ObservedGeneration),
@@ -122,8 +122,8 @@ var (
 	}
 )
 
-func wrapPodDisruptionBudgetFunc(f func(*v1beta1.PodDisruptionBudget) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapPodDisruptionBudgetFunc(f func(*v1beta1.PodDisruptionBudget) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		podDisruptionBudget := obj.(*v1beta1.PodDisruptionBudget)
 
 		metricFamily := f(podDisruptionBudget)

--- a/internal/collector/replicaset.go
+++ b/internal/collector/replicaset.go
@@ -39,7 +39,7 @@ var (
 			Name: "kube_replicaset_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !r.CreationTimestamp.IsZero() {
@@ -49,7 +49,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -58,8 +58,8 @@ var (
 			Name: "kube_replicaset_status_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of replicas per ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.Status.Replicas),
@@ -72,8 +72,8 @@ var (
 			Name: "kube_replicaset_status_fully_labeled_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of fully labeled replicas per ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.Status.FullyLabeledReplicas),
@@ -86,8 +86,8 @@ var (
 			Name: "kube_replicaset_status_ready_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of ready replicas per ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.Status.ReadyReplicas),
@@ -100,8 +100,8 @@ var (
 			Name: "kube_replicaset_status_observed_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "The generation observed by the ReplicaSet controller.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.Status.ObservedGeneration),
@@ -114,7 +114,7 @@ var (
 			Name: "kube_replicaset_spec_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "Number of desired pods for a ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if r.Spec.Replicas != nil {
@@ -123,7 +123,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -132,8 +132,8 @@ var (
 			Name: "kube_replicaset_metadata_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.ObjectMeta.Generation),
@@ -146,7 +146,7 @@ var (
 			Name: "kube_replicaset_owner",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about the ReplicaSet's owner.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				owners := r.GetOwnerReferences()
@@ -173,7 +173,7 @@ var (
 					m.Value = 1
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -182,9 +182,9 @@ var (
 			Name: descReplicaSetLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descReplicaSetLabelsHelp,
-			GenerateFunc: wrapReplicaSetFunc(func(d *v1beta1.ReplicaSet) metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(d *v1beta1.ReplicaSet) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -198,8 +198,8 @@ var (
 	}
 )
 
-func wrapReplicaSetFunc(f func(*v1beta1.ReplicaSet) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapReplicaSetFunc(f func(*v1beta1.ReplicaSet) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		replicaSet := obj.(*v1beta1.ReplicaSet)
 
 		metricFamily := f(replicaSet)

--- a/internal/collector/replicationcontroller.go
+++ b/internal/collector/replicationcontroller.go
@@ -35,7 +35,7 @@ var (
 			Name: "kube_replicationcontroller_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !r.CreationTimestamp.IsZero() {
@@ -44,7 +44,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -53,8 +53,8 @@ var (
 			Name: "kube_replicationcontroller_status_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of replicas per ReplicationController.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.Status.Replicas),
@@ -67,8 +67,8 @@ var (
 			Name: "kube_replicationcontroller_status_fully_labeled_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of fully labeled replicas per ReplicationController.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.Status.FullyLabeledReplicas),
@@ -81,8 +81,8 @@ var (
 			Name: "kube_replicationcontroller_status_ready_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of ready replicas per ReplicationController.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.Status.ReadyReplicas),
@@ -95,8 +95,8 @@ var (
 			Name: "kube_replicationcontroller_status_available_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of available replicas per ReplicationController.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.Status.AvailableReplicas),
@@ -109,8 +109,8 @@ var (
 			Name: "kube_replicationcontroller_status_observed_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "The generation observed by the ReplicationController controller.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.Status.ObservedGeneration),
@@ -123,7 +123,7 @@ var (
 			Name: "kube_replicationcontroller_spec_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "Number of desired pods for a ReplicationController.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if r.Spec.Replicas != nil {
@@ -132,7 +132,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -141,8 +141,8 @@ var (
 			Name: "kube_replicationcontroller_metadata_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(r.ObjectMeta.Generation),
@@ -154,8 +154,8 @@ var (
 	}
 )
 
-func wrapReplicationControllerFunc(f func(*v1.ReplicationController) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapReplicationControllerFunc(f func(*v1.ReplicationController) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		replicationController := obj.(*v1.ReplicationController)
 
 		metricFamily := f(replicationController)

--- a/internal/collector/resourcequota.go
+++ b/internal/collector/resourcequota.go
@@ -35,7 +35,7 @@ var (
 			Name: "kube_resourcequota_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) metric.Family {
+			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !r.CreationTimestamp.IsZero() {
@@ -45,7 +45,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -54,7 +54,7 @@ var (
 			Name: "kube_resourcequota",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about resource quota.",
-			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) metric.Family {
+			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for res, qty := range r.Status.Hard {
@@ -74,7 +74,7 @@ var (
 					m.LabelKeys = []string{"resource", "type"}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -82,8 +82,8 @@ var (
 	}
 )
 
-func wrapResourceQuotaFunc(f func(*v1.ResourceQuota) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapResourceQuotaFunc(f func(*v1.ResourceQuota) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		resourceQuota := obj.(*v1.ResourceQuota)
 
 		metricFamily := f(resourceQuota)

--- a/internal/collector/secret.go
+++ b/internal/collector/secret.go
@@ -37,8 +37,8 @@ var (
 			Name: "kube_secret_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about secret.",
-			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: 1,
@@ -51,8 +51,8 @@ var (
 			Name: "kube_secret_type",
 			Type: metric.MetricTypeGauge,
 			Help: "Type about secret.",
-			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"type"},
@@ -67,9 +67,9 @@ var (
 			Name: descSecretLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descSecretLabelsHelp,
-			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metric.Family {
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -85,7 +85,7 @@ var (
 			Name: "kube_secret_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metric.Family {
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !s.CreationTimestamp.IsZero() {
@@ -94,7 +94,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -103,8 +103,8 @@ var (
 			Name: "kube_secret_metadata_resource_version",
 			Type: metric.MetricTypeGauge,
 			Help: "Resource version representing a specific version of secret.",
-			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"resource_version"},
@@ -118,8 +118,8 @@ var (
 	}
 )
 
-func wrapSecretFunc(f func(*v1.Secret) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapSecretFunc(f func(*v1.Secret) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		secret := obj.(*v1.Secret)
 
 		metricFamily := f(secret)

--- a/internal/collector/service.go
+++ b/internal/collector/service.go
@@ -37,50 +37,50 @@ var (
 			Name: "kube_service_info",
 			Type: metric.MetricTypeGauge,
 			Help: "Information about service.",
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metric.Family {
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				m := metric.Metric{
 					LabelKeys:   []string{"cluster_ip", "external_name", "load_balancer_ip"},
 					LabelValues: []string{s.Spec.ClusterIP, s.Spec.ExternalName, s.Spec.LoadBalancerIP},
 					Value:       1,
 				}
-				return metric.Family{Metrics: []*metric.Metric{&m}}
+				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
 		},
 		{
 			Name: "kube_service_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metric.Family {
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if !s.CreationTimestamp.IsZero() {
 					m := metric.Metric{
 						LabelKeys:   nil,
 						LabelValues: nil,
 						Value:       float64(s.CreationTimestamp.Unix()),
 					}
-					return metric.Family{Metrics: []*metric.Metric{&m}}
+					return &metric.Family{Metrics: []*metric.Metric{&m}}
 				}
-				return metric.Family{Metrics: []*metric.Metric{}}
+				return &metric.Family{Metrics: []*metric.Metric{}}
 			}),
 		},
 		{
 			Name: "kube_service_spec_type",
 			Type: metric.MetricTypeGauge,
 			Help: "Type about service.",
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metric.Family {
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				m := metric.Metric{
 
 					LabelKeys:   []string{"type"},
 					LabelValues: []string{string(s.Spec.Type)},
 					Value:       1,
 				}
-				return metric.Family{Metrics: []*metric.Metric{&m}}
+				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
 		},
 		{
 			Name: descServiceLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descServiceLabelsHelp,
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metric.Family {
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
 				m := metric.Metric{
 
@@ -88,14 +88,14 @@ var (
 					LabelValues: labelValues,
 					Value:       1,
 				}
-				return metric.Family{Metrics: []*metric.Metric{&m}}
+				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
 		},
 		{
 			Name: "kube_service_spec_external_ip",
 			Type: metric.MetricTypeGauge,
 			Help: "Service external ips. One series for each ip",
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metric.Family {
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if len(s.Spec.ExternalIPs) > 0 {
@@ -108,7 +108,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -117,7 +117,7 @@ var (
 			Name: "kube_service_status_load_balancer_ingress",
 			Type: metric.MetricTypeGauge,
 			Help: "Service load balancer ingress status",
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) metric.Family {
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if len(s.Status.LoadBalancer.Ingress) > 0 {
@@ -130,7 +130,7 @@ var (
 					}
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -138,8 +138,8 @@ var (
 	}
 )
 
-func wrapSvcFunc(f func(*v1.Service) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapSvcFunc(f func(*v1.Service) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		svc := obj.(*v1.Service)
 
 		metricFamily := f(svc)

--- a/internal/collector/statefulset.go
+++ b/internal/collector/statefulset.go
@@ -37,7 +37,7 @@ var (
 			Name: "kube_statefulset_created",
 			Type: metric.MetricTypeGauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !s.CreationTimestamp.IsZero() {
@@ -46,7 +46,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -55,8 +55,8 @@ var (
 			Name: "kube_statefulset_status_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of replicas per StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(s.Status.Replicas),
@@ -69,8 +69,8 @@ var (
 			Name: "kube_statefulset_status_replicas_current",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of current replicas per StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(s.Status.CurrentReplicas),
@@ -83,8 +83,8 @@ var (
 			Name: "kube_statefulset_status_replicas_ready",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of ready replicas per StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(s.Status.ReadyReplicas),
@@ -97,8 +97,8 @@ var (
 			Name: "kube_statefulset_status_replicas_updated",
 			Type: metric.MetricTypeGauge,
 			Help: "The number of updated replicas per StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(s.Status.UpdatedReplicas),
@@ -111,7 +111,7 @@ var (
 			Name: "kube_statefulset_status_observed_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "The generation observed by the StatefulSet controller.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if s.Status.ObservedGeneration != nil {
@@ -120,7 +120,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -129,7 +129,7 @@ var (
 			Name: "kube_statefulset_replicas",
 			Type: metric.MetricTypeGauge,
 			Help: "Number of desired pods for a StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if s.Spec.Replicas != nil {
@@ -138,7 +138,7 @@ var (
 					})
 				}
 
-				return metric.Family{
+				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
@@ -147,8 +147,8 @@ var (
 			Name: "kube_statefulset_metadata_generation",
 			Type: metric.MetricTypeGauge,
 			Help: "Sequence number representing a specific generation of the desired state for the StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							Value: float64(s.ObjectMeta.Generation),
@@ -161,9 +161,9 @@ var (
 			Name: descStatefulSetLabelsName,
 			Type: metric.MetricTypeGauge,
 			Help: descStatefulSetLabelsHelp,
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
-				return metric.Family{
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
@@ -178,8 +178,8 @@ var (
 			Name: "kube_statefulset_status_current_revision",
 			Type: metric.MetricTypeGauge,
 			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"revision"},
@@ -194,8 +194,8 @@ var (
 			Name: "kube_statefulset_status_update_revision",
 			Type: metric.MetricTypeGauge,
 			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) metric.Family {
-				return metric.Family{
+			GenerateFunc: wrapStatefulSetFunc(func(s *v1beta1.StatefulSet) *metric.Family {
+				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"revision"},
@@ -209,8 +209,8 @@ var (
 	}
 )
 
-func wrapStatefulSetFunc(f func(*v1beta1.StatefulSet) metric.Family) func(interface{}) metric.Family {
-	return func(obj interface{}) metric.Family {
+func wrapStatefulSetFunc(f func(*v1beta1.StatefulSet) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
 		statefulSet := obj.(*v1beta1.StatefulSet)
 
 		metricFamily := f(statefulSet)

--- a/pkg/metric/generator.go
+++ b/pkg/metric/generator.go
@@ -28,7 +28,7 @@ type FamilyGenerator struct {
 	Name         string
 	Help         string
 	Type         MetricType
-	GenerateFunc func(obj interface{}) Family
+	GenerateFunc func(obj interface{}) *Family
 }
 
 func (f *FamilyGenerator) generateHeader() string {
@@ -68,7 +68,7 @@ func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) [
 			family := gen.GenerateFunc(obj)
 			// Make family aware of its name.
 			family.Name = gen.Name
-			families[i] = &family
+			families[i] = family
 		}
 
 		return families


### PR DESCRIPTION
**What this PR does / why we need it**:

**pkg/metric/generator: Introduce Generate method calling GenerateFunc**

Instead of making an external component responsible of adding the family name to
each family, enforce this in the generator via the `Generate` function.

**pkg/metric/generator: Make GenerateFunc return pointer to Family**

Instead of returning a Family right away, make GenerateFunc return a pointer to
a Family, matching the convention across the k8s project and removing the need
to do so later in the code path.
