### PR TITLE
Deterministic label ordering

### DIFF
--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -19,6 +19,7 @@ package store
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -59,25 +60,31 @@ func addConditionMetrics(cs v1.ConditionStatus) []*metric.Metric {
 }
 
 func kubeLabelsToPrometheusLabels(labels map[string]string) ([]string, []string) {
-	labelKeys := make([]string, len(labels))
-	labelValues := make([]string, len(labels))
-	i := 0
-	for k, v := range labels {
+	labelKeys := make([]string, 0, len(labels))
+	for k := range labels {
+		labelKeys = append(labelKeys, k)
+	}
+	sort.Strings(labelKeys)
+
+	labelValues := make([]string, 0, len(labels))
+	for i, k := range labelKeys {
 		labelKeys[i] = "label_" + sanitizeLabelName(k)
-		labelValues[i] = v
-		i++
+		labelValues = append(labelValues, labels[k])
 	}
 	return labelKeys, labelValues
 }
 
 func kubeAnnotationsToPrometheusLabels(annotations map[string]string) ([]string, []string) {
-	annotationKeys := make([]string, len(annotations))
-	annotationValues := make([]string, len(annotations))
-	i := 0
-	for k, v := range annotations {
+	annotationKeys := make([]string, 0, len(annotations))
+	for k := range annotations {
+		annotationKeys = append(annotationKeys, k)
+	}
+	sort.Strings(annotationKeys)
+
+	annotationValues := make([]string, 0, len(annotations))
+	for i, k := range annotationKeys {
 		annotationKeys[i] = "annotation_" + sanitizeLabelName(k)
-		annotationValues[i] = v
-		i++
+		annotationValues = append(annotationValues, annotations[k])
 	}
 	return annotationKeys, annotationValues
 }

--- a/internal/store/utils_test.go
+++ b/internal/store/utils_test.go
@@ -167,6 +167,15 @@ func TestKubeLabelsToPrometheusLabels(t *testing.T) {
 			expectKeys:   []string{"label__app5"},
 			expectValues: []string{"starts_with_underscore"},
 		},
+		{
+			kubeLabels: map[string]string{
+				"an":    "",
+				"order": "",
+				"test":  "",
+			},
+			expectKeys:   []string{"label_an", "label_order", "label_test"},
+			expectValues: []string{"", "", ""},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:

Prometheus caches the byte representation of a time-series in a metrics endpoint, so non-deterministic behavior in this ordering causes lots of cache misses in Prometheus' scrape logic. Beyond that, testing these metrics is painful when it's not deterministic.

Discovered this while working on #613 .

@tariq1890 @LiliC @mxinden @andyxning 