### PR TITLE
Add metrics for tls host and secretname

### DIFF
--- a/docs/ingress-metrics.md
+++ b/docs/ingress-metrics.md
@@ -8,3 +8,4 @@
 | kube_ingress_metadata_resource_version  | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `resource_version`=&lt;ingress-resource-version&gt; | STABLE |
 | kube_ingress_path | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `host`=&lt;ingress-host&gt; <br> `path`=&lt;ingress-path&gt; <br> `service_name`=&lt;service name for the path&gt; <br> `service_port`=&lt;service port for hte path&gt; | STABLE |
 | kube_ingress_annotations | Gauge | `annotation_INGRESS_ANNOTATION`=&lt;INGRESS_ANNOTATION&gt; <br> `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; | EXPERIMENTAL |
+| kube_ingress_tls | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `tls_host`=&lt;tls hostname&gt; <br> `secret`=&lt;tls secret name&gt;| STABLE |

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -136,6 +136,26 @@ var (
 				}
 			}),
 		},
+		{
+			Name: "kube_ingress_tls",
+			Type: metric.Gauge,
+			Help: "Ingress TLS host and secret information.",
+			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
+				ms := []*metric.Metric{}
+				for _, tls := range i.Spec.TLS {
+					for _, host := range tls.Hosts {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"tls_host", "secret"},
+							LabelValues: []string{host, tls.SecretName},
+							Value:       1,
+						})
+					}
+				}
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
 	}
 )
 

--- a/internal/store/ingress_test.go
+++ b/internal/store/ingress_test.go
@@ -45,6 +45,8 @@ func TestIngressStore(t *testing.T) {
 		# TYPE kube_ingress_path gauge
 		# HELP kube_ingress_annotations Kubernetes annotations converted to Prometheus labels.
 		# TYPE kube_ingress_annotations gauge
+		# HELP kube_ingress_tls Ingress TLS host and secret information.
+		# TYPE kube_ingress_tls gauge
 	`
 	cases := []generateMetricsTestCase{
 		{
@@ -64,7 +66,7 @@ func TestIngressStore(t *testing.T) {
 				kube_ingress_labels{namespace="ns1",ingress="ingress1"} 1
 				kube_ingress_annotations{namespace="ns1",ingress="ingress1",annotation_app="ingress1"} 1
 `,
-			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_annotations"},
+			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_annotations", "kube_ingress_tls"},
 		},
 		{
 			Obj: &v1beta1.Ingress{
@@ -85,7 +87,7 @@ func TestIngressStore(t *testing.T) {
 				kube_ingress_labels{namespace="ns2",ingress="ingress2"} 1
 				kube_ingress_annotations{namespace="ns2",ingress="ingress2",annotation_app="ingress2"} 1
 				`,
-			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_annotations"},
+			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_annotations", "kube_ingress_tls"},
 		},
 		{
 			Obj: &v1beta1.Ingress{
@@ -107,7 +109,7 @@ func TestIngressStore(t *testing.T) {
 				kube_ingress_labels{label_test_3="test-3",namespace="ns3",ingress="ingress3"} 1
 				kube_ingress_annotations{namespace="ns3",ingress="ingress3",annotation_test_3="test-3"} 1
 `,
-			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_annotations"},
+			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_annotations", "kube_ingress_tls"},
 		},
 		{
 			Obj: &v1beta1.Ingress{
@@ -153,7 +155,39 @@ func TestIngressStore(t *testing.T) {
 				kube_ingress_path{namespace="ns4",ingress="ingress4",host="somehost",path="/somepath",service_name="someservice",service_port="1234"} 1
 				kube_ingress_annotations{namespace="ns4",ingress="ingress4",annotation_test_4="test-4"} 1
 `,
-			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_annotations"},
+			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_annotations", "kube_ingress_tls"},
+		},
+		{
+			Obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "ingress5",
+					Namespace:         "ns5",
+					CreationTimestamp: metav1StartTime,
+					Labels:            map[string]string{"test-5": "test-5"},
+					ResourceVersion:   "abcdef",
+					Annotations: map[string]string{
+						"test-5": "test-5",
+					},
+				},
+				Spec: v1beta1.IngressSpec{
+					TLS: []v1beta1.IngressTLS{
+						{
+							Hosts:      []string{"somehost1", "somehost2"},
+							SecretName: "somesecret",
+						},
+					},
+				},
+			},
+			Want: `
+				kube_ingress_info{namespace="ns5",ingress="ingress5"} 1
+				kube_ingress_created{namespace="ns5",ingress="ingress5"} 1.501569018e+09
+				kube_ingress_metadata_resource_version{namespace="ns5",resource_version="abcdef",ingress="ingress5"} 1
+				kube_ingress_labels{label_test_5="test-5",namespace="ns5",ingress="ingress5"} 1
+				kube_ingress_annotations{namespace="ns5",ingress="ingress5",annotation_test_5="test-5"} 1
+				kube_ingress_tls{namespace="ns5",ingress="ingress5",tls_host="somehost1",secret="somesecret"} 1
+				kube_ingress_tls{namespace="ns5",ingress="ingress5",tls_host="somehost2",secret="somesecret"} 1
+`,
+			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_annotations", "kube_ingress_tls"},
 		},
 	}
 	for i, c := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: It adds metrics for the ingress tls host section, indicating which secret is being used for which host.

This is useful to alert in case multiple ingresses are defining different tls secrets for the same host, which could lead to undefined behaviour by some ingress controllers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

