### PR TITLE
[WIP] Native pod termination counter - proposed implementation

### DIFF
--- a/Documentation/pod-metrics.md
+++ b/Documentation/pod-metrics.md
@@ -16,6 +16,7 @@
 | kube_pod_container_status_running | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_container_status_terminated | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_container_status_terminated_reason | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `reason`=&lt;OOMKilled\|Error\|Completed\|ContainerCannotRun&gt; | STABLE |
+| kube_pod_container_status_terminated_reasons_total | Counter | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `reason`=&lt;OOMKilled\|Error\|Completed\|ContainerCannotRun&gt; | STABLE |
 | kube_pod_container_status_last_terminated_reason | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `reason`=&lt;OOMKilled\|Error\|Completed\|ContainerCannotRun&gt; | STABLE |
 | kube_pod_container_status_ready | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_container_status_restarts_total | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; | STABLE |

--- a/internal/collector/configmap_test.go
+++ b/internal/collector/configmap_test.go
@@ -41,11 +41,13 @@ func TestConfigMapCollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "configmap1",
-					Namespace:       "ns1",
-					ResourceVersion: "123456",
+			Objs: []interface{}{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "configmap1",
+						Namespace:       "ns1",
+						ResourceVersion: "123456",
+					},
 				},
 			},
 			Want: `
@@ -55,12 +57,14 @@ func TestConfigMapCollector(t *testing.T) {
 			MetricNames: []string{"kube_configmap_info", "kube_configmap_metadata_resource_version"},
 		},
 		{
-			Obj: &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "configmap2",
-					Namespace:         "ns2",
-					CreationTimestamp: metav1StartTime,
-					ResourceVersion:   "abcdef",
+			Objs: []interface{}{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "configmap2",
+						Namespace:         "ns2",
+						CreationTimestamp: metav1StartTime,
+						ResourceVersion:   "abcdef",
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/cronjob_test.go
+++ b/internal/collector/cronjob_test.go
@@ -121,24 +121,26 @@ func TestCronJobCollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &batchv1beta1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "ActiveRunningCronJob1",
-					Namespace:  "ns1",
-					Generation: 1,
-					Labels: map[string]string{
-						"app": "example-active-running-1",
+			Objs: []interface{}{
+				&batchv1beta1.CronJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "ActiveRunningCronJob1",
+						Namespace:  "ns1",
+						Generation: 1,
+						Labels: map[string]string{
+							"app": "example-active-running-1",
+						},
 					},
-				},
-				Status: batchv1beta1.CronJobStatus{
-					Active:           []v1.ObjectReference{{Name: "FakeJob1"}, {Name: "FakeJob2"}},
-					LastScheduleTime: &metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
-				},
-				Spec: batchv1beta1.CronJobSpec{
-					StartingDeadlineSeconds: &StartingDeadlineSeconds300,
-					ConcurrencyPolicy:       "Forbid",
-					Suspend:                 &SuspendFalse,
-					Schedule:                "0 */6 * * *",
+					Status: batchv1beta1.CronJobStatus{
+						Active:           []v1.ObjectReference{{Name: "FakeJob1"}, {Name: "FakeJob2"}},
+						LastScheduleTime: &metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
+					},
+					Spec: batchv1beta1.CronJobSpec{
+						StartingDeadlineSeconds: &StartingDeadlineSeconds300,
+						ConcurrencyPolicy:       "Forbid",
+						Suspend:                 &SuspendFalse,
+						Schedule:                "0 */6 * * *",
+					},
 				},
 			},
 			Want: `
@@ -153,24 +155,26 @@ func TestCronJobCollector(t *testing.T) {
 			MetricNames: []string{"kube_cronjob_next_schedule_time", "kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels", "kube_cronjob_status_last_schedule_time"},
 		},
 		{
-			Obj: &batchv1beta1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "SuspendedCronJob1",
-					Namespace:  "ns1",
-					Generation: 1,
-					Labels: map[string]string{
-						"app": "example-suspended-1",
+			Objs: []interface{}{
+				&batchv1beta1.CronJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "SuspendedCronJob1",
+						Namespace:  "ns1",
+						Generation: 1,
+						Labels: map[string]string{
+							"app": "example-suspended-1",
+						},
 					},
-				},
-				Status: batchv1beta1.CronJobStatus{
-					Active:           []v1.ObjectReference{},
-					LastScheduleTime: &metav1.Time{Time: SuspendedCronJob1LastScheduleTime},
-				},
-				Spec: batchv1beta1.CronJobSpec{
-					StartingDeadlineSeconds: &StartingDeadlineSeconds300,
-					ConcurrencyPolicy:       "Forbid",
-					Suspend:                 &SuspendTrue,
-					Schedule:                "0 */3 * * *",
+					Status: batchv1beta1.CronJobStatus{
+						Active:           []v1.ObjectReference{},
+						LastScheduleTime: &metav1.Time{Time: SuspendedCronJob1LastScheduleTime},
+					},
+					Spec: batchv1beta1.CronJobSpec{
+						StartingDeadlineSeconds: &StartingDeadlineSeconds300,
+						ConcurrencyPolicy:       "Forbid",
+						Suspend:                 &SuspendTrue,
+						Schedule:                "0 */3 * * *",
+					},
 				},
 			},
 			Want: `
@@ -184,25 +188,27 @@ func TestCronJobCollector(t *testing.T) {
 			MetricNames: []string{"kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels", "kube_cronjob_status_last_schedule_time"},
 		},
 		{
-			Obj: &batchv1beta1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "ActiveCronJob1NoLastScheduled",
-					CreationTimestamp: metav1.Time{Time: ActiveCronJob1NoLastScheduledCreationTimestamp},
-					Namespace:         "ns1",
-					Generation:        1,
-					Labels: map[string]string{
-						"app": "example-active-no-last-scheduled-1",
+			Objs: []interface{}{
+				&batchv1beta1.CronJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ActiveCronJob1NoLastScheduled",
+						CreationTimestamp: metav1.Time{Time: ActiveCronJob1NoLastScheduledCreationTimestamp},
+						Namespace:         "ns1",
+						Generation:        1,
+						Labels: map[string]string{
+							"app": "example-active-no-last-scheduled-1",
+						},
 					},
-				},
-				Status: batchv1beta1.CronJobStatus{
-					Active:           []v1.ObjectReference{},
-					LastScheduleTime: nil,
-				},
-				Spec: batchv1beta1.CronJobSpec{
-					StartingDeadlineSeconds: &StartingDeadlineSeconds300,
-					ConcurrencyPolicy:       "Forbid",
-					Suspend:                 &SuspendFalse,
-					Schedule:                "25 * * * *",
+					Status: batchv1beta1.CronJobStatus{
+						Active:           []v1.ObjectReference{},
+						LastScheduleTime: nil,
+					},
+					Spec: batchv1beta1.CronJobSpec{
+						StartingDeadlineSeconds: &StartingDeadlineSeconds300,
+						ConcurrencyPolicy:       "Forbid",
+						Suspend:                 &SuspendFalse,
+						Schedule:                "25 * * * *",
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/daemonset_test.go
+++ b/internal/collector/daemonset_test.go
@@ -52,20 +52,22 @@ func TestDaemonSetCollector(t *testing.T) {
 `
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1beta1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ds1",
-					Namespace: "ns1",
-					Labels: map[string]string{
-						"app": "example1",
+			Objs: []interface{}{
+				&v1beta1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ds1",
+						Namespace: "ns1",
+						Labels: map[string]string{
+							"app": "example1",
+						},
+						Generation: 21,
 					},
-					Generation: 21,
-				},
-				Status: v1beta1.DaemonSetStatus{
-					CurrentNumberScheduled: 15,
-					NumberMisscheduled:     10,
-					DesiredNumberScheduled: 5,
-					NumberReady:            5,
+					Status: v1beta1.DaemonSetStatus{
+						CurrentNumberScheduled: 15,
+						NumberMisscheduled:     10,
+						DesiredNumberScheduled: 5,
+						NumberReady:            5,
+					},
 				},
 			},
 			Want: `
@@ -92,21 +94,23 @@ func TestDaemonSetCollector(t *testing.T) {
 			},
 		},
 		{
-			Obj: &v1beta1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "ds2",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "ns2",
-					Labels: map[string]string{
-						"app": "example2",
+			Objs: []interface{}{
+				&v1beta1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ds2",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "ns2",
+						Labels: map[string]string{
+							"app": "example2",
+						},
+						Generation: 14,
 					},
-					Generation: 14,
-				},
-				Status: v1beta1.DaemonSetStatus{
-					CurrentNumberScheduled: 10,
-					NumberMisscheduled:     5,
-					DesiredNumberScheduled: 0,
-					NumberReady:            0,
+					Status: v1beta1.DaemonSetStatus{
+						CurrentNumberScheduled: 10,
+						NumberMisscheduled:     5,
+						DesiredNumberScheduled: 0,
+						NumberReady:            0,
+					},
 				},
 			},
 			Want: `
@@ -135,24 +139,26 @@ func TestDaemonSetCollector(t *testing.T) {
 			},
 		},
 		{
-			Obj: &v1beta1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "ds3",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "ns3",
-					Labels: map[string]string{
-						"app": "example3",
+			Objs: []interface{}{
+				&v1beta1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ds3",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "ns3",
+						Labels: map[string]string{
+							"app": "example3",
+						},
+						Generation: 15,
 					},
-					Generation: 15,
-				},
-				Status: v1beta1.DaemonSetStatus{
-					CurrentNumberScheduled: 10,
-					NumberMisscheduled:     5,
-					DesiredNumberScheduled: 15,
-					NumberReady:            5,
-					NumberAvailable:        5,
-					NumberUnavailable:      5,
-					UpdatedNumberScheduled: 5,
+					Status: v1beta1.DaemonSetStatus{
+						CurrentNumberScheduled: 10,
+						NumberMisscheduled:     5,
+						DesiredNumberScheduled: 15,
+						NumberReady:            5,
+						NumberAvailable:        5,
+						NumberUnavailable:      5,
+						UpdatedNumberScheduled: 5,
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/deployment_test.go
+++ b/internal/collector/deployment_test.go
@@ -68,29 +68,31 @@ func TestDeploymentCollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1beta1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "depl1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "ns1",
-					Labels: map[string]string{
-						"app": "example1",
+			Objs: []interface{}{
+				&v1beta1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "depl1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "ns1",
+						Labels: map[string]string{
+							"app": "example1",
+						},
+						Generation: 21,
 					},
-					Generation: 21,
-				},
-				Status: v1beta1.DeploymentStatus{
-					Replicas:            15,
-					AvailableReplicas:   10,
-					UnavailableReplicas: 5,
-					UpdatedReplicas:     2,
-					ObservedGeneration:  111,
-				},
-				Spec: v1beta1.DeploymentSpec{
-					Replicas: &depl1Replicas,
-					Strategy: v1beta1.DeploymentStrategy{
-						RollingUpdate: &v1beta1.RollingUpdateDeployment{
-							MaxUnavailable: &depl1MaxUnavailable,
-							MaxSurge:       &depl1MaxSurge,
+					Status: v1beta1.DeploymentStatus{
+						Replicas:            15,
+						AvailableReplicas:   10,
+						UnavailableReplicas: 5,
+						UpdatedReplicas:     2,
+						ObservedGeneration:  111,
+					},
+					Spec: v1beta1.DeploymentSpec{
+						Replicas: &depl1Replicas,
+						Strategy: v1beta1.DeploymentStrategy{
+							RollingUpdate: &v1beta1.RollingUpdateDeployment{
+								MaxUnavailable: &depl1MaxUnavailable,
+								MaxSurge:       &depl1MaxSurge,
+							},
 						},
 					},
 				},
@@ -111,29 +113,31 @@ func TestDeploymentCollector(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1beta1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "depl2",
-					Namespace: "ns2",
-					Labels: map[string]string{
-						"app": "example2",
+			Objs: []interface{}{
+				&v1beta1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "depl2",
+						Namespace: "ns2",
+						Labels: map[string]string{
+							"app": "example2",
+						},
+						Generation: 14,
 					},
-					Generation: 14,
-				},
-				Status: v1beta1.DeploymentStatus{
-					Replicas:            10,
-					AvailableReplicas:   5,
-					UnavailableReplicas: 0,
-					UpdatedReplicas:     1,
-					ObservedGeneration:  1111,
-				},
-				Spec: v1beta1.DeploymentSpec{
-					Paused:   true,
-					Replicas: &depl2Replicas,
-					Strategy: v1beta1.DeploymentStrategy{
-						RollingUpdate: &v1beta1.RollingUpdateDeployment{
-							MaxUnavailable: &depl2MaxUnavailable,
-							MaxSurge:       &depl2MaxSurge,
+					Status: v1beta1.DeploymentStatus{
+						Replicas:            10,
+						AvailableReplicas:   5,
+						UnavailableReplicas: 0,
+						UpdatedReplicas:     1,
+						ObservedGeneration:  1111,
+					},
+					Spec: v1beta1.DeploymentSpec{
+						Paused:   true,
+						Replicas: &depl2Replicas,
+						Strategy: v1beta1.DeploymentStrategy{
+							RollingUpdate: &v1beta1.RollingUpdateDeployment{
+								MaxUnavailable: &depl2MaxUnavailable,
+								MaxSurge:       &depl2MaxSurge,
+							},
 						},
 					},
 				},

--- a/internal/collector/endpoint_test.go
+++ b/internal/collector/endpoint_test.go
@@ -44,42 +44,44 @@ func TestEndpointCollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-endpoint",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "default",
-					Labels: map[string]string{
-						"app": "foobar",
-					},
-				},
-				Subsets: []v1.EndpointSubset{
-					{Addresses: []v1.EndpointAddress{
-						{IP: "127.0.0.1"}, {IP: "10.0.0.1"},
-					},
-						Ports: []v1.EndpointPort{
-							{Port: 8080}, {Port: 8081},
+			Objs: []interface{}{
+				&v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-endpoint",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "default",
+						Labels: map[string]string{
+							"app": "foobar",
 						},
 					},
-					{Addresses: []v1.EndpointAddress{
-						{IP: "172.22.23.202"},
-					},
-						Ports: []v1.EndpointPort{
-							{Port: 8443}, {Port: 9090},
+					Subsets: []v1.EndpointSubset{
+						{Addresses: []v1.EndpointAddress{
+							{IP: "127.0.0.1"}, {IP: "10.0.0.1"},
 						},
-					},
-					{NotReadyAddresses: []v1.EndpointAddress{
-						{IP: "192.168.1.1"},
-					},
-						Ports: []v1.EndpointPort{
-							{Port: 1234}, {Port: 5678},
+							Ports: []v1.EndpointPort{
+								{Port: 8080}, {Port: 8081},
+							},
 						},
-					},
-					{NotReadyAddresses: []v1.EndpointAddress{
-						{IP: "192.168.1.3"}, {IP: "192.168.2.2"},
-					},
-						Ports: []v1.EndpointPort{
-							{Port: 1234}, {Port: 5678},
+						{Addresses: []v1.EndpointAddress{
+							{IP: "172.22.23.202"},
+						},
+							Ports: []v1.EndpointPort{
+								{Port: 8443}, {Port: 9090},
+							},
+						},
+						{NotReadyAddresses: []v1.EndpointAddress{
+							{IP: "192.168.1.1"},
+						},
+							Ports: []v1.EndpointPort{
+								{Port: 1234}, {Port: 5678},
+							},
+						},
+						{NotReadyAddresses: []v1.EndpointAddress{
+							{IP: "192.168.1.3"}, {IP: "192.168.2.2"},
+						},
+							Ports: []v1.EndpointPort{
+								{Port: 1234}, {Port: 5678},
+							},
 						},
 					},
 				},

--- a/internal/collector/hpa_test.go
+++ b/internal/collector/hpa_test.go
@@ -46,24 +46,26 @@ func TestHPACollector(t *testing.T) {
 	cases := []generateMetricsTestCase{
 		{
 			// Verify populating base metric.
-			Obj: &autoscaling.HorizontalPodAutoscaler{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 2,
-					Name:       "hpa1",
-					Namespace:  "ns1",
-				},
-				Spec: autoscaling.HorizontalPodAutoscalerSpec{
-					MaxReplicas: 4,
-					MinReplicas: &hpa1MinReplicas,
-					ScaleTargetRef: autoscaling.CrossVersionObjectReference{
-						APIVersion: "extensions/v1beta1",
-						Kind:       "Deployment",
-						Name:       "deployment1",
+			Objs: []interface{}{
+				&autoscaling.HorizontalPodAutoscaler{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 2,
+						Name:       "hpa1",
+						Namespace:  "ns1",
 					},
-				},
-				Status: autoscaling.HorizontalPodAutoscalerStatus{
-					CurrentReplicas: 2,
-					DesiredReplicas: 2,
+					Spec: autoscaling.HorizontalPodAutoscalerSpec{
+						MaxReplicas: 4,
+						MinReplicas: &hpa1MinReplicas,
+						ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+							APIVersion: "extensions/v1beta1",
+							Kind:       "Deployment",
+							Name:       "deployment1",
+						},
+					},
+					Status: autoscaling.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 2,
+						DesiredReplicas: 2,
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/job_test.go
+++ b/internal/collector/job_test.go
@@ -74,27 +74,29 @@ func TestJobCollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1batch.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "RunningJob1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "ns1",
-					Generation:        1,
-					Labels: map[string]string{
-						"app": "example-running-1",
+			Objs: []interface{}{
+				&v1batch.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "RunningJob1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "ns1",
+						Generation:        1,
+						Labels: map[string]string{
+							"app": "example-running-1",
+						},
 					},
-				},
-				Status: v1batch.JobStatus{
-					Active:         1,
-					Failed:         0,
-					Succeeded:      0,
-					CompletionTime: nil,
-					StartTime:      &metav1.Time{Time: RunningJob1StartTime},
-				},
-				Spec: v1batch.JobSpec{
-					ActiveDeadlineSeconds: &ActiveDeadlineSeconds900,
-					Parallelism:           &Parallelism1,
-					Completions:           &Completions1,
+					Status: v1batch.JobStatus{
+						Active:         1,
+						Failed:         0,
+						Succeeded:      0,
+						CompletionTime: nil,
+						StartTime:      &metav1.Time{Time: RunningJob1StartTime},
+					},
+					Spec: v1batch.JobSpec{
+						ActiveDeadlineSeconds: &ActiveDeadlineSeconds900,
+						Parallelism:           &Parallelism1,
+						Completions:           &Completions1,
+					},
 				},
 			},
 			Want: `
@@ -111,29 +113,31 @@ func TestJobCollector(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1batch.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "SuccessfulJob1",
-					Namespace:  "ns1",
-					Generation: 1,
-					Labels: map[string]string{
-						"app": "example-successful-1",
+			Objs: []interface{}{
+				&v1batch.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "SuccessfulJob1",
+						Namespace:  "ns1",
+						Generation: 1,
+						Labels: map[string]string{
+							"app": "example-successful-1",
+						},
 					},
-				},
-				Status: v1batch.JobStatus{
-					Active:         0,
-					Failed:         0,
-					Succeeded:      1,
-					CompletionTime: &metav1.Time{Time: SuccessfulJob1CompletionTime},
-					StartTime:      &metav1.Time{Time: SuccessfulJob1StartTime},
-					Conditions: []v1batch.JobCondition{
-						{Type: v1batch.JobComplete, Status: v1.ConditionTrue},
+					Status: v1batch.JobStatus{
+						Active:         0,
+						Failed:         0,
+						Succeeded:      1,
+						CompletionTime: &metav1.Time{Time: SuccessfulJob1CompletionTime},
+						StartTime:      &metav1.Time{Time: SuccessfulJob1StartTime},
+						Conditions: []v1batch.JobCondition{
+							{Type: v1batch.JobComplete, Status: v1.ConditionTrue},
+						},
 					},
-				},
-				Spec: v1batch.JobSpec{
-					ActiveDeadlineSeconds: &ActiveDeadlineSeconds900,
-					Parallelism:           &Parallelism1,
-					Completions:           &Completions1,
+					Spec: v1batch.JobSpec{
+						ActiveDeadlineSeconds: &ActiveDeadlineSeconds900,
+						Parallelism:           &Parallelism1,
+						Completions:           &Completions1,
+					},
 				},
 			},
 			Want: `
@@ -153,29 +157,31 @@ func TestJobCollector(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1batch.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "FailedJob1",
-					Namespace:  "ns1",
-					Generation: 1,
-					Labels: map[string]string{
-						"app": "example-failed-1",
+			Objs: []interface{}{
+				&v1batch.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "FailedJob1",
+						Namespace:  "ns1",
+						Generation: 1,
+						Labels: map[string]string{
+							"app": "example-failed-1",
+						},
 					},
-				},
-				Status: v1batch.JobStatus{
-					Active:         0,
-					Failed:         1,
-					Succeeded:      0,
-					CompletionTime: &metav1.Time{Time: FailedJob1CompletionTime},
-					StartTime:      &metav1.Time{Time: FailedJob1StartTime},
-					Conditions: []v1batch.JobCondition{
-						{Type: v1batch.JobFailed, Status: v1.ConditionTrue},
+					Status: v1batch.JobStatus{
+						Active:         0,
+						Failed:         1,
+						Succeeded:      0,
+						CompletionTime: &metav1.Time{Time: FailedJob1CompletionTime},
+						StartTime:      &metav1.Time{Time: FailedJob1StartTime},
+						Conditions: []v1batch.JobCondition{
+							{Type: v1batch.JobFailed, Status: v1.ConditionTrue},
+						},
 					},
-				},
-				Spec: v1batch.JobSpec{
-					ActiveDeadlineSeconds: &ActiveDeadlineSeconds900,
-					Parallelism:           &Parallelism1,
-					Completions:           &Completions1,
+					Spec: v1batch.JobSpec{
+						ActiveDeadlineSeconds: &ActiveDeadlineSeconds900,
+						Parallelism:           &Parallelism1,
+						Completions:           &Completions1,
+					},
 				},
 			},
 			Want: `
@@ -195,29 +201,31 @@ func TestJobCollector(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1batch.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "SuccessfulJob2NoActiveDeadlineSeconds",
-					Namespace:  "ns1",
-					Generation: 1,
-					Labels: map[string]string{
-						"app": "example-successful-2",
+			Objs: []interface{}{
+				&v1batch.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "SuccessfulJob2NoActiveDeadlineSeconds",
+						Namespace:  "ns1",
+						Generation: 1,
+						Labels: map[string]string{
+							"app": "example-successful-2",
+						},
 					},
-				},
-				Status: v1batch.JobStatus{
-					Active:         0,
-					Failed:         0,
-					Succeeded:      1,
-					CompletionTime: &metav1.Time{Time: SuccessfulJob2CompletionTime},
-					StartTime:      &metav1.Time{Time: SuccessfulJob2StartTime},
-					Conditions: []v1batch.JobCondition{
-						{Type: v1batch.JobComplete, Status: v1.ConditionTrue},
+					Status: v1batch.JobStatus{
+						Active:         0,
+						Failed:         0,
+						Succeeded:      1,
+						CompletionTime: &metav1.Time{Time: SuccessfulJob2CompletionTime},
+						StartTime:      &metav1.Time{Time: SuccessfulJob2StartTime},
+						Conditions: []v1batch.JobCondition{
+							{Type: v1batch.JobComplete, Status: v1.ConditionTrue},
+						},
 					},
-				},
-				Spec: v1batch.JobSpec{
-					ActiveDeadlineSeconds: nil,
-					Parallelism:           &Parallelism1,
-					Completions:           &Completions1,
+					Spec: v1batch.JobSpec{
+						ActiveDeadlineSeconds: nil,
+						Parallelism:           &Parallelism1,
+						Completions:           &Completions1,
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/limitrange_test.go
+++ b/internal/collector/limitrange_test.go
@@ -39,30 +39,32 @@ func TestLimitRangeollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1.LimitRange{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "quotaTest",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "testNS",
-				},
-				Spec: v1.LimitRangeSpec{
-					Limits: []v1.LimitRangeItem{
-						{
-							Type: v1.LimitTypePod,
-							Max: map[v1.ResourceName]resource.Quantity{
-								v1.ResourceMemory: testMemoryQuantity,
-							},
-							Min: map[v1.ResourceName]resource.Quantity{
-								v1.ResourceMemory: testMemoryQuantity,
-							},
-							Default: map[v1.ResourceName]resource.Quantity{
-								v1.ResourceMemory: testMemoryQuantity,
-							},
-							DefaultRequest: map[v1.ResourceName]resource.Quantity{
-								v1.ResourceMemory: testMemoryQuantity,
-							},
-							MaxLimitRequestRatio: map[v1.ResourceName]resource.Quantity{
-								v1.ResourceMemory: testMemoryQuantity,
+			Objs: []interface{}{
+				&v1.LimitRange{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "quotaTest",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "testNS",
+					},
+					Spec: v1.LimitRangeSpec{
+						Limits: []v1.LimitRangeItem{
+							{
+								Type: v1.LimitTypePod,
+								Max: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceMemory: testMemoryQuantity,
+								},
+								Min: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceMemory: testMemoryQuantity,
+								},
+								Default: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceMemory: testMemoryQuantity,
+								},
+								DefaultRequest: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceMemory: testMemoryQuantity,
+								},
+								MaxLimitRequestRatio: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceMemory: testMemoryQuantity,
+								},
 							},
 						},
 					},

--- a/internal/collector/namespace_test.go
+++ b/internal/collector/namespace_test.go
@@ -41,15 +41,17 @@ func TestNamespaceCollector(t *testing.T) {
 
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "nsActiveTest",
-				},
-				Spec: v1.NamespaceSpec{
-					Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
-				},
-				Status: v1.NamespaceStatus{
-					Phase: v1.NamespaceActive,
+			Objs: []interface{}{
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nsActiveTest",
+					},
+					Spec: v1.NamespaceSpec{
+						Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
+					},
+					Status: v1.NamespaceStatus{
+						Phase: v1.NamespaceActive,
+					},
 				},
 			},
 			Want: `
@@ -60,15 +62,17 @@ func TestNamespaceCollector(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "nsTerminateTest",
-				},
-				Spec: v1.NamespaceSpec{
-					Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
-				},
-				Status: v1.NamespaceStatus{
-					Phase: v1.NamespaceTerminating,
+			Objs: []interface{}{
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nsTerminateTest",
+					},
+					Spec: v1.NamespaceSpec{
+						Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
+					},
+					Status: v1.NamespaceStatus{
+						Phase: v1.NamespaceTerminating,
+					},
 				},
 			},
 			Want: `
@@ -80,22 +84,24 @@ func TestNamespaceCollector(t *testing.T) {
 		},
 		{
 
-			Obj: &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "ns1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Labels: map[string]string{
-						"app": "example1",
+			Objs: []interface{}{
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "ns1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Labels: map[string]string{
+							"app": "example1",
+						},
+						Annotations: map[string]string{
+							"app": "example1",
+						},
 					},
-					Annotations: map[string]string{
-						"app": "example1",
+					Spec: v1.NamespaceSpec{
+						Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
 					},
-				},
-				Spec: v1.NamespaceSpec{
-					Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
-				},
-				Status: v1.NamespaceStatus{
-					Phase: v1.NamespaceActive,
+					Status: v1.NamespaceStatus{
+						Phase: v1.NamespaceActive,
+					},
 				},
 			},
 			Want: `
@@ -107,23 +113,25 @@ func TestNamespaceCollector(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "ns2",
-					Labels: map[string]string{
-						"app": "example2",
-						"l2":  "label2",
+			Objs: []interface{}{
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns2",
+						Labels: map[string]string{
+							"app": "example2",
+							"l2":  "label2",
+						},
+						Annotations: map[string]string{
+							"app": "example2",
+							"l2":  "label2",
+						},
 					},
-					Annotations: map[string]string{
-						"app": "example2",
-						"l2":  "label2",
+					Spec: v1.NamespaceSpec{
+						Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
 					},
-				},
-				Spec: v1.NamespaceSpec{
-					Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
-				},
-				Status: v1.NamespaceStatus{
-					Phase: v1.NamespaceActive,
+					Status: v1.NamespaceStatus{
+						Phase: v1.NamespaceActive,
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/node_test.go
+++ b/internal/collector/node_test.go
@@ -64,21 +64,23 @@ func TestNodeCollector(t *testing.T) {
 	cases := []generateMetricsTestCase{
 		// Verify populating base metric and that metric for unset fields are skipped.
 		{
-			Obj: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "127.0.0.1",
-				},
-				Status: v1.NodeStatus{
-					NodeInfo: v1.NodeSystemInfo{
-						KernelVersion:           "kernel",
-						KubeletVersion:          "kubelet",
-						KubeProxyVersion:        "kubeproxy",
-						OSImage:                 "osimage",
-						ContainerRuntimeVersion: "rkt",
+			Objs: []interface{}{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.1",
 					},
-				},
-				Spec: v1.NodeSpec{
-					ProviderID: "provider://i-uniqueid",
+					Status: v1.NodeStatus{
+						NodeInfo: v1.NodeSystemInfo{
+							KernelVersion:           "kernel",
+							KubeletVersion:          "kubelet",
+							KubeProxyVersion:        "kubeproxy",
+							OSImage:                 "osimage",
+							ContainerRuntimeVersion: "rkt",
+						},
+					},
+					Spec: v1.NodeSpec{
+						ProviderID: "provider://i-uniqueid",
+					},
 				},
 			},
 			Want: `
@@ -89,41 +91,43 @@ func TestNodeCollector(t *testing.T) {
 		},
 		// Verify resource metric.
 		{
-			Obj: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "127.0.0.1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Labels: map[string]string{
-						"type": "master",
+			Objs: []interface{}{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "127.0.0.1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Labels: map[string]string{
+							"type": "master",
+						},
 					},
-				},
-				Spec: v1.NodeSpec{
-					Unschedulable: true,
-					ProviderID:    "provider://i-randomidentifier",
-				},
-				Status: v1.NodeStatus{
-					NodeInfo: v1.NodeSystemInfo{
-						KernelVersion:           "kernel",
-						KubeletVersion:          "kubelet",
-						KubeProxyVersion:        "kubeproxy",
-						OSImage:                 "osimage",
-						ContainerRuntimeVersion: "rkt",
+					Spec: v1.NodeSpec{
+						Unschedulable: true,
+						ProviderID:    "provider://i-randomidentifier",
 					},
-					Capacity: v1.ResourceList{
-						v1.ResourceCPU:                    resource.MustParse("4.3"),
-						v1.ResourceMemory:                 resource.MustParse("2G"),
-						v1.ResourcePods:                   resource.MustParse("1000"),
-						v1.ResourceStorage:                resource.MustParse("3G"),
-						v1.ResourceEphemeralStorage:       resource.MustParse("4G"),
-						v1.ResourceName("nvidia.com/gpu"): resource.MustParse("4"),
-					},
-					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:                    resource.MustParse("3"),
-						v1.ResourceMemory:                 resource.MustParse("1G"),
-						v1.ResourcePods:                   resource.MustParse("555"),
-						v1.ResourceStorage:                resource.MustParse("2G"),
-						v1.ResourceEphemeralStorage:       resource.MustParse("3G"),
-						v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+					Status: v1.NodeStatus{
+						NodeInfo: v1.NodeSystemInfo{
+							KernelVersion:           "kernel",
+							KubeletVersion:          "kubelet",
+							KubeProxyVersion:        "kubeproxy",
+							OSImage:                 "osimage",
+							ContainerRuntimeVersion: "rkt",
+						},
+						Capacity: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("4.3"),
+							v1.ResourceMemory:                 resource.MustParse("2G"),
+							v1.ResourcePods:                   resource.MustParse("1000"),
+							v1.ResourceStorage:                resource.MustParse("3G"),
+							v1.ResourceEphemeralStorage:       resource.MustParse("4G"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("4"),
+						},
+						Allocatable: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("3"),
+							v1.ResourceMemory:                 resource.MustParse("1G"),
+							v1.ResourcePods:                   resource.MustParse("555"),
+							v1.ResourceStorage:                resource.MustParse("2G"),
+							v1.ResourceEphemeralStorage:       resource.MustParse("3G"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
 					},
 				},
 			},
@@ -154,12 +158,14 @@ func TestNodeCollector(t *testing.T) {
 		},
 		// Verify phase enumerations.
 		{
-			Obj: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "127.0.0.1",
-				},
-				Status: v1.NodeStatus{
-					Phase: v1.NodeRunning,
+			Objs: []interface{}{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.1",
+					},
+					Status: v1.NodeStatus{
+						Phase: v1.NodeRunning,
+					},
 				},
 			},
 			Want: `
@@ -170,12 +176,14 @@ func TestNodeCollector(t *testing.T) {
 			MetricNames: []string{"kube_node_status_phase"},
 		},
 		{
-			Obj: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "127.0.0.2",
-				},
-				Status: v1.NodeStatus{
-					Phase: v1.NodePending,
+			Objs: []interface{}{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.2",
+					},
+					Status: v1.NodeStatus{
+						Phase: v1.NodePending,
+					},
 				},
 			},
 			Want: `
@@ -186,12 +194,14 @@ func TestNodeCollector(t *testing.T) {
 			MetricNames: []string{"kube_node_status_phase"},
 		},
 		{
-			Obj: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "127.0.0.3",
-				},
-				Status: v1.NodeStatus{
-					Phase: v1.NodeTerminated,
+			Objs: []interface{}{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.3",
+					},
+					Status: v1.NodeStatus{
+						Phase: v1.NodeTerminated,
+					},
 				},
 			},
 			Want: `
@@ -203,15 +213,17 @@ func TestNodeCollector(t *testing.T) {
 		},
 		// Verify StatusCondition
 		{
-			Obj: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "127.0.0.1",
-				},
-				Status: v1.NodeStatus{
-					Conditions: []v1.NodeCondition{
-						{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionTrue},
-						{Type: v1.NodeReady, Status: v1.ConditionTrue},
-						{Type: v1.NodeConditionType("CustomizedType"), Status: v1.ConditionTrue},
+			Objs: []interface{}{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.1",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionTrue},
+							{Type: v1.NodeReady, Status: v1.ConditionTrue},
+							{Type: v1.NodeConditionType("CustomizedType"), Status: v1.ConditionTrue},
+						},
 					},
 				},
 			},
@@ -229,15 +241,17 @@ func TestNodeCollector(t *testing.T) {
 			MetricNames: []string{"kube_node_status_condition"},
 		},
 		{
-			Obj: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "127.0.0.2",
-				},
-				Status: v1.NodeStatus{
-					Conditions: []v1.NodeCondition{
-						{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionUnknown},
-						{Type: v1.NodeReady, Status: v1.ConditionUnknown},
-						{Type: v1.NodeConditionType("CustomizedType"), Status: v1.ConditionUnknown},
+			Objs: []interface{}{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.2",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionUnknown},
+							{Type: v1.NodeReady, Status: v1.ConditionUnknown},
+							{Type: v1.NodeConditionType("CustomizedType"), Status: v1.ConditionUnknown},
+						},
 					},
 				},
 			},
@@ -255,15 +269,17 @@ func TestNodeCollector(t *testing.T) {
 			MetricNames: []string{"kube_node_status_condition"},
 		},
 		{
-			Obj: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "127.0.0.3",
-				},
-				Status: v1.NodeStatus{
-					Conditions: []v1.NodeCondition{
-						{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionFalse},
-						{Type: v1.NodeReady, Status: v1.ConditionFalse},
-						{Type: v1.NodeConditionType("CustomizedType"), Status: v1.ConditionFalse},
+			Objs: []interface{}{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.3",
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionFalse},
+							{Type: v1.NodeReady, Status: v1.ConditionFalse},
+							{Type: v1.NodeConditionType("CustomizedType"), Status: v1.ConditionFalse},
+						},
 					},
 				},
 			},
@@ -282,15 +298,17 @@ func TestNodeCollector(t *testing.T) {
 		},
 		// Verify SpecTaints
 		{
-			Obj: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "127.0.0.1",
-				},
-				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{
-						{Key: "node.kubernetes.io/memory-pressure", Value: "true", Effect: v1.TaintEffectPreferNoSchedule},
-						{Key: "Accelerated", Value: "gpu", Effect: v1.TaintEffectPreferNoSchedule},
-						{Key: "Dedicated", Effect: v1.TaintEffectPreferNoSchedule},
+			Objs: []interface{}{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "127.0.0.1",
+					},
+					Spec: v1.NodeSpec{
+						Taints: []v1.Taint{
+							{Key: "node.kubernetes.io/memory-pressure", Value: "true", Effect: v1.TaintEffectPreferNoSchedule},
+							{Key: "Accelerated", Value: "gpu", Effect: v1.TaintEffectPreferNoSchedule},
+							{Key: "Dedicated", Effect: v1.TaintEffectPreferNoSchedule},
+						},
 					},
 				},
 			},

--- a/internal/collector/persistentvolume_test.go
+++ b/internal/collector/persistentvolume_test.go
@@ -38,12 +38,14 @@ func TestPersistentVolumeCollector(t *testing.T) {
 	cases := []generateMetricsTestCase{
 		// Verify phase enumerations.
 		{
-			Obj: &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pv-pending",
-				},
-				Status: v1.PersistentVolumeStatus{
-					Phase: v1.VolumePending,
+			Objs: []interface{}{
+				&v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pv-pending",
+					},
+					Status: v1.PersistentVolumeStatus{
+						Phase: v1.VolumePending,
+					},
 				},
 			},
 			Want: `
@@ -58,12 +60,14 @@ func TestPersistentVolumeCollector(t *testing.T) {
 			},
 		},
 		{
-			Obj: &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pv-available",
-				},
-				Status: v1.PersistentVolumeStatus{
-					Phase: v1.VolumeAvailable,
+			Objs: []interface{}{
+				&v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pv-available",
+					},
+					Status: v1.PersistentVolumeStatus{
+						Phase: v1.VolumeAvailable,
+					},
 				},
 			},
 			Want: `
@@ -76,12 +80,14 @@ func TestPersistentVolumeCollector(t *testing.T) {
 			MetricNames: []string{"kube_persistentvolume_status_phase"},
 		},
 		{
-			Obj: &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pv-bound",
-				},
-				Status: v1.PersistentVolumeStatus{
-					Phase: v1.VolumeBound,
+			Objs: []interface{}{
+				&v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pv-bound",
+					},
+					Status: v1.PersistentVolumeStatus{
+						Phase: v1.VolumeBound,
+					},
 				},
 			},
 			Want: `
@@ -94,12 +100,14 @@ func TestPersistentVolumeCollector(t *testing.T) {
 			MetricNames: []string{"kube_persistentvolume_status_phase"},
 		},
 		{
-			Obj: &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pv-released",
-				},
-				Status: v1.PersistentVolumeStatus{
-					Phase: v1.VolumeReleased,
+			Objs: []interface{}{
+				&v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pv-released",
+					},
+					Status: v1.PersistentVolumeStatus{
+						Phase: v1.VolumeReleased,
+					},
 				},
 			},
 			Want: `
@@ -113,12 +121,14 @@ func TestPersistentVolumeCollector(t *testing.T) {
 		},
 		{
 
-			Obj: &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pv-failed",
-				},
-				Status: v1.PersistentVolumeStatus{
-					Phase: v1.VolumeFailed,
+			Objs: []interface{}{
+				&v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pv-failed",
+					},
+					Status: v1.PersistentVolumeStatus{
+						Phase: v1.VolumeFailed,
+					},
 				},
 			},
 			Want: `
@@ -131,15 +141,17 @@ func TestPersistentVolumeCollector(t *testing.T) {
 			MetricNames: []string{"kube_persistentvolume_status_phase"},
 		},
 		{
-			Obj: &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pv-pending",
-				},
-				Status: v1.PersistentVolumeStatus{
-					Phase: v1.VolumePending,
-				},
-				Spec: v1.PersistentVolumeSpec{
-					StorageClassName: "test",
+			Objs: []interface{}{
+				&v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pv-pending",
+					},
+					Status: v1.PersistentVolumeStatus{
+						Phase: v1.VolumePending,
+					},
+					Spec: v1.PersistentVolumeSpec{
+						StorageClassName: "test",
+					},
 				},
 			},
 			Want: `
@@ -154,12 +166,14 @@ func TestPersistentVolumeCollector(t *testing.T) {
 			},
 		},
 		{
-			Obj: &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pv-available",
-				},
-				Status: v1.PersistentVolumeStatus{
-					Phase: v1.VolumeAvailable,
+			Objs: []interface{}{
+				&v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pv-available",
+					},
+					Status: v1.PersistentVolumeStatus{
+						Phase: v1.VolumeAvailable,
+					},
 				},
 			},
 			Want: `
@@ -168,18 +182,20 @@ func TestPersistentVolumeCollector(t *testing.T) {
 			MetricNames: []string{"kube_persistentvolume_info"},
 		},
 		{
-			Obj: &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-labeled-pv",
-					Labels: map[string]string{
-						"app": "mysql-server",
+			Objs: []interface{}{
+				&v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-labeled-pv",
+						Labels: map[string]string{
+							"app": "mysql-server",
+						},
 					},
-				},
-				Status: v1.PersistentVolumeStatus{
-					Phase: v1.VolumePending,
-				},
-				Spec: v1.PersistentVolumeSpec{
-					StorageClassName: "test",
+					Status: v1.PersistentVolumeStatus{
+						Phase: v1.VolumePending,
+					},
+					Spec: v1.PersistentVolumeSpec{
+						StorageClassName: "test",
+					},
 				},
 			},
 			Want: `
@@ -188,12 +204,14 @@ func TestPersistentVolumeCollector(t *testing.T) {
 			MetricNames: []string{"kube_persistentvolume_labels"},
 		},
 		{
-			Obj: &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-unlabeled-pv",
-				},
-				Status: v1.PersistentVolumeStatus{
-					Phase: v1.VolumeAvailable,
+			Objs: []interface{}{
+				&v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-unlabeled-pv",
+					},
+					Status: v1.PersistentVolumeStatus{
+						Phase: v1.VolumeAvailable,
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/persistentvolumeclaim_test.go
+++ b/internal/collector/persistentvolumeclaim_test.go
@@ -42,25 +42,27 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 	cases := []generateMetricsTestCase{
 		// Verify phase enumerations.
 		{
-			Obj: &v1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "mysql-data",
-					Namespace: "default",
-					Labels: map[string]string{
-						"app": "mysql-server",
-					},
-				},
-				Spec: v1.PersistentVolumeClaimSpec{
-					StorageClassName: &storageClassName,
-					Resources: v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceStorage: resource.MustParse("1Gi"),
+			Objs: []interface{}{
+				&v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mysql-data",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "mysql-server",
 						},
 					},
-					VolumeName: "pvc-mysql-data",
-				},
-				Status: v1.PersistentVolumeClaimStatus{
-					Phase: v1.ClaimBound,
+					Spec: v1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClassName,
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+						VolumeName: "pvc-mysql-data",
+					},
+					Status: v1.PersistentVolumeClaimStatus{
+						Phase: v1.ClaimBound,
+					},
 				},
 			},
 			Want: `
@@ -74,17 +76,19 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels"},
 		},
 		{
-			Obj: &v1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "prometheus-data",
-					Namespace: "default",
-				},
-				Spec: v1.PersistentVolumeClaimSpec{
-					StorageClassName: &storageClassName,
-					VolumeName:       "pvc-prometheus-data",
-				},
-				Status: v1.PersistentVolumeClaimStatus{
-					Phase: v1.ClaimPending,
+			Objs: []interface{}{
+				&v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prometheus-data",
+						Namespace: "default",
+					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						StorageClassName: &storageClassName,
+						VolumeName:       "pvc-prometheus-data",
+					},
+					Status: v1.PersistentVolumeClaimStatus{
+						Phase: v1.ClaimPending,
+					},
 				},
 			},
 			Want: `
@@ -97,12 +101,14 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels"},
 		},
 		{
-			Obj: &v1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "mongo-data",
-				},
-				Status: v1.PersistentVolumeClaimStatus{
-					Phase: v1.ClaimLost,
+			Objs: []interface{}{
+				&v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mongo-data",
+					},
+					Status: v1.PersistentVolumeClaimStatus{
+						Phase: v1.ClaimLost,
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/pod_test.go
+++ b/internal/collector/pod_test.go
@@ -94,18 +94,20 @@ func TestPodCollector(t *testing.T) {
 	// 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: "ns1",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name:        "container1",
-							Image:       "k8s.gcr.io/hyperkube1",
-							ImageID:     "docker://sha256:aaa",
-							ContainerID: "docker://ab123",
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:        "container1",
+								Image:       "k8s.gcr.io/hyperkube1",
+								ImageID:     "docker://sha256:aaa",
+								ContainerID: "docker://ab123",
+							},
 						},
 					},
 				},
@@ -114,24 +116,26 @@ func TestPodCollector(t *testing.T) {
 			MetricNames: []string{"kube_pod_container_info"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod2",
-					Namespace: "ns2",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name:        "container2",
-							Image:       "k8s.gcr.io/hyperkube2",
-							ImageID:     "docker://sha256:bbb",
-							ContainerID: "docker://cd456",
-						},
-						{
-							Name:        "container3",
-							Image:       "k8s.gcr.io/hyperkube3",
-							ImageID:     "docker://sha256:ccc",
-							ContainerID: "docker://ef789",
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "ns2",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:        "container2",
+								Image:       "k8s.gcr.io/hyperkube2",
+								ImageID:     "docker://sha256:bbb",
+								ContainerID: "docker://cd456",
+							},
+							{
+								Name:        "container3",
+								Image:       "k8s.gcr.io/hyperkube3",
+								ImageID:     "docker://sha256:ccc",
+								ContainerID: "docker://ef789",
+							},
 						},
 					},
 				},
@@ -141,16 +145,18 @@ func TestPodCollector(t *testing.T) {
 			MetricNames: []string{"kube_pod_container_info"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: "ns1",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name:  "container1",
-							Ready: true,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:  "container1",
+								Ready: true,
+							},
 						},
 					},
 				},
@@ -159,20 +165,22 @@ func TestPodCollector(t *testing.T) {
 			MetricNames: []string{"kube_pod_container_status_ready"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod2",
-					Namespace: "ns2",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name:  "container2",
-							Ready: true,
-						},
-						{
-							Name:  "container3",
-							Ready: false,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "ns2",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:  "container2",
+								Ready: true,
+							},
+							{
+								Name:  "container3",
+								Ready: false,
+							},
 						},
 					},
 				},
@@ -184,16 +192,18 @@ func TestPodCollector(t *testing.T) {
 			MetricNames: []string{"kube_pod_container_status_ready"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: "ns1",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name:         "container1",
-							RestartCount: 0,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:         "container1",
+								RestartCount: 0,
+							},
 						},
 					},
 				},
@@ -202,20 +212,22 @@ func TestPodCollector(t *testing.T) {
 			MetricNames: []string{"kube_pod_container_status_restarts_total"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod2",
-					Namespace: "ns2",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name:         "container2",
-							RestartCount: 0,
-						},
-						{
-							Name:         "container3",
-							RestartCount: 1,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "ns2",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:         "container2",
+								RestartCount: 0,
+							},
+							{
+								Name:         "container3",
+								RestartCount: 1,
+							},
 						},
 					},
 				},
@@ -227,17 +239,19 @@ func TestPodCollector(t *testing.T) {
 			MetricNames: []string{"kube_pod_container_status_restarts_total"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: "ns1",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name: "container1",
-							State: v1.ContainerState{
-								Running: &v1.ContainerStateRunning{},
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name: "container1",
+								State: v1.ContainerState{
+									Running: &v1.ContainerStateRunning{},
+								},
 							},
 						},
 					},
@@ -268,26 +282,28 @@ func TestPodCollector(t *testing.T) {
 			},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod2",
-					Namespace: "ns2",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name: "container2",
-							State: v1.ContainerState{
-								Terminated: &v1.ContainerStateTerminated{
-									Reason: "OOMKilled",
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "ns2",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name: "container2",
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{
+										Reason: "OOMKilled",
+									},
 								},
 							},
-						},
-						{
-							Name: "container3",
-							State: v1.ContainerState{
-								Waiting: &v1.ContainerStateWaiting{
-									Reason: "ContainerCreating",
+							{
+								Name: "container3",
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "ContainerCreating",
+									},
 								},
 							},
 						},
@@ -330,18 +346,20 @@ func TestPodCollector(t *testing.T) {
 			},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod3",
-					Namespace: "ns3",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name: "container4",
-							State: v1.ContainerState{
-								Waiting: &v1.ContainerStateWaiting{
-									Reason: "CrashLoopBackOff",
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod3",
+						Namespace: "ns3",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name: "container4",
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "CrashLoopBackOff",
+									},
 								},
 							},
 						},
