### PR TITLE
Revert "Do not export Job's owner metrics if Job's OwnerReference is …

### DIFF
--- a/internal/collector/job.go
+++ b/internal/collector/job.go
@@ -271,7 +271,13 @@ var (
 				ms := []*metric.Metric{}
 
 				owners := j.GetOwnerReferences()
-				if len(owners) > 0 {
+				if len(owners) == 0 {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   labelKeys,
+						LabelValues: []string{"<none>", "<none>", "<none>"},
+						Value:       1,
+					})
+				} else {
 					for _, owner := range owners {
 						if owner.Controller != nil {
 							ms = append(ms, &metric.Metric{

--- a/internal/collector/job_test.go
+++ b/internal/collector/job_test.go
@@ -149,6 +149,7 @@ func TestJobCollector(t *testing.T) {
 				},
 			},
 			Want: `
+				kube_job_owner{job_name="SuccessfulJob1",namespace="ns1",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>"} 1
 				kube_job_complete{condition="false",job_name="SuccessfulJob1",namespace="ns1"} 0
 				kube_job_complete{condition="true",job_name="SuccessfulJob1",namespace="ns1"} 1
 				kube_job_complete{condition="unknown",job_name="SuccessfulJob1",namespace="ns1"} 0
@@ -191,6 +192,7 @@ func TestJobCollector(t *testing.T) {
 				},
 			},
 			Want: `
+				kube_job_owner{job_name="FailedJob1",namespace="ns1",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>"} 1
 				kube_job_failed{condition="false",job_name="FailedJob1",namespace="ns1"} 0
 				kube_job_failed{condition="true",job_name="FailedJob1",namespace="ns1"} 1
 				kube_job_failed{condition="unknown",job_name="FailedJob1",namespace="ns1"} 0
@@ -233,6 +235,7 @@ func TestJobCollector(t *testing.T) {
 				},
 			},
 			Want: `
+				kube_job_owner{job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>"} 1
 				kube_job_complete{condition="false",job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 0
 				kube_job_complete{condition="true",job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 1
 


### PR DESCRIPTION
This reverts commit 15b93c4706372623cd0bbba413f7ae461cce4406.

Based on @brancz's decision here: https://github.com/kubernetes/kube-state-metrics/issues/569#issuecomment-467393722
