### PR TITLE
bump golangci-lint to latest stable release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PKG = k8s.io/kube-state-metrics/pkg
 GO_VERSION = 1.13
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell go env GOPATH)))
 BENCHCMP_BINARY := $(FIRST_GOPATH)/bin/benchcmp
-GOLANGCI_VERSION := v1.17.1
+GOLANGCI_VERSION := v1.18.0
 HAS_GOLANGCI := $(shell which golangci-lint)
 
 IMAGE = $(REGISTRY)/kube-state-metrics


### PR DESCRIPTION
Older versions of Golangci-lint has been known to run into issues with the `go1.13` runtime. The latest release contains the fix for them

[Details](https://github.com/golangci/golangci-lint/blob/master/CHANGELOG.md#september-2019)