### PR TITLE
rename kubeAnnotationsToPrometheusAnnotations to kubeAnnotationsToPrometheusLabels

### DIFF
--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -100,7 +100,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapCSRFunc(func(j *certv1beta1.CertificateSigningRequest) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(j.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(j.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -86,7 +86,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(c.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(c.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -195,7 +195,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(j.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(j.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -200,7 +200,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(d.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(d.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -232,7 +232,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(d.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(d.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -125,7 +125,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(e.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(e.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/hpa.go
+++ b/internal/store/hpa.go
@@ -148,7 +148,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(a.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(a.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -122,7 +122,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(i.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(i.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -311,7 +311,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(j.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(j.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/limitrange.go
+++ b/internal/store/limitrange.go
@@ -109,7 +109,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(r.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(r.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -72,7 +72,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(n.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(n.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -483,7 +483,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(n.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(n.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -132,7 +132,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(p.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(p.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -149,7 +149,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(p.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(p.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -124,7 +124,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(p.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(p.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -207,7 +207,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapReplicaSetFunc(func(d *v1.ReplicaSet) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(d.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(d.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -156,7 +156,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(r.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(r.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/resourcequota.go
+++ b/internal/store/resourcequota.go
@@ -84,7 +84,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(r.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(r.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -120,7 +120,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(s.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(s.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -148,7 +148,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(s.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(s.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -207,7 +207,7 @@ var (
 			Type: metric.Gauge,
 			Help: "Kubernetes annotations converted to Prometheus labels.",
 			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
-				annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(s.Annotations)
+				annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(s.Annotations)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -70,7 +70,7 @@ func kubeLabelsToPrometheusLabels(labels map[string]string) ([]string, []string)
 	return labelKeys, labelValues
 }
 
-func kubeAnnotationsToPrometheusAnnotations(annotations map[string]string) ([]string, []string) {
+func kubeAnnotationsToPrometheusLabels(annotations map[string]string) ([]string, []string) {
 	annotationKeys := make([]string, len(annotations))
 	annotationValues := make([]string, len(annotations))
 	i := 0

--- a/internal/store/utils_test.go
+++ b/internal/store/utils_test.go
@@ -190,7 +190,7 @@ func TestKubeLabelsToPrometheusLabels(t *testing.T) {
 
 }
 
-func TestKubeAnnotationsToPrometheusAnnotations(t *testing.T) {
+func TestKubeAnnotationsToPrometheusLabels(t *testing.T) {
 	testCases := []struct {
 		kubeAnnotations map[string]string
 		expectKeys      []string
@@ -235,7 +235,7 @@ func TestKubeAnnotationsToPrometheusAnnotations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("kubeannotations input=%v , expected prometheus keys=%v, expected prometheus values=%v", tc.kubeAnnotations, tc.expectKeys, tc.expectValues), func(t *testing.T) {
-			annotationKeys, annotationValues := kubeAnnotationsToPrometheusAnnotations(tc.kubeAnnotations)
+			annotationKeys, annotationValues := kubeAnnotationsToPrometheusLabels(tc.kubeAnnotations)
 			if len(annotationKeys) != len(tc.expectKeys) {
 				t.Errorf("Got Prometheus label keys with len %d but expected %d", len(annotationKeys), len(tc.expectKeys))
 			}


### PR DESCRIPTION
Renaming as the name `kubeAnnotationsToPrometheusLabels` is more appropriate and accurate.