### PR TITLE
Export Job's owner

### DIFF
--- a/docs/job-metrics.md
+++ b/docs/job-metrics.md
@@ -4,6 +4,7 @@
 | ---------- | ----------- | ----------- | ----------- |
 | kube_job_info | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
 | kube_job_labels | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; <br> `label_JOB_LABEL`=&lt;JOB_LABEL&gt;  | STABLE |
+| kube_job_owner | Gauge | `job_name`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  | STABLE |
 | kube_job_spec_parallelism | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
 | kube_job_spec_completions | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
 | kube_job_spec_active_deadline_seconds | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |

--- a/internal/collector/job.go
+++ b/internal/collector/job.go
@@ -271,13 +271,7 @@ var (
 				ms := []*metric.Metric{}
 
 				owners := j.GetOwnerReferences()
-				if len(owners) == 0 {
-					ms = append(ms, &metric.Metric{
-						LabelKeys:   labelKeys,
-						LabelValues: []string{"<none>", "<none>", "<none>"},
-						Value:       1,
-					})
-				} else {
+				if len(owners) > 0 {
 					for _, owner := range owners {
 						if owner.Controller != nil {
 							ms = append(ms, &metric.Metric{

--- a/internal/collector/job.go
+++ b/internal/collector/job.go
@@ -17,6 +17,8 @@ limitations under the License.
 package collector
 
 import (
+	"strconv"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 
 	v1batch "k8s.io/api/batch/v1"
@@ -253,6 +255,44 @@ var (
 
 						Value: float64(j.Status.CompletionTime.Unix()),
 					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_job_owner",
+			Type: metric.MetricTypeGauge,
+			Help: "Information about the Job's owner.",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
+				ms := []*metric.Metric{}
+
+				owners := j.GetOwnerReferences()
+				if len(owners) == 0 {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   labelKeys,
+						LabelValues: []string{"<none>", "<none>", "<none>"},
+						Value:       1,
+					})
+				} else {
+					for _, owner := range owners {
+						if owner.Controller != nil {
+							ms = append(ms, &metric.Metric{
+								LabelKeys:   labelKeys,
+								LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
+								Value:       1,
+							})
+						} else {
+							ms = append(ms, &metric.Metric{
+								LabelKeys:   labelKeys,
+								LabelValues: []string{owner.Kind, owner.Name, "false"},
+								Value:       1,
+							})
+						}
+					}
 				}
 
 				return &metric.Family{

--- a/internal/collector/job_test.go
+++ b/internal/collector/job_test.go
@@ -149,7 +149,6 @@ func TestJobCollector(t *testing.T) {
 				},
 			},
 			Want: `
-				kube_job_owner{job_name="SuccessfulJob1",namespace="ns1",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>"} 1
 				kube_job_complete{condition="false",job_name="SuccessfulJob1",namespace="ns1"} 0
 				kube_job_complete{condition="true",job_name="SuccessfulJob1",namespace="ns1"} 1
 				kube_job_complete{condition="unknown",job_name="SuccessfulJob1",namespace="ns1"} 0
@@ -192,7 +191,6 @@ func TestJobCollector(t *testing.T) {
 				},
 			},
 			Want: `
-				kube_job_owner{job_name="FailedJob1",namespace="ns1",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>"} 1
 				kube_job_failed{condition="false",job_name="FailedJob1",namespace="ns1"} 0
 				kube_job_failed{condition="true",job_name="FailedJob1",namespace="ns1"} 1
 				kube_job_failed{condition="unknown",job_name="FailedJob1",namespace="ns1"} 0
@@ -235,7 +233,6 @@ func TestJobCollector(t *testing.T) {
 				},
 			},
 			Want: `
-				kube_job_owner{job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>"} 1
 				kube_job_complete{condition="false",job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 0
 				kube_job_complete{condition="true",job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 1
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a Job's object owner metric similar to the Pod's owner. It is quite helpful when trying to correlate Jobs and CronJobs.
