### PR TITLE
deployment status conditions

### DIFF
--- a/docs/deployment-metrics.md
+++ b/docs/deployment-metrics.md
@@ -7,6 +7,7 @@
 | kube_deployment_status_replicas_unavailable | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_status_replicas_updated | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_status_observed_generation | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
+| kube_deployment_status_condition | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; <br> `condition`=&lt;deployment-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_deployment_spec_replicas | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_spec_paused | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_spec_strategy_rollingupdate_max_unavailable | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -123,6 +123,30 @@ var (
 			}),
 		},
 		{
+			Name: "kube_deployment_status_condition",
+			Type: metric.Gauge,
+			Help: "The current status conditions of a deployment.",
+			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				ms := make([]*metric.Metric, len(d.Status.Conditions)*len(conditionStatuses))
+
+				for i, c := range d.Status.Conditions {
+					conditionMetrics := addConditionMetrics(c.Status)
+
+					for j, m := range conditionMetrics {
+						metric := m
+
+						metric.LabelKeys = []string{"condition", "status"}
+						metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
+						ms[i*len(conditionStatuses)+j] = metric
+					}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
 			Name: "kube_deployment_spec_replicas",
 			Type: metric.Gauge,
 			Help: "Number of desired pods for a deployment.",

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -60,6 +61,8 @@ func TestDeploymentStore(t *testing.T) {
 		# TYPE kube_deployment_status_replicas_updated gauge
 		# HELP kube_deployment_status_observed_generation The generation observed by the deployment controller.
 		# TYPE kube_deployment_status_observed_generation gauge
+		# HELP kube_deployment_status_condition The current status conditions of a deployment.
+		# TYPE kube_deployment_status_condition gauge
 		# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable Maximum number of unavailable replicas during a rolling update of a deployment.
 		# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
 		# HELP kube_deployment_spec_strategy_rollingupdate_max_surge Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
@@ -85,6 +88,10 @@ func TestDeploymentStore(t *testing.T) {
 					UnavailableReplicas: 5,
 					UpdatedReplicas:     2,
 					ObservedGeneration:  111,
+					Conditions: []v1.DeploymentCondition{
+						{Type: v1.DeploymentAvailable, Status: corev1.ConditionTrue},
+						{Type: v1.DeploymentProgressing, Status: corev1.ConditionTrue},
+					},
 				},
 				Spec: v1.DeploymentSpec{
 					Replicas: &depl1Replicas,
@@ -109,6 +116,12 @@ func TestDeploymentStore(t *testing.T) {
         kube_deployment_status_replicas_unavailable{deployment="depl1",namespace="ns1"} 5
         kube_deployment_status_replicas_updated{deployment="depl1",namespace="ns1"} 2
         kube_deployment_status_replicas{deployment="depl1",namespace="ns1"} 15
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="true"} 1
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="true"} 1
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="false"} 0
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="false"} 0
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="unknown"} 0
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="unknown"} 0
 `,
 		},
 		{
@@ -127,6 +140,11 @@ func TestDeploymentStore(t *testing.T) {
 					UnavailableReplicas: 0,
 					UpdatedReplicas:     1,
 					ObservedGeneration:  1111,
+					Conditions: []v1.DeploymentCondition{
+						{Type: v1.DeploymentAvailable, Status: corev1.ConditionFalse},
+						{Type: v1.DeploymentProgressing, Status: corev1.ConditionFalse},
+						{Type: v1.DeploymentReplicaFailure, Status: corev1.ConditionTrue},
+					},
 				},
 				Spec: v1.DeploymentSpec{
 					Paused:   true,
@@ -151,6 +169,15 @@ func TestDeploymentStore(t *testing.T) {
         kube_deployment_status_replicas_unavailable{deployment="depl2",namespace="ns2"} 0
         kube_deployment_status_replicas_updated{deployment="depl2",namespace="ns2"} 1
         kube_deployment_status_replicas{deployment="depl2",namespace="ns2"} 10
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="true"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="true"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="true"} 1
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="false"} 1
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="false"} 1
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="false"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="unknown"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="unknown"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="unknown"} 0
 `,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Deployments, like Nodes, have status conditions observing the
current state. While the state of Available and Progressing conditions
can likely be inferred by other metrics, the state of ReplicaFailure can
not be inferred.

This changelist adds a new metric `kube_deployment_status_condition`
that observes all the conditions on a deployment for each condition
status. This is analogous to the status conditions observed by nodes and
horizontal pod autoscalers, and allows kube-state-metrics to observe
status conditions added by third-parties.

As an example, for a deployment that has stalled, the following new
metrics observed would allow an operator to detect the condition:

    kube_deployment_status_condition{deployment="example", namespace="default", condition="ReplicaFailure", status="true"} 1
    kube_deployment_status_condition{deployment="example", namespace="default", condition="ReplicaFailure", status="false"} 0
    kube_deployment_status_condition{deployment="example", namespace="default", condition="ReplicaFailure", status="unknown"} 0

**Which issue(s) this PR fixes**:
Fixes #886 

