### PR TITLE
kube-state-metrics-deployment: add k8s-app label

### DIFF
--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 # Kubernetes versions before 1.8.0 should use apps/v1beta1 or extensions/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    k8s-app: kube-state-metrics
   name: kube-state-metrics
   namespace: kube-system
 spec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This is a super small PR that adds the `k8s-app` label to kube-state-metrics deployment.

The motivation for this was to replicate labels from the [service yaml](https://github.com/kubernetes/kube-state-metrics/blob/master/kubernetes/kube-state-metrics-service.yaml) and to also keep things in line with other Kubernetes deployment yaml such as kubernetes-dashboard, metrics-server, etc.

**Which issue(s) this PR fixes**: N/A

