### PR TITLE
Makefile: Enable benchmarking against master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ shellcheck:
 # Runs benchmark tests on the current git ref and the last release and compares
 # the two.
 test-benchmark-compare: $(BENCHCMP_BINARY)
+	./tests/compare_benchmarks.sh master
 	./tests/compare_benchmarks.sh ${LATEST_RELEASE_BRANCH}
 
 TEMP_DIR := $(shell mktemp -d)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
 Adding a benchmark against master helps us catch performance
    regressions on the PR that introduces them, instead of at release
    time, or only in a later PRs.
