### PR TITLE
use MustRegister instead of Register

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	vpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	clientset "k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -153,8 +152,10 @@ func main() {
 	storeBuilder.WithKubeClient(kubeClient)
 	storeBuilder.WithVPAClient(vpaClient)
 
-	ksmMetricsRegistry.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-	ksmMetricsRegistry.Register(prometheus.NewGoCollector())
+	ksmMetricsRegistry.MustRegister(
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		prometheus.NewGoCollector(),
+	)
 	go telemetryServer(ksmMetricsRegistry, opts.TelemetryHost, opts.TelemetryPort)
 
 	stores := storeBuilder.Build()

--- a/pkg/watch/watch.go
+++ b/pkg/watch/watch.go
@@ -18,7 +18,6 @@ package watch
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -51,8 +50,10 @@ func NewListWatchMetrics(r *prometheus.Registry) *ListWatchMetrics {
 		[]string{"result", "resource"},
 	)
 	if r != nil {
-		r.Register(m.WatchTotal)
-		r.Register(m.ListTotal)
+		r.MustRegister(
+			m.ListTotal,
+			m.WatchTotal,
+		)
 	}
 	return &m
 }


### PR DESCRIPTION
Minor code improvment. Using MustRegister removes the unhandled error warning and allows for variadic args. 