### PR TITLE
kubernetes/deployment.yaml: Remove addon resizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,6 @@ kube-state-metrics exposes its own general process metrics under `--telemetry-ho
 
 Resource usage for kube-state-metrics changes with the Kubernetes objects(Pods/Nodes/Deployments/Secrets etc.) size of the cluster.
 To some extent, the Kubernetes objects in a cluster are in direct proportion to the node number of the cluster.
-[addon-resizer](https://github.com/kubernetes/autoscaler/tree/master/addon-resizer)
-can watch and automatically vertically scale the dependent container up and down based on the number of nodes.
-Thus kube-state-metrics uses `addon-resizer` to automatically scale its resource request. To learn more about the usage of
-`addon-resizer`, please go to its [README](https://github.com/kubernetes/autoscaler/tree/master/addon-resizer/README.md#nanny-program-and-arguments).
 
 As a general rule, you should allocate
 

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -30,30 +30,3 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
-      - name: addon-resizer
-        image: k8s.gcr.io/addon-resizer:1.8.4
-        resources:
-          limits:
-            cpu: 150m
-            memory: 50Mi
-          requests:
-            cpu: 150m
-            memory: 50Mi
-        env:
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        command:
-          - /pod_nanny
-          - --container=kube-state-metrics
-          - --cpu=100m
-          - --extra-cpu=1m
-          - --memory=100Mi
-          - --extra-memory=2Mi
-          - --threshold=5
-          - --deployment=kube-state-metrics


### PR DESCRIPTION
**What this PR does / why we need it**:

The addon resizer sidecar of the kube-state-metrics deployment caused
problems recently e.g. starting multiple pods [1]. In addition it seems
to be best practice to solve auto-scaling not on a per pod sidecar
basis, but instead via the autoscaling project.

This commit removes the sidecar, leaving autoscaling up to the user.

What do you all think?

[1] https://github.com/kubernetes/kube-state-metrics/issues/672