### PR TITLE
store: add kube_node_role metric

### DIFF
--- a/docs/node-metrics.md
+++ b/docs/node-metrics.md
@@ -4,6 +4,7 @@
 | ---------- | ----------- | ----------- | ----------- |
 | kube_node_info | Gauge | `node`=&lt;node-address&gt; <br> `kernel_version`=&lt;kernel-version&gt; <br> `os_image`=&lt;os-image-name&gt; <br> `container_runtime_version`=&lt;container-runtime-and-version-combination&gt; <br> `kubelet_version`=&lt;kubelet-version&gt; <br> `kubeproxy_version`=&lt;kubeproxy-version&gt; <br> `provider_id`=&lt;provider-id&gt; | STABLE |
 | kube_node_labels | Gauge | `node`=&lt;node-address&gt; <br> `label_NODE_LABEL`=&lt;NODE_LABEL&gt;  | STABLE |
+| kube_node_role | Gauge | `node`=&lt;node-address&gt; <br> `role`=&lt;NODE_ROLE&gt; | EXPERIMENTAL |
 | kube_node_spec_unschedulable | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_spec_taint | Gauge | `node`=&lt;node-address&gt; <br> `key`=&lt;taint-key&gt; <br> `value=`&lt;taint-value&gt; <br> `effect=`&lt;taint-effect&gt; | STABLE |
 | kube_node_status_phase| Gauge | `node`=&lt;node-address&gt; <br> `phase`=&lt;Pending\|Running\|Terminated&gt; | DEPRECATED |

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -17,6 +17,8 @@ limitations under the License.
 package store
 
 import (
+	"strings"
+
 	"k8s.io/kube-state-metrics/pkg/constant"
 	"k8s.io/kube-state-metrics/pkg/metric"
 
@@ -97,6 +99,27 @@ var (
 							Value:       1,
 						},
 					},
+				}
+			}),
+		},
+		{
+			Name: "kube_node_role",
+			Type: metric.Gauge,
+			Help: "The role of a cluster node.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+				const prefix = "node-role.kubernetes.io/"
+				ms := []*metric.Metric{}
+				for lbl := range n.Labels {
+					if strings.HasPrefix(lbl, prefix) {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"role"},
+							LabelValues: []string{strings.TrimPrefix(lbl, prefix)},
+							Value:       float64(1),
+						})
+					}
+				}
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		},

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -68,7 +68,7 @@ func TestNodeStore(t *testing.T) {
 					Name:              "127.0.0.1",
 					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 					Labels: map[string]string{
-						"type": "master",
+						"node-role.kubernetes.io/master": "",
 					},
 				},
 				Spec: v1.NodeSpec{
@@ -105,6 +105,7 @@ func TestNodeStore(t *testing.T) {
 		# HELP kube_node_created Unix creation timestamp
 		# HELP kube_node_info Information about a cluster node.
 		# HELP kube_node_labels Kubernetes labels converted to Prometheus labels.
+		# HELP kube_node_role The role of a cluster node.
 		# HELP kube_node_spec_unschedulable Whether a node can schedule new pods.
 		# HELP kube_node_status_allocatable The allocatable for different resources of a node that are available for scheduling.
 		# HELP kube_node_status_allocatable_cpu_cores The CPU resources of a node that are available for scheduling.
@@ -117,6 +118,7 @@ func TestNodeStore(t *testing.T) {
 		# TYPE kube_node_created gauge
 		# TYPE kube_node_info gauge
 		# TYPE kube_node_labels gauge
+		# TYPE kube_node_role gauge
 		# TYPE kube_node_spec_unschedulable gauge
 		# TYPE kube_node_status_allocatable gauge
 		# TYPE kube_node_status_allocatable_cpu_cores gauge
@@ -128,7 +130,8 @@ func TestNodeStore(t *testing.T) {
 		# TYPE kube_node_status_capacity_pods gauge
 		kube_node_created{node="127.0.0.1"} 1.5e+09
         kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",provider_id="provider://i-randomidentifier"} 1
-        kube_node_labels{label_type="master",node="127.0.0.1"} 1
+		kube_node_labels{label_node_role_kubernetes_io_master="",node="127.0.0.1"} 1
+		kube_node_role{node="127.0.0.1",role="master"} 1
         kube_node_spec_unschedulable{node="127.0.0.1"} 1
         kube_node_status_allocatable_cpu_cores{node="127.0.0.1"} 3
         kube_node_status_allocatable_memory_bytes{node="127.0.0.1"} 1e+09
@@ -149,7 +152,21 @@ func TestNodeStore(t *testing.T) {
         kube_node_status_capacity{node="127.0.0.1",resource="pods",unit="integer"} 1000
         kube_node_status_capacity{node="127.0.0.1",resource="storage",unit="byte"} 3e+09
 			`,
-			MetricNames: []string{"kube_node_status_capacity", "kube_node_status_capacity_pods", "kube_node_status_capacity_memory_bytes", "kube_node_status_capacity_cpu_cores", "kube_node_status_allocatable", "kube_node_status_allocatable_pods", "kube_node_status_allocatable_memory_bytes", "kube_node_status_allocatable_cpu_cores", "kube_node_spec_unschedulable", "kube_node_labels", "kube_node_info", "kube_node_created"},
+			MetricNames: []string{
+				"kube_node_status_capacity",
+				"kube_node_status_capacity_pods",
+				"kube_node_status_capacity_memory_bytes",
+				"kube_node_status_capacity_cpu_cores",
+				"kube_node_status_allocatable",
+				"kube_node_status_allocatable_pods",
+				"kube_node_status_allocatable_memory_bytes",
+				"kube_node_status_allocatable_cpu_cores",
+				"kube_node_spec_unschedulable",
+				"kube_node_labels",
+				"kube_node_role",
+				"kube_node_info",
+				"kube_node_created",
+			},
 		},
 		// Verify phase enumerations.
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a `kube_node_role` metric for node roles based on `node-role.kubernetes.io/<ROLE>` node labels.

This is implemented like `kube_node_spec_taint` where each taint is a separate metric in the same family, as opposed to `kube_node_labels` where each label is mapped to the same metric and family.

I've tried to implement this with recording rules on top of `kube_node_labels`, but an empty `node-role.kubernetes.io/<ROLE>` label value is valid and, as far as i can tell, there's no way to differentiate between a missing label and an empty value in a query. Further, every possible role must be known in advance to query for the expected labels.

**Which issue(s) this PR fixes**
N/A