### PR TITLE
Enable use as kustomize base layer

### DIFF
--- a/kubernetes/kube-state-metrics-cluster-role.yaml
+++ b/kubernetes/kube-state-metrics-cluster-role.yaml
@@ -27,6 +27,9 @@ rules:
   verbs: ["list", "watch"]
 - apiGroups: ["apps"]
   resources:
+  - daemonsets
+  - deployments
+  - replicasets
   - statefulsets
   verbs: ["list", "watch"]
 - apiGroups: ["batch"]

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -1,5 +1,5 @@
-apiVersion: apps/v1beta2
-# Kubernetes versions after 1.9.0 should use apps/v1
+apiVersion: apps/v1
+# Kubernetes version 1.8.x should use apps/v1beta2
 # Kubernetes versions before 1.8.0 should use apps/v1beta1 or extensions/v1beta1
 kind: Deployment
 metadata:

--- a/kubernetes/kube-state-metrics-role.yaml
+++ b/kubernetes/kube-state-metrics-role.yaml
@@ -9,6 +9,11 @@ rules:
   resources:
   - pods
   verbs: ["get"]
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]
 - apiGroups: ["extensions"]
   resources:
   - deployments

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -1,12 +1,6 @@
 commonLabels:
   app.kubernetes.io/name: kube-state-metrics
 
-imageTags:
-- name: quay.io/coreos/kube-state-metrics
-  newTag: v1.5.0
-- name: k8s.gcr.io/addon-resizer
-  newTag: 1.8.3
-
 namespace: kube-system
 
 resources:

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -1,0 +1,19 @@
+commonLabels:
+  app.kubernetes.io/name: kube-state-metrics
+
+imageTags:
+- name: quay.io/coreos/kube-state-metrics
+  newTag: v1.5.0
+- name: k8s.gcr.io/addon-resizer
+  newTag: 1.8.3
+
+namespace: kube-system
+
+resources:
+- kube-state-metrics-cluster-role-binding.yaml
+- kube-state-metrics-cluster-role.yaml
+- kube-state-metrics-deployment.yaml
+- kube-state-metrics-role-binding.yaml
+- kube-state-metrics-role.yaml
+- kube-state-metrics-service-account.yaml
+- kube-state-metrics-service.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

- Primarily adds a `kustomization.yaml` file to enable use as a [kustomize](https://github.com/kubernetes-sigs/kustomize) base layer.
- Also adds resources from the `apps` group to the Role and ClusterRole.
- Updates the Deployment to `apps/v1`
