### PR TITLE
add LiLiC as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,9 @@ reviewers:
   - andyxning
   - zouyee
   - tariq1890
+  - LiliC
 approvers:
   - brancz
   - andyxning
   - tariq1890
+  - LiliC


### PR DESCRIPTION
@LiliC has been contributing to the kube-state-metrics project since a long time. With all of her quality contributions, invaluable improvements to the CI processes and participations in several PR reviews, it's only fitting that we add her to the team.

Welcome @LiliC ! 