### PR TITLE
OWNERS: Removing mxinden

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,10 +2,8 @@ reviewers:
   - brancz
   - andyxning
   - zouyee
-  - mxinden
   - tariq1890
 approvers:
   - brancz
   - andyxning
-  - mxinden
   - tariq1890


### PR DESCRIPTION
**What this PR does / why we need it**:

Given that I have been pretty much inactive the last two month, which I don't foresee to be changing in the near future, I am removing myself from the OWNERS file, thus stepping down as a maintainer.

Happy to see so many people involved, especially with @tariq1890 and @LiliC.

Feel free to ping me any time, in case you have questions e.g. around https://github.com/kubernetes/kube-state-metrics/issues/498.