### PR TITLE
Add kube-state-metrics own alerting rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ env:
       - MINIKUBE_DRIVER=none
       - SUDO=sudo
 
+before_script:
+- make install-tools
+
 install:
 - mkdir -p $HOME/gopath/src/k8s.io
 - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/kube-state-metrics

--- a/Makefile
+++ b/Makefile
@@ -124,11 +124,12 @@ endif
 
 clean:
 	rm -f kube-state-metrics
+	git clean -Xfd .
 
 e2e:
 	./tests/e2e.sh
 
-generate: build-local embedmd
+generate: build-local
 	@echo ">> generating docs"
 	@./scripts/generate-help-text.sh
 	@$(GOPATH)/bin/embedmd -w `find . -path ./vendor -prune -o -name "*.md" -print`
@@ -136,34 +137,29 @@ generate: build-local embedmd
 validate-manifests: examples
 	@git diff --exit-code
 
-examples: examples/standard examples/autosharding
+mixin: examples/prometheus-alerting-rules/alerts.yaml
 
-examples/standard: jsonnet $(shell find jsonnet | grep ".libsonnet") scripts/standard.jsonnet scripts/vendor gojsontoyaml VERSION
+examples/prometheus-alerting-rules/alerts.yaml: jsonnet $(shell find jsonnet | grep ".libsonnet") scripts/mixin.jsonnet scripts/vendor
+	mkdir -p examples/prometheus-alerting-rules
+	jsonnet -J scripts/vendor scripts/mixin.jsonnet | gojsontoyaml > examples/prometheus-alerting-rules/alerts.yaml
+
+examples: examples/standard examples/autosharding mixin
+
+examples/standard: jsonnet $(shell find jsonnet | grep ".libsonnet") scripts/standard.jsonnet scripts/vendor VERSION
 	mkdir -p examples/standard
 	jsonnet -J scripts/vendor -m examples/standard --ext-str version="$(VERSION)" scripts/standard.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > `echo {} | sed "s/\(.\)\([A-Z]\)/\1-\2/g" | tr "[:upper:]" "[:lower:]"`.yaml' -- {}
 	find examples -type f ! -name '*.yaml' -delete
 
-examples/autosharding: jsonnet $(shell find jsonnet | grep ".libsonnet") scripts/autosharding.jsonnet scripts/vendor gojsontoyaml VERSION
+examples/autosharding: jsonnet $(shell find jsonnet | grep ".libsonnet") scripts/autosharding.jsonnet scripts/vendor VERSION
 	mkdir -p examples/autosharding
 	jsonnet -J scripts/vendor -m examples/autosharding --ext-str version="$(VERSION)" scripts/autosharding.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > `echo {} | sed "s/\(.\)\([A-Z]\)/\1-\2/g" | tr "[:upper:]" "[:lower:]"`.yaml' -- {}
 	find examples -type f ! -name '*.yaml' -delete
 
-scripts/vendor: jb scripts/jsonnetfile.json scripts/jsonnetfile.lock.json
+scripts/vendor: scripts/jsonnetfile.json scripts/jsonnetfile.lock.json
 	cd scripts && jb install
 
-gojsontoyaml:
-	go install github.com/brancz/gojsontoyaml
-
-jsonnet:
-	 go install github.com/google/go-jsonnet/cmd/jsonnet
-
-jb:
-	 go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
-
-embedmd:
-	 go install github.com/campoy/embedmd
-
-$(BENCHCMP_BINARY):
-	 go install golang.org/x/tools/cmd/benchcmp
+install-tools:
+	@echo Installing tools from tools.go
+	@cat tools/tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
 
 .PHONY: all build build-local all-push all-container test-unit test-benchmark-compare container push quay-push clean e2e validate-modules shellcheck licensecheck lint generate embedmd

--- a/examples/prometheus-alerting-rules/alerts.yaml
+++ b/examples/prometheus-alerting-rules/alerts.yaml
@@ -1,0 +1,29 @@
+groups:
+- name: kube-state-metrics
+  rules:
+  - alert: KubeStateMetricsListErrors
+    annotations:
+      message: kube-state-metrics is experiencing errors at an elevated rate in list
+        operations. This is likely causing it to not be able to expose metrics about
+        Kubernetes objects correctly or at all.
+    expr: |
+      (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m]))
+        /
+      sum(rate(kube_state_metrics_list_total{job="kube-state-metrics"}[5m])))
+      > 0.01
+    for: 15m
+    labels:
+      severity: critical
+  - alert: KubeStateMetricsWatchErrors
+    annotations:
+      message: kube-state-metrics is experiencing errors at an elevated rate in watch
+        operations. This is likely causing it to not be able to expose metrics about
+        Kubernetes objects correctly or at all.
+    expr: |
+      (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m]))
+        /
+      sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])))
+      > 0.01
+    for: 15m
+    labels:
+      severity: critical