@@ -387,21 +405,23 @@ kube_pod_container_status_last_terminated_reason{container="container4",namespac
 		},
 		{
 
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod6",
-					Namespace: "ns6",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name: "container7",
-							State: v1.ContainerState{
-								Running: &v1.ContainerStateRunning{},
-							},
-							LastTerminationState: v1.ContainerState{
-								Terminated: &v1.ContainerStateTerminated{
-									Reason: "OOMKilled",
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod6",
+						Namespace: "ns6",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name: "container7",
+								State: v1.ContainerState{
+									Running: &v1.ContainerStateRunning{},
+								},
+								LastTerminationState: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{
+										Reason: "OOMKilled",
+									},
 								},
 							},
 						},
@@ -436,18 +456,20 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod4",
-					Namespace: "ns4",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name: "container5",
-							State: v1.ContainerState{
-								Waiting: &v1.ContainerStateWaiting{
-									Reason: "ImagePullBackOff",
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod4",
+						Namespace: "ns4",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name: "container5",
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "ImagePullBackOff",
+									},
 								},
 							},
 						},
@@ -477,18 +499,20 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod5",
-					Namespace: "ns5",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name: "container6",
-							State: v1.ContainerState{
-								Waiting: &v1.ContainerStateWaiting{
-									Reason: "ErrImagePull",
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod5",
+						Namespace: "ns5",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name: "container6",
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "ErrImagePull",
+									},
 								},
 							},
 						},
