### PR TITLE
Do not run as root by default in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,8 @@ COPY kube-state-metrics /
 
 ENTRYPOINT ["/kube-state-metrics", "--port=8080", "--telemetry-port=8081"]
 
+RUN adduser -D kube-state-metrics
+
+USER kube-state-metrics
+
 EXPOSE 8080 8081


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: IMHO it is accepted as best practice to not run [processes in containers as root](https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b). I'm not sure if this was discussed before or if root permissions are in fact needed for the metrics to work, but it would be nice if we could change this.