### PR TITLE
lint: add golangci-lint to the CI pipeline of kube-state-metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+run:
+  deadline: 2m
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - goimports
+    - golint
+    - gosimple
+    - gocyclo
+    - ineffassign
+    - misspell
+    - govet
+
+linters-settings:
+  goimports:
+local-prefixes: k8s.io/kube-state-metrics

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ install:
 
 jobs:
   include:
-    # Format
-    - script: make format
+    # Lint
+    - script: make lint
     # Check that all the go modules manifests, vendors, and packages are in sync
     - script: make validate-modules
     # Check that all metrics are documented

--- a/internal/collector/configmap.go
+++ b/internal/collector/configmap.go
@@ -17,9 +17,9 @@ limitations under the License.
 package collector
 
 import (
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/collector/configmap_test.go
+++ b/internal/collector/configmap_test.go
@@ -19,7 +19,7 @@ package collector
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )

--- a/internal/collector/cronjob_test.go
+++ b/internal/collector/cronjob_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )

--- a/internal/collector/endpoint.go
+++ b/internal/collector/endpoint.go
@@ -17,9 +17,9 @@ limitations under the License.
 package collector
 
 import (
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/collector/endpoint_test.go
+++ b/internal/collector/endpoint_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )

--- a/internal/collector/hpa_test.go
+++ b/internal/collector/hpa_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package collector
 
 import (
-	v12 "k8s.io/api/core/v1"
 	"testing"
+
+	v12 "k8s.io/api/core/v1"
 
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/collector/job_test.go
+++ b/internal/collector/job_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	v1batch "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )

--- a/internal/collector/limitrange.go
+++ b/internal/collector/limitrange.go
@@ -17,9 +17,9 @@ limitations under the License.
 package collector
 
 import (
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/collector/limitrange_test.go
+++ b/internal/collector/limitrange_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"

--- a/internal/collector/namespace.go
+++ b/internal/collector/namespace.go
@@ -19,7 +19,7 @@ package collector
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/collector/namespace_test.go
+++ b/internal/collector/namespace_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )

--- a/internal/collector/node_test.go
+++ b/internal/collector/node_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"

--- a/internal/collector/persistentvolume.go
+++ b/internal/collector/persistentvolume.go
@@ -19,7 +19,7 @@ package collector
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/collector/persistentvolume_test.go
+++ b/internal/collector/persistentvolume_test.go
@@ -19,7 +19,7 @@ package collector
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"

--- a/internal/collector/persistentvolumeclaim.go
+++ b/internal/collector/persistentvolumeclaim.go
@@ -19,7 +19,7 @@ package collector
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/collector/persistentvolumeclaim_test.go
+++ b/internal/collector/persistentvolumeclaim_test.go
@@ -19,7 +19,7 @@ package collector
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"

--- a/internal/collector/replicationcontroller.go
+++ b/internal/collector/replicationcontroller.go
@@ -17,9 +17,9 @@ limitations under the License.
 package collector
 
 import (
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/collector/replicationcontroller_test.go
+++ b/internal/collector/replicationcontroller_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )

--- a/internal/collector/resourcequota.go
+++ b/internal/collector/resourcequota.go
@@ -17,9 +17,9 @@ limitations under the License.
 package collector
 
 import (
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/collector/resourcequota_test.go
+++ b/internal/collector/resourcequota_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"

--- a/internal/collector/secret.go
+++ b/internal/collector/secret.go
@@ -17,9 +17,9 @@ limitations under the License.
 package collector
 
 import (
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/collector/secret_test.go
+++ b/internal/collector/secret_test.go
@@ -19,7 +19,7 @@ package collector
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )

--- a/internal/collector/service.go
+++ b/internal/collector/service.go
@@ -17,9 +17,9 @@ limitations under the License.
 package collector
 
 import (
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/collector/service_test.go
+++ b/internal/collector/service_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )

--- a/main_test.go
+++ b/main_test.go
@@ -31,7 +31,7 @@ import (
 	coll "k8s.io/kube-state-metrics/pkg/collector"
 	"k8s.io/kube-state-metrics/pkg/options"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"

--- a/pkg/metrics_store/metrics_store_test.go
+++ b/pkg/metrics_store/metrics_store_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/tests/lib/lib_test.go
+++ b/tests/lib/lib_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"


### PR DESCRIPTION
Follow up PR of #693 
This PR also fixes goimports(as of go 1.11) issues reported by golangci-lint

/cc @brancz @andyxning 