### PR TITLE
fix shell script bug in licensecheck logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ licensecheck:
 	@licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*') ; do \
                awk 'NR<=5' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
        done); \
-       if [[ -n "$${licRes}" ]]; then \
+       if [ -n "$${licRes}" ]; then \
                echo "license header checking failed:"; echo "$${licRes}"; \
                exit 1; \
        fi


### PR DESCRIPTION
Found this issue while reviewing #893. This was a bug introduced by me as `[[` is a bashism and not supported in `/bin/sh`