### PR TITLE
correct hpa condition status

### DIFF
--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -7,5 +7,5 @@
 | kube_hpa_spec_min_replicas        | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_hpa_status_current_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_hpa_status_desired_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
-| kube_hpa_status_condition         | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_hpa_status_condition         | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_hpa_labels                   | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |

--- a/internal/store/hpa.go
+++ b/internal/store/hpa.go
@@ -133,7 +133,7 @@ var (
 					for j, m := range metrics {
 						metric := m
 						metric.LabelKeys = []string{"condition", "status"}
-						metric.LabelValues = append(metric.LabelValues, string(c.Type))
+						metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
 						ms[i*len(conditionStatuses)+j] = metric
 					}
 				}

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -44,10 +44,10 @@ func TestHPAStore(t *testing.T) {
 		# TYPE kube_hpa_status_current_replicas gauge
 		# HELP kube_hpa_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
 		# TYPE kube_hpa_status_desired_replicas gauge
-        # HELP kube_hpa_status_condition The condition of this autoscaler.
-        # TYPE kube_hpa_status_condition gauge
-        # HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
-        # TYPE kube_hpa_labels gauge
+		# HELP kube_hpa_status_condition The condition of this autoscaler.
+		# TYPE kube_hpa_status_condition gauge
+		# HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
+		# TYPE kube_hpa_labels gauge
 	`
 	cases := []generateMetricsTestCase{
 		{
@@ -82,13 +82,13 @@ func TestHPAStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-                kube_hpa_labels{hpa="hpa1",label_app="foobar",namespace="ns1"} 1
+				kube_hpa_labels{hpa="hpa1",label_app="foobar",namespace="ns1"} 1
 				kube_hpa_metadata_generation{hpa="hpa1",namespace="ns1"} 2
 				kube_hpa_spec_max_replicas{hpa="hpa1",namespace="ns1"} 4
 				kube_hpa_spec_min_replicas{hpa="hpa1",namespace="ns1"} 2
-                kube_hpa_status_condition{condition="false",hpa="hpa1",namespace="ns1",status="AbleToScale"} 0
-                kube_hpa_status_condition{condition="true",hpa="hpa1",namespace="ns1",status="AbleToScale"} 1
-                kube_hpa_status_condition{condition="unknown",hpa="hpa1",namespace="ns1",status="AbleToScale"} 0
+				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="false"} 0
+				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="true"} 1
+				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="unknown"} 0
 				kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
 				kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
 			`,


### PR DESCRIPTION
:rotating_light: This may be considered a breaking change. :rotating_light: 

**What this PR does / why we need it**:

The status and condition labels for horizontal pod autoscalers status
condition metrics are reversed. This CL corrects the order.

**Which issue(s) this PR fixes**: