### PR TITLE
internal/collector+pkg/metrics_store: Reduce allocation & improve hot path

### DIFF
--- a/internal/collector/hpa.go
+++ b/internal/collector/hpa.go
@@ -125,16 +125,16 @@ var (
 			Type: metric.Gauge,
 			Help: "The condition of this autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-				ms := []*metric.Metric{}
+				ms := make([]*metric.Metric, len(a.Status.Conditions)*len(conditionStatuses))
 
-				for _, c := range a.Status.Conditions {
+				for i, c := range a.Status.Conditions {
 					metrics := addConditionMetrics(c.Status)
 
-					for _, m := range metrics {
+					for j, m := range metrics {
 						metric := m
 						metric.LabelKeys = []string{"condition", "status"}
 						metric.LabelValues = append(metric.LabelValues, string(c.Type))
-						ms = append(ms, metric)
+						ms[i*len(conditionStatuses)+j] = metric
 					}
 				}
 

--- a/internal/collector/job.go
+++ b/internal/collector/job.go
@@ -268,29 +268,35 @@ var (
 			Help: "Information about the Job's owner.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
-				ms := []*metric.Metric{}
 
 				owners := j.GetOwnerReferences()
+
 				if len(owners) == 0 {
-					ms = append(ms, &metric.Metric{
-						LabelKeys:   labelKeys,
-						LabelValues: []string{"<none>", "<none>", "<none>"},
-						Value:       1,
-					})
-				} else {
-					for _, owner := range owners {
-						if owner.Controller != nil {
-							ms = append(ms, &metric.Metric{
+					return &metric.Family{
+						Metrics: []*metric.Metric{
+							{
 								LabelKeys:   labelKeys,
-								LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
+								LabelValues: []string{"<none>", "<none>", "<none>"},
 								Value:       1,
-							})
-						} else {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   labelKeys,
-								LabelValues: []string{owner.Kind, owner.Name, "false"},
-								Value:       1,
-							})
+							},
+						},
+					}
+				}
+
+				ms := make([]*metric.Metric, len(owners))
+
+				for i, owner := range owners {
+					if owner.Controller != nil {
+						ms[i] = &metric.Metric{
+							LabelKeys:   labelKeys,
+							LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
+							Value:       1,
+						}
+					} else {
+						ms[i] = &metric.Metric{
+							LabelKeys:   labelKeys,
+							LabelValues: []string{owner.Kind, owner.Name, "false"},
+							Value:       1,
 						}
 					}
 				}

--- a/internal/collector/persistentvolume.go
+++ b/internal/collector/persistentvolume.go
@@ -55,32 +55,36 @@ var (
 			Type: metric.Gauge,
 			Help: "The phase indicates if a volume is available, bound to a claim, or released by a claim.",
 			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
-				ms := []*metric.Metric{}
+				phase := p.Status.Phase
+
+				if phase == "" {
+					return &metric.Family{
+						Metrics: []*metric.Metric{},
+					}
+				}
 
 				// Set current phase to 1, others to 0 if it is set.
-				if p := p.Status.Phase; p != "" {
-					ms = append(ms,
-						&metric.Metric{
-							LabelValues: []string{string(v1.VolumePending)},
-							Value:       boolFloat64(p == v1.VolumePending),
-						},
-						&metric.Metric{
-							LabelValues: []string{string(v1.VolumeAvailable)},
-							Value:       boolFloat64(p == v1.VolumeAvailable),
-						},
-						&metric.Metric{
-							LabelValues: []string{string(v1.VolumeBound)},
-							Value:       boolFloat64(p == v1.VolumeBound),
-						},
-						&metric.Metric{
-							LabelValues: []string{string(v1.VolumeReleased)},
-							Value:       boolFloat64(p == v1.VolumeReleased),
-						},
-						&metric.Metric{
-							LabelValues: []string{string(v1.VolumeFailed)},
-							Value:       boolFloat64(p == v1.VolumeFailed),
-						},
-					)
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{string(v1.VolumePending)},
+						Value:       boolFloat64(phase == v1.VolumePending),
+					},
+					{
+						LabelValues: []string{string(v1.VolumeAvailable)},
+						Value:       boolFloat64(phase == v1.VolumeAvailable),
+					},
+					{
+						LabelValues: []string{string(v1.VolumeBound)},
+						Value:       boolFloat64(phase == v1.VolumeBound),
+					},
+					{
+						LabelValues: []string{string(v1.VolumeReleased)},
+						Value:       boolFloat64(phase == v1.VolumeReleased),
+					},
+					{
+						LabelValues: []string{string(v1.VolumeFailed)},
+						Value:       boolFloat64(phase == v1.VolumeFailed),
+					},
 				}
 
 				for _, m := range ms {

--- a/internal/collector/pod_test.go
+++ b/internal/collector/pod_test.go
@@ -1062,3 +1062,75 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 		}
 	}
 }
+
+func BenchmarkPodCollector(b *testing.B) {
+	b.ReportAllocs()
+
+	f := metric.ComposeMetricGenFuncs(podMetricFamilies)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "ns1",
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:         "container1",
+					Image:        "k8s.gcr.io/hyperkube1",
+					ImageID:      "docker://sha256:aaa",
+					ContainerID:  "docker://ab123",
+					Ready:        true,
+					RestartCount: 0,
+					State: v1.ContainerState{
+						Running: &v1.ContainerStateRunning{},
+					},
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Reason: "OOMKilled",
+						},
+					},
+				},
+				{
+					Name:         "container1",
+					Image:        "k8s.gcr.io/hyperkube1",
+					ImageID:      "docker://sha256:aaa",
+					ContainerID:  "docker://ab123",
+					Ready:        true,
+					RestartCount: 0,
+					State: v1.ContainerState{
+						Running: &v1.ContainerStateRunning{},
+					},
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Reason: "OOMKilled",
+						},
+					},
+				},
+				{
+					Name:         "container1",
+					Image:        "k8s.gcr.io/hyperkube1",
+					ImageID:      "docker://sha256:aaa",
+					ContainerID:  "docker://ab123",
+					Ready:        true,
+					RestartCount: 0,
+					State: v1.ContainerState{
+						Running: &v1.ContainerStateRunning{},
+					},
+					LastTerminationState: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Reason: "OOMKilled",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for n := 0; n < b.N; n++ {
+		families := f(pod)
+		if len(families) != 27 {
+			b.Fatalf("expected 27 but got %v", len(families))
+		}
+	}
+}