@@ -518,18 +542,20 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod7",
-					Namespace: "ns7",
-				},
-				Status: v1.PodStatus{
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name: "container8",
-							State: v1.ContainerState{
-								Waiting: &v1.ContainerStateWaiting{
-									Reason: "CreateContainerConfigError",
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod7",
+						Namespace: "ns7",
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name: "container8",
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "CreateContainerConfigError",
+									},
 								},
 							},
 						},
@@ -560,20 +586,22 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 		},
 		{
 
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "pod1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "ns1",
-					UID:               "abc-123-xxx",
-				},
-				Spec: v1.PodSpec{
-					NodeName: "node1",
-				},
-				Status: v1.PodStatus{
-					HostIP:    "1.1.1.1",
-					PodIP:     "1.2.3.4",
-					StartTime: &metav1StartTime,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "ns1",
+						UID:               "abc-123-xxx",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
+					Status: v1.PodStatus{
+						HostIP:    "1.1.1.1",
+						PodIP:     "1.2.3.4",
+						StartTime: &metav1StartTime,
+					},
 				},
 			},
 			// TODO: Should it be '1501569018' instead?
@@ -586,61 +614,63 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			MetricNames: []string{"kube_pod_created", "kube_pod_info", "kube_pod_start_time", "kube_pod_completion_time", "kube_pod_owner"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod2",
-					Namespace: "ns2",
-					UID:       "abc-456-xxx",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind:       "ReplicaSet",
-							Name:       "rs-name",
-							Controller: &test,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "ns2",
+						UID:       "abc-456-xxx",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind:       "ReplicaSet",
+								Name:       "rs-name",
+								Controller: &test,
+							},
 						},
 					},
