### PR TITLE
Add additional ingress metrics

### DIFF
--- a/docs/ingress-metrics.md
+++ b/docs/ingress-metrics.md
@@ -6,3 +6,4 @@
 | kube_ingress_labels | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `label_INGRESS_LABEL`=&lt;INGRESS_LABEL&gt; | STABLE |
 | kube_ingress_created  | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; | STABLE |
 | kube_ingress_metadata_resource_version  | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `resource_version`=&lt;ingress-resource-version&gt; | STABLE |
+| kube_ingress_path | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `host`=&lt;ingress-host&gt; <br> `path`=&lt;ingress-path&gt; <br> `service_name`=&lt;service name for the path&gt; <br> `service_port`=&lt;service port for hte path&gt; | STABLE |

--- a/internal/collector/ingress.go
+++ b/internal/collector/ingress.go
@@ -97,6 +97,26 @@ var (
 					}}
 			}),
 		},
+		{
+			Name: "kube_ingress_path",
+			Type: metric.Gauge,
+			Help: "Ingress host, paths and backend service information.",
+			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
+				ms := []*metric.Metric{}
+				for _, rule := range i.Spec.Rules {
+					for _, path := range rule.HTTP.Paths {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"host", "path", "service_name", "service_port"},
+							LabelValues: []string{rule.Host, path.Path, path.Backend.ServiceName, path.Backend.ServicePort.String()},
+							Value:       1,
+						})
+					}
+				}
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
 	}
 )
 


### PR DESCRIPTION
Report on ingress host, path, service backend and port.

**What this PR does / why we need it**: It adds an additional ingress metric, with information about the hostname, path and service backend. This allows additional use cases, such as alerting on 2 ingresses using the same host and path.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: None

