### PR TITLE
add persistent volume capacity metric

### DIFF
--- a/docs/persistentvolume-metrics.md
+++ b/docs/persistentvolume-metrics.md
@@ -2,7 +2,7 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
-| kube_persistentvolume_capacity | Gauge | `persistentvolume`=&lt;pv-name&gt; | STABLE |
+| kube_persistentvolume_capacity_bytes | Gauge | `persistentvolume`=&lt;pv-name&gt; | STABLE |
 | kube_persistentvolume_status_phase | Gauge | `persistentvolume`=&lt;pv-name&gt; <br>`phase`=&lt;Bound\|Failed\|Pending\|Available\|Released&gt;| STABLE |
 | kube_persistentvolume_labels | Gauge | `persistentvolume`=&lt;persistentvolume-name&gt; <br> `label_PERSISTENTVOLUME_LABEL`=&lt;PERSISTENTVOLUME_LABEL&gt;  | STABLE |
 | kube_persistentvolume_info | Gauge | `persistentvolume`=&lt;pv-name&gt; <br> `storageclass`=&lt;storageclass-name&gt; | STABLE |

--- a/docs/persistentvolume-metrics.md
+++ b/docs/persistentvolume-metrics.md
@@ -2,6 +2,7 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
+| kube_persistentvolume_capacity | Gauge | `persistentvolume`=&lt;pv-name&gt; | STABLE |
 | kube_persistentvolume_status_phase | Gauge | `persistentvolume`=&lt;pv-name&gt; <br>`phase`=&lt;Bound\|Failed\|Pending\|Available\|Released&gt;| STABLE |
 | kube_persistentvolume_labels | Gauge | `persistentvolume`=&lt;persistentvolume-name&gt; <br> `label_PERSISTENTVOLUME_LABEL`=&lt;PERSISTENTVOLUME_LABEL&gt;  | STABLE |
 | kube_persistentvolume_info | Gauge | `persistentvolume`=&lt;pv-name&gt; <br> `storageclass`=&lt;storageclass-name&gt; | STABLE |

--- a/internal/collector/persistentvolume.go
+++ b/internal/collector/persistentvolume.go
@@ -109,7 +109,7 @@ var (
 			}),
 		},
 		{
-			Name: "kube_persistentvolume_capacity",
+			Name: "kube_persistentvolume_capacity_bytes",
 			Type: metric.MetricTypeGauge,
 			Help: "Persistentvolume capacity in bytes.",
 			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {

--- a/internal/collector/persistentvolume.go
+++ b/internal/collector/persistentvolume.go
@@ -108,6 +108,21 @@ var (
 				}
 			}),
 		},
+		{
+			Name: "kube_persistentvolume_capacity",
+			Type: metric.MetricTypeGauge,
+			Help: "persistentvolume capacity in Gigabytes.",
+			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+				storage := p.Spec.Capacity[v1.ResourceStorage]
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(storage.Size()),
+						},
+					},
+				}
+			}),
+		},
 	}
 )
 

--- a/internal/collector/persistentvolume.go
+++ b/internal/collector/persistentvolume.go
@@ -111,13 +111,13 @@ var (
 		{
 			Name: "kube_persistentvolume_capacity",
 			Type: metric.MetricTypeGauge,
-			Help: "persistentvolume capacity in Gigabytes.",
+			Help: "Persistentvolume capacity in bytes.",
 			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				storage := p.Spec.Capacity[v1.ResourceStorage]
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							Value: float64(storage.Size()),
+							Value: float64(storage.Value()),
 						},
 					},
 				}

--- a/internal/collector/persistentvolume_test.go
+++ b/internal/collector/persistentvolume_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
@@ -34,6 +35,8 @@ func TestPersistentVolumeCollector(t *testing.T) {
 			# TYPE kube_persistentvolume_labels gauge
 			# HELP kube_persistentvolume_info Information about persistentvolume.
 			# TYPE kube_persistentvolume_info gauge
+			# HELP kube_persistentvolume_capacity The size of the persistentvolume in Gigabytes.
+			# TYPE kube_persistentvolume_capacity gauge
 	`
 	cases := []generateMetricsTestCase{
 		// Verify phase enumerations.
@@ -200,6 +203,22 @@ func TestPersistentVolumeCollector(t *testing.T) {
 					kube_persistentvolume_labels{persistentvolume="test-unlabeled-pv"} 1
 				`,
 			MetricNames: []string{"kube_persistentvolume_labels"},
+		},
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv",
+				},
+				Spec: v1.PersistentVolumeSpec{
+					Capacity: v1.ResourceList{
+						v1.ResourceStorage: resource.MustParse("5Gi"),
+					},
+				},
+			},
+			Want: `
+					kube_persistentvolume_capacity{persistentvolume="test-pv"} 5
+				`,
+			MetricNames: []string{"kube_persistentvolume_capacity"},
 		},
 	}
 	for i, c := range cases {

--- a/internal/collector/persistentvolume_test.go
+++ b/internal/collector/persistentvolume_test.go
@@ -35,7 +35,7 @@ func TestPersistentVolumeCollector(t *testing.T) {
 			# TYPE kube_persistentvolume_labels gauge
 			# HELP kube_persistentvolume_info Information about persistentvolume.
 			# TYPE kube_persistentvolume_info gauge
-			# HELP kube_persistentvolume_capacity The size of the persistentvolume in Gigabytes.
+			# HELP kube_persistentvolume_capacity The size of the Persistentvolume in bytes.
 			# TYPE kube_persistentvolume_capacity gauge
 	`
 	cases := []generateMetricsTestCase{
@@ -216,7 +216,7 @@ func TestPersistentVolumeCollector(t *testing.T) {
 				},
 			},
 			Want: `
-					kube_persistentvolume_capacity{persistentvolume="test-pv"} 5
+					kube_persistentvolume_capacity{persistentvolume="test-pv"} 5.36870912e+09
 				`,
 			MetricNames: []string{"kube_persistentvolume_capacity"},
 		},

--- a/internal/collector/persistentvolume_test.go
+++ b/internal/collector/persistentvolume_test.go
@@ -35,8 +35,8 @@ func TestPersistentVolumeCollector(t *testing.T) {
 			# TYPE kube_persistentvolume_labels gauge
 			# HELP kube_persistentvolume_info Information about persistentvolume.
 			# TYPE kube_persistentvolume_info gauge
-			# HELP kube_persistentvolume_capacity The size of the Persistentvolume in bytes.
-			# TYPE kube_persistentvolume_capacity gauge
+			# HELP kube_persistentvolume_capacity_bytes The size of the Persistentvolume in bytes.
+			# TYPE kube_persistentvolume_capacity_bytes gauge
 	`
 	cases := []generateMetricsTestCase{
 		// Verify phase enumerations.
@@ -216,9 +216,9 @@ func TestPersistentVolumeCollector(t *testing.T) {
 				},
 			},
 			Want: `
-					kube_persistentvolume_capacity{persistentvolume="test-pv"} 5.36870912e+09
+					kube_persistentvolume_capacity_bytes{persistentvolume="test-pv"} 5.36870912e+09
 				`,
-			MetricNames: []string{"kube_persistentvolume_capacity"},
+			MetricNames: []string{"kube_persistentvolume_capacity_bytes"},
 		},
 	}
 	for i, c := range cases {


### PR DESCRIPTION
**What this PR does / why we need it**: Add `kube_persistentvolume_capacity` to track PV capacity.

**Which issue(s) this PR fixes**:
Fixes #555

