### PR TITLE
fix go vet issues in whitblacklist.go

### DIFF
--- a/pkg/whiteblacklist/whiteblacklist.go
+++ b/pkg/whiteblacklist/whiteblacklist.go
@@ -26,7 +26,7 @@ import (
 // WhiteBlackList encapsulates the logic needed to filter based on a string.
 type WhiteBlackList struct {
 	list        map[string]struct{}
-	rList       []regexp.Regexp
+	rList       []*regexp.Regexp
 	isWhiteList bool
 }
 
@@ -62,13 +62,13 @@ func New(w, b map[string]struct{}) (*WhiteBlackList, error) {
 
 // Parse parses and compiles all of the regexes in the whiteBlackList.
 func (l *WhiteBlackList) Parse() error {
-	var regexes []regexp.Regexp
+	var regexes []*regexp.Regexp
 	for item := range l.list {
 		r, err := regexp.Compile(item)
 		if err != nil {
 			return err
 		}
-		regexes = append(regexes, *r)
+		regexes = append(regexes, r)
 	}
 	l.rList = regexes
 	return nil


### PR DESCRIPTION
This fixes a code issue created by #773. Passing regex structs by value is highly advised against as this entails creating a new mutex (`regexp.Regexp` contains  `sync.Mutex` as a field inside it.) instead of re-using the existing mutex which is required for thread-safety.

Thankfully, `go vet` caught this issue beforehand.

For more details, see [here](https://eli.thegreenplace.net/2018/beware-of-copying-mutexes-in-go/)