### PR TITLE
use appsv1 apigroup for ReplicaSet

### DIFF
--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/kube-state-metrics/pkg/metric"
 
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -39,7 +39,7 @@ var (
 			Name: "kube_replicaset_created",
 			Type: metric.Gauge,
 			Help: "Unix creation timestamp",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !r.CreationTimestamp.IsZero() {
@@ -58,7 +58,7 @@ var (
 			Name: "kube_replicaset_status_replicas",
 			Type: metric.Gauge,
 			Help: "The number of replicas per ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -72,7 +72,7 @@ var (
 			Name: "kube_replicaset_status_fully_labeled_replicas",
 			Type: metric.Gauge,
 			Help: "The number of fully labeled replicas per ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -86,7 +86,7 @@ var (
 			Name: "kube_replicaset_status_ready_replicas",
 			Type: metric.Gauge,
 			Help: "The number of ready replicas per ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -100,7 +100,7 @@ var (
 			Name: "kube_replicaset_status_observed_generation",
 			Type: metric.Gauge,
 			Help: "The generation observed by the ReplicaSet controller.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -114,7 +114,7 @@ var (
 			Name: "kube_replicaset_spec_replicas",
 			Type: metric.Gauge,
 			Help: "Number of desired pods for a ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if r.Spec.Replicas != nil {
@@ -132,7 +132,7 @@ var (
 			Name: "kube_replicaset_metadata_generation",
 			Type: metric.Gauge,
 			Help: "Sequence number representing a specific generation of the desired state.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -146,7 +146,7 @@ var (
 			Name: "kube_replicaset_owner",
 			Type: metric.Gauge,
 			Help: "Information about the ReplicaSet's owner.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1beta1.ReplicaSet) *metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				owners := r.GetOwnerReferences()
 
 				if len(owners) == 0 {
@@ -189,7 +189,7 @@ var (
 			Name: descReplicaSetLabelsName,
 			Type: metric.Gauge,
 			Help: descReplicaSetLabelsHelp,
-			GenerateFunc: wrapReplicaSetFunc(func(d *v1beta1.ReplicaSet) *metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(d *v1.ReplicaSet) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -206,7 +206,7 @@ var (
 			Name: "kube_replicaset_annotations",
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
-			GenerateFunc: wrapReplicaSetFunc(func(d *v1beta1.ReplicaSet) *metric.Family {
+			GenerateFunc: wrapReplicaSetFunc(func(d *v1.ReplicaSet) *metric.Family {
 				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(d.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -222,9 +222,9 @@ var (
 	}
 )
 
-func wrapReplicaSetFunc(f func(*v1beta1.ReplicaSet) *metric.Family) func(interface{}) *metric.Family {
+func wrapReplicaSetFunc(f func(*v1.ReplicaSet) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {
-		replicaSet := obj.(*v1beta1.ReplicaSet)
+		replicaSet := obj.(*v1.ReplicaSet)
 
 		metricFamily := f(replicaSet)
 
@@ -240,10 +240,10 @@ func wrapReplicaSetFunc(f func(*v1beta1.ReplicaSet) *metric.Family) func(interfa
 func createReplicaSetListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.ExtensionsV1beta1().ReplicaSets(ns).List(opts)
+			return kubeClient.AppsV1().ReplicaSets(ns).List(opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.ExtensionsV1beta1().ReplicaSets(ns).Watch(opts)
+			return kubeClient.AppsV1().ReplicaSets(ns).Watch(opts)
 		},
 	}
 }

--- a/internal/store/replicaset_test.go
+++ b/internal/store/replicaset_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
@@ -59,7 +59,7 @@ func TestReplicaSetStore(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1beta1.ReplicaSet{
+			Obj: &v1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "rs1",
 					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
@@ -79,13 +79,13 @@ func TestReplicaSetStore(t *testing.T) {
 						"app": "example1",
 					},
 				},
-				Status: v1beta1.ReplicaSetStatus{
+				Status: v1.ReplicaSetStatus{
 					Replicas:             5,
 					FullyLabeledReplicas: 10,
 					ReadyReplicas:        5,
 					ObservedGeneration:   1,
 				},
-				Spec: v1beta1.ReplicaSetSpec{
+				Spec: v1.ReplicaSetSpec{
 					Replicas: &rs1Replicas,
 				},
 			},
@@ -103,7 +103,7 @@ func TestReplicaSetStore(t *testing.T) {
 `,
 		},
 		{
-			Obj: &v1beta1.ReplicaSet{
+			Obj: &v1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "rs2",
 					Namespace:  "ns2",
@@ -117,13 +117,13 @@ func TestReplicaSetStore(t *testing.T) {
 						"env": "ex",
 					},
 				},
-				Status: v1beta1.ReplicaSetStatus{
+				Status: v1.ReplicaSetStatus{
 					Replicas:             0,
 					FullyLabeledReplicas: 5,
 					ReadyReplicas:        0,
 					ObservedGeneration:   5,
 				},
-				Spec: v1beta1.ReplicaSetSpec{
+				Spec: v1.ReplicaSetSpec{
 					Replicas: &rs2Replicas,
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Using the "k8s.io/api/apps/v1" for the replicaset object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #802

