### PR TITLE
Pre-allocation of slices

### DIFF
--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -48,16 +48,11 @@ func (ms *MetricSet) Set(value string) error {
 
 // asSlice returns the MetricSet in the form of plain string slice.
 func (ms MetricSet) asSlice() []string {
-	metrics := []string{}
+	metrics := make([]string, 0, len(ms))
 	for metric := range ms {
 		metrics = append(metrics, metric)
 	}
 	return metrics
-}
-
-// IsEmpty returns true if the length of the MetricSet is zero.
-func (ms MetricSet) IsEmpty() bool {
-	return len(ms.asSlice()) == 0
 }
 
 // Type returns a descriptive string about the MetricSet type.
@@ -90,16 +85,11 @@ func (c *CollectorSet) Set(value string) error {
 
 // AsSlice returns the Collector in the form of a plain string slice.
 func (c CollectorSet) AsSlice() []string {
-	cols := []string{}
+	cols := make([]string, 0, len(c))
 	for col := range c {
 		cols = append(cols, col)
 	}
 	return cols
-}
-
-// isEmpty() returns true if the length of the CollectorSet is zero.
-func (c CollectorSet) isEmpty() bool {
-	return len(c.AsSlice()) == 0
 }
 
 // Type returns a descriptive string about the CollectorSet type.

--- a/pkg/whiteblacklist/whiteblacklist.go
+++ b/pkg/whiteblacklist/whiteblacklist.go
@@ -32,25 +32,22 @@ type WhiteBlackList struct {
 
 // New constructs a new WhiteBlackList based on a white- and a
 // blacklist. Only one of them can be not empty.
-func New(w, b map[string]struct{}) (*WhiteBlackList, error) {
-	if len(w) != 0 && len(b) != 0 {
+func New(white, black map[string]struct{}) (*WhiteBlackList, error) {
+	if len(white) != 0 && len(black) != 0 {
 		return nil, errors.New(
 			"whitelist and blacklist are both set, they are mutually exclusive, only one of them can be set",
 		)
 	}
-
-	white := copyList(w)
-	black := copyList(b)
 
 	var list map[string]struct{}
 	var isWhiteList bool
 
 	// Default to blacklisting
 	if len(white) != 0 {
-		list = white
+		list = copyList(white)
 		isWhiteList = true
 	} else {
-		list = black
+		list = copyList(black)
 		isWhiteList = false
 	}
 
@@ -62,7 +59,7 @@ func New(w, b map[string]struct{}) (*WhiteBlackList, error) {
 
 // Parse parses and compiles all of the regexes in the whiteBlackList.
 func (l *WhiteBlackList) Parse() error {
-	var regexes []*regexp.Regexp
+	regexes := make([]*regexp.Regexp, 0, len(l.list))
 	for item := range l.list {
 		r, err := regexp.Compile(item)
 		if err != nil {
@@ -125,7 +122,7 @@ func (l *WhiteBlackList) IsExcluded(item string) bool {
 // Status returns the status of the WhiteBlackList that can e.g. be passed into
 // a logger.
 func (l *WhiteBlackList) Status() string {
-	items := []string{}
+	items := make([]string, 0, len(l.list))
 	for key := range l.list {
 		items = append(items, key)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cleans up collector/metric set code to make sure slices are pre-allocated when conversion from maps occurs. It also cleans up the IsEmpty functions to check size of underlying map rather than doing a conversion to a slice.

The PR also cleans up whitelist/blacklist code to make sure that slices are pre-allocated.