### PR TITLE
add missing godoc comment for the WhiteBlackList.Parse method

### DIFF
--- a/pkg/whiteblacklist/whiteblacklist.go
+++ b/pkg/whiteblacklist/whiteblacklist.go
@@ -60,6 +60,7 @@ func New(w, b map[string]struct{}) (*WhiteBlackList, error) {
 	}, nil
 }
 
+// Parse parses and compiles all of the regexes in the whiteBlackList.
 func (l *WhiteBlackList) Parse() error {
 	var regexes []regexp.Regexp
 	for item := range l.list {


### PR DESCRIPTION
Fixes the golint issue reported for WhiteBlacklist.Parse(). I am unsure why `make lint` does not catch this. That will need to be investigated and fixed.