### PR TITLE
feat: add kube_pod_status_unschedulable metric

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -40,3 +40,4 @@
 | kube_pod_spec_volumes_persistentvolumeclaims_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `volume`=&lt;volume-name&gt;  <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-claimname&gt; | STABLE |
 | kube_pod_spec_volumes_persistentvolumeclaims_readonly | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt;  <br> `volume`=&lt;volume-name&gt;  <br> `persistentvolumeclaim`=&lt;persistentvolumeclaim-claimname&gt; | STABLE |
 | kube_pod_status_scheduled_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
+| kube_pod_status_unschedulable | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -238,6 +238,31 @@ var (
 			}),
 		},
 		{
+			Name: "kube_pod_status_unschedulable",
+			Type: metric.Gauge,
+			Help: "Describes the unschedulable status for the pod.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, c := range p.Status.Conditions {
+					switch c.Type {
+					case v1.PodScheduled:
+						if c.Status == v1.ConditionFalse {
+							ms = append(ms, &metric.Metric{
+								LabelKeys:   []string{},
+								LabelValues: []string{},
+								Value:       1,
+							})
+						}
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
 			Name: "kube_pod_status_phase",
 			Type: metric.Gauge,
 			Help: "The pods current phase.",

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1157,6 +1157,30 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 		{
 			Obj: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "ns2",
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Type:    v1.PodScheduled,
+							Status:  v1.ConditionFalse,
+							Reason:  "Unschedulable",
+							Message: "0/3 nodes are available: 3 Insufficient cpu.",
+						},
+					},
+				},
+			},
+			Want: `
+				# HELP kube_pod_status_unschedulable Describes the unschedulable status for the pod.
+				# TYPE kube_pod_status_unschedulable gauge
+				kube_pod_status_unschedulable{namespace="ns2",pod="pod2"} 1
+			`,
+			MetricNames: []string{"kube_pod_status_unschedulable"},
+		},
+		{
+			Obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod1",
 					Namespace: "ns1",
 				},
@@ -1541,7 +1565,7 @@ func BenchmarkPodStore(b *testing.B) {
 		},
 	}
 
-	expectedFamilies := 38
+	expectedFamilies := 39
 	for n := 0; n < b.N; n++ {
 		families := f(pod)
 		if len(families) != expectedFamilies {

--- a/main_test.go
+++ b/main_test.go
@@ -169,6 +169,8 @@ kube_pod_restart_policy{namespace="default",pod="pod0",type="Always"} 1
 # TYPE kube_pod_status_scheduled_time gauge
 # HELP kube_pod_status_phase The pods current phase.
 # TYPE kube_pod_status_phase gauge
+# HELP kube_pod_status_unschedulable Describes the unschedulable status for the pod.
+# TYPE kube_pod_status_unschedulable gauge
 kube_pod_status_phase{namespace="default",pod="pod0",phase="Pending"} 0
 kube_pod_status_phase{namespace="default",pod="pod0",phase="Succeeded"} 0
 kube_pod_status_phase{namespace="default",pod="pod0",phase="Failed"} 0


### PR DESCRIPTION

**What this PR does / why we need it**:

add kube_pod_status_unscheduled

**Which issue(s) this PR fixes** :

Fixes #829 

