### PR TITLE
Remove unnecessary type conversion

### DIFF
--- a/pkg/metric/metric_test.go
+++ b/pkg/metric/metric_test.go
@@ -61,7 +61,7 @@ func BenchmarkMetricWrite(b *testing.B) {
 			metric: Metric{
 				LabelKeys:   []string{"container", "container_id", "image", "image_id", "namespace", "pod"},
 				LabelValues: []string{"container2", "docker://cd456", "k8s.gcr.io/hyperkube2", "docker://sha256:bbb", "ns2", "pod2"},
-				Value:       float64(35.7),
+				Value:       35.7,
 			},
 			expectedLength: 148,
 		},

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -108,7 +108,7 @@ func (m *MetricsHandler) Run(ctx context.Context) error {
 	statefulSetName := ss.Name
 
 	labelSelectorOptions := func(o *metav1.ListOptions) {
-		o.LabelSelector = fields.SelectorFromSet(fields.Set(ss.Labels)).String()
+		o.LabelSelector = fields.SelectorFromSet(ss.Labels).String()
 	}
 
 	i := cache.NewSharedIndexInformer(

--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -73,7 +73,7 @@ func (s *shardedListWatch) Watch(options metav1.ListOptions) (watch.Interface, e
 		return nil, err
 	}
 
-	return watch.Filter(w, watch.FilterFunc(func(in watch.Event) (out watch.Event, keep bool) {
+	return watch.Filter(w, func(in watch.Event) (out watch.Event, keep bool) {
 		a, err := meta.Accessor(in.Object)
 		if err != nil {
 			// TODO(brancz): needs logging
@@ -81,7 +81,7 @@ func (s *shardedListWatch) Watch(options metav1.ListOptions) (watch.Interface, e
 		}
 
 		return in, s.sharding.keep(a)
-	})), nil
+	}), nil
 }
 
 type sharding struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow up to PR #934 to remove some more unnecessary type conversions. The aim is to improve readability.
