### PR TITLE
Update compatibility matrix to record only 5 kubernetes releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ The compatibility matrix for client-go and Kubernetes cluster can be found
 All additional compatibility is only best effort, or happens to still/already be supported.
 
 #### Compatibility matrix
-At most 5 kube-state-metrics releases will be recorded below.
+At most, 5 kube-state-metrics and 5 [kubernetes releases](https://github.com/kubernetes/kubernetes/releases) will be recorded below.
 
-| kube-state-metrics | client-go  | **Kubernetes 1.10** | **Kubernetes 1.11** | **Kubernetes 1.12** | **Kubernetes 1.13** | **Kubernetes 1.14** |  **Kubernetes 1.15** |
-|--------------------|------------|---------------------|---------------------|---------------------|---------------------|---------------------|----------------------|
-| **v1.2.0**         |  v6.0.0    |         ✓           |         ✓           |         ✓           |         -           |         -           |          -           |          
-| **v1.3.1**         |  v6.0.0    |         ✓           |         ✓           |         ✓           |         -           |         -           |          -           |
-| **v1.4.0**         |  v8.0.0    |         ✓           |         ✓           |         ✓           |         -           |         -           |          -           |
-| **v1.5.0**         |  v8.0.0    |         ✓           |         ✓           |         ✓           |         -           |         -           |          -           |
-| **v1.6.0**         |  v11.0.0   |         ✓           |         ✓           |         ✓           |         ✓           |         ✓           |          -           |
-| **master**         |  v12.0.0   |         ✓           |         ✓           |         ✓           |         ✓           |         ✓           |          ✓           |
+| kube-state-metrics | client-go  | **Kubernetes 1.11** | **Kubernetes 1.12** | **Kubernetes 1.13** | **Kubernetes 1.14** |  **Kubernetes 1.15** |
+|--------------------|------------|---------------------|---------------------|---------------------|---------------------|----------------------|
+| **v1.2.0**         |  v6.0.0    |         ✓           |         ✓           |         -           |         -           |          -           |          
+| **v1.3.1**         |  v6.0.0    |         ✓           |         ✓           |         -           |         -           |          -           |
+| **v1.4.0**         |  v8.0.0    |         ✓           |         ✓           |         -           |         -           |          -           |
+| **v1.5.0**         |  v8.0.0    |         ✓           |         ✓           |         -           |         -           |          -           |
+| **v1.6.0**         |  v11.0.0   |         ✓           |         ✓           |         ✓           |         ✓           |          -           |
+| **master**         |  v12.0.0   |         ✓           |         ✓           |         ✓           |         ✓           |          ✓           |
 - `✓` Fully supported version range.
 - `-` The Kubernetes cluster has features the client-go library can't use (additional API objects, etc).
 


### PR DESCRIPTION
Updating the Support matrix as per the discussion in #798. Thanks to @LiliC for highlighting this.