### PR TITLE
lint: enforce goimports local prefixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
     - gofmt
     - goimports
     - golint
-    - gosimple
+    - staticcheck
     - gocyclo
     - ineffassign
     - misspell
@@ -16,4 +16,4 @@ linters:
 
 linters-settings:
   goimports:
-local-prefixes: k8s.io/kube-state-metrics
+    local-prefixes: k8s.io/kube-state-metrics

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -37,6 +37,7 @@ import (
 	vpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
 	"k8s.io/kube-state-metrics/pkg/options"

--- a/internal/store/certificatesigningrequest_test.go
+++ b/internal/store/certificatesigningrequest_test.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	certv1beta1 "k8s.io/api/certificates/v1beta1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -18,13 +18,13 @@ package store
 
 import (
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/kube-state-metrics/pkg/metric"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
 var (

--- a/internal/store/configmap_test.go
+++ b/internal/store/configmap_test.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -21,13 +21,13 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/robfig/cron/v3"
-
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
@@ -230,5 +230,5 @@ func getNextScheduledTime(schedule string, lastScheduleTime *metav1.Time, create
 	if !createdTime.IsZero() {
 		return sched.Next(createdTime.Time), nil
 	}
-	return time.Time{}, errors.New("Created time and lastScheduleTime are both zero")
+	return time.Time{}, errors.New("createdTime and lastScheduleTime are both zero")
 }

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -25,6 +25,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/daemonset_test.go
+++ b/internal/store/daemonset_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -18,13 +18,13 @@ package store
 
 import (
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/kube-state-metrics/pkg/metric"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
 var (

--- a/internal/store/endpoint_test.go
+++ b/internal/store/endpoint_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -19,10 +19,10 @@ package store
 import (
 	"testing"
 
-	v12 "k8s.io/api/core/v1"
-
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
@@ -76,7 +76,7 @@ func TestHPAStore(t *testing.T) {
 					Conditions: []autoscaling.HorizontalPodAutoscalerCondition{
 						{
 							Type:   autoscaling.AbleToScale,
-							Status: v12.ConditionTrue,
+							Status: v1.ConditionTrue,
 						},
 					},
 				},

--- a/internal/store/ingress_test.go
+++ b/internal/store/ingress_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/job_test.go
+++ b/internal/store/job_test.go
@@ -23,6 +23,7 @@ import (
 	v1batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/limitrange.go
+++ b/internal/store/limitrange.go
@@ -18,13 +18,13 @@ package store
 
 import (
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/kube-state-metrics/pkg/metric"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
 var (

--- a/internal/store/limitrange_test.go
+++ b/internal/store/limitrange_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/namespace_test.go
+++ b/internal/store/namespace_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/persistentvolume_test.go
+++ b/internal/store/persistentvolume_test.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/persistentvolumeclaim_test.go
+++ b/internal/store/persistentvolumeclaim_test.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -18,13 +18,13 @@ package store
 
 import (
 	"k8s.io/api/policy/v1beta1"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/kube-state-metrics/pkg/metric"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
 var (

--- a/internal/store/poddisruptionbudget_test.go
+++ b/internal/store/poddisruptionbudget_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/replicaset_test.go
+++ b/internal/store/replicaset_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -18,13 +18,13 @@ package store
 
 import (
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/kube-state-metrics/pkg/metric"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
 var (

--- a/internal/store/replicationcontroller_test.go
+++ b/internal/store/replicationcontroller_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/resourcequota.go
+++ b/internal/store/resourcequota.go
@@ -18,13 +18,13 @@ package store
 
 import (
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/kube-state-metrics/pkg/metric"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
 var (

--- a/internal/store/resourcequota_test.go
+++ b/internal/store/resourcequota_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -18,13 +18,13 @@ package store
 
 import (
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/kube-state-metrics/pkg/metric"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
 var (

--- a/internal/store/secret_test.go
+++ b/internal/store/secret_test.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -18,13 +18,13 @@ package store
 
 import (
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/kube-state-metrics/pkg/metric"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
 var (

--- a/internal/store/service_test.go
+++ b/internal/store/service_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/statefulset_test.go
+++ b/internal/store/statefulset_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/storageclass_test.go
+++ b/internal/store/storageclass_test.go
@@ -19,6 +19,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -21,7 +21,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"time"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 
@@ -31,7 +30,6 @@ import (
 )
 
 var (
-	resyncPeriod       = 5 * time.Minute
 	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 	conditionStatuses  = []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionUnknown}
 )

--- a/internal/store/verticalpodautoscaler.go
+++ b/internal/store/verticalpodautoscaler.go
@@ -21,12 +21,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/kube-state-metrics/pkg/constant"
-
 	autoscaling "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	vpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/pkg/constant"
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/internal/store/verticalpodautoscaler_test.go
+++ b/internal/store/verticalpodautoscaler_test.go
@@ -19,12 +19,12 @@ package store
 import (
 	"testing"
 
+	k8sautoscaling "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	k8sautoscaling "k8s.io/api/autoscaling/v1"
 	autoscaling "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 )
 

--- a/tests/lib/lib_test.go
+++ b/tests/lib/lib_test.go
@@ -29,6 +29,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+
 	"k8s.io/kube-state-metrics/pkg/metric"
 	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
 )


### PR DESCRIPTION
Raising this PR because I was wondering why the `goimports` settings were never being enforced. Turns out, it was a YAML format fail in `.golangci.yml` *facepalm*. This PR corrects that.