--- a/internal/collector/replicaset.go
+++ b/internal/collector/replicaset.go
@@ -147,23 +147,30 @@ var (
 			Type: metric.Gauge,
 			Help: "Information about the ReplicaSet's owner.",
 			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
-				ms := []*metric.Metric{}
-
 				owners := r.GetOwnerReferences()
+
 				if len(owners) == 0 {
-					ms = append(ms, &metric.Metric{
-						LabelValues: []string{"<none>", "<none>", "<none>"},
-					})
-				} else {
-					for _, owner := range owners {
-						if owner.Controller != nil {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
-							})
-						} else {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{owner.Kind, owner.Name, "false"},
-							})
+					return &metric.Family{
+						Metrics: []*metric.Metric{
+							{
+								LabelKeys:   []string{"owner_kind", "owner_name", "owner_is_controller"},
+								LabelValues: []string{"<none>", "<none>", "<none>"},
+								Value:       1,
+							},
+						},
+					}
+				}
+
+				ms := make([]*metric.Metric, len(owners))
+
+				for i, owner := range owners {
+					if owner.Controller != nil {
+						ms[i] = &metric.Metric{
+							LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
+						}
+					} else {
+						ms[i] = &metric.Metric{
+							LabelValues: []string{owner.Kind, owner.Name, "false"},
 						}
 					}
 				}

--- a/internal/collector/service.go
+++ b/internal/collector/service.go
@@ -96,15 +96,19 @@ var (
 			Type: metric.Gauge,
 			Help: "Service external ips. One series for each ip",
 			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
-				ms := []*metric.Metric{}
+				if len(s.Spec.ExternalIPs) == 0 {
+					return &metric.Family{
+						Metrics: []*metric.Metric{},
+					}
+				}
 
-				if len(s.Spec.ExternalIPs) > 0 {
-					for _, externalIP := range s.Spec.ExternalIPs {
-						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"external_ip"},
-							LabelValues: []string{externalIP},
-							Value:       1,
-						})
+				ms := make([]*metric.Metric, len(s.Spec.ExternalIPs))
+
+				for i, externalIP := range s.Spec.ExternalIPs {
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"external_ip"},
+						LabelValues: []string{externalIP},
+						Value:       1,
 					}
 				}
 
