### PR TITLE
Fix crash due to missing ingress http block

### DIFF
--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -104,12 +104,14 @@ var (
 			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
 				ms := []*metric.Metric{}
 				for _, rule := range i.Spec.Rules {
-					for _, path := range rule.HTTP.Paths {
-						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"host", "path", "service_name", "service_port"},
-							LabelValues: []string{rule.Host, path.Path, path.Backend.ServiceName, path.Backend.ServicePort.String()},
-							Value:       1,
-						})
+					if rule.HTTP != nil {
+						for _, path := range rule.HTTP.Paths {
+							ms = append(ms, &metric.Metric{
+								LabelKeys:   []string{"host", "path", "service_name", "service_port"},
+								LabelValues: []string{rule.Host, path.Path, path.Backend.ServiceName, path.Backend.ServicePort.String()},
+								Value:       1,
+							})
+						}
 					}
 				}
 				return &metric.Family{

--- a/internal/store/ingress_test.go
+++ b/internal/store/ingress_test.go
@@ -139,6 +139,9 @@ func TestIngressStore(t *testing.T) {
 								},
 							},
 						},
+						{
+							Host: "somehost2",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
It's acceptable although uncommon for an ingress to have a rule and a host,
but no HTTP block for that particular rule.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes a crash when an ingress exists with rules but no `HTTP` block.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