-				},
-				Spec: v1.PodSpec{
-					NodeName: "node2",
-				},
-				Status: v1.PodStatus{
-					HostIP: "1.1.1.1",
-					PodIP:  "2.3.4.5",
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name:        "container2_1",
-							Image:       "k8s.gcr.io/hyperkube2",
-							ImageID:     "docker://sha256:bbb",
-							ContainerID: "docker://cd456",
-							State: v1.ContainerState{
-								Terminated: &v1.ContainerStateTerminated{
-									FinishedAt: metav1.Time{
-										Time: time.Unix(1501777018, 0),
+					Spec: v1.PodSpec{
+						NodeName: "node2",
+					},
+					Status: v1.PodStatus{
+						HostIP: "1.1.1.1",
+						PodIP:  "2.3.4.5",
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:        "container2_1",
+								Image:       "k8s.gcr.io/hyperkube2",
+								ImageID:     "docker://sha256:bbb",
+								ContainerID: "docker://cd456",
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{
+										FinishedAt: metav1.Time{
+											Time: time.Unix(1501777018, 0),
+										},
 									},
 								},
 							},
-						},
-						{
-							Name:        "container2_2",
-							Image:       "k8s.gcr.io/hyperkube2",
-							ImageID:     "docker://sha256:bbb",
-							ContainerID: "docker://cd456",
-							State: v1.ContainerState{
-								Terminated: &v1.ContainerStateTerminated{
-									FinishedAt: metav1.Time{
-										Time: time.Unix(1501888018, 0),
+							{
+								Name:        "container2_2",
+								Image:       "k8s.gcr.io/hyperkube2",
+								ImageID:     "docker://sha256:bbb",
+								ContainerID: "docker://cd456",
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{
+										FinishedAt: metav1.Time{
+											Time: time.Unix(1501888018, 0),
+										},
 									},
 								},
 							},
-						},
-						{
-							Name:        "container2_3",
-							Image:       "k8s.gcr.io/hyperkube2",
-							ImageID:     "docker://sha256:bbb",
-							ContainerID: "docker://cd456",
-							State: v1.ContainerState{
-								Terminated: &v1.ContainerStateTerminated{
-									FinishedAt: metav1.Time{
-										Time: time.Unix(1501666018, 0),
+							{
+								Name:        "container2_3",
+								Image:       "k8s.gcr.io/hyperkube2",
+								ImageID:     "docker://sha256:bbb",
+								ContainerID: "docker://cd456",
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{
+										FinishedAt: metav1.Time{
+											Time: time.Unix(1501666018, 0),
+										},
 									},
 								},
 							},
@@ -656,13 +686,15 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			MetricNames: []string{"kube_pod_created", "kube_pod_info", "kube_pod_start_time", "kube_pod_completion_time", "kube_pod_owner"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: "ns1",
-				},
-				Status: v1.PodStatus{
-					Phase: v1.PodRunning,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+					},
 				},
 			},
 			Want: `
@@ -675,13 +707,15 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			MetricNames: []string{"kube_pod_status_phase"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod2",
-					Namespace: "ns2",
-				},
-				Status: v1.PodStatus{
-					Phase: v1.PodPending,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "ns2",
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+					},
 				},
 			},
 			Want: `
@@ -695,13 +729,15 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 		},
 		{
 
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod3",
-					Namespace: "ns3",
-				},
-				Status: v1.PodStatus{
-					Phase: v1.PodUnknown,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod3",
+						Namespace: "ns3",
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodUnknown,
+					},
 				},
 			},
 			Want: `
@@ -714,15 +750,17 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			MetricNames: []string{"kube_pod_status_phase"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "pod4",
-					Namespace:         "ns4",
-					DeletionTimestamp: &metav1.Time{},
-				},
-				Status: v1.PodStatus{
-					Phase:  v1.PodRunning,
-					Reason: nodeUnreachablePodReason,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod4",
+						Namespace:         "ns4",
+						DeletionTimestamp: &metav1.Time{},
+					},
+					Status: v1.PodStatus{
+						Phase:  v1.PodRunning,
+						Reason: nodeUnreachablePodReason,
+					},
 				},
 			},
 			Want: `
@@ -735,16 +773,18 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			MetricNames: []string{"kube_pod_status_phase"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: "ns1",
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:   v1.PodReady,
-							Status: v1.ConditionTrue,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+					},
+					Status: v1.PodStatus{
+						Conditions: []v1.PodCondition{
+							{
+								Type:   v1.PodReady,
+								Status: v1.ConditionTrue,
+							},
 						},
 					},
 				},
@@ -757,16 +797,18 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			MetricNames: []string{"kube_pod_status_ready"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod2",
-					Namespace: "ns2",
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:   v1.PodReady,
-							Status: v1.ConditionFalse,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "ns2",
+					},
+					Status: v1.PodStatus{
+						Conditions: []v1.PodCondition{
+							{
+								Type:   v1.PodReady,
+								Status: v1.ConditionFalse,
+							},
 						},
 					},
 				},
