### PR TITLE
add pvc access mode metric

### DIFF
--- a/Documentation/persistentvolumeclaim-metrics.md
+++ b/Documentation/persistentvolumeclaim-metrics.md
@@ -2,6 +2,7 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
+| kube_persistentvolumeclaim_access_mode | Gauge | `access_mode`=&lt;persistentvolumeclaim-access-mode&gt; <br>`namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; | STABLE |
 | kube_persistentvolumeclaim_info | Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `storageclass`=&lt;persistentvolumeclaim-storageclassname&gt;<br>`volumename`=&lt;volumename&gt; | STABLE |
 | kube_persistentvolumeclaim_labels | Gauge | `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `label_PERSISTENTVOLUMECLAIM_LABEL`=&lt;PERSISTENTVOLUMECLAIM_LABEL&gt;  | STABLE |
 | kube_persistentvolumeclaim_status_phase | Gauge | `namespace`=&lt;persistentvolumeclaim-namespace&gt; <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-name&gt; <br> `phase`=&lt;Pending\|Bound\|Lost&gt; | STABLE |

--- a/internal/collector/persistentvolumeclaim.go
+++ b/internal/collector/persistentvolumeclaim.go
@@ -120,6 +120,26 @@ var (
 				}
 			}),
 		},
+		{
+			Name: "kube_persistentvolumeclaim_access_mode",
+			Type: metric.MetricTypeGauge,
+			Help: "The access mode(s) specified by the persistent volume claim.",
+			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, mode := range p.Spec.AccessModes {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{"access_mode"},
+						LabelValues: []string{string(mode)},
+						Value:       1,
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
 	}
 )
 

--- a/internal/collector/persistentvolumeclaim_test.go
+++ b/internal/collector/persistentvolumeclaim_test.go
@@ -37,6 +37,8 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 		# TYPE kube_persistentvolumeclaim_status_phase gauge
 		# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
 		# TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
+		# HELP kube_persistentvolumeclaim_access_mode The access mode of the persistent volume.
+		# TYPE kube_persistentvolumeclaim_access_mode gauge
 	`
 	storageClassName := "rbd"
 	cases := []generateMetricsTestCase{
@@ -51,6 +53,9 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 					},
 				},
 				Spec: v1.PersistentVolumeClaimSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{
+						v1.ReadWriteOnce,
+					},
 					StorageClassName: &storageClassName,
 					Resources: v1.ResourceRequirements{
 						Requests: v1.ResourceList{
@@ -70,8 +75,9 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
 				kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
 				kube_persistentvolumeclaim_labels{label_app="mysql-server",namespace="default",persistentvolumeclaim="mysql-data"} 1
+				kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="mysql-data",access_mode="ReadWriteOnce"} 1
 `,
-			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels"},
+			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels", "kube_persistentvolumeclaim_access_mode"},
 		},
 		{
 			Obj: &v1.PersistentVolumeClaim{
@@ -80,6 +86,9 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: v1.PersistentVolumeClaimSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{
+						v1.ReadWriteOnce,
+					},
 					StorageClassName: &storageClassName,
 					VolumeName:       "pvc-prometheus-data",
 				},
@@ -93,13 +102,19 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Lost"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Pending"} 1
 				kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="prometheus-data"} 1
+				kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="prometheus-data",access_mode="ReadWriteOnce"} 1
 			`,
-			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels"},
+			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels", "kube_persistentvolumeclaim_access_mode"},
 		},
 		{
 			Obj: &v1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mongo-data",
+				},
+				Spec: v1.PersistentVolumeClaimSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{
+						v1.ReadWriteOnce,
+					},
 				},
 				Status: v1.PersistentVolumeClaimStatus{
 					Phase: v1.ClaimLost,
@@ -111,8 +126,9 @@ func TestPersistentVolumeClaimCollector(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Lost"} 1
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Pending"} 0
 				kube_persistentvolumeclaim_labels{namespace="",persistentvolumeclaim="mongo-data"} 1
+				kube_persistentvolumeclaim_access_mode{namespace="",persistentvolumeclaim="mongo-data",access_mode="ReadWriteOnce"} 1
 `,
-			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels"},
+			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels", "kube_persistentvolumeclaim_access_mode"},
 		},
 	}
 	for i, c := range cases {


### PR DESCRIPTION
**What this PR does / why we need it**: Adds PVC access mode as metric `kube_persistentvolumeclaim_access_mode`

**Which issue(s) this PR fixes**:
Fixes #554 

