### PR TITLE
tests/e2e.sh: Check for errors in the logs

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -185,12 +185,12 @@ sleep 33
 klog_err=E$(date +%m%d)
 echo "check for errors in logs"
 output_logs=$(kubectl --namespace=kube-system logs deployment/kube-state-metrics kube-state-metrics)
-if echo "$output_logs" | grep "^$klog_err"; then
+if echo "${output_logs}" | grep "^${klog_err}"; then
     echo ""
-    echo "======================================="
-    echo "found errors in kube-state-metrics logs"
-    echo "======================================="
+    echo "==========================================="
+    echo "Found errors in the kube-state-metrics logs"
+    echo "==========================================="
     echo ""
-    echo "$output_logs"
+    echo "${output_logs}"
     exit 1
 fi

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -178,10 +178,19 @@ done
 KUBE_STATE_METRICS_STATUS=$(curl -s "http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy/healthz")
 if [[ "${KUBE_STATE_METRICS_STATUS}" == "OK" ]]; then
     echo "kube-state-metrics is still running after accessing metrics endpoint"
-    exit 0
 fi
 
 # wait for klog to flush to log file
 sleep 33
-kubectl --namespace=kube-system logs deployment/kube-state-metrics kube-state-metrics
-exit 1
+klog_err=E$(date +%m%d)
+echo "check for errors in logs"
+output_logs=$(kubectl --namespace=kube-system logs deployment/kube-state-metrics kube-state-metrics)
+if echo "$output_logs" | grep "^$klog_err"; then
+    echo ""
+    echo "======================================="
+    echo "found errors in kube-state-metrics logs"
+    echo "======================================="
+    echo ""
+    echo "$output_logs"
+    exit 1
+fi


### PR DESCRIPTION

**What this PR does / why we need it**:
kube-state-metrics does not terminate the pod on errors, so to actually
detect the errors in CI, we are adding this check by grepping for errors
in the kube-state-metrics logs.

This makes the assumption that any errors that are present in logs start
wtih the string 'E<MONTHDAY>' (e.g.: 'E0711') as this is how klog starts
all error log lines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
As discussed in https://github.com/kubernetes/kube-state-metrics/issues/815#issuecomment-510173932

Tested this with errors in logs and it looks like this on FAIL:
```
check for errors in logs
E0711 15:51:09.896317       1 reflector.go:342] k8s.io/kube-state-metrics/internal/store/builder.go:295: expected type *v1beta1.ReplicaSet, but watch event object had type *v1.ReplicaSet
=======================================
found errors in kube-state-metrics logs
=======================================
I0711 15:51:02.037704       1 main.go:87] Using default collectors
I0711 15:51:02.037789       1 main.go:99] Using all namespace
I0711 15:51:02.037809       1 main.go:140] metric white-blacklisting: blacklisting the following items: 
W0711 15:51:02.039405       1 client_config.go:541] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0711 15:51:02.041468       1 main.go:185] Testing communication with server
I0711 15:51:02.054346       1 main.go:190] Running with Kubernetes cluster version: v1.14. git version: v1.14.3. git tree state: clean. commit: 5e53fd6bc17c0dec8434817e69b04a25d8ae0ff0. platform: linux/amd64
I0711 15:51:02.054371       1 main.go:192] Communication with server successful
I0711 15:51:02.055704       1 builder.go:126] Active collectors: certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,namespaces,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses
I0711 15:51:02.055727       1 main.go:226] Starting metrics server: 0.0.0.0:8080
I0711 15:51:02.058555       1 main.go:201] Starting kube-state-metrics self metrics server: 0.0.0.0:8081
E0711 15:51:09.896317       1 reflector.go:342] k8s.io/kube-state-metrics/internal/store/builder.go:295: expected type *v1beta1.ReplicaSet, but watch event object had type *v1.ReplicaSet
```