### PR TITLE
enable useless code check and more strict comment check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
     - gofmt
     - goimports
     - golint
-    - gosimple
+    - megacheck
     - gocyclo
     - ineffassign
     - misspell
@@ -16,4 +16,10 @@ linters:
 
 linters-settings:
   goimports:
+  golint:
+    min-confidence: 0
+issues:
+  exclude-use-default: false
+  exclude:
+    - (should have a package comment)
 local-prefixes: k8s.io/kube-state-metrics

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ doccheck: generate
 	@git diff --exit-code
 	@echo "- Checking if the documentation is in sync with the code..."
 	@grep -hoE '(kube_[^ |]+)' docs/* --exclude=README.md| sort -u > documented_metrics
-	@sed -n 's/.*# TYPE \(kube_[^ ]\+\).*/\1/p' internal/store/*_test.go | sort -u > tested_metrics
+	@grep -o -E 'kube_[^\{]+{' internal/store/*_test.go|awk -F: '{print $$2}'|awk -F{ '{print $$1}'|sort -u > tested_metrics
 	@diff -u0 tested_metrics documented_metrics || (echo "ERROR: Metrics with - are present in tests but missing in documentation, metrics with + are documented but not tested."; exit 1)
 	@echo OK
 	@rm -f tested_metrics documented_metrics

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package store provides access for different Kubernetes resources.
 package store
 
 import (

--- a/internal/store/certificatesigningrequest_test.go
+++ b/internal/store/certificatesigningrequest_test.go
@@ -27,18 +27,6 @@ import (
 )
 
 func TestCsrStore(t *testing.T) {
-	const metadata = `
-		# HELP kube_certificatesigningrequest_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_certificatesigningrequest_labels gauge
-		# HELP kube_certificatesigningrequest_created Unix creation timestamp
-		# TYPE kube_certificatesigningrequest_created gauge
-		# HELP kube_certificatesigningrequest_condition The number of each certificatesigningrequest condition
-		# TYPE kube_certificatesigningrequest_condition gauge
-		# HELP kube_certificatesigningrequest_cert_length Length of the issued cert
-		# TYPE kube_certificatesigningrequest_cert_length gauge
-		# HELP kube_certificatesigningrequest_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_certificatesigningrequest_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &certv1beta1.CertificateSigningRequest{

--- a/internal/store/configmap_test.go
+++ b/internal/store/configmap_test.go
@@ -25,22 +25,9 @@ import (
 )
 
 func TestConfigMapStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-
 	startTime := 1501569018
 	metav1StartTime := metav1.Unix(int64(startTime), 0)
 
-	const metadata = `
-		# HELP kube_configmap_info Information about configmap.
-		# TYPE kube_configmap_info gauge
-		# HELP kube_configmap_created Unix creation timestamp
-		# TYPE kube_configmap_created gauge
-		# HELP kube_configmap_metadata_resource_version Resource version representing a specific version of the configmap.
-		# TYPE kube_configmap_metadata_resource_version gauge
-		# HELP kube_configmap_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_configmap_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.ConfigMap{

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -247,5 +247,5 @@ func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, create
 	if !createdTime.IsZero() {
 		return sched.Next(createdTime.Time), nil
 	}
-	return time.Time{}, errors.New("Created time and lastScheduleTime are both zero")
+	return time.Time{}, errors.New("created time and lastScheduleTime are both zero")
 }

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -40,9 +40,6 @@ var (
 )
 
 func TestCronJobStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-
 	hour := ActiveRunningCronJob1LastScheduleTime.Hour()
 	ActiveRunningCronJob1NextScheduleTime := time.Time{}
 	switch {
@@ -101,26 +98,6 @@ func TestCronJobStore(t *testing.T) {
 			0, 0, time.Local)
 	}
 
-	const metadata = `
-		# HELP kube_cronjob_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_cronjob_labels gauge
-		# HELP kube_cronjob_info Info about cronjob.
-		# TYPE kube_cronjob_info gauge
-		# HELP kube_cronjob_created Unix creation timestamp
-		# TYPE kube_cronjob_created gauge
-		# HELP kube_cronjob_spec_starting_deadline_seconds Deadline in seconds for starting the job if it misses scheduled time for any reason.
-		# TYPE kube_cronjob_spec_starting_deadline_seconds gauge
-		# HELP kube_cronjob_spec_suspend Suspend flag tells the controller to suspend subsequent executions.
-		# TYPE kube_cronjob_spec_suspend gauge
-		# HELP kube_cronjob_status_active Active holds pointers to currently running jobs.
-		# TYPE kube_cronjob_status_active gauge
-		# HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
-		# TYPE kube_cronjob_status_last_schedule_time gauge
-		# HELP kube_cronjob_next_schedule_time Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.
-		# TYPE kube_cronjob_next_schedule_time gauge
-		# HELP kube_cronjob_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_cronjob_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &batchv1beta1.CronJob{

--- a/internal/store/daemonset_test.go
+++ b/internal/store/daemonset_test.go
@@ -26,32 +26,6 @@ import (
 )
 
 func TestDaemonSetStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_daemonset_created Unix creation timestamp
-		# TYPE kube_daemonset_created gauge
-		# HELP kube_daemonset_metadata_generation Sequence number representing a specific generation of the desired state.
-		# TYPE kube_daemonset_metadata_generation gauge
-		# HELP kube_daemonset_status_current_number_scheduled The number of nodes running at least one daemon pod and are supposed to.
-		# TYPE kube_daemonset_status_current_number_scheduled gauge
-		# HELP kube_daemonset_status_number_misscheduled The number of nodes running a daemon pod but are not supposed to.
-		# TYPE kube_daemonset_status_number_misscheduled gauge
-		# HELP kube_daemonset_status_desired_number_scheduled The number of nodes that should be running the daemon pod.
-		# TYPE kube_daemonset_status_desired_number_scheduled gauge
-		# HELP kube_daemonset_status_number_available The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available
-		# TYPE kube_daemonset_status_number_available gauge
-		# HELP kube_daemonset_status_number_ready The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
-		# TYPE kube_daemonset_status_number_ready gauge
-		# HELP kube_daemonset_status_number_unavailable The number of nodes that should be running the daemon pod and have none of the daemon pod running and available
-		# TYPE kube_daemonset_status_number_unavailable gauge
-		# HELP kube_daemonset_updated_number_scheduled The total number of nodes that are running updated daemon pod
-		# TYPE kube_daemonset_updated_number_scheduled gauge
-		# HELP kube_daemonset_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_daemonset_labels gauge
-		# HELP kube_daemonset_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_daemonset_annotations gauge
-`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.DaemonSet{

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -38,36 +38,6 @@ var (
 )
 
 func TestDeploymentStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_deployment_created Unix creation timestamp
-		# TYPE kube_deployment_created gauge
-		# HELP kube_deployment_metadata_generation Sequence number representing a specific generation of the desired state.
-		# TYPE kube_deployment_metadata_generation gauge
-		# HELP kube_deployment_spec_paused Whether the deployment is paused and will not be processed by the deployment controller.
-		# TYPE kube_deployment_spec_paused gauge
-		# HELP kube_deployment_spec_replicas Number of desired pods for a deployment.
-		# TYPE kube_deployment_spec_replicas gauge
-		# HELP kube_deployment_status_replicas The number of replicas per deployment.
-		# TYPE kube_deployment_status_replicas gauge
-		# HELP kube_deployment_status_replicas_available The number of available replicas per deployment.
-		# TYPE kube_deployment_status_replicas_available gauge
-		# HELP kube_deployment_status_replicas_unavailable The number of unavailable replicas per deployment.
-		# TYPE kube_deployment_status_replicas_unavailable gauge
-		# HELP kube_deployment_status_replicas_updated The number of updated replicas per deployment.
-		# TYPE kube_deployment_status_replicas_updated gauge
-		# HELP kube_deployment_status_observed_generation The generation observed by the deployment controller.
-		# TYPE kube_deployment_status_observed_generation gauge
-		# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable Maximum number of unavailable replicas during a rolling update of a deployment.
-		# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
-		# HELP kube_deployment_spec_strategy_rollingupdate_max_surge Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
-		# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
-		# HELP kube_deployment_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_deployment_labels gauge
-		# HELP kube_deployment_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_deployment_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.Deployment{

--- a/internal/store/endpoint_test.go
+++ b/internal/store/endpoint_test.go
@@ -28,22 +28,6 @@ import (
 )
 
 func TestEndpointStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_endpoint_address_available Number of addresses available in endpoint.
-		# TYPE kube_endpoint_address_available gauge
-		# HELP kube_endpoint_address_not_ready Number of addresses not ready in endpoint
-		# TYPE kube_endpoint_address_not_ready gauge
-		# HELP kube_endpoint_created Unix creation timestamp
-		# TYPE kube_endpoint_created gauge
-		# HELP kube_endpoint_info Information about endpoint.
-		# TYPE kube_endpoint_info gauge
-		# HELP kube_endpoint_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_endpoint_labels gauge
-		# HELP kube_endpoint_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_endpoint_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.Endpoints{

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -31,26 +31,6 @@ var (
 )
 
 func TestHPAStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_hpa_metadata_generation The generation observed by the HorizontalPodAutoscaler controller.
-		# TYPE kube_hpa_metadata_generation gauge
-		# HELP kube_hpa_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
-		# TYPE kube_hpa_spec_max_replicas gauge
-		# HELP kube_hpa_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
-		# TYPE kube_hpa_spec_min_replicas gauge
-		# HELP kube_hpa_status_current_replicas Current number of replicas of pods managed by this autoscaler.
-		# TYPE kube_hpa_status_current_replicas gauge
-		# HELP kube_hpa_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
-		# TYPE kube_hpa_status_desired_replicas gauge
-        # HELP kube_hpa_status_condition The condition of this autoscaler.
-        # TYPE kube_hpa_status_condition gauge
-        # HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
-        # TYPE kube_hpa_labels gauge
-		# HELP kube_hpa_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_hpa_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			// Verify populating base metric.

--- a/internal/store/ingress_test.go
+++ b/internal/store/ingress_test.go
@@ -26,26 +26,9 @@ import (
 )
 
 func TestIngressStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-
 	startTime := 1501569018
 	metav1StartTime := metav1.Unix(int64(startTime), 0)
 
-	const metadata = `
-		# HELP kube_ingress_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_ingress_labels gauge
-		# HELP kube_ingress_info Information about ingress.
-		# TYPE kube_ingress_info gauge
-		# HELP kube_ingress_created Unix creation timestamp
-		# TYPE kube_ingress_created gauge
-		# HELP kube_ingress_metadata_resource_version Resource version representing a specific version of ingress.
-		# TYPE kube_ingress_metadata_resource_version gauge
-		# HELP kube_ingress_path Ingress host, paths and backend service.
-		# TYPE kube_ingress_path gauge
-		# HELP kube_ingress_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_ingress_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1beta1.Ingress{

--- a/internal/store/job_test.go
+++ b/internal/store/job_test.go
@@ -44,40 +44,6 @@ var (
 func TestJobStore(t *testing.T) {
 	var trueValue = true
 
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_job_created Unix creation timestamp
-		# TYPE kube_job_created gauge
-		# HELP kube_job_owner Information about the Job's owner.
-		# TYPE kube_job_owner gauge
-		# HELP kube_job_complete The job has completed its execution.
-		# TYPE kube_job_complete gauge
-		# HELP kube_job_failed The job has failed its execution.
-		# TYPE kube_job_failed gauge
-		# HELP kube_job_info Information about job.
-		# TYPE kube_job_info gauge
-		# HELP kube_job_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_job_labels gauge
-		# HELP kube_job_spec_active_deadline_seconds The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.
-		# TYPE kube_job_spec_active_deadline_seconds gauge
-		# HELP kube_job_spec_completions The desired number of successfully finished pods the job should be run with.
-		# TYPE kube_job_spec_completions gauge
-		# HELP kube_job_spec_parallelism The maximum desired number of pods the job should run at any given time.
-		# TYPE kube_job_spec_parallelism gauge
-		# HELP kube_job_status_active The number of actively running pods.
-		# TYPE kube_job_status_active gauge
-		# HELP kube_job_status_completion_time CompletionTime represents time when the job was completed.
-		# TYPE kube_job_status_completion_time gauge
-		# HELP kube_job_status_failed The number of pods which reached Phase Failed.
-		# TYPE kube_job_status_failed gauge
-		# HELP kube_job_status_start_time StartTime represents time when the job was acknowledged by the Job Manager.
-		# TYPE kube_job_status_start_time gauge
-		# HELP kube_job_status_succeeded The number of pods which reached Phase Succeeded.
-		# TYPE kube_job_status_succeeded gauge
-		# HELP kube_job_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_job_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1batch.Job{

--- a/internal/store/limitrange_test.go
+++ b/internal/store/limitrange_test.go
@@ -27,18 +27,8 @@ import (
 )
 
 func TestLimitRangeollector(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
 	testMemory := "2.1G"
 	testMemoryQuantity := resource.MustParse(testMemory)
-	const metadata = `
-	# HELP kube_limitrange_created Unix creation timestamp
-	# TYPE kube_limitrange_created gauge
-	# HELP kube_limitrange Information about limit range.
-	# TYPE kube_limitrange gauge
-	# HELP kube_limitrange_annotations Kubernetes annotations converted to Prometheus labels.
-	# TYPE kube_limitrange_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.LimitRange{

--- a/internal/store/namespace_test.go
+++ b/internal/store/namespace_test.go
@@ -26,19 +26,6 @@ import (
 )
 
 func TestNamespaceStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_namespace_created Unix creation timestamp
-		# TYPE kube_namespace_created gauge
-		# HELP kube_namespace_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_namespace_labels gauge
-		# HELP kube_namespace_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_namespace_annotations gauge
-		# HELP kube_namespace_status_phase kubernetes namespace status phase.
-		# TYPE kube_namespace_status_phase gauge
-	`
-
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.Namespace{

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -27,42 +27,6 @@ import (
 )
 
 func TestNodeStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_node_created Unix creation timestamp
-		# TYPE kube_node_created gauge
-		# HELP kube_node_info Information about a cluster node.
-		# TYPE kube_node_info gauge
-		# HELP kube_node_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_node_labels gauge
-		# HELP kube_node_spec_unschedulable Whether a node can schedule new pods.
-		# TYPE kube_node_spec_unschedulable gauge
-		# HELP kube_node_spec_taint The taint of a cluster node.
-		# TYPE kube_node_spec_taint gauge
-		# TYPE kube_node_status_phase gauge
-		# HELP kube_node_status_phase The phase the node is currently in.
-		# TYPE kube_node_status_capacity gauge
-		# HELP kube_node_status_capacity The capacity for different resources of a node.
-		# TYPE kube_node_status_capacity_pods gauge
-		# HELP kube_node_status_capacity_pods The total pod resources of the node.
-		# TYPE kube_node_status_capacity_cpu_cores gauge
-		# HELP kube_node_status_capacity_cpu_cores The total CPU resources of the node.
-		# TYPE kube_node_status_capacity_memory_bytes gauge
-		# HELP kube_node_status_capacity_memory_bytes The total memory resources of the node.
-		# TYPE kube_node_status_allocatable gauge
-		# HELP kube_node_status_allocatable The allocatable for different resources of a node that are available for scheduling.
-		# TYPE kube_node_status_allocatable_pods gauge
-		# HELP kube_node_status_allocatable_pods The pod resources of a node that are available for scheduling.
-		# TYPE kube_node_status_allocatable_cpu_cores gauge
-		# HELP kube_node_status_allocatable_cpu_cores The CPU resources of a node that are available for scheduling.
-		# TYPE kube_node_status_allocatable_memory_bytes gauge
-		# HELP kube_node_status_allocatable_memory_bytes The memory resources of a node that are available for scheduling.
-		# HELP kube_node_status_condition The condition of a cluster node.
-		# TYPE kube_node_status_condition gauge
-		# HELP kube_node_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_node_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		// Verify populating base metric and that metric for unset fields are skipped.
 		{

--- a/internal/store/persistentvolume_test.go
+++ b/internal/store/persistentvolume_test.go
@@ -26,20 +26,6 @@ import (
 )
 
 func TestPersistentVolumeStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-			# HELP kube_persistentvolume_status_phase The phase indicates if a volume is available, bound to a claim, or released by a claim.
-			# TYPE kube_persistentvolume_status_phase gauge
-			# HELP kube_persistentvolume_labels Kubernetes labels converted to Prometheus labels.
-			# TYPE kube_persistentvolume_labels gauge
-			# HELP kube_persistentvolume_info Information about persistentvolume.
-			# TYPE kube_persistentvolume_info gauge
-			# HELP kube_persistentvolume_capacity_bytes The size of the Persistentvolume in bytes.
-			# TYPE kube_persistentvolume_capacity_bytes gauge
-			# HELP kube_persistentvolume_annotations Kubernetes annotations converted to Prometheus labels.
-			# TYPE kube_persistentvolume_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		// Verify phase enumerations.
 		{

--- a/internal/store/persistentvolumeclaim_test.go
+++ b/internal/store/persistentvolumeclaim_test.go
@@ -26,22 +26,6 @@ import (
 )
 
 func TestPersistentVolumeClaimStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
-		# TYPE kube_persistentvolumeclaim_info gauge
-		# HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_persistentvolumeclaim_labels gauge
-		# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
-		# TYPE kube_persistentvolumeclaim_status_phase gauge
-		# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
-		# TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
-		# HELP kube_persistentvolumeclaim_access_mode The access mode of the persistent volume.
-		# TYPE kube_persistentvolumeclaim_access_mode gauge
-		# HELP kube_persistentvolumeclaim_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_persistentvolumeclaim_annotations gauge
-	`
 	storageClassName := "rbd"
 	cases := []generateMetricsTestCase{
 		// Verify phase enumerations.

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -363,11 +363,16 @@ func TestPodStore(t *testing.T) {
 			Want: `
 				kube_pod_container_status_running{container="container1",namespace="ns1",pod="pod1"} 1
 				kube_pod_container_status_terminated_reason{container="container1",namespace="ns1",pod="pod1",reason="Completed"} 0
-                kube_pod_container_status_terminated_reason{container="container1",namespace="ns1",pod="pod1",reason="ContainerCannotRun"} 0
+                                kube_pod_container_status_terminated_reason{container="container1",namespace="ns1",pod="pod1",reason="ContainerCannotRun"} 0
 				kube_pod_container_status_terminated_reason{container="container1",namespace="ns1",pod="pod1",reason="Error"} 0
 				kube_pod_container_status_terminated_reason{container="container1",namespace="ns1",pod="pod1",reason="OOMKilled"} 0
 				kube_pod_container_status_terminated_reason{container="container1",namespace="ns1",pod="pod1",reason="DeadlineExceeded"} 0
-                kube_pod_container_status_terminated{container="container1",namespace="ns1",pod="pod1"} 0
+				kube_pod_init_container_status_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="Completed"} 0
+                                kube_pod_init_container_status_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="ContainerCannotRun"} 0
+				kube_pod_init_container_status_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="Error"} 0
+				kube_pod_init_container_status_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="OOMKilled"} 0
+				kube_pod_init_container_status_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="DeadlineExceeded"} 0
+                                kube_pod_container_status_terminated{container="container1",namespace="ns1",pod="pod1"} 0
 				kube_pod_container_status_waiting{container="container1",namespace="ns1",pod="pod1"} 0
 				kube_pod_container_status_waiting_reason{container="container1",namespace="ns1",pod="pod1",reason="ContainerCreating"} 0
 				kube_pod_container_status_waiting_reason{container="container1",namespace="ns1",pod="pod1",reason="ImagePullBackOff"} 0
@@ -377,11 +382,11 @@ func TestPodStore(t *testing.T) {
 				kube_pod_container_status_waiting_reason{container="container1",namespace="ns1",pod="pod1",reason="CreateContainerError"} 0
 				kube_pod_container_status_waiting_reason{container="container1",namespace="ns1",pod="pod1",reason="InvalidImageName"} 0
 				kube_pod_init_container_status_running{container="initcontainer1",namespace="ns1",pod="pod1"} 1
-				kube_pod_init_container_status_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="Completed"} 0
-                kube_pod_init_container_status_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="ContainerCannotRun"} 0
-				kube_pod_init_container_status_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="Error"} 0
-				kube_pod_init_container_status_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="OOMKilled"} 0
-				kube_pod_init_container_status_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="DeadlineExceeded"} 0
+				kube_pod_init_container_status_last_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="Completed"} 0
+                kube_pod_init_container_status_last_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="ContainerCannotRun"} 0
+				kube_pod_init_container_status_last_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="Error"} 0
+				kube_pod_init_container_status_last_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="OOMKilled"} 0
+				kube_pod_init_container_status_last_terminated_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="DeadlineExceeded"} 0
                 kube_pod_init_container_status_terminated{container="initcontainer1",namespace="ns1",pod="pod1"} 0
 				kube_pod_init_container_status_waiting{container="initcontainer1",namespace="ns1",pod="pod1"} 0
 				kube_pod_init_container_status_waiting_reason{container="initcontainer1",namespace="ns1",pod="pod1",reason="ContainerCreating"} 0
@@ -403,6 +408,7 @@ func TestPodStore(t *testing.T) {
 				"kube_pod_init_container_status_waiting_reason",
 				"kube_pod_init_container_status_terminated",
 				"kube_pod_init_container_status_terminated_reason",
+				"kube_pod_init_container_status_last_terminated_reason",
 			},
 		},
 		{
@@ -494,20 +500,20 @@ func TestPodStore(t *testing.T) {
 			Want: `
 				kube_pod_container_status_running{container="container4",namespace="ns3",pod="pod3"} 0
 				kube_pod_container_status_terminated{container="container4",namespace="ns3",pod="pod3"} 0
-kube_pod_container_status_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="Completed"} 0
+                                kube_pod_container_status_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="Completed"} 0
 				kube_pod_container_status_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="ContainerCannotRun"} 0
 				kube_pod_container_status_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="Error"} 0
 				kube_pod_container_status_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="OOMKilled"} 0
 				kube_pod_container_status_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="DeadlineExceeded"} 0
 				kube_pod_container_status_waiting{container="container4",namespace="ns3",pod="pod3"} 1
-kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="ContainerCreating"} 0
+                                kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="ContainerCreating"} 0
 				kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="ImagePullBackOff"} 0
 				kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="CrashLoopBackOff"} 1
 				kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="ErrImagePull"} 0
 				kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="CreateContainerConfigError"} 0
 				kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="CreateContainerError"} 0
 				kube_pod_container_status_waiting_reason{container="container4",namespace="ns3",pod="pod3",reason="InvalidImageName"} 0
-kube_pod_container_status_last_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="Completed"} 0
+                                kube_pod_container_status_last_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="Completed"} 0
 				kube_pod_container_status_last_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="ContainerCannotRun"} 0
 				kube_pod_container_status_last_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="Error"} 0
 				kube_pod_container_status_last_terminated_reason{container="container4",namespace="ns3",pod="pod3",reason="OOMKilled"} 0
@@ -1128,11 +1134,16 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				kube_pod_container_resource_limits{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 2e+08
 				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="storage",unit="byte"} 4e+08
 				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.2
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 1e+08
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="storage",unit="byte"} 4e+08
+                                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.2
+                                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
+                                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 1e+08
+                                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
+                                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="storage",unit="byte"} 4e+08
+                                kube_pod_init_container_resource_requests{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.2
+                                kube_pod_init_container_resource_requests{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
+                                kube_pod_init_container_resource_requests{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 1e+08
+                                kube_pod_init_container_resource_requests{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
+                                kube_pod_init_container_resource_requests{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="storage",unit="byte"} 4e+08
 		`,
 			MetricNames: []string{
 				"kube_pod_container_resource_requests_cpu_cores",
@@ -1222,6 +1233,8 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				kube_pod_container_resource_limits{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 4e+08
                 kube_pod_init_container_resource_limits{container="pod2_initcon1",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.4
                 kube_pod_init_container_resource_limits{container="pod2_initcon1",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 3e+08
+                kube_pod_init_container_resource_requests{container="pod2_initcon1",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.4
+                kube_pod_init_container_resource_requests{container="pod2_initcon1",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 3e+08
 		`,
 			MetricNames: []string{
 				"kube_pod_container_resource_requests_cpu_cores",
@@ -1242,10 +1255,6 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				"kube_pod_container_resource_limits",
 				"kube_pod_init_container_resource_requests",
 				"kube_pod_init_container_resource_requests",
-				"kube_pod_init_container_resource_requests",
-				"kube_pod_init_container_resource_requests",
-				"kube_pod_init_container_resource_limits",
-				"kube_pod_init_container_resource_limits",
 				"kube_pod_init_container_resource_limits",
 				"kube_pod_init_container_resource_limits",
 			},
@@ -1397,7 +1406,7 @@ func BenchmarkPodStore(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		families := f(pod)
 		if len(families) != 38 {
-			b.Fatalf("expected 39 but got %v", len(families))
+			b.Fatalf("expected 38 but got %v", len(families))
 		}
 	}
 }

--- a/internal/store/poddisruptionbudget_test.go
+++ b/internal/store/poddisruptionbudget_test.go
@@ -26,24 +26,6 @@ import (
 )
 
 func TestPodDisruptionBudgetStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-	# HELP kube_poddisruptionbudget_created Unix creation timestamp
-	# TYPE kube_poddisruptionbudget_created gauge
-	# HELP kube_poddisruptionbudget_status_current_healthy Current number of healthy pods
-	# TYPE kube_poddisruptionbudget_status_current_healthy gauge
-	# HELP kube_poddisruptionbudget_status_desired_healthy Minimum desired number of healthy pods
-	# TYPE kube_poddisruptionbudget_status_desired_healthy gauge
-	# HELP kube_poddisruptionbudget_status_pod_disruptions_allowed Number of pod disruptions that are currently allowed
-	# TYPE kube_poddisruptionbudget_status_pod_disruptions_allowed gauge
-	# HELP kube_poddisruptionbudget_status_expected_pods Total number of pods counted by this disruption budget
-	# TYPE kube_poddisruptionbudget_status_expected_pods gauge
-	# HELP kube_poddisruptionbudget_status_observed_generation Most recent generation observed when updating this PDB status
-	# TYPE kube_poddisruptionbudget_status_observed_generation gauge
-	# HELP kube_poddisruptionbudget_annotations Kubernetes annotations converted to Prometheus labels.
-	# TYPE kube_poddisruptionbudget_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1beta1.PodDisruptionBudget{

--- a/internal/store/replicaset_test.go
+++ b/internal/store/replicaset_test.go
@@ -31,32 +31,8 @@ var (
 )
 
 func TestReplicaSetStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
 	var test = true
 
-	const metadata = `
-		# HELP kube_replicaset_created Unix creation timestamp
-		# TYPE kube_replicaset_created gauge
-	  # HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
-		# TYPE kube_replicaset_metadata_generation gauge
-		# HELP kube_replicaset_status_replicas The number of replicas per ReplicaSet.
-		# TYPE kube_replicaset_status_replicas gauge
-		# HELP kube_replicaset_status_fully_labeled_replicas The number of fully labeled replicas per ReplicaSet.
-		# TYPE kube_replicaset_status_fully_labeled_replicas gauge
-		# HELP kube_replicaset_status_ready_replicas The number of ready replicas per ReplicaSet.
-		# TYPE kube_replicaset_status_ready_replicas gauge
-		# HELP kube_replicaset_status_observed_generation The generation observed by the ReplicaSet controller.
-		# TYPE kube_replicaset_status_observed_generation gauge
-		# HELP kube_replicaset_spec_replicas Number of desired pods for a ReplicaSet.
-		# TYPE kube_replicaset_spec_replicas gauge
-		# HELP kube_replicaset_owner Information about the ReplicaSet's owner.
-		# TYPE kube_replicaset_owner gauge
-		# HELP kube_replicaset_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_replicaset_labels gauge
-		# HELP kube_replicaset_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_replicaset_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.ReplicaSet{

--- a/internal/store/replicationcontroller_test.go
+++ b/internal/store/replicationcontroller_test.go
@@ -31,28 +31,6 @@ var (
 )
 
 func TestReplicationControllerStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_replicationcontroller_created Unix creation timestamp
-		# TYPE kube_replicationcontroller_created gauge
-		# HELP kube_replicationcontroller_metadata_generation Sequence number representing a specific generation of the desired state.
-		# TYPE kube_replicationcontroller_metadata_generation gauge
-		# HELP kube_replicationcontroller_status_replicas The number of replicas per ReplicationController.
-		# TYPE kube_replicationcontroller_status_replicas gauge
-		# HELP kube_replicationcontroller_status_fully_labeled_replicas The number of fully labeled replicas per ReplicationController.
-		# TYPE kube_replicationcontroller_status_fully_labeled_replicas gauge
-		# HELP kube_replicationcontroller_status_available_replicas The number of available replicas per ReplicationController.
-		# TYPE kube_replicationcontroller_status_available_replicas gauge
-		# HELP kube_replicationcontroller_status_ready_replicas The number of ready replicas per ReplicationController.
-		# TYPE kube_replicationcontroller_status_ready_replicas gauge
-		# HELP kube_replicationcontroller_status_observed_generation The generation observed by the ReplicationController controller.
-		# TYPE kube_replicationcontroller_status_observed_generation gauge
-		# HELP kube_replicationcontroller_spec_replicas Number of desired pods for a ReplicationController.
-		# TYPE kube_replicationcontroller_spec_replicas gauge
-		# HELP kube_replicationcontroller_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_replicationcontroller_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.ReplicationController{

--- a/internal/store/resourcequota_test.go
+++ b/internal/store/resourcequota_test.go
@@ -27,16 +27,6 @@ import (
 )
 
 func TestResourceQuotaStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-	# HELP kube_resourcequota Information about resource quota.
-	# TYPE kube_resourcequota gauge
-	# HELP kube_resourcequota_created Unix creation timestamp
-	# TYPE kube_resourcequota_created gauge
-	# HELP kube_resourcequota_annotations Kubernetes annotations converted to Prometheus labels.
-	# TYPE kube_resourcequota_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		// Verify populating base metric and that metric for unset fields are skipped.
 		{

--- a/internal/store/secret_test.go
+++ b/internal/store/secret_test.go
@@ -25,26 +25,9 @@ import (
 )
 
 func TestSecretStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-
 	startTime := 1501569018
 	metav1StartTime := metav1.Unix(int64(startTime), 0)
 
-	const metadata = `
-        # HELP kube_secret_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_secret_labels gauge
-        # HELP kube_secret_info Information about secret.
-		# TYPE kube_secret_info gauge
-		# HELP kube_secret_type Type about secret.
-		# TYPE kube_secret_type gauge
-		# HELP kube_secret_created Unix creation timestamp
-		# TYPE kube_secret_created gauge
-		# HELP kube_secret_metadata_resource_version Resource version representing a specific version of secret.
-		# TYPE kube_secret_metadata_resource_version gauge
-		# HELP kube_secret_annotations Kubernetes annotations converted to Prometheus labels
-		# TYPE kube_secret_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.Secret{

--- a/internal/store/service_test.go
+++ b/internal/store/service_test.go
@@ -26,24 +26,6 @@ import (
 )
 
 func TestServiceStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_service_info Information about service.
-		# TYPE kube_service_info gauge
-		# HELP kube_service_created Unix creation timestamp
-		# TYPE kube_service_created gauge
-		# HELP kube_service_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_service_labels gauge
-		# HELP kube_service_spec_type Type about service.
-		# TYPE kube_service_spec_type gauge
-		# HELP kube_service_spec_external_ip Service external ips. One series for each ip
-		# TYPE kube_service_spec_external_ip gauge
-		# HELP kube_service_status_load_balancer_ingress Service load balancer ingress status
-		# TYPE kube_service_status_load_balancer_ingress gauge
-		# HELP kube_service_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_service_annotations gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.Service{

--- a/internal/store/statefulset_test.go
+++ b/internal/store/statefulset_test.go
@@ -35,34 +35,6 @@ var (
 )
 
 func TestStatefuleSetStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_statefulset_created Unix creation timestamp
-		# TYPE kube_statefulset_created gauge
-		# HELP kube_statefulset_status_current_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
-		# TYPE kube_statefulset_status_current_revision gauge
- 		# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
- 		# TYPE kube_statefulset_status_replicas gauge
-		# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
-		# TYPE kube_statefulset_status_replicas_current gauge
-		# HELP kube_statefulset_status_replicas_ready The number of ready replicas per StatefulSet.
-		# TYPE kube_statefulset_status_replicas_ready gauge
-		# HELP kube_statefulset_status_replicas_updated The number of updated replicas per StatefulSet.
-		# TYPE kube_statefulset_status_replicas_updated gauge
- 		# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
- 		# TYPE kube_statefulset_status_observed_generation gauge
-		# HELP kube_statefulset_status_update_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
-		# TYPE kube_statefulset_status_update_revision gauge
- 		# HELP kube_statefulset_replicas Number of desired pods for a StatefulSet.
- 		# TYPE kube_statefulset_replicas gauge
- 		# HELP kube_statefulset_metadata_generation Sequence number representing a specific generation of the desired state for the StatefulSet.
- 		# TYPE kube_statefulset_metadata_generation gauge
-		# HELP kube_statefulset_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_statefulset_labels gauge
-		# HELP kube_statefulset_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_statefulset_annotations gauge
- 	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &v1.StatefulSet{

--- a/internal/store/storageclass_test.go
+++ b/internal/store/storageclass_test.go
@@ -23,22 +23,11 @@ import (
 )
 
 func TestStorageClassStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-
 	startTime := 1501569018
 	metav1StartTime := metav1.Unix(int64(startTime), 0)
 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
 	volumeBindingMode := storagev1.VolumeBindingImmediate
 
-	const metadata = `
-			# HELP kube_storageclass_labels Kubernetes labels converted to Prometheus labels.
-			# TYPE kube_storageclass_labels gauge
-			# HELP kube_storageclass_info Information about storageclass.
-			# TYPE kube_storageclass_info gauge
-			# HELP kube_storageclass_created Unix creation timestamp
-			# TYPE kube_storageclass_created gauge
-	`
 	cases := []generateMetricsTestCase{
 		{
 			Obj: &storagev1.StorageClass{

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 
@@ -30,7 +29,6 @@ import (
 )
 
 var (
-	resyncPeriod       = 5 * time.Minute
 	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 	conditionStatuses  = []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionUnknown}
 )

--- a/internal/store/verticalpodautoscaler_test.go
+++ b/internal/store/verticalpodautoscaler_test.go
@@ -29,26 +29,6 @@ import (
 )
 
 func TestVPAStore(t *testing.T) {
-
-	const metadata = `
-		# HELP kube_verticalpodautoscaler_labels Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_verticalpodautoscaler_labels gauge
-		# HELP kube_verticalpodautoscaler_spec_updatepolicy_updatemode Update mode of the VPA.
-		# TYPE kube_verticalpodautoscaler_spec_updatepolicy_updatemode gauge
-		# HELP kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed Minimum resources the VPA can set for containers matching the name.
-		# TYPE kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed gauge
-		# HELP kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed Maximum resources the VPA can set for containers matching the name.
-		# TYPE kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed gauge
-		# HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound Minimum resources the container can use before the VPA updater evicts it.
-		# TYPE kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound gauge
-		# HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound Maximum resources the container can use before the VPA updater evicts it.
-		# TYPE kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound gauge
-		# HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target Target resources the VPA recommends for the container.
-		# TYPE kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target gauge
-		# HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget Target resources the VPA recommends for the container ignoring bounds.
-		# TYPE kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget gauge
-	`
-
 	updateMode := autoscaling.UpdateModeRecreate
 
 	v1Resource := func(cpu, mem string) v1.ResourceList {

--- a/main_test.go
+++ b/main_test.go
@@ -268,6 +268,8 @@ kube_pod_container_resource_requests{namespace="default",pod="pod0",container="p
 kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="memory",unit="byte"} 2e+08
 # HELP kube_pod_init_container_resource_limits The number of requested limit resource by the init container.
 # TYPE kube_pod_init_container_resource_limits gauge
+# HELP kube_pod_init_container_resource_requests The number of requested request resource by the init container.
+# TYPE kube_pod_init_container_resource_requests gauge
 # HELP kube_pod_container_resource_limits The number of requested limit resource by a container.
 # TYPE kube_pod_container_resource_limits gauge
 kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="nvidia_com_gpu",unit="integer"} 1

--- a/pkg/constant/resource_unit.go
+++ b/pkg/constant/resource_unit.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package constant defines constant values used in kube-state-metrics project.
 package constant
 
 // ResourceUnit represents the unit of measure for certain metrics.

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package metric provides functionality for exporting metrics in Prometheus format.
 package metric
 
 import (

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package metricsstore provides a memory tuned store for Kubernetes objects.
 package metricsstore
 
 import (

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package options defines options used by kube-state-metrics.
 package options
 
 import (

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -97,11 +97,6 @@ func (c CollectorSet) AsSlice() []string {
 	return cols
 }
 
-// isEmpty() returns true if the length of the CollectorSet is zero.
-func (c CollectorSet) isEmpty() bool {
-	return len(c.AsSlice()) == 0
-}
-
 // Type returns a descriptive string about the CollectorSet type.
 func (c *CollectorSet) Type() string {
 	return "string"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package version provides version info for kube-state-metrics.
 package version
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
By default, golangci-lint will not enable check for exported function comment check and some other issues. Enable this manually for kube-state-metrics.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #800

