### PR TITLE
pin go version to go mod artifact file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,3 +25,5 @@ require (
 	k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580 // indirect
 	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect
 )
+
+go 1.12


### PR DESCRIPTION
This PR is to make sure that we can that smoothly transition to the next go version. It is recommended as a best practice to pin the go version in the `go mod` file. This is because the `go 1.13` auto-adds this version pin to the `go mod` and hence causes CI tests to while when we switch git branch while running `test-benchcmp-compare`.

IMPORTANT: This has to go in before #881 