### PR TITLE
[Fea] Get failure information for failed pods.

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -8,6 +8,7 @@
 | kube_pod_owner | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  | STABLE |
 | kube_pod_labels | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `label_POD_LABEL`=&lt;POD_LABEL&gt;  | STABLE |
 | kube_pod_status_phase | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `phase`=&lt;Pending\|Running\|Succeeded\|Failed\|Unknown&gt; | STABLE |
+| kube_pod_failure_information | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `reason`=&lt;failure-reason&gt; <br> `message`=&lt;failure-message&gt; | STABLE |
 | kube_pod_status_ready | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_pod_status_scheduled | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_pod_container_info | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `image`=&lt;image-name&gt; <br> `image_id`=&lt;image-id&gt; <br> `container_id`=&lt;containerid&gt; | STABLE |

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -279,6 +279,27 @@ var (
 			}),
 		},
 		{
+			Name: "kube_pod_failure_information",
+			Type: metric.Gauge,
+			Help: "The failed pods failure information (reason and message).",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				phase := p.Status.Phase
+				if phase == v1.PodFailed {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{"reason", "message"},
+						LabelValues: []string{p.Status.Reason, p.Status.Message},
+						Value:       1,
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
 			Name: "kube_pod_status_ready",
 			Type: metric.Gauge,
 			Help: "Describes whether the pod is ready to serve requests.",

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1105,6 +1105,25 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 					Namespace: "ns1",
 				},
 				Status: v1.PodStatus{
+					Phase:   v1.PodFailed,
+					Reason:  "FailureReason",
+					Message: "FailureMessage",
+				},
+			},
+			Want: `
+				# HELP kube_pod_failure_information The failed pods failure information (reason and message).
+	            # TYPE kube_pod_failure_information gauge
+				kube_pod_failure_information{namespace="ns1",reason="FailureReason",message="FailureMessage",pod="pod1"} 1
+			`,
+			MetricNames: []string{"kube_pod_failure_information"},
+		},
+		{
+			Obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "ns1",
+				},
+				Status: v1.PodStatus{
 					Conditions: []v1.PodCondition{
 						{
 							Type:   v1.PodScheduled,
@@ -1541,7 +1560,7 @@ func BenchmarkPodStore(b *testing.B) {
 		},
 	}
 
-	expectedFamilies := 38
+	expectedFamilies := 39
 	for n := 0; n < b.N; n++ {
 		families := f(pod)
 		if len(families) != expectedFamilies {

--- a/main_test.go
+++ b/main_test.go
@@ -174,6 +174,8 @@ kube_pod_status_phase{namespace="default",pod="pod0",phase="Succeeded"} 0
 kube_pod_status_phase{namespace="default",pod="pod0",phase="Failed"} 0
 kube_pod_status_phase{namespace="default",pod="pod0",phase="Running"} 1
 kube_pod_status_phase{namespace="default",pod="pod0",phase="Unknown"} 0
+# HELP kube_pod_failure_information The failed pods failure information (reason and message).
+# TYPE kube_pod_failure_information gauge
 # HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
 # TYPE kube_pod_status_ready gauge
 # HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables, for a pod in Failed phase, to extract information (reason and message) regarding the failure.

The rationale behind this PR is to be able to define and generate _detailed_ alerts using prometheus/alertmanager when pods fail, typically due to eviction.

*Note:*
After some investigation, it seems not possible to list all the possible values for PodStatus.reason and PodStatus.message (see [Kubernetes API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podstatus-v1-core)). 
Therefore, the information retrieval in pod.go file is kind of generic and will be able to collect any strings for failure reason and message.