### PR TITLE
Cherry-Pick for 1.6: update documentation to reflect the latest release of kube-state-metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ release.
 #### Container Image
 
 The latest container image can be found at:
-* `quay.io/coreos/kube-state-metrics:v1.5.0`
-* `k8s.gcr.io/kube-state-metrics:v1.5.0`
+* `quay.io/coreos/kube-state-metrics:v1.6.0`
+* `k8s.gcr.io/kube-state-metrics:v1.6.0`
 
 **Note**:
 The recommended docker registry for kube-state-metrics is `quay.io`. kube-state-metrics on

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry-pick a patch from master branch into release-1.6
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #760 

