### PR TITLE
update Dockerfile to use latest alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 COPY kube-state-metrics /
 


### PR DESCRIPTION
Use the latest alpine linux base image. v3.9 was released last month

More details: http://dl-cdn.alpinelinux.org/alpine/v3.9/