### PR TITLE
pods: Add pod_restart_policy metric

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -26,6 +26,7 @@
 | kube_pod_container_resource_limits | Gauge | `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt; <br> `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; | STABLE |
 | kube_pod_container_resource_limits_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; | DEPRECATED |
 | kube_pod_created | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
+| kube_pod_restart_policy | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `type`=&lt;Always|Never|OnFailure&gt; | STABLE |
 | kube_pod_init_container_info | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `image`=&lt;image-name&gt; <br> `image_id`=&lt;image-id&gt; <br> `container_id`=&lt;containerid&gt; | STABLE |
 | kube_pod_init_container_status_waiting | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_init_container_status_waiting_reason | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `reason`=&lt;ContainerCreating\|CrashLoopBackOff\|ErrImagePull\|ImagePullBackOff\|CreateContainerConfigError&gt; | STABLE |

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -197,6 +197,22 @@ var (
 			}),
 		},
 		{
+			Name: "kube_pod_restart_policy",
+			Type: metric.Gauge,
+			Help: "Describes the restart policy in use by this pod.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{"type"},
+							LabelValues: []string{string(p.Spec.RestartPolicy)},
+							Value:       float64(1),
+						},
+					},
+				}
+			}),
+		},
+		{
 			Name: "kube_pod_status_scheduled_time",
 			Type: metric.Gauge,
 			Help: "Unix timestamp when pod moved into scheduled status",

--- a/main_test.go
+++ b/main_test.go
@@ -162,6 +162,9 @@ kube_pod_labels{namespace="default",pod="pod0"} 1
 # HELP kube_pod_created Unix creation timestamp
 # TYPE kube_pod_created gauge
 kube_pod_created{namespace="default",pod="pod0"} 1.5e+09
+# HELP kube_pod_restart_policy Describes the restart policy in use by this pod.
+# TYPE kube_pod_restart_policy gauge
+kube_pod_restart_policy{namespace="default",pod="pod0",type="Always"} 1
 # HELP kube_pod_status_scheduled_time Unix timestamp when pod moved into scheduled status
 # TYPE kube_pod_status_scheduled_time gauge
 # HELP kube_pod_status_phase The pods current phase.
@@ -385,7 +388,8 @@ func pod(client *fake.Clientset, index int) error {
 			},
 		},
 		Spec: v1.PodSpec{
-			NodeName: "node1",
+			RestartPolicy: v1.RestartPolicyAlways,
+			NodeName:      "node1",
 			Containers: []v1.Container{
 				{
 					Name: "pod1_con1",


### PR DESCRIPTION
Report pod_restart_policy{..., type="Always|OnFailure|Never"} 1 for each pod, which allows an admin to know how many batch vs service workload pods are running on the cluster.

Fixes #263