### PR TITLE
Enable unconvert linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - misspell
     - gocritic
     - govet
+    - unconvert
 
 linters-settings:
   goimports:

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -74,7 +74,7 @@ var (
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"resource_version"},
-							LabelValues: []string{string(c.ObjectMeta.ResourceVersion)},
+							LabelValues: []string{c.ObjectMeta.ResourceVersion},
 							Value:       1,
 						},
 					},

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -91,7 +91,7 @@ var (
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"resource_version"},
-							LabelValues: []string{string(i.ObjectMeta.ResourceVersion)},
+							LabelValues: []string{i.ObjectMeta.ResourceVersion},
 							Value:       1,
 						},
 					}}

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -72,7 +72,7 @@ var (
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"resource_version"},
-							LabelValues: []string{string(mwc.ObjectMeta.ResourceVersion)},
+							LabelValues: []string{mwc.ObjectMeta.ResourceVersion},
 							Value:       1,
 						},
 					},

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -108,7 +108,7 @@ var (
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"resource_version"},
-							LabelValues: []string{string(s.ObjectMeta.ResourceVersion)},
+							LabelValues: []string{s.ObjectMeta.ResourceVersion},
 							Value:       1,
 						},
 					},

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -90,7 +90,7 @@ func isExtendedResourceName(name v1.ResourceName) bool {
 	}
 	// Ensure it satisfies the rules in IsQualifiedName() after converted into quota resource name
 	nameForQuota := fmt.Sprintf("%s%s", v1.DefaultResourceRequestsPrefix, string(name))
-	if errs := validation.IsQualifiedName(string(nameForQuota)); len(errs) != 0 {
+	if errs := validation.IsQualifiedName(nameForQuota); len(errs) != 0 {
 		return false
 	}
 	return true

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -72,7 +72,7 @@ var (
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   []string{"resource_version"},
-							LabelValues: []string{string(vwc.ObjectMeta.ResourceVersion)},
+							LabelValues: []string{vwc.ObjectMeta.ResourceVersion},
 							Value:       1,
 						},
 					},

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -159,7 +159,7 @@ func (s *MetricsStore) WriteAll(w io.Writer) {
 		w.Write([]byte(help))
 		w.Write([]byte{'\n'})
 		for _, metricFamilies := range s.metrics {
-			w.Write([]byte(metricFamilies[i]))
+			w.Write(metricFamilies[i])
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the unconvert linter and fixes various issues across the code base where type conversion is unnecessary. The PR aims to improve code readability.

Hope this is useful!