### PR TITLE
Fixes Wrong description about metrics-server in README.md #794

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ By default, kube-state-metrics exposes several metrics for events across your cl
 The [metrics-server](https://github.com/kubernetes-incubator/metrics-server)
 is a project that has been inspired by
 [Heapster](https://github.com/kubernetes-retired/heapster) and is implemented
-to serve the goals of the [Kubernetes Monitoring
-Pipeline](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/monitoring_architecture.md).
+to serve the goals of core metrics pipelines in [Kubernetes monitoring
+architecture](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/monitoring_architecture.md).
 It is a cluster level component which periodically scrapes metrics from all
 Kubernetes nodes served by Kubelet through Summary API. The metrics are
 aggregated, stored in memory and served in [Metrics API


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes Wrong description about metrics-server in README.md #794

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #794

