### PR TITLE
adds kube-state-metrics slack channel to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 
 ## Contact Information
 
-- [Slack channel](https://kubernetes.slack.com/?redir=%2Fmessages%2FCJJ529RUY) - Open channel that can be used by people who have questions about the project. It offers an alternative to submitting a Github issue;
+- [Slack channel](https://kubernetes.slack.com/?redir=%2Fmessages%2FCJJ529RUY) - A channel that can be used by people who have questions about the project. It offers an alternative to submitting a Github issue;
 
 <!---
 Custom Information - if you're copying this template for the first time you can add custom content here, for example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,10 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 
 - [Mentoring Initiatives](https://git.k8s.io/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!
 
+## Contact Information
+
+- [Slack channel](https://kubernetes.slack.com/?redir=%2Fmessages%2FCJJ529RUY) - Open channel that can be used by people who have questions about the project. It offers an alternative to submitting a Github issue;
+
 <!---
 Custom Information - if you're copying this template for the first time you can add custom content here, for example:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
It adds the slack `kube-state-metrics` link to CONTRIBUTING.md. It's helpful for those who wants to contribute and needs to clarify some doubts about this project.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #930

