### PR TITLE
use distroless/static as base image to further reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM alpine:3.9
 
-COPY kube-state-metrics /
-
-ENTRYPOINT ["/kube-state-metrics", "--port=8080", "--telemetry-port=8081"]
-
 RUN adduser -D kube-state-metrics
 
+FROM gcr.io/distroless/static
+
+COPY kube-state-metrics /
+
+COPY --from=0 /etc/passwd /etc/passwd
+
 USER kube-state-metrics
+
+ENTRYPOINT ["/kube-state-metrics", "--port=8080", "--telemetry-port=8081"]
 
 EXPOSE 8080 8081


### PR DESCRIPTION
Motivation: Given the Alpine CVE https://www.alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html (touted as the security-focused distro ironically), I would like to go one step further in preventive action by using ~~`scratch`~~ `distroless/static` as the base image. This will reduce the attack vectors  and the overall image size.