### PR TITLE
Dockerfile: Set user to nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
-FROM alpine:3.9
-
-RUN adduser -D kube-state-metrics
-
 FROM gcr.io/distroless/static
 
 COPY kube-state-metrics /
 
-COPY --from=0 /etc/passwd /etc/passwd
-
-USER kube-state-metrics
+USER nobody
 
 ENTRYPOINT ["/kube-state-metrics", "--port=8080", "--telemetry-port=8081"]
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Simplifies Dockerfile and helm chart defaults to nobody for a long time.
