### PR TITLE
collector: De-duplicate common code for building collectors

### DIFF
--- a/internal/collector/builder.go
+++ b/internal/collector/builder.go
@@ -138,322 +138,99 @@ var availableCollectors = map[string]func(f *Builder) *coll.Collector{
 }
 
 func (b *Builder) buildConfigMapCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, configMapMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ConfigMap{}, store, b.namespaces, createConfigMapListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(configMapMetricFamilies, &v1.ConfigMap{}, createConfigMapListWatch)
 }
 
 func (b *Builder) buildCronJobCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, cronJobMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &batchv1beta1.CronJob{}, store, b.namespaces, createCronJobListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(cronJobMetricFamilies, &batchv1beta1.CronJob{}, createCronJobListWatch)
 }
 
 func (b *Builder) buildDaemonSetCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, daemonSetMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &appsv1.DaemonSet{}, store, b.namespaces, createDaemonSetListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(daemonSetMetricFamilies, &appsv1.DaemonSet{}, createDaemonSetListWatch)
 }
 
 func (b *Builder) buildDeploymentCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, deploymentMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &appsv1.Deployment{}, store, b.namespaces, createDeploymentListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(deploymentMetricFamilies, &appsv1.Deployment{}, createDeploymentListWatch)
 }
 
 func (b *Builder) buildEndpointsCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, endpointMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Endpoints{}, store, b.namespaces, createEndpointsListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(endpointMetricFamilies, &v1.Endpoints{}, createEndpointsListWatch)
 }
 
 func (b *Builder) buildHPACollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, hpaMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &autoscaling.HorizontalPodAutoscaler{}, store, b.namespaces, createHPAListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(hpaMetricFamilies, &autoscaling.HorizontalPodAutoscaler{}, createHPAListWatch)
 }
 
 func (b *Builder) buildIngressCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, ingressMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.Ingress{}, store, b.namespaces, createIngressListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(ingressMetricFamilies, &extensions.Ingress{}, createIngressListWatch)
 }
 
 func (b *Builder) buildJobCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, jobMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &batchv1.Job{}, store, b.namespaces, createJobListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(jobMetricFamilies, &batchv1.Job{}, createJobListWatch)
 }
 
 func (b *Builder) buildLimitRangeCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, limitRangeMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.LimitRange{}, store, b.namespaces, createLimitRangeListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(limitRangeMetricFamilies, &v1.LimitRange{}, createLimitRangeListWatch)
 }
 
 func (b *Builder) buildNamespaceCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, namespaceMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Namespace{}, store, b.namespaces, createNamespaceListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(namespaceMetricFamilies, &v1.Namespace{}, createNamespaceListWatch)
 }
 
 func (b *Builder) buildNodeCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, nodeMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Node{}, store, b.namespaces, createNodeListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(nodeMetricFamilies, &v1.Node{}, createNodeListWatch)
 }
 
 func (b *Builder) buildPersistentVolumeClaimCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, persistentVolumeClaimMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolumeClaim{}, store, b.namespaces, createPersistentVolumeClaimListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(persistentVolumeClaimMetricFamilies, &v1.PersistentVolumeClaim{}, createPersistentVolumeClaimListWatch)
 }
 
 func (b *Builder) buildPersistentVolumeCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, persistentVolumeMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.PersistentVolume{}, store, b.namespaces, createPersistentVolumeListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(persistentVolumeMetricFamilies, &v1.PersistentVolume{}, createPersistentVolumeListWatch)
 }
 
 func (b *Builder) buildPodDisruptionBudgetCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, podDisruptionBudgetMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &policy.PodDisruptionBudget{}, store, b.namespaces, createPodDisruptionBudgetListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(podDisruptionBudgetMetricFamilies, &policy.PodDisruptionBudget{}, createPodDisruptionBudgetListWatch)
 }
 
 func (b *Builder) buildReplicaSetCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, replicaSetMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &extensions.ReplicaSet{}, store, b.namespaces, createReplicaSetListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(replicaSetMetricFamilies, &extensions.ReplicaSet{}, createReplicaSetListWatch)
 }
 
 func (b *Builder) buildReplicationControllerCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, replicationControllerMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ReplicationController{}, store, b.namespaces, createReplicationControllerListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(replicationControllerMetricFamilies, &v1.ReplicationController{}, createReplicationControllerListWatch)
 }
 
 func (b *Builder) buildResourceQuotaCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, resourceQuotaMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.ResourceQuota{}, store, b.namespaces, createResourceQuotaListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(resourceQuotaMetricFamilies, &v1.ResourceQuota{}, createResourceQuotaListWatch)
 }
 
 func (b *Builder) buildSecretCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, secretMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Secret{}, store, b.namespaces, createSecretListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(secretMetricFamilies, &v1.Secret{}, createSecretListWatch)
 }
 
 func (b *Builder) buildServiceCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, serviceMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Service{}, store, b.namespaces, createServiceListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(serviceMetricFamilies, &v1.Service{}, createServiceListWatch)
 }
 
 func (b *Builder) buildStatefulSetCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, statefulSetMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &appsv1.StatefulSet{}, store, b.namespaces, createStatefulSetListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(statefulSetMetricFamilies, &appsv1.StatefulSet{}, createStatefulSetListWatch)
 }
 
 func (b *Builder) buildPodCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, podMetricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
