### PR TITLE
Add list/watch access to ClusterRole for CSR collector

### DIFF
--- a/kubernetes/kube-state-metrics-cluster-role.yaml
+++ b/kubernetes/kube-state-metrics-cluster-role.yaml
@@ -46,3 +46,8 @@ rules:
   resources:
   - poddisruptionbudgets
   verbs: ["list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+


### PR DESCRIPTION
* Certificate Signing Request collector was added in #650, but the ClusterRole wasn't updated with access to the resource

Intended to fix this error log noticed with v1.6.0-rc.0:

```
E0410 06:42:49.568036       1 reflector.go:126] k8s.io/kube-state-metrics/internal/collector/builder.go:482: Failed to list *v1beta1.CertificateSigningRequest: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:monitoring:kube-state-metrics" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
```