### PR TITLE
*: Cleanup references to removed API

### DIFF
--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -70,7 +70,7 @@ func TestHPAStore(t *testing.T) {
 					MaxReplicas: 4,
 					MinReplicas: &hpa1MinReplicas,
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{
-						APIVersion: "extensions/v1beta1",
+						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       "deployment1",
 					},

--- a/kubernetes/kube-state-metrics-deployment.yaml
+++ b/kubernetes/kube-state-metrics-deployment.yaml
@@ -1,6 +1,4 @@
 apiVersion: apps/v1
-# Kubernetes version 1.8.x should use apps/v1beta2
-# Kubernetes versions before 1.8.0 should use apps/v1beta1 or extensions/v1beta1
 kind: Deployment
 metadata:
   labels:

--- a/tests/manifests/hpa.yaml
+++ b/tests/manifests/hpa.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: deployment
   minReplicas: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Just some cleanup that was leftover as part of https://github.com/kubernetes/kube-state-metrics/issues/802.


@tariq1890 you left the issue open, is there anything else that needs to be done as part of https://github.com/kubernetes/kube-state-metrics/issues/802 that you found. 
