### PR TITLE
internal/store/pod.go: Remove unnecessary metric

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -900,29 +900,6 @@ var (
 			}),
 		},
 		{
-			Name: "kube_init_pod_container_resource_requests_cpu_cores",
-			Type: metric.Gauge,
-			Help: "The number of requested cpu cores by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					req := c.Resources.Requests
-					if cpu, ok := req[v1.ResourceCPU]; ok {
-						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"container", "node"},
-							LabelValues: []string{c.Name, p.Spec.NodeName},
-							Value:       float64(cpu.MilliValue()) / 1000,
-						})
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		},
-		{
 			Name: "kube_pod_container_resource_requests_memory_bytes",
 			Type: metric.Gauge,
 			Help: "The number of requested memory bytes by a container.",

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1541,7 +1541,7 @@ func BenchmarkPodStore(b *testing.B) {
 		},
 	}
 
-	expectedFamilies := 39
+	expectedFamilies := 38
 	for n := 0; n < b.N; n++ {
 		families := f(pod)
 		if len(families) != expectedFamilies {


### PR DESCRIPTION

**What this PR does / why we need it**:
This was found in https://github.com/kubernetes/kube-state-metrics/pull/851 PR. As per the comment in https://github.com/kubernetes/kube-state-metrics/pull/801#discussion_r298700970  we do not need this metric at all:
> CPU core requests are deprecated for pod containers and should never be added to pod init containers since they are new. This is my bad.

cc @tariq1890 
