### PR TITLE
OWNERS: Add tariq1890 as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,3 +8,4 @@ approvers:
   - brancz
   - andyxning
   - mxinden
+  - tariq1890


### PR DESCRIPTION
@tariq1890 has been contributing to kube-state-metrics for a number of months. Back in February we added him as a reviewer with the premise that if commitment continues we would make him approver. Given that he continues to do so while setting a high bar of quality for everyone, I think he more than deserves this! :tada: 

@andyxning @mxinden 