### PR TITLE
Capital letters for ENDPOINT string

### DIFF
--- a/docs/endpoint-metrics.md
+++ b/docs/endpoint-metrics.md
@@ -5,5 +5,5 @@
 | kube_endpoint_address_not_ready | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; | STABLE |
 | kube_endpoint_address_available | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; | STABLE |
 | kube_endpoint_info | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt;  | STABLE |
-| kube_endpoint_labels | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `label_endpoint_LABEL`=&lt;endpoint_LABEL&gt;  | STABLE |
+| kube_endpoint_labels | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `label_ENDPOINT_LABEL`=&lt;ENDPOINT_LABEL&gt;  | STABLE |
 | kube_endpoint_created | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; | STABLE |


### PR DESCRIPTION
Update of documentation for consistency reasons (see e.g. kube_service_labels or kube_deployment_labels or kube_persistenvolume_labels): 

label_RESOURCESTRINGINCAPITALLETTERS_LABEL=<RESOURCESTRINGINCAPITALLETTERS_LABEL>