### PR TITLE
lint: fix gocritic issues and add gocritic linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - gocyclo
     - ineffassign
     - misspell
+    - gocritic
     - govet
 
 linters-settings:

--- a/internal/collector/cronjob.go
+++ b/internal/collector/cronjob.go
@@ -225,7 +225,7 @@ func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, create
 		return time.Time{}, errors.Wrapf(err, "Failed to parse cron job schedule '%s'", schedule)
 	}
 	if !lastScheduleTime.IsZero() {
-		return sched.Next((*lastScheduleTime).Time), nil
+		return sched.Next(lastScheduleTime.Time), nil
 	}
 	if !createdTime.IsZero() {
 		return sched.Next(createdTime.Time), nil

--- a/internal/collector/pod.go
+++ b/internal/collector/pod.go
@@ -78,7 +78,7 @@ var (
 					ms = append(ms, &metric.Metric{
 						LabelKeys:   []string{},
 						LabelValues: []string{},
-						Value:       float64((*(p.Status.StartTime)).Unix()),
+						Value:       float64((p.Status.StartTime).Unix()),
 					})
 				}
 


### PR DESCRIPTION
`gocritic` is a very strict linter and the fact that it reported only two issues speaks highly of kube-state-metrics :). Adding the `gocritic` linter will help ensure that the code quality stays.