@@ -118,15 +122,19 @@ var (
 			Type: metric.Gauge,
 			Help: "Service load balancer ingress status",
 			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
-				ms := []*metric.Metric{}
+				if len(s.Status.LoadBalancer.Ingress) == 0 {
+					return &metric.Family{
+						Metrics: []*metric.Metric{},
+					}
+				}
 
-				if len(s.Status.LoadBalancer.Ingress) > 0 {
-					for _, ingress := range s.Status.LoadBalancer.Ingress {
-						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"ip", "hostname"},
-							LabelValues: []string{ingress.IP, ingress.Hostname},
-							Value:       1,
-						})
+				ms := make([]*metric.Metric, len(s.Status.LoadBalancer.Ingress))
+
+				for i, ingress := range s.Status.LoadBalancer.Ingress {
+					ms[i] = &metric.Metric{
+						LabelKeys:   []string{"ip", "hostname"},
+						LabelValues: []string{ingress.IP, ingress.Hostname},
+						Value:       1,
 					}
 				}
 

--- a/internal/collector/testutils.go
+++ b/internal/collector/testutils.go
@@ -31,14 +31,14 @@ type generateMetricsTestCase struct {
 	Obj         interface{}
 	MetricNames []string
 	Want        string
-	Func        func(interface{}) []metricsstore.FamilyStringer
+	Func        func(interface{}) []metricsstore.FamilyByteSlicer
 }
 
 func (testCase *generateMetricsTestCase) run() error {
 	metricFamilies := testCase.Func(testCase.Obj)
 	metricFamilyStrings := []string{}
 	for _, f := range metricFamilies {
-		metricFamilyStrings = append(metricFamilyStrings, f.String())
+		metricFamilyStrings = append(metricFamilyStrings, string(f.ByteSlice()))
 	}
 
 	metric := strings.Split(strings.Join(metricFamilyStrings, ""), "\n")

--- a/pkg/metric/family.go
+++ b/pkg/metric/family.go
@@ -26,19 +26,13 @@ type Family struct {
 	Metrics []*Metric
 }
 
-// String returns the given Family in its string representation.
-func (f Family) String() string {
+// ByteSlice returns the given Family in its string representation.
+func (f Family) ByteSlice() []byte {
 	b := strings.Builder{}
 	for _, m := range f.Metrics {
 		b.WriteString(f.Name)
 		m.Write(&b)
 	}
 
-	return b.String()
-}
-
-// FamilyStringer represents a metric family that can be converted to its string
-// representation.
-type FamilyStringer interface {
-	String() string
+	return []byte(b.String())
 }

--- a/pkg/metric/generator.go
+++ b/pkg/metric/generator.go
@@ -70,9 +70,9 @@ func ExtractMetricFamilyHeaders(families []FamilyGenerator) []string {
 
 // ComposeMetricGenFuncs takes a slice of metric families and returns a function
 // that composes their metric generation functions into a single one.
-func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []metricsstore.FamilyStringer {
-	return func(obj interface{}) []metricsstore.FamilyStringer {
-		families := make([]metricsstore.FamilyStringer, len(familyGens))
+func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []metricsstore.FamilyByteSlicer {
+	return func(obj interface{}) []metricsstore.FamilyByteSlicer {
+		families := make([]metricsstore.FamilyByteSlicer, len(familyGens))
 
 		for i, gen := range familyGens {
 			families[i] = gen.Generate(obj)

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metric
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -56,7 +57,10 @@ type Metric struct {
 
 func (m *Metric) Write(s *strings.Builder) {
 	if len(m.LabelKeys) != len(m.LabelValues) {
-		panic("expected labelKeys to be of same length as labelValues")
+		panic(fmt.Sprintf(
+			"expected labelKeys %q to be of same length as labelValues %q",
+			m.LabelKeys, m.LabelValues,
+		))
 	}
 
 	labelsToString(s, m.LabelKeys, m.LabelValues)

--- a/pkg/metric/metric_test.go
+++ b/pkg/metric/metric_test.go
@@ -34,7 +34,7 @@ func TestFamilyString(t *testing.T) {
 	}
 
 	expected := "kube_pod_info{namespace=\"default\"} 1"
-	got := strings.TrimSpace(f.String())
+	got := strings.TrimSpace(string(f.ByteSlice()))
 
 	if got != expected {
 		t.Fatalf("expected %v but got %v", expected, got)

--- a/pkg/metrics_store/metrics_store_test.go
+++ b/pkg/metrics_store/metrics_store_test.go
@@ -30,28 +30,28 @@ import (
 // Mock metricFamily instead of importing /pkg/metric to prevent cyclic
 // dependency.
 type metricFamily struct {
-	value string
+	value []byte
 }
 
-// Implement FamilyStringer interface.
-func (f *metricFamily) String() string {
+// Implement FamilyByteSlicer interface.
+func (f *metricFamily) ByteSlice() []byte {
 	return f.value
 }
 
 func TestObjectsSameNameDifferentNamespaces(t *testing.T) {
 	serviceIDS := []string{"a", "b"}
 
-	genFunc := func(obj interface{}) []FamilyStringer {
+	genFunc := func(obj interface{}) []FamilyByteSlicer {
 		o, err := meta.Accessor(obj)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		metricFamily := metricFamily{
-			fmt.Sprintf("kube_service_info{uid=\"%v\"} 1", string(o.GetUID())),
+			[]byte(fmt.Sprintf("kube_service_info{uid=\"%v\"} 1", string(o.GetUID()))),
 		}
 
-		return []FamilyStringer{&metricFamily}
+		return []FamilyByteSlicer{&metricFamily}
 	}
 
 	ms := NewMetricsStore([]string{"Information about service."}, genFunc)

--- a/tests/lib/lib_test.go
+++ b/tests/lib/lib_test.go
@@ -82,7 +82,7 @@ func serviceCollector(kubeClient clientset.Interface) *collector.Collector {
 	return collector.NewCollector(store)
 }
 
-func generateServiceMetrics(obj interface{}) []metricsstore.FamilyStringer {
+func generateServiceMetrics(obj interface{}) []metricsstore.FamilyByteSlicer {
 	sPointer := obj.(*v1.Service)
 	s := *sPointer
 
@@ -97,5 +97,5 @@ func generateServiceMetrics(obj interface{}) []metricsstore.FamilyStringer {
 		Metrics: []*metric.Metric{&m},
 	}
 
-	return []metricsstore.FamilyStringer{&family}
+	return []metricsstore.FamilyByteSlicer{&family}
 }


### PR DESCRIPTION
This pull request includes two performance optimizations found while testing the kube-state-metrics *v1.6.0* release candidate. Given that v1.6.0-rc.0 doesn't seem to introduce any performance regressions, these patches don't need to be included in the release.

### 1. internal/collector: Preallocate metric slice length when known upfront

Profiling kube-state-metrics shows that a lot of CPU time is spent on
`runtime.growslice`. This is related to metric generation when
converting a Kuberntes object to a slice of metrics in
`metric.FamilyGenerator`s. Oftentimes the length of the metric slice is
known upfront.

When the needed size of the metrics slice is known upfront, allocate an
appropriately sized metric slice.

### 2. pkg/metrics_store: Cache byte slices instead of strings

When converting a string to a byte slice, in Golang would do a full copy
which introduces memory allocations. On an HTTP scrape request WriteAll
in the metrics store component is called, which writes all cached
metrics into the given io.Writer. io.Writer takes a byte slice, whereas
metrics are cached as strings. The connect the two, the metrics store
component converts the metric strings to byte slices. This results in
`runtime.stringtoslicebyte` [1] being a prominent CPU user.

Instead of caching metrics as strings, cache them as byte slices,
removing the additional translation from the hot-path.

### Test setup

#### Unit benchmark

The first patch gets us some reasonable memory and runtime optimizations. Running `internal.collector.BenchmarkPodCollector` with (*new*) and without (*old*) returns the following:

```
benchmark                   old ns/op     new ns/op     delta
BenchmarkPodCollector-4     25942         24475         -5.65%

benchmark                   old allocs     new allocs     delta
BenchmarkPodCollector-4     419            395            -5.73%

benchmark                   old bytes     new bytes     delta
BenchmarkPodCollector-4     20112         19544         -2.82%
```

#### End to end test

I have compared kube-state-metrics *v1.6.0-rc.0-0* (vanilla https://github.com/kubernetes/kube-state-metrics/pull/702),  *v1.6.0-rc.0-4* (vanilla + patch 1) and *v1.6.0-rc.0-5* (vanilla + patch 1 & 2) on a 9 node cluster with AWS m5.large compute instances. During the comparison a test script would create and delete pods ranging from 250 - 5000 pods total. In addition the cluster had 8000 secrets constantly. Kube-state-metrics instances are scraped every 2s.

##### Scrape duration

Both patches seem to be neutral in regards to the Prometheus scrape duration.

![image](https://user-images.githubusercontent.com/7047859/55469099-0928ba00-5605-11e9-83c7-dd310173db90.png)


##### CPU usage

Patch 1 seems to have only a subtle impact on the CPU usage, patch 2 constantly performs better, given that we only need to convert the metric string to a byte slice once and not on every scrape.

![image](https://user-images.githubusercontent.com/7047859/55468812-7e47bf80-5604-11e9-930b-344c1ca4aa41.png)





[1] https://golang.org/src/runtime/string.go?s=4063:4115#L145