-
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &v1.Pod{}, store, b.namespaces, createPodListWatch)
-
-	return coll.NewCollector(store)
+	return b.buildCollector(podMetricFamilies, &v1.Pod{}, createPodListWatch)
 }
 
 func (b *Builder) buildCsrCollector() *coll.Collector {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, csrMetricFamilies)
+	return b.buildCollector(csrMetricFamilies, &certv1beta1.CertificateSigningRequest{}, createCSRListWatch)
+}
+
+func (b *Builder) buildCollector(
+	metricFamilies []metric.FamilyGenerator,
+	expectedType interface{},
+	listWatchFunc func(kubeClient clientset.Interface, ns string) cache.ListerWatcher,
+) *coll.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, metricFamilies)
 	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
 
 	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
@@ -462,24 +239,21 @@ func (b *Builder) buildCsrCollector() *coll.Collector {
 		familyHeaders,
 		composedMetricGenFuncs,
 	)
-	reflectorPerNamespace(b.ctx, b.kubeClient, &certv1beta1.CertificateSigningRequest{}, store, b.namespaces, createCSRListWatch)
+	b.reflectorPerNamespace(expectedType, store, listWatchFunc)
 
 	return coll.NewCollector(store)
 }
 
 // reflectorPerNamespace creates a Kubernetes client-go reflector with the given
 // listWatchFunc for each given namespace and registers it with the given store.
-func reflectorPerNamespace(
-	ctx context.Context,
-	kubeClient clientset.Interface,
+func (b *Builder) reflectorPerNamespace(
 	expectedType interface{},
 	store cache.Store,
-	namespaces []string,
-	listWatchFunc func(kubeClient clientset.Interface, ns string) cache.ListWatch,
+	listWatchFunc func(kubeClient clientset.Interface, ns string) cache.ListerWatcher,
 ) {
-	for _, ns := range namespaces {
-		lw := listWatchFunc(kubeClient, ns)
-		reflector := cache.NewReflector(&lw, expectedType, store, 0)
-		go reflector.Run(ctx.Done())
+	for _, ns := range b.namespaces {
+		lw := listWatchFunc(b.kubeClient, ns)
+		reflector := cache.NewReflector(lw, expectedType, store, 0)
+		go reflector.Run(b.ctx.Done())
 	}
 }

--- a/internal/collector/certificatesigningrequest.go
+++ b/internal/collector/certificatesigningrequest.go
@@ -113,8 +113,8 @@ func wrapCSRFunc(f func(*certv1beta1.CertificateSigningRequest) *metric.Family) 
 	}
 }
 
-func createCSRListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createCSRListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CertificatesV1beta1().CertificateSigningRequests().List(opts)
 		},

--- a/internal/collector/configmap.go
+++ b/internal/collector/configmap.go
@@ -84,8 +84,8 @@ var (
 	}
 )
 
-func createConfigMapListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createConfigMapListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().ConfigMaps(ns).List(opts)
 		},

--- a/internal/collector/cronjob.go
+++ b/internal/collector/cronjob.go
@@ -208,8 +208,8 @@ func wrapCronJobFunc(f func(*batchv1beta1.CronJob) *metric.Family) func(interfac
 	}
 }
 
-func createCronJobListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createCronJobListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.BatchV1beta1().CronJobs(ns).List(opts)
 		},

--- a/internal/collector/daemonset.go
+++ b/internal/collector/daemonset.go
@@ -213,8 +213,8 @@ func wrapDaemonSetFunc(f func(*v1.DaemonSet) *metric.Family) func(interface{}) *
 	}
 }
 
-func createDaemonSetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createDaemonSetListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.AppsV1().DaemonSets(ns).List(opts)
 		},

--- a/internal/collector/deployment.go
+++ b/internal/collector/deployment.go
@@ -245,8 +245,8 @@ func wrapDeploymentFunc(f func(*v1.Deployment) *metric.Family) func(interface{})
 	}
 }
 
-func createDeploymentListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createDeploymentListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.AppsV1().Deployments(ns).List(opts)
 		},

--- a/internal/collector/endpoint.go
+++ b/internal/collector/endpoint.go
@@ -138,8 +138,8 @@ func wrapEndpointFunc(f func(*v1.Endpoints) *metric.Family) func(interface{}) *m
 	}
 }
 
-func createEndpointsListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createEndpointsListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().Endpoints(ns).List(opts)
 		},

--- a/internal/collector/hpa.go
+++ b/internal/collector/hpa.go
@@ -161,8 +161,8 @@ func wrapHPAFunc(f func(*autoscaling.HorizontalPodAutoscaler) *metric.Family) fu
 	}
 }
 
-func createHPAListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createHPAListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(ns).List(opts)
 		},

--- a/internal/collector/ingress.go
+++ b/internal/collector/ingress.go
@@ -135,8 +135,8 @@ func wrapIngressFunc(f func(*v1beta1.Ingress) *metric.Family) func(interface{}) 
 	}
 }
 
-func createIngressListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createIngressListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.ExtensionsV1beta1().Ingresses(ns).List(opts)
 		},

--- a/internal/collector/job.go
+++ b/internal/collector/job.go
@@ -324,8 +324,8 @@ func wrapJobFunc(f func(*v1batch.Job) *metric.Family) func(interface{}) *metric.
 	}
 }
 
-func createJobListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createJobListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.BatchV1().Jobs(ns).List(opts)
 		},

--- a/internal/collector/limitrange.go
+++ b/internal/collector/limitrange.go
@@ -122,8 +122,8 @@ func wrapLimitRangeFunc(f func(*v1.LimitRange) *metric.Family) func(interface{})
 	}
 }
 
-func createLimitRangeListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createLimitRangeListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().LimitRanges(ns).List(opts)
 		},

--- a/internal/collector/namespace.go
+++ b/internal/collector/namespace.go
@@ -131,8 +131,8 @@ func wrapNamespaceFunc(f func(*v1.Namespace) *metric.Family) func(interface{}) *
 	}
 }
 
-func createNamespaceListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createNamespaceListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().Namespaces().List(opts)
 		},

--- a/internal/collector/node.go
+++ b/internal/collector/node.go
@@ -496,8 +496,8 @@ func wrapNodeFunc(f func(*v1.Node) *metric.Family) func(interface{}) *metric.Fam
 	}
 }
 
-func createNodeListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createNodeListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().Nodes().List(opts)
 		},

--- a/internal/collector/persistentvolume.go
+++ b/internal/collector/persistentvolume.go
@@ -145,8 +145,8 @@ func wrapPersistentVolumeFunc(f func(*v1.PersistentVolume) *metric.Family) func(
 	}
 }
 