@@ -779,18 +821,20 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			MetricNames: []string{"kube_pod_status_ready"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: "ns1",
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:   v1.PodScheduled,
-							Status: v1.ConditionTrue,
-							LastTransitionTime: metav1.Time{
-								Time: time.Unix(1501666018, 0),
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+					},
+					Status: v1.PodStatus{
+						Conditions: []v1.PodCondition{
+							{
+								Type:   v1.PodScheduled,
+								Status: v1.ConditionTrue,
+								LastTransitionTime: metav1.Time{
+									Time: time.Unix(1501666018, 0),
+								},
 							},
 						},
 					},
@@ -805,16 +849,18 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			MetricNames: []string{"kube_pod_status_scheduled", "kube_pod_status_scheduled_time"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod2",
-					Namespace: "ns2",
-				},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:   v1.PodScheduled,
-							Status: v1.ConditionFalse,
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "ns2",
+					},
+					Status: v1.PodStatus{
+						Conditions: []v1.PodCondition{
+							{
+								Type:   v1.PodScheduled,
+								Status: v1.ConditionFalse,
+							},
 						},
 					},
 				},
@@ -827,43 +873,45 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			MetricNames: []string{"kube_pod_status_scheduled", "kube_pod_status_scheduled_time"},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: "ns1",
-				},
-				Spec: v1.PodSpec{
-					NodeName: "node1",
-					Containers: []v1.Container{
-						{
-							Name: "pod1_con1",
-							Resources: v1.ResourceRequirements{
-								Requests: map[v1.ResourceName]resource.Quantity{
-									v1.ResourceCPU:                    resource.MustParse("200m"),
-									v1.ResourceMemory:                 resource.MustParse("100M"),
-									v1.ResourceEphemeralStorage:       resource.MustParse("300M"),
-									v1.ResourceStorage:                resource.MustParse("400M"),
-									v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
-								},
-								Limits: map[v1.ResourceName]resource.Quantity{
-									v1.ResourceCPU:                    resource.MustParse("200m"),
-									v1.ResourceMemory:                 resource.MustParse("100M"),
-									v1.ResourceEphemeralStorage:       resource.MustParse("300M"),
-									v1.ResourceStorage:                resource.MustParse("400M"),
-									v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+						Containers: []v1.Container{
+							{
+								Name: "pod1_con1",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:                    resource.MustParse("200m"),
+										v1.ResourceMemory:                 resource.MustParse("100M"),
+										v1.ResourceEphemeralStorage:       resource.MustParse("300M"),
+										v1.ResourceStorage:                resource.MustParse("400M"),
+										v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:                    resource.MustParse("200m"),
+										v1.ResourceMemory:                 resource.MustParse("100M"),
+										v1.ResourceEphemeralStorage:       resource.MustParse("300M"),
+										v1.ResourceStorage:                resource.MustParse("400M"),
+										v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+									},
 								},
 							},
-						},
-						{
-							Name: "pod1_con2",
-							Resources: v1.ResourceRequirements{
-								Requests: map[v1.ResourceName]resource.Quantity{
-									v1.ResourceCPU:    resource.MustParse("300m"),
-									v1.ResourceMemory: resource.MustParse("200M"),
-								},
-								Limits: map[v1.ResourceName]resource.Quantity{
-									v1.ResourceCPU:    resource.MustParse("300m"),
-									v1.ResourceMemory: resource.MustParse("200M"),
+							{
+								Name: "pod1_con2",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("300m"),
+										v1.ResourceMemory: resource.MustParse("200M"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("300m"),
+										v1.ResourceMemory: resource.MustParse("200M"),
+									},
 								},
 							},
 						},
@@ -905,43 +953,45 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 		},
 		{
 
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod2",
-					Namespace: "ns2",
-				},
-				Spec: v1.PodSpec{
-					NodeName: "node2",
-					Containers: []v1.Container{
-						{
-							Name: "pod2_con1",
-							Resources: v1.ResourceRequirements{
-								Requests: map[v1.ResourceName]resource.Quantity{
-									v1.ResourceCPU:    resource.MustParse("400m"),
-									v1.ResourceMemory: resource.MustParse("300M"),
-								},
-								Limits: map[v1.ResourceName]resource.Quantity{
-									v1.ResourceCPU:    resource.MustParse("400m"),
-									v1.ResourceMemory: resource.MustParse("300M"),
-								},
-							},
-						},
-						{
-							Name: "pod2_con2",
-							Resources: v1.ResourceRequirements{
-								Requests: map[v1.ResourceName]resource.Quantity{
-									v1.ResourceCPU:    resource.MustParse("500m"),
-									v1.ResourceMemory: resource.MustParse("400M"),
-								},
-								Limits: map[v1.ResourceName]resource.Quantity{
-									v1.ResourceCPU:    resource.MustParse("500m"),
-									v1.ResourceMemory: resource.MustParse("400M"),
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "ns2",
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node2",
+						Containers: []v1.Container{
+							{
+								Name: "pod2_con1",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("400m"),
+										v1.ResourceMemory: resource.MustParse("300M"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("400m"),
+										v1.ResourceMemory: resource.MustParse("300M"),
+									},
 								},
 							},
-						},
-						// A container without a resource specicication. No metrics will be emitted for that.
-						{
-							Name: "pod2_con3",
+							{
+								Name: "pod2_con2",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("500m"),
+										v1.ResourceMemory: resource.MustParse("400M"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("500m"),
+										v1.ResourceMemory: resource.MustParse("400M"),
+									},
+								},
+							},
+							// A container without a resource specicication. No metrics will be emitted for that.
+							{
+								Name: "pod2_con3",
+							},
 						},
 					},
 				},
@@ -984,15 +1034,17 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: "ns1",
-					Labels: map[string]string{
-						"app": "example",
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+						Labels: map[string]string{
+							"app": "example",
+						},
 					},
+					Spec: v1.PodSpec{},
 				},
-				Spec: v1.PodSpec{},
 			},
 			Want: metadata + `
 				kube_pod_labels{label_app="example",namespace="ns1",pod="pod1"} 1
@@ -1002,39 +1054,41 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			},
 		},
 		{
-			Obj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: "ns1",
-					Labels: map[string]string{
-						"app": "example",
+			Objs: []interface{}{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "ns1",
+						Labels: map[string]string{
+							"app": "example",
+						},
 					},
-				},
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
-						{
-							Name: "myvol",
-							VolumeSource: v1.VolumeSource{
-								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "claim1",
-									ReadOnly:  false,
+					Spec: v1.PodSpec{
+						Volumes: []v1.Volume{
+							{
+								Name: "myvol",
+								VolumeSource: v1.VolumeSource{
+									PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "claim1",
+										ReadOnly:  false,
+									},
 								},
 							},
-						},
-						{
-							Name: "my-readonly-vol",
-							VolumeSource: v1.VolumeSource{
-								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "claim2",
-									ReadOnly:  true,
+							{
+								Name: "my-readonly-vol",
+								VolumeSource: v1.VolumeSource{
+									PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "claim2",
+										ReadOnly:  true,
+									},
 								},
 							},
-						},
-						{
-							Name: "not-pvc-vol",
-							VolumeSource: v1.VolumeSource{
-								EmptyDir: &v1.EmptyDirVolumeSource{
-									Medium: "memory",
+							{
+								Name: "not-pvc-vol",
+								VolumeSource: v1.VolumeSource{
+									EmptyDir: &v1.EmptyDirVolumeSource{
+										Medium: "memory",
+									},
 								},
 							},
 						},

--- a/internal/collector/poddisruptionbudget_test.go
+++ b/internal/collector/poddisruptionbudget_test.go
@@ -44,19 +44,21 @@ func TestPodDisruptionBudgetCollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1beta1.PodDisruptionBudget{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "pdb1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "ns1",
-					Generation:        21,
-				},
-				Status: v1beta1.PodDisruptionBudgetStatus{
-					CurrentHealthy:        12,
-					DesiredHealthy:        10,
-					PodDisruptionsAllowed: 2,
-					ExpectedPods:          15,
-					ObservedGeneration:    111,
+			Objs: []interface{}{
+				&v1beta1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pdb1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "ns1",
+						Generation:        21,
+					},
+					Status: v1beta1.PodDisruptionBudgetStatus{
+						CurrentHealthy:        12,
+						DesiredHealthy:        10,
+						PodDisruptionsAllowed: 2,
+						ExpectedPods:          15,
+						ObservedGeneration:    111,
+					},
 				},
 			},
 			Want: `
@@ -69,18 +71,20 @@ func TestPodDisruptionBudgetCollector(t *testing.T) {
 			`,
 		},
 		{
-			Obj: &v1beta1.PodDisruptionBudget{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "pdb2",
-					Namespace:  "ns2",
-					Generation: 14,
-				},
-				Status: v1beta1.PodDisruptionBudgetStatus{
-					CurrentHealthy:        8,
-					DesiredHealthy:        9,
-					PodDisruptionsAllowed: 0,
-					ExpectedPods:          10,
-					ObservedGeneration:    1111,
+			Objs: []interface{}{
+				&v1beta1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "pdb2",
+						Namespace:  "ns2",
+						Generation: 14,
+					},
+					Status: v1beta1.PodDisruptionBudgetStatus{
+						CurrentHealthy:        8,
+						DesiredHealthy:        9,
+						PodDisruptionsAllowed: 0,
+						ExpectedPods:          10,
+						ObservedGeneration:    1111,
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/replicaset_test.go
+++ b/internal/collector/replicaset_test.go
@@ -57,31 +57,33 @@ func TestReplicaSetCollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1beta1.ReplicaSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "rs1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "ns1",
-					Generation:        21,
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind:       "Deployment",
-							Name:       "dp-name",
-							Controller: &test,
+			Objs: []interface{}{
+				&v1beta1.ReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "rs1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "ns1",
+						Generation:        21,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind:       "Deployment",
+								Name:       "dp-name",
+								Controller: &test,
+							},
+						},
+						Labels: map[string]string{
+							"app": "example1",
 						},
 					},
-					Labels: map[string]string{
-						"app": "example1",
+					Status: v1beta1.ReplicaSetStatus{
+						Replicas:             5,
+						FullyLabeledReplicas: 10,
+						ReadyReplicas:        5,
+						ObservedGeneration:   1,
 					},
-				},
-				Status: v1beta1.ReplicaSetStatus{
-					Replicas:             5,
-					FullyLabeledReplicas: 10,
-					ReadyReplicas:        5,
-					ObservedGeneration:   1,
-				},
-				Spec: v1beta1.ReplicaSetSpec{
-					Replicas: &rs1Replicas,
+					Spec: v1beta1.ReplicaSetSpec{
+						Replicas: &rs1Replicas,
+					},
 				},
 			},
 			Want: `
@@ -97,24 +99,26 @@ func TestReplicaSetCollector(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1beta1.ReplicaSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "rs2",
-					Namespace:  "ns2",
-					Generation: 14,
-					Labels: map[string]string{
-						"app": "example2",
-						"env": "ex",
+			Objs: []interface{}{
+				&v1beta1.ReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "rs2",
+						Namespace:  "ns2",
+						Generation: 14,
+						Labels: map[string]string{
+							"app": "example2",
+							"env": "ex",
+						},
 					},
-				},
-				Status: v1beta1.ReplicaSetStatus{
-					Replicas:             0,
-					FullyLabeledReplicas: 5,
-					ReadyReplicas:        0,
-					ObservedGeneration:   5,
-				},
-				Spec: v1beta1.ReplicaSetSpec{
-					Replicas: &rs2Replicas,
+					Status: v1beta1.ReplicaSetStatus{
+						Replicas:             0,
+						FullyLabeledReplicas: 5,
+						ReadyReplicas:        0,
+						ObservedGeneration:   5,
+					},
+					Spec: v1beta1.ReplicaSetSpec{
+						Replicas: &rs2Replicas,
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/replicationcontroller_test.go
+++ b/internal/collector/replicationcontroller_test.go
@@ -53,22 +53,24 @@ func TestReplicationControllerCollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1.ReplicationController{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "rc1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "ns1",
-					Generation:        21,
-				},
-				Status: v1.ReplicationControllerStatus{
-					Replicas:             5,
-					FullyLabeledReplicas: 10,
-					ReadyReplicas:        5,
-					AvailableReplicas:    3,
-					ObservedGeneration:   1,
-				},
-				Spec: v1.ReplicationControllerSpec{
-					Replicas: &rc1Replicas,
+			Objs: []interface{}{
+				&v1.ReplicationController{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "rc1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "ns1",
+						Generation:        21,
+					},
+					Status: v1.ReplicationControllerStatus{
+						Replicas:             5,
+						FullyLabeledReplicas: 10,
+						ReadyReplicas:        5,
+						AvailableReplicas:    3,
+						ObservedGeneration:   1,
+					},
+					Spec: v1.ReplicationControllerSpec{
+						Replicas: &rc1Replicas,
+					},
 				},
 			},
 			Want: `
@@ -83,21 +85,23 @@ func TestReplicationControllerCollector(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1.ReplicationController{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "rc2",
-					Namespace:  "ns2",
-					Generation: 14,
-				},
-				Status: v1.ReplicationControllerStatus{
-					Replicas:             0,
-					FullyLabeledReplicas: 5,
-					ReadyReplicas:        0,
-					AvailableReplicas:    0,
-					ObservedGeneration:   5,
-				},
-				Spec: v1.ReplicationControllerSpec{
-					Replicas: &rc2Replicas,
+			Objs: []interface{}{
+				&v1.ReplicationController{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "rc2",
+						Namespace:  "ns2",
+						Generation: 14,
+					},
+					Status: v1.ReplicationControllerStatus{
+						Replicas:             0,
+						FullyLabeledReplicas: 5,
+						ReadyReplicas:        0,
+						AvailableReplicas:    0,
+						ObservedGeneration:   5,
+					},
+					Spec: v1.ReplicationControllerSpec{
+						Replicas: &rc2Replicas,
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/resourcequota_test.go
+++ b/internal/collector/resourcequota_test.go
@@ -38,13 +38,15 @@ func TestResourceQuotaCollector(t *testing.T) {
 	cases := []generateMetricsTestCase{
 		// Verify populating base metric and that metric for unset fields are skipped.
 		{
-			Obj: &v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "quotaTest",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "testNS",
+			Objs: []interface{}{
+				&v1.ResourceQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "quotaTest",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "testNS",
+					},
+					Status: v1.ResourceQuotaStatus{},
 				},
-				Status: v1.ResourceQuotaStatus{},
 			},
 			Want: `
 			kube_resourcequota_created{namespace="testNS",resourcequota="quotaTest"} 1.5e+09
@@ -52,55 +54,57 @@ func TestResourceQuotaCollector(t *testing.T) {
 		},
 		// Verify resource metric.
 		{
-			Obj: &v1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "quotaTest",
-					Namespace: "testNS",
-				},
-				Spec: v1.ResourceQuotaSpec{
-					Hard: v1.ResourceList{
-						v1.ResourceCPU:                    resource.MustParse("4.3"),
-						v1.ResourceMemory:                 resource.MustParse("2.1G"),
-						v1.ResourceStorage:                resource.MustParse("10G"),
-						v1.ResourcePods:                   resource.MustParse("9"),
-						v1.ResourceServices:               resource.MustParse("8"),
-						v1.ResourceReplicationControllers: resource.MustParse("7"),
-						v1.ResourceQuotas:                 resource.MustParse("6"),
-						v1.ResourceSecrets:                resource.MustParse("5"),
-						v1.ResourceConfigMaps:             resource.MustParse("4"),
-						v1.ResourcePersistentVolumeClaims: resource.MustParse("3"),
-						v1.ResourceServicesNodePorts:      resource.MustParse("2"),
-						v1.ResourceServicesLoadBalancers:  resource.MustParse("1"),
+			Objs: []interface{}{
+				&v1.ResourceQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "quotaTest",
+						Namespace: "testNS",
 					},
-				},
-				Status: v1.ResourceQuotaStatus{
-					Hard: v1.ResourceList{
-						v1.ResourceCPU:                    resource.MustParse("4.3"),
-						v1.ResourceMemory:                 resource.MustParse("2.1G"),
-						v1.ResourceStorage:                resource.MustParse("10G"),
-						v1.ResourcePods:                   resource.MustParse("9"),
-						v1.ResourceServices:               resource.MustParse("8"),
-						v1.ResourceReplicationControllers: resource.MustParse("7"),
-						v1.ResourceQuotas:                 resource.MustParse("6"),
-						v1.ResourceSecrets:                resource.MustParse("5"),
-						v1.ResourceConfigMaps:             resource.MustParse("4"),
-						v1.ResourcePersistentVolumeClaims: resource.MustParse("3"),
-						v1.ResourceServicesNodePorts:      resource.MustParse("2"),
-						v1.ResourceServicesLoadBalancers:  resource.MustParse("1"),
+					Spec: v1.ResourceQuotaSpec{
+						Hard: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("4.3"),
+							v1.ResourceMemory:                 resource.MustParse("2.1G"),
+							v1.ResourceStorage:                resource.MustParse("10G"),
+							v1.ResourcePods:                   resource.MustParse("9"),
+							v1.ResourceServices:               resource.MustParse("8"),
+							v1.ResourceReplicationControllers: resource.MustParse("7"),
+							v1.ResourceQuotas:                 resource.MustParse("6"),
+							v1.ResourceSecrets:                resource.MustParse("5"),
+							v1.ResourceConfigMaps:             resource.MustParse("4"),
+							v1.ResourcePersistentVolumeClaims: resource.MustParse("3"),
+							v1.ResourceServicesNodePorts:      resource.MustParse("2"),
+							v1.ResourceServicesLoadBalancers:  resource.MustParse("1"),
+						},
 					},
-					Used: v1.ResourceList{
-						v1.ResourceCPU:                    resource.MustParse("2.1"),
-						v1.ResourceMemory:                 resource.MustParse("500M"),
-						v1.ResourceStorage:                resource.MustParse("9G"),
-						v1.ResourcePods:                   resource.MustParse("8"),
-						v1.ResourceServices:               resource.MustParse("7"),
-						v1.ResourceReplicationControllers: resource.MustParse("6"),
-						v1.ResourceQuotas:                 resource.MustParse("5"),
-						v1.ResourceSecrets:                resource.MustParse("4"),
-						v1.ResourceConfigMaps:             resource.MustParse("3"),
-						v1.ResourcePersistentVolumeClaims: resource.MustParse("2"),
-						v1.ResourceServicesNodePorts:      resource.MustParse("1"),
-						v1.ResourceServicesLoadBalancers:  resource.MustParse("0"),
+					Status: v1.ResourceQuotaStatus{
+						Hard: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("4.3"),
+							v1.ResourceMemory:                 resource.MustParse("2.1G"),
+							v1.ResourceStorage:                resource.MustParse("10G"),
+							v1.ResourcePods:                   resource.MustParse("9"),
+							v1.ResourceServices:               resource.MustParse("8"),
+							v1.ResourceReplicationControllers: resource.MustParse("7"),
+							v1.ResourceQuotas:                 resource.MustParse("6"),
+							v1.ResourceSecrets:                resource.MustParse("5"),
+							v1.ResourceConfigMaps:             resource.MustParse("4"),
+							v1.ResourcePersistentVolumeClaims: resource.MustParse("3"),
+							v1.ResourceServicesNodePorts:      resource.MustParse("2"),
+							v1.ResourceServicesLoadBalancers:  resource.MustParse("1"),
+						},
+						Used: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("2.1"),
+							v1.ResourceMemory:                 resource.MustParse("500M"),
+							v1.ResourceStorage:                resource.MustParse("9G"),
+							v1.ResourcePods:                   resource.MustParse("8"),
+							v1.ResourceServices:               resource.MustParse("7"),
+							v1.ResourceReplicationControllers: resource.MustParse("6"),
+							v1.ResourceQuotas:                 resource.MustParse("5"),
+							v1.ResourceSecrets:                resource.MustParse("4"),
+							v1.ResourceConfigMaps:             resource.MustParse("3"),
+							v1.ResourcePersistentVolumeClaims: resource.MustParse("2"),
+							v1.ResourceServicesNodePorts:      resource.MustParse("1"),
+							v1.ResourceServicesLoadBalancers:  resource.MustParse("0"),
+						},
 					},
 				},
 			},

--- a/internal/collector/secret_test.go
+++ b/internal/collector/secret_test.go
@@ -45,13 +45,15 @@ func TestSecretCollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "secret1",
-					Namespace:       "ns1",
-					ResourceVersion: "000000",
+			Objs: []interface{}{
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "secret1",
+						Namespace:       "ns1",
+						ResourceVersion: "000000",
+					},
+					Type: v1.SecretTypeOpaque,
 				},
-				Type: v1.SecretTypeOpaque,
 			},
 			Want: `
 				kube_secret_info{namespace="ns1",secret="secret1"} 1
@@ -62,14 +64,16 @@ func TestSecretCollector(t *testing.T) {
 			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},
 		},
 		{
-			Obj: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "secret2",
-					Namespace:         "ns2",
-					CreationTimestamp: metav1StartTime,
-					ResourceVersion:   "123456",
+			Objs: []interface{}{
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "secret2",
+						Namespace:         "ns2",
+						CreationTimestamp: metav1StartTime,
+						ResourceVersion:   "123456",
+					},
+					Type: v1.SecretTypeServiceAccountToken,
 				},
-				Type: v1.SecretTypeServiceAccountToken,
 			},
 			Want: `
 				kube_secret_info{namespace="ns2",secret="secret2"} 1
@@ -81,15 +85,17 @@ func TestSecretCollector(t *testing.T) {
 			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},
 		},
 		{
-			Obj: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "secret3",
-					Namespace:         "ns3",
-					CreationTimestamp: metav1StartTime,
-					Labels:            map[string]string{"test-3": "test-3"},
-					ResourceVersion:   "abcdef",
+			Objs: []interface{}{
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "secret3",
+						Namespace:         "ns3",
+						CreationTimestamp: metav1StartTime,
+						Labels:            map[string]string{"test-3": "test-3"},
+						ResourceVersion:   "abcdef",
+					},
+					Type: v1.SecretTypeDockercfg,
 				},
-				Type: v1.SecretTypeDockercfg,
 			},
 			Want: `
 				kube_secret_info{namespace="ns3",secret="secret3"} 1

--- a/internal/collector/service_test.go
+++ b/internal/collector/service_test.go
@@ -44,18 +44,20 @@ func TestServiceCollector(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-service1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "default",
-					Labels: map[string]string{
-						"app": "example1",
+			Objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-service1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "default",
+						Labels: map[string]string{
+							"app": "example1",
+						},
 					},
-				},
-				Spec: v1.ServiceSpec{
-					ClusterIP: "1.2.3.4",
-					Type:      v1.ServiceTypeClusterIP,
+					Spec: v1.ServiceSpec{
+						ClusterIP: "1.2.3.4",
+						Type:      v1.ServiceTypeClusterIP,
+					},
 				},
 			},
 			Want: `
@@ -73,18 +75,20 @@ func TestServiceCollector(t *testing.T) {
 		},
 		{
 
-			Obj: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-service2",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "default",
-					Labels: map[string]string{
-						"app": "example2",
+			Objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-service2",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "default",
+						Labels: map[string]string{
+							"app": "example2",
+						},
 					},
-				},
-				Spec: v1.ServiceSpec{
-					ClusterIP: "1.2.3.5",
-					Type:      v1.ServiceTypeNodePort,
+					Spec: v1.ServiceSpec{
+						ClusterIP: "1.2.3.5",
+						Type:      v1.ServiceTypeNodePort,
+					},
 				},
 			},
 			Want: `
@@ -95,19 +99,21 @@ func TestServiceCollector(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-service3",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "default",
-					Labels: map[string]string{
-						"app": "example3",
+			Objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-service3",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "default",
+						Labels: map[string]string{
+							"app": "example3",
+						},
 					},
-				},
-				Spec: v1.ServiceSpec{
-					ClusterIP:      "1.2.3.6",
-					LoadBalancerIP: "1.2.3.7",
-					Type:           v1.ServiceTypeLoadBalancer,
+					Spec: v1.ServiceSpec{
+						ClusterIP:      "1.2.3.6",
+						LoadBalancerIP: "1.2.3.7",
+						Type:           v1.ServiceTypeLoadBalancer,
+					},
 				},
 			},
 			Want: `
