### PR TITLE
Fix metric labels for kube_job_failed

### DIFF
--- a/internal/collector/job.go
+++ b/internal/collector/job.go
@@ -215,7 +215,7 @@ var (
 						for _, m := range metrics {
 							metric := m
 							metric.LabelKeys = []string{"condition"}
-							ms = append(ms, m)
+							ms = append(ms, metric)
 						}
 					}
 				}


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes an inconsistency with the way the `condition` label key is applied to the `kube_job_failed` metric.