-func createPersistentVolumeListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createPersistentVolumeListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().PersistentVolumes().List(opts)
 		},

--- a/internal/collector/persistentvolumeclaim.go
+++ b/internal/collector/persistentvolumeclaim.go
@@ -162,8 +162,8 @@ func wrapPersistentVolumeClaimFunc(f func(*v1.PersistentVolumeClaim) *metric.Fam
 	}
 }
 
-func createPersistentVolumeClaimListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createPersistentVolumeClaimListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().PersistentVolumeClaims(ns).List(opts)
 		},

--- a/internal/collector/pod.go
+++ b/internal/collector/pod.go
@@ -770,8 +770,8 @@ func wrapPodFunc(f func(*v1.Pod) *metric.Family) func(interface{}) *metric.Famil
 	}
 }
 
-func createPodListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createPodListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().Pods(ns).List(opts)
 		},

--- a/internal/collector/poddisruptionbudget.go
+++ b/internal/collector/poddisruptionbudget.go
@@ -137,8 +137,8 @@ func wrapPodDisruptionBudgetFunc(f func(*v1beta1.PodDisruptionBudget) *metric.Fa
 	}
 }
 
-func createPodDisruptionBudgetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createPodDisruptionBudgetListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.PolicyV1beta1().PodDisruptionBudgets(ns).List(opts)
 		},

--- a/internal/collector/replicaset.go
+++ b/internal/collector/replicaset.go
@@ -220,8 +220,8 @@ func wrapReplicaSetFunc(f func(*v1beta1.ReplicaSet) *metric.Family) func(interfa
 	}
 }
 
-func createReplicaSetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createReplicaSetListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.ExtensionsV1beta1().ReplicaSets(ns).List(opts)
 		},

--- a/internal/collector/replicationcontroller.go
+++ b/internal/collector/replicationcontroller.go
@@ -169,8 +169,8 @@ func wrapReplicationControllerFunc(f func(*v1.ReplicationController) *metric.Fam
 	}
 }
 
-func createReplicationControllerListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createReplicationControllerListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().ReplicationControllers(ns).List(opts)
 		},

--- a/internal/collector/resourcequota.go
+++ b/internal/collector/resourcequota.go
@@ -97,8 +97,8 @@ func wrapResourceQuotaFunc(f func(*v1.ResourceQuota) *metric.Family) func(interf
 	}
 }
 
-func createResourceQuotaListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createResourceQuotaListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().ResourceQuotas(ns).List(opts)
 		},

--- a/internal/collector/secret.go
+++ b/internal/collector/secret.go
@@ -133,8 +133,8 @@ func wrapSecretFunc(f func(*v1.Secret) *metric.Family) func(interface{}) *metric
 	}
 }
 
-func createSecretListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createSecretListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().Secrets(ns).List(opts)
 		},

--- a/internal/collector/service.go
+++ b/internal/collector/service.go
@@ -161,8 +161,8 @@ func wrapSvcFunc(f func(*v1.Service) *metric.Family) func(interface{}) *metric.F
 	}
 }
 
-func createServiceListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createServiceListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().Services(ns).List(opts)
 		},

--- a/internal/collector/statefulset.go
+++ b/internal/collector/statefulset.go
@@ -220,8 +220,8 @@ func wrapStatefulSetFunc(f func(*v1.StatefulSet) *metric.Family) func(interface{
 	}
 }
 
-func createStatefulSetListWatch(kubeClient clientset.Interface, ns string) cache.ListWatch {
-	return cache.ListWatch{
+func createStatefulSetListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
+	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.AppsV1().StatefulSets(ns).List(opts)
 		},


### PR DESCRIPTION
This refactors some duplication that is unnecessary in the collector builder.

I extracted this as I continued the work on #613 and this is a refactoring that can be done individually to not bloat the PR even more.

@mxinden @tariq1890 @andyxning @zouyee 