--- a/jsonnet/kube-state-metrics-mixin/alerts.libsonnet
+++ b/jsonnet/kube-state-metrics-mixin/alerts.libsonnet
@@ -1,0 +1,46 @@
+{
+  _config+:: {
+    kubeStateMetricsSelectmr: error 'must provide selector for kube-state-metrics',
+  },
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'kube-state-metrics',
+        rules: [
+          {
+            alert: 'KubeStateMetricsListErrors',
+            expr: |||
+              (sum(rate(kube_state_metrics_list_total{%(kubeStateMetricsSelector)s,result="error"}[5m]))
+                /
+              sum(rate(kube_state_metrics_list_total{%(kubeStateMetricsSelector)s}[5m])))
+              > 0.01
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'kube-state-metrics is experiencing errors at an elevated rate in list operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.',
+            },
+          },
+          {
+            alert: 'KubeStateMetricsWatchErrors',
+            expr: |||
+              (sum(rate(kube_state_metrics_watch_total{%(kubeStateMetricsSelector)s,result="error"}[5m]))
+                /
+              sum(rate(kube_state_metrics_watch_total{%(kubeStateMetricsSelector)s}[5m])))
+              > 0.01
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'kube-state-metrics is experiencing errors at an elevated rate in watch operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/jsonnet/kube-state-metrics-mixin/mixin.libsonnet
+++ b/jsonnet/kube-state-metrics-mixin/mixin.libsonnet
@@ -1,0 +1,1 @@
+(import 'alerts.libsonnet')

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -119,6 +119,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       rulesType.withApiGroups(['storage.k8s.io']) +
       rulesType.withResources([
         'storageclasses',
+        'volumeattachments',
       ]) +
       rulesType.withVerbs(['list', 'watch']),
 
@@ -156,11 +157,11 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         containerPort.newNamed(8080, 'http-metrics'),
         containerPort.newNamed(8081, 'telemetry'),
       ]) +
-      container.mixin.livenessProbe.httpGet.withPath("/healthz") +
+      container.mixin.livenessProbe.httpGet.withPath('/healthz') +
       container.mixin.livenessProbe.httpGet.withPort(8080) +
       container.mixin.livenessProbe.withInitialDelaySeconds(5) +
       container.mixin.livenessProbe.withTimeoutSeconds(5) +
-      container.mixin.readinessProbe.httpGet.withPath("/") +
+      container.mixin.readinessProbe.httpGet.withPath('/') +
       container.mixin.readinessProbe.httpGet.withPort(8081) +
       container.mixin.readinessProbe.withInitialDelaySeconds(5) +
       container.mixin.readinessProbe.withTimeoutSeconds(5);
@@ -231,16 +232,16 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       local containerEnv = container.envType;
 
       local c = ksm.deployment.spec.template.spec.containers[0] +
-          container.withArgs([
-                  "--pod=$(POD_NAME)",
-                  "--pod-namespace=$(POD_NAMESPACE)",
-          ]) +
-          container.withEnv([
-              containerEnv.new('POD_NAME') +
-              containerEnv.mixin.valueFrom.fieldRef.withFieldPath('metadata.name'),
-              containerEnv.new('POD_NAMESPACE') +
-              containerEnv.mixin.valueFrom.fieldRef.withFieldPath('metadata.namespace'),
-          ]);
+                container.withArgs([
+                  '--pod=$(POD_NAME)',
+                  '--pod-namespace=$(POD_NAMESPACE)',
+                ]) +
+                container.withEnv([
+                  containerEnv.new('POD_NAME') +
+                  containerEnv.mixin.valueFrom.fieldRef.withFieldPath('metadata.name'),
+                  containerEnv.new('POD_NAMESPACE') +
+                  containerEnv.mixin.valueFrom.fieldRef.withFieldPath('metadata.namespace'),
+                ]);
 
       statefulset.new(ksm.name, 2, c, [], ksm.commonLabels) +
       statefulset.mixin.metadata.withNamespace(ksm.namespace) +

--- a/scripts/jsonnetfile.json
+++ b/scripts/jsonnetfile.json
@@ -8,6 +8,15 @@
                 }
             },
             "version": ""
+        },
+        {
+            "name": "kube-state-metrics-mixin",
+            "source": {
+                "local": {
+                    "directory": "../jsonnet/kube-state-metrics-mixin"
+                }
+            },
+            "version": ""
         }
     ]
 }

--- a/scripts/jsonnetfile.lock.json
+++ b/scripts/jsonnetfile.lock.json
@@ -18,6 +18,15 @@
                 }
             },
             "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f"
+        },
+        {
+            "name": "kube-state-metrics-mixin",
+            "source": {
+                "local": {
+                    "directory": "../jsonnet/kube-state-metrics-mixin"
+                }
+            },
+            "version": ""
         }
     ]
 }

--- a/scripts/mixin.jsonnet
+++ b/scripts/mixin.jsonnet
@@ -1,0 +1,6 @@
+((import 'kube-state-metrics-mixin/mixin.libsonnet') {
+   _config+:: {
+     // Selectors are inserted between {} in Prometheus queries.
+     kubeStateMetricsSelector: 'job="kube-state-metrics"',
+   },
+ }).prometheusAlerts


### PR DESCRIPTION
This PR introduces a kube-state-metrics mixin and adds generated `KubeStateMetricsListErrors` and `KubeStateMetricsWatchErrors`.

I guess we should add some docs as well, should these live in the main README?

cc @tariq1890 @brancz @metalmatze 