### PR TITLE
Fixes New metric for deployment revision #746

### DIFF
--- a/docs/deployment-metrics.md
+++ b/docs/deployment-metrics.md
@@ -14,3 +14,4 @@
 | kube_deployment_metadata_generation | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_labels | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_created | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
+| kube_deployment_revision | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |

--- a/internal/collector/deployment.go
+++ b/internal/collector/deployment.go
@@ -34,6 +34,7 @@ var (
 	descDeploymentLabelsName          = "kube_deployment_labels"
 	descDeploymentLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
+	annotationDeploymentRevision      = "deployment.kubernetes.io/revision"
 
 	deploymentMetricFamilies = []metric.FamilyGenerator{
 		{
@@ -232,12 +233,12 @@ var (
 		{
 			Name: "kube_deployment_revision",
 			Type: metric.Gauge,
-			Help: "Sequence number representing a specific revision of the deployment controller represented by the annotaion 'deployment.kubernetes.io/revision'.",
+			Help: "Number representing a specific revision of the deployment controller represented by the annotation 'deployment.kubernetes.io/revision'.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.ObjectMeta.Annotations == nil {
 					return &metric.Family{}
 				}
-				revision, err := strconv.Atoi(d.ObjectMeta.Annotations["deployment.kubernetes.io/revision"])
+				revision, err := strconv.Atoi(d.ObjectMeta.Annotations[annotationDeploymentRevision])
 				if err != nil {
 					return &metric.Family{}
 				}

--- a/internal/collector/deployment.go
+++ b/internal/collector/deployment.go
@@ -17,6 +17,8 @@ limitations under the License.
 package collector
 
 import (
+	"strconv"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 
 	v1 "k8s.io/api/apps/v1"
@@ -222,6 +224,27 @@ var (
 							LabelKeys:   labelKeys,
 							LabelValues: labelValues,
 							Value:       1,
+						},
+					},
+				}
+			}),
+		},
+		{
+			Name: "kube_deployment_revision",
+			Type: metric.Gauge,
+			Help: "Sequence number representing a specific revision of the deployment controller represented by the annotaion 'deployment.kubernetes.io/revision'.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				if d.ObjectMeta.Annotations == nil {
+					return &metric.Family{}
+				}
+				revision, err := strconv.Atoi(d.ObjectMeta.Annotations["deployment.kubernetes.io/revision"])
+				if err != nil {
+					return &metric.Family{}
+				}
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(revision),
 						},
 					},
 				}

--- a/internal/collector/deployment_test.go
+++ b/internal/collector/deployment_test.go
@@ -65,7 +65,7 @@ func TestDeploymentCollector(t *testing.T) {
 		# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
 		# HELP kube_deployment_labels Kubernetes labels converted to Prometheus labels.
 		# TYPE kube_deployment_labels gauge
-		# HELP kube_deployment_revision Sequence number representing a specific revision of the deployment controller represented by the annotaion 'deployment.kubernetes.io/revision'.
+		# HELP kube_deployment_revision Number representing a specific revision of the deployment controller represented by the annotation 'deployment.kubernetes.io/revision'.
 		# TYPE kube_deployment_revision gauge
 	`
 	cases := []generateMetricsTestCase{
@@ -100,7 +100,7 @@ func TestDeploymentCollector(t *testing.T) {
 					},
 				},
 			},
-			Want: `
+			Want: metadata + `
         kube_deployment_created{deployment="depl1",namespace="ns1"} 1.5e+09
         kube_deployment_labels{deployment="depl1",label_app="example1",namespace="ns1"} 1
         kube_deployment_metadata_generation{deployment="depl1",namespace="ns1"} 21

--- a/internal/collector/deployment_test.go
+++ b/internal/collector/deployment_test.go
@@ -100,7 +100,7 @@ func TestDeploymentCollector(t *testing.T) {
 					},
 				},
 			},
-			Want: metadata + `
+			Want: `
         kube_deployment_created{deployment="depl1",namespace="ns1"} 1.5e+09
         kube_deployment_labels{deployment="depl1",label_app="example1",namespace="ns1"} 1
         kube_deployment_metadata_generation{deployment="depl1",namespace="ns1"} 21

--- a/internal/collector/deployment_test.go
+++ b/internal/collector/deployment_test.go
@@ -65,6 +65,8 @@ func TestDeploymentCollector(t *testing.T) {
 		# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
 		# HELP kube_deployment_labels Kubernetes labels converted to Prometheus labels.
 		# TYPE kube_deployment_labels gauge
+		# HELP kube_deployment_revision Sequence number representing a specific revision of the deployment controller represented by the annotaion 'deployment.kubernetes.io/revision'.
+		# TYPE kube_deployment_revision gauge
 	`
 	cases := []generateMetricsTestCase{
 		{
@@ -75,6 +77,9 @@ func TestDeploymentCollector(t *testing.T) {
 					Namespace:         "ns1",
 					Labels: map[string]string{
 						"app": "example1",
+					},
+					Annotations: map[string]string{
+						"deployment.kubernetes.io/revision": "1",
 					},
 					Generation: 21,
 				},
@@ -108,6 +113,7 @@ func TestDeploymentCollector(t *testing.T) {
         kube_deployment_status_replicas_unavailable{deployment="depl1",namespace="ns1"} 5
         kube_deployment_status_replicas_updated{deployment="depl1",namespace="ns1"} 2
         kube_deployment_status_replicas{deployment="depl1",namespace="ns1"} 15
+		kube_deployment_revision{deployment="depl1",namespace="ns1"} 1
 `,
 		},
 		{
@@ -117,6 +123,9 @@ func TestDeploymentCollector(t *testing.T) {
 					Namespace: "ns2",
 					Labels: map[string]string{
 						"app": "example2",
+					},
+					Annotations: map[string]string{
+						"deployment.kubernetes.io/revision": "3",
 					},
 					Generation: 14,
 				},
@@ -150,6 +159,7 @@ func TestDeploymentCollector(t *testing.T) {
         kube_deployment_status_replicas_unavailable{deployment="depl2",namespace="ns2"} 0
         kube_deployment_status_replicas_updated{deployment="depl2",namespace="ns2"} 1
         kube_deployment_status_replicas{deployment="depl2",namespace="ns2"} 10
+		kube_deployment_revision{deployment="depl2",namespace="ns2"} 3
 `,
 		},
 	}


### PR DESCRIPTION
Add metric for deployment revision based on the annotation 'deployment.kubernetes.io/revision'