### PR TITLE
Modify label(snake_case from camelCase) key in kube_storageclass_info…

### DIFF
--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -49,7 +49,7 @@ var (
 				}
 
 				m := metric.Metric{
-					LabelKeys:   []string{"provisioner", "reclaimPolicy", "volumeBindingMode"},
+					LabelKeys:   []string{"provisioner", "reclaim_policy", "volume_binding_mode"},
 					LabelValues: []string{s.Provisioner, string(*s.ReclaimPolicy), string(*s.VolumeBindingMode)},
 					Value:       1,
 				}

--- a/internal/store/storageclass_test.go
+++ b/internal/store/storageclass_test.go
@@ -42,7 +42,7 @@ func TestStorageClassStore(t *testing.T) {
 			Want: `
 					# HELP kube_storageclass_info Information about storageclass.
 					# TYPE kube_storageclass_info gauge
-					kube_storageclass_info{storageclass="test_storageclass-info",provisioner="kubernetes.io/rbd",reclaimPolicy="Delete",volumeBindingMode="Immediate"} 1
+					kube_storageclass_info{storageclass="test_storageclass-info",provisioner="kubernetes.io/rbd",reclaim_policy="Delete",volume_binding_mode="Immediate"} 1
 				`,
 			MetricNames: []string{
 				"kube_storageclass_info",
@@ -60,7 +60,7 @@ func TestStorageClassStore(t *testing.T) {
 			Want: `
 					# HELP kube_storageclass_info Information about storageclass.
 					# TYPE kube_storageclass_info gauge
-					kube_storageclass_info{storageclass="test_storageclass-default-info",provisioner="kubernetes.io/rbd",reclaimPolicy="Delete",volumeBindingMode="Immediate"} 1
+					kube_storageclass_info{storageclass="test_storageclass-default-info",provisioner="kubernetes.io/rbd",reclaim_policy="Delete",volume_binding_mode="Immediate"} 1
 				`,
 			MetricNames: []string{
 				"kube_storageclass_info",


### PR DESCRIPTION
… in storageclass and it's unit test.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In metric kube_storageclass_info change label from camelCase to snake_case, as it is required in e2e testing and was mentioned that label must be in snake_case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