@@ -118,18 +124,20 @@ func TestServiceCollector(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-service4",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "default",
-					Labels: map[string]string{
-						"app": "example4",
+			Objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-service4",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "default",
+						Labels: map[string]string{
+							"app": "example4",
+						},
 					},
-				},
-				Spec: v1.ServiceSpec{
-					ExternalName: "www.example.com",
-					Type:         v1.ServiceTypeExternalName,
+					Spec: v1.ServiceSpec{
+						ExternalName: "www.example.com",
+						Type:         v1.ServiceTypeExternalName,
+					},
 				},
 			},
 			Want: `
@@ -140,24 +148,26 @@ func TestServiceCollector(t *testing.T) {
 			`,
 		},
 		{
-			Obj: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-service5",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "default",
-					Labels: map[string]string{
-						"app": "example5",
+			Objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-service5",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "default",
+						Labels: map[string]string{
+							"app": "example5",
+						},
 					},
-				},
-				Spec: v1.ServiceSpec{
-					Type: v1.ServiceTypeLoadBalancer,
-				},
-				Status: v1.ServiceStatus{
-					LoadBalancer: v1.LoadBalancerStatus{
-						Ingress: []v1.LoadBalancerIngress{
-							{
-								IP:       "1.2.3.8",
-								Hostname: "www.example.com",
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeLoadBalancer,
+					},
+					Status: v1.ServiceStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{
+								{
+									IP:       "1.2.3.8",
+									Hostname: "www.example.com",
+								},
 							},
 						},
 					},
@@ -172,20 +182,22 @@ func TestServiceCollector(t *testing.T) {
 			`,
 		},
 		{
-			Obj: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-service6",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "default",
-					Labels: map[string]string{
-						"app": "example6",
+			Objs: []interface{}{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-service6",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "default",
+						Labels: map[string]string{
+							"app": "example6",
+						},
 					},
-				},
-				Spec: v1.ServiceSpec{
-					Type: v1.ServiceTypeClusterIP,
-					ExternalIPs: []string{
-						"1.2.3.9",
-						"1.2.3.10",
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeClusterIP,
+						ExternalIPs: []string{
+							"1.2.3.9",
+							"1.2.3.10",
+						},
 					},
 				},
 			},

--- a/internal/collector/statefulset_test.go
+++ b/internal/collector/statefulset_test.go
@@ -63,25 +63,27 @@ func TestStatefuleSetCollector(t *testing.T) {
  	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1beta1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "statefulset1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "ns1",
-					Labels: map[string]string{
-						"app": "example1",
+			Objs: []interface{}{
+				&v1beta1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "statefulset1",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						Namespace:         "ns1",
+						Labels: map[string]string{
+							"app": "example1",
+						},
+						Generation: 3,
 					},
-					Generation: 3,
-				},
-				Spec: v1beta1.StatefulSetSpec{
-					Replicas:    &statefulSet1Replicas,
-					ServiceName: "statefulset1service",
-				},
-				Status: v1beta1.StatefulSetStatus{
-					ObservedGeneration: &statefulSet1ObservedGeneration,
-					Replicas:           2,
-					UpdateRevision:     "ur1",
-					CurrentRevision:    "cr1",
+					Spec: v1beta1.StatefulSetSpec{
+						Replicas:    &statefulSet1Replicas,
+						ServiceName: "statefulset1service",
+					},
+					Status: v1beta1.StatefulSetStatus{
+						ObservedGeneration: &statefulSet1ObservedGeneration,
+						Replicas:           2,
+						UpdateRevision:     "ur1",
+						CurrentRevision:    "cr1",
+					},
 				},
 			},
 			Want: `
@@ -112,27 +114,29 @@ func TestStatefuleSetCollector(t *testing.T) {
 			},
 		},
 		{
-			Obj: &v1beta1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "statefulset2",
-					Namespace: "ns2",
-					Labels: map[string]string{
-						"app": "example2",
+			Objs: []interface{}{
+				&v1beta1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "statefulset2",
+						Namespace: "ns2",
+						Labels: map[string]string{
+							"app": "example2",
+						},
+						Generation: 21,
 					},
-					Generation: 21,
-				},
-				Spec: v1beta1.StatefulSetSpec{
-					Replicas:    &statefulSet2Replicas,
-					ServiceName: "statefulset2service",
-				},
-				Status: v1beta1.StatefulSetStatus{
-					CurrentReplicas:    2,
-					ObservedGeneration: &statefulSet2ObservedGeneration,
-					ReadyReplicas:      5,
-					Replicas:           5,
-					UpdatedReplicas:    3,
-					UpdateRevision:     "ur2",
-					CurrentRevision:    "cr2",
+					Spec: v1beta1.StatefulSetSpec{
+						Replicas:    &statefulSet2Replicas,
+						ServiceName: "statefulset2service",
+					},
+					Status: v1beta1.StatefulSetStatus{
+						CurrentReplicas:    2,
+						ObservedGeneration: &statefulSet2ObservedGeneration,
+						ReadyReplicas:      5,
+						Replicas:           5,
+						UpdatedReplicas:    3,
+						UpdateRevision:     "ur2",
+						CurrentRevision:    "cr2",
+					},
 				},
 			},
 			Want: `
@@ -161,24 +165,26 @@ func TestStatefuleSetCollector(t *testing.T) {
 			},
 		},
 		{
-			Obj: &v1beta1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "statefulset3",
-					Namespace: "ns3",
-					Labels: map[string]string{
-						"app": "example3",
+			Objs: []interface{}{
+				&v1beta1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "statefulset3",
+						Namespace: "ns3",
+						Labels: map[string]string{
+							"app": "example3",
+						},
+						Generation: 36,
 					},
-					Generation: 36,
-				},
-				Spec: v1beta1.StatefulSetSpec{
-					Replicas:    &statefulSet3Replicas,
-					ServiceName: "statefulset2service",
-				},
-				Status: v1beta1.StatefulSetStatus{
-					ObservedGeneration: nil,
-					Replicas:           7,
-					UpdateRevision:     "ur3",
-					CurrentRevision:    "cr3",
+					Spec: v1beta1.StatefulSetSpec{
+						Replicas:    &statefulSet3Replicas,
+						ServiceName: "statefulset2service",
+					},
+					Status: v1beta1.StatefulSetStatus{
+						ObservedGeneration: nil,
+						Replicas:           7,
+						UpdateRevision:     "ur3",
+						CurrentRevision:    "cr3",
+					},
 				},
 			},
 			Want: `

--- a/internal/collector/testutils.go
+++ b/internal/collector/testutils.go
@@ -28,14 +28,17 @@ import (
 )
 
 type generateMetricsTestCase struct {
-	Obj         interface{}
+	Objs        []interface{}
 	MetricNames []string
 	Want        string
 	Func        func(interface{}) []metricsstore.FamilyStringer
 }
 
 func (testCase *generateMetricsTestCase) run() error {
-	metricFamilies := testCase.Func(testCase.Obj)
+	var metricFamilies []metricsstore.FamilyStringer
+	for _, obj := range testCase.Objs {
+		metricFamilies = testCase.Func(obj)
+	}
 	metricFamilyStrings := []string{}
 	for _, f := range metricFamilies {
 		metricFamilyStrings = append(metricFamilyStrings, f.String())

--- a/internal/collector/testutils.go
+++ b/internal/collector/testutils.go
@@ -115,7 +115,7 @@ func filterMetrics(ms []string, names []string) []string {
 
 	regexps := []*regexp.Regexp{}
 	for _, n := range names {
-		regexps = append(regexps, regexp.MustCompile(fmt.Sprintf("^%v", n)))
+		regexps = append(regexps, regexp.MustCompile(fmt.Sprintf("^%v\\{", n)))
 	}
 
 	for _, m := range ms {

--- a/main_test.go
+++ b/main_test.go
@@ -209,6 +209,16 @@ kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",conta
 kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Completed"} 0
 kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Error"} 0
 kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="ContainerCannotRun"} 0
+# HELP kube_pod_container_status_terminated_reasons_total Counter with observed container restarts and reason the container was terminated.
+# TYPE kube_pod_container_status_terminated_reasons_total counter
+kube_pod_container_status_terminated_reasons_total{namespace="default",pod="pod0",container="container2",reason="Completed"} 0
+kube_pod_container_status_terminated_reasons_total{namespace="default",pod="pod0",container="container2",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reasons_total{namespace="default",pod="pod0",container="container2",reason="Error"} 0
+kube_pod_container_status_terminated_reasons_total{namespace="default",pod="pod0",container="container2",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reasons_total{namespace="default",pod="pod0",container="container3",reason="Completed"} 0
+kube_pod_container_status_terminated_reasons_total{namespace="default",pod="pod0",container="container3",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reasons_total{namespace="default",pod="pod0",container="container3",reason="Error"} 0
+kube_pod_container_status_terminated_reasons_total{namespace="default",pod="pod0",container="container3",reason="OOMKilled"} 0
 # HELP kube_pod_container_status_last_terminated_reason Describes the last reason the container was in terminated state.
 # TYPE kube_pod_container_status_last_terminated_reason gauge
 kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="OOMKilled"} 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
I would like to continue discussion from https://github.com/kubernetes/kube-state-metrics/issues/344. While using `LastTerminationState` allows to catch more OOMKills, it still misses those where during the scrape period container dies more than once with different termination state. I am not entirely sure this implementation would follow conventions set by other metrics but it does allow never to miss an OOMKill because it can increment own counter on each observed pod change.

It is split into two commits
- first one allowing unit tests to take more than one object
- implementing the observed termination counter

Looking forward to any comments and hoping we can come up with good solution together :)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

