### PR TITLE
go.mod: Pin k8s.io/client-go to v11.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	gopkg.in/inf.v0 v0.9.0 // indirect
 	k8s.io/api v0.0.0-20190313235455-40a48860b5ab
 	k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1
-	k8s.io/client-go v2.0.0-alpha.0.0.20190313235726-6ee68ca5fd83+incompatible
+	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/klog v0.2.0
 	k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580 // indirect
 	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ k8s.io/api v0.0.0-20190313235455-40a48860b5ab h1:DG9A67baNpoeweOy2spF1OWHhnVY5KR
 k8s.io/api v0.0.0-20190313235455-40a48860b5ab/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1 h1:IS7K02iBkQXpCeieSiyJjGoLSdVOv2DbPaWHJ+ZtgKg=
 k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/client-go v2.0.0-alpha.0.0.20190313235726-6ee68ca5fd83+incompatible h1:+SiikveGdttGGsPhWZsGg+RD1ziNvr+PL8zKqLDIrbE=
-k8s.io/client-go v2.0.0-alpha.0.0.20190313235726-6ee68ca5fd83+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
+k8s.io/client-go v11.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580 h1:fq0ZXW/BAIFZH+dazlups6JTVdwzRo5d9riFA103yuQ=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -195,7 +195,7 @@ k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/third_party/forked/golang/json
-# k8s.io/client-go v2.0.0-alpha.0.0.20190313235726-6ee68ca5fd83+incompatible
+# k8s.io/client-go v11.0.0+incompatible
 k8s.io/client-go/kubernetes
 k8s.io/client-go/plugin/pkg/client/auth
 k8s.io/client-go/tools/clientcmd


### PR DESCRIPTION
The previous patch updating kube-state-metrics to Kubernetes v1.14 (https://github.com/kubernetes/kube-state-metrics/pull/701) resulted in k8s.io/client-go module set to `v2.0.0-alpha.0.0.20190313235726-6ee68ca5fd83+incompatible`. While `6ee68ca5fd83` is the right reference to client-go release (v11), `v2.0.0-alpha` is clearly not. The k8s.io/client-go code checked in into /vendor follows the commit sha, not the version.

This patch pins k8s.io/client-go to `v11.0.0` via `GO111MODULE=on go get k8s.io/client-go@v11.0`. As /vendor was already correctly updated with the previous patch, this patch does not include any changes to /vendor.

So far I have not been able to understand, why go modules would pin the version to an old tag, but vendor the new version. Maybe @tariq1890 do you have an idea?
