### PR TITLE
Add prometheus.io annotations to example services

### DIFF
--- a/examples/autosharding/service.yaml
+++ b/examples/autosharding/service.yaml
@@ -4,6 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/version: v1.8.0
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
   name: kube-state-metrics
   namespace: kube-system
 spec:

--- a/examples/standard/service.yaml
+++ b/examples/standard/service.yaml
@@ -4,6 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/version: v1.8.0
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
   name: kube-state-metrics
   namespace: kube-system
 spec:


### PR DESCRIPTION
The [`README` section `Kubernetes Deployment`](https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment) states:

> The service already has a prometheus.io/scrape: 'true' annotation and if you added the recommended Prometheus service-endpoint scraping configuration, Prometheus will pick it up automatically and you can start using the generated metrics right away.

However, neither https://github.com/kubernetes/kube-state-metrics/blob/master/examples/autosharding/service.yaml nor https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/service.yaml have these annotations in place, which is confusing when debugging why Prometheus service discovery does not work right away, as advertised.

This PR adds the necessary annotations for Prometheus to be able to discover the service, and so one can start using the generated metrics right away.