### PR TITLE
.travis.yml: Add job names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,17 +28,18 @@ install:
 
 jobs:
   include:
-    # Lint
-    - script: make lint
-    # Check that all the go modules manifests, vendors, and packages are in sync
-    - script: make validate-modules
-    # Check that all metrics are documented
-    - script: make doccheck
-    # Unit Test
-    - script: make test-unit
-    # Benchmark Test
-    - script: make test-benchmark-compare
-    # Build
-    - script: make build
-    # E2e
-    - script: make e2e
+    - stage: all
+      name: Lint
+      script: make lint
+    - name: Validate vendor is in sync with go modules
+      script: make validate-modules
+    - name: Check that all metrics are documented
+      script: make doccheck
+    - name: Unit tests
+      script: make test-unit
+    - name: Benchmark tests
+      script: make test-benchmark-compare
+    - name: Build
+      script: make build
+    - name: End to end tests
+      script: make e2e


### PR DESCRIPTION
What this PR does / why we need it:

Adding the names of the jobs makes it easier to spot which jobs failed.

Fixed #780. Adding `stage` should mark all following jobs in a list as ones which should be run in parallel. More in https://docs.travis-ci.com/user/build-stages/#how-do-build-stages-work

/cc @brancz @LiliC 