### PR TITLE
*: Add list/watch success/error count total metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ See the [`docs`](docs) directory for more information on the exposed metrics.
 kube-state-metrics exposes its own general process metrics under `--telemetry-host` and `--telemetry-port` (default 81).
 
 kube-state-metrics also exposes list and watch success and error metrics. These can be used to calculate the error rate of list or watch resources.
+If you encounter those errors in the metrics, it is most likely a configuration or permission issue, and the next thing to investigate would be looking
+at the logs of kube-state-metrics.
+
 Example of the above mentioned metrics:
 ```
 kube_state_metrics_list_total{resource="*v1.Node",result="success"} 1

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ additional metrics!
 > For now, the following metrics and collectors
 >
 > **metrics**
->	* kube_pod_container_resource_requests_nvidia_gpu_devices
->	* kube_pod_container_resource_limits_nvidia_gpu_devices
->	* kube_node_status_capacity_nvidia_gpu_cards
->	* kube_node_status_allocatable_nvidia_gpu_cards
+>	* `kube_pod_container_resource_requests_nvidia_gpu_devices`
+>	* `kube_pod_container_resource_limits_nvidia_gpu_devices`
+>	* `kube_node_status_capacity_nvidia_gpu_cards`
+>	* `kube_node_status_allocatable_nvidia_gpu_cards`
 >
 >	are removed in kube-state-metrics v1.4.0.
 >
@@ -104,7 +104,16 @@ additional metrics!
 See the [`docs`](docs) directory for more information on the exposed metrics.
 
 ### Kube-state-metrics self metrics
+
 kube-state-metrics exposes its own general process metrics under `--telemetry-host` and `--telemetry-port` (default 81).
+
+kube-state-metrics also exposes list and watch success and error metrics. These can be used to calculate the error rate of list or watch resources.
+Example of the above mentioned metrics:
+```
+kube_state_metrics_list_total{resource="*v1.Node",result="success"} 1
+kube_state_metrics_list_total{resource="*v1.Node",result="error"} 52
+kube_state_metrics_watch_total{resource="*v1beta1.Ingress",result="success"} 1
+```
 
 ### Resource recommendation
 

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/klog"
-
 	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -39,11 +37,12 @@ import (
 	vpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
 	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
 	"k8s.io/kube-state-metrics/pkg/options"
-	"k8s.io/kube-state-metrics/pkg/util/watcher"
+	"k8s.io/kube-state-metrics/pkg/watch"
 )
 
 type whiteBlackLister interface {
@@ -60,22 +59,23 @@ type Builder struct {
 	ctx              context.Context
 	enabledResources []string
 	whiteBlackList   whiteBlackLister
-	metrics          *watcher.ListWatchMetrics
+	metrics          *watch.ListWatchMetrics
 }
 
 // NewBuilder returns a new builder.
-func NewBuilder(
-	ctx context.Context,
-	r *prometheus.Registry,
-) *Builder {
-	metrics := watcher.NewListWatchMetrics(r)
+func NewBuilder(ctx context.Context) *Builder {
 	return &Builder{
-		ctx:     ctx,
-		metrics: metrics,
+		ctx: ctx,
 	}
 }
 
+// WithMetrics sets the metrics property of a Builder.
+func (b *Builder) WithMetrics(r *prometheus.Registry) {
+	b.metrics = watch.NewListWatchMetrics(r)
+}
+
 // WithEnabledResources sets the enabledResources property of a Builder.
+
 func (b *Builder) WithEnabledResources(c []string) error {
 	for _, col := range c {
 		if !collectorExists(col) {
@@ -300,7 +300,7 @@ func (b *Builder) reflectorPerNamespace(
 ) {
 	for _, ns := range b.namespaces {
 		lw := listWatchFunc(b.kubeClient, ns)
-		reflector := cache.NewReflector(watcher.NewInstrumentedListerWatcher(lw, b.metrics, reflect.TypeOf(expectedType).String()), expectedType, store, 0)
+		reflector := cache.NewReflector(watch.NewInstrumentedListerWatcher(lw, b.metrics, reflect.TypeOf(expectedType).String()), expectedType, store, 0)
 		go reflector.Run(b.ctx.Done())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -80,8 +80,10 @@ func main() {
 		opts.Usage()
 		os.Exit(0)
 	}
+	storeBuilder := store.NewBuilder(ctx)
+
 	ksmMetricsRegistry := prometheus.NewRegistry()
-	storeBuilder := store.NewBuilder(ctx, ksmMetricsRegistry)
+	storeBuilder.WithMetrics(ksmMetricsRegistry)
 
 	var collectors []string
 	if len(opts.Collectors) == 0 {

--- a/main.go
+++ b/main.go
@@ -80,8 +80,8 @@ func main() {
 		opts.Usage()
 		os.Exit(0)
 	}
-
-	storeBuilder := store.NewBuilder(ctx)
+	ksmMetricsRegistry := prometheus.NewRegistry()
+	storeBuilder := store.NewBuilder(ctx, ksmMetricsRegistry)
 
 	var collectors []string
 	if len(opts.Collectors) == 0 {
@@ -151,7 +151,6 @@ func main() {
 	storeBuilder.WithKubeClient(kubeClient)
 	storeBuilder.WithVPAClient(vpaClient)
 
-	ksmMetricsRegistry := prometheus.NewRegistry()
 	ksmMetricsRegistry.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 	ksmMetricsRegistry.Register(prometheus.NewGoCollector())
 	go telemetryServer(ksmMetricsRegistry, opts.TelemetryHost, opts.TelemetryPort)

--- a/main_test.go
+++ b/main_test.go
@@ -27,12 +27,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/kube-state-metrics/internal/store"
 	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
 	"k8s.io/kube-state-metrics/pkg/options"
 	"k8s.io/kube-state-metrics/pkg/whiteblacklist"
 
+	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +60,8 @@ func BenchmarkKubeStateMetrics(b *testing.B) {
 	defer cancel()
 	reg := prometheus.NewRegistry()
 
-	builder := store.NewBuilder(ctx, reg)
+	builder := store.NewBuilder(ctx)
+	builder.WithMetrics(reg)
 	builder.WithEnabledResources(options.DefaultCollectors.AsSlice())
 	builder.WithKubeClient(kubeClient)
 	builder.WithNamespaces(options.DefaultNamespaces)
@@ -121,7 +122,8 @@ func TestFullScrapeCycle(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	reg := prometheus.NewRegistry()
-	builder := store.NewBuilder(ctx, reg)
+	builder := store.NewBuilder(ctx)
+	builder.WithMetrics(reg)
 	builder.WithEnabledResources(options.DefaultCollectors.AsSlice())
 	builder.WithKubeClient(kubeClient)
 	builder.WithNamespaces(options.DefaultNamespaces)

--- a/main_test.go
+++ b/main_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/kube-state-metrics/internal/store"
 	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
 	"k8s.io/kube-state-metrics/pkg/options"
@@ -57,7 +58,9 @@ func BenchmarkKubeStateMetrics(b *testing.B) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	builder := store.NewBuilder(ctx)
+	reg := prometheus.NewRegistry()
+
+	builder := store.NewBuilder(ctx, reg)
 	builder.WithEnabledResources(options.DefaultCollectors.AsSlice())
 	builder.WithKubeClient(kubeClient)
 	builder.WithNamespaces(options.DefaultNamespaces)
@@ -117,7 +120,8 @@ func TestFullScrapeCycle(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	builder := store.NewBuilder(ctx)
+	reg := prometheus.NewRegistry()
+	builder := store.NewBuilder(ctx, reg)
 	builder.WithEnabledResources(options.DefaultCollectors.AsSlice())
 	builder.WithKubeClient(kubeClient)
 	builder.WithNamespaces(options.DefaultNamespaces)

--- a/pkg/util/watcher/watch.go
+++ b/pkg/util/watcher/watch.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watcher
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+type ListWatchMetrics struct {
+	WatchTotal *prometheus.CounterVec
+	ListTotal  *prometheus.CounterVec
+}
+
+// NewListWatchMetrics takes in a prometheus registry and initializes
+// and registers the kube_state_metrics_list_total and kube_state_metrics_watch_total
+// metrics. It returns those registered metrics.
+func NewListWatchMetrics(r *prometheus.Registry) *ListWatchMetrics {
+	var m ListWatchMetrics
+	m.WatchTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kube_state_metrics_watch_total",
+			Help: "Number of total resource watches in kube-state-metrics",
+		},
+		[]string{"result", "resource"},
+	)
+
+	m.ListTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kube_state_metrics_list_total",
+			Help: "Number of total resource list in kube-state-metrics",
+		},
+		[]string{"result", "resource"},
+	)
+	if r != nil {
+		r.Register(m.WatchTotal)
+		r.Register(m.ListTotal)
+	}
+	return &m
+}
+
+type InstrumentedListerWatcher struct {
+	lw       cache.ListerWatcher
+	metrics  *ListWatchMetrics
+	resource string
+}
+
+// NewInstrumentedListerWatcher returns a new InstrumentedListerWatcher.
+func NewInstrumentedListerWatcher(lw cache.ListerWatcher, metrics *ListWatchMetrics, resource string) cache.ListerWatcher {
+	return &InstrumentedListerWatcher{
+		lw:       lw,
+		metrics:  metrics,
+		resource: resource,
+	}
+}
+
+// List is a wraper func around the cache.ListerWatcher.List func. It also increases the counter whenever any
+// errors occur with trying to list a resource.
+func (i *InstrumentedListerWatcher) List(options metav1.ListOptions) (res runtime.Object, err error) {
+	res, err = i.lw.List(options)
+	if err != nil {
+		i.metrics.ListTotal.WithLabelValues("error", i.resource).Inc()
+		return
+	}
+
+	i.metrics.ListTotal.WithLabelValues("success", i.resource).Inc()
+	return
+}
+
+// Watch is a wraper func around the cache.ListerWatcher.Watch func. It also increases the counter whenever any
+// errors occur when trying to watch a resource.
+func (i *InstrumentedListerWatcher) Watch(options metav1.ListOptions) (res watch.Interface, err error) {
+	res, err = i.lw.Watch(options)
+	if err != nil {
+		i.metrics.WatchTotal.WithLabelValues("error", i.resource).Inc()
+		return
+	}
+
+	i.metrics.WatchTotal.WithLabelValues("success", i.resource).Inc()
+	return
+}

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package watcher
+package watch
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,8 +31,8 @@ type ListWatchMetrics struct {
 }
 
 // NewListWatchMetrics takes in a prometheus registry and initializes
-// and registers the kube_state_metrics_list_total and kube_state_metrics_watch_total
-// metrics. It returns those registered metrics.
+// and registers the kube_state_metrics_list_total and
+// kube_state_metrics_watch_total metrics. It returns those registered metrics.
 func NewListWatchMetrics(r *prometheus.Registry) *ListWatchMetrics {
 	var m ListWatchMetrics
 	m.WatchTotal = prometheus.NewCounterVec(
@@ -72,8 +72,8 @@ func NewInstrumentedListerWatcher(lw cache.ListerWatcher, metrics *ListWatchMetr
 	}
 }
 
-// List is a wraper func around the cache.ListerWatcher.List func. It also increases the counter whenever any
-// errors occur with trying to list a resource.
+// List is a wrapper func around the cache.ListerWatcher.List func. It increases the success/error
+// / counters based on the outcome of the List operation it instruments.
 func (i *InstrumentedListerWatcher) List(options metav1.ListOptions) (res runtime.Object, err error) {
 	res, err = i.lw.List(options)
 	if err != nil {
@@ -85,8 +85,8 @@ func (i *InstrumentedListerWatcher) List(options metav1.ListOptions) (res runtim
 	return
 }
 
-// Watch is a wraper func around the cache.ListerWatcher.Watch func. It also increases the counter whenever any
-// errors occur when trying to watch a resource.
+// Watch is a wrapper func around the cache.ListerWatcher.Watch func. It increases the success/error
+// counters based on the outcome of the Watch operation it instruments.
 func (i *InstrumentedListerWatcher) Watch(options metav1.ListOptions) (res watch.Interface, err error) {
 	res, err = i.lw.Watch(options)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

When kube-state-metrics does not have the correct roles to list or watch on
a resource, it just logs this error but not actually error out. This
is a problem as the pod never restarts and it is hard to catch any
problems as other resource metrics continue to be created correctly. We
only see this error in the noisy kube-state-metrics logs.

This registers two metrics `kube_state_metrics_watch_total` and
`kube_state_metrics_list_total`. With the following labels:
"result" label is the type of action count relates to, error or success.
"resource" label contains the resource <apiVersion.Kind>.

This way we can do a rate alert when kube-state-metrics error rate is
too high.

Example of the metrics:
```
kube_state_metrics_list_total{resource="*v1.Namespace",result="success"} 1
kube_state_metrics_list_total{resource="*v1.Node",result="error"} 52
kube_state_metrics_watch_total{resource="*v1beta1.Ingress",result="success"} 1
```

*Note:* We can also use this new metric in our e2e tests, but I would suggest we migrate our e2e tests from bash to `go`. As parsing the metric on only certain resources that have errors, finding the rate etc. is complex in bash (at least my regex skills are not that good), but we can easily do that in go by using the prometheus library. 
I would suggest to split this up in follow-up PRs, one PR to convert the e2e tests to go, and there we can add this test as well. I can put a TODO maybe in the e2e test to not forget to add this. WDYT?


cc @brancz @tariq1890 