### PR TITLE
expose the PodCIDR in node info

### DIFF
--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -51,6 +51,7 @@ var (
 								"kubelet_version",
 								"kubeproxy_version",
 								"provider_id",
+								"pod_cidr",
 							},
 							LabelValues: []string{
 								n.Status.NodeInfo.KernelVersion,
@@ -59,6 +60,7 @@ var (
 								n.Status.NodeInfo.KubeletVersion,
 								n.Status.NodeInfo.KubeProxyVersion,
 								n.Spec.ProviderID,
+								n.Spec.PodCIDR,
 							},
 							Value: 1,
 						},

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -62,6 +62,20 @@ func TestNodeStore(t *testing.T) {
 			`,
 			MetricNames: []string{"kube_node_spec_unschedulable", "kube_node_labels", "kube_node_info"},
 		},
+		// Verify unset fields are skipped. Note that prometheus subsequently drops empty labels.
+		{
+			Obj: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{},
+				Status:     v1.NodeStatus{},
+				Spec:       v1.NodeSpec{},
+			},
+			Want: `
+				# HELP kube_node_info Information about a cluster node.
+				# TYPE kube_node_info gauge
+				kube_node_info{container_runtime_version="",kernel_version="",kubelet_version="",kubeproxy_version="",node="",os_image="",pod_cidr="",provider_id=""} 1
+			`,
+			MetricNames: []string{"kube_node_info"},
+		},
 		// Verify resource metric.
 		{
 			Obj: &v1.Node{

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -46,6 +46,7 @@ func TestNodeStore(t *testing.T) {
 				},
 				Spec: v1.NodeSpec{
 					ProviderID: "provider://i-uniqueid",
+					PodCIDR:    "172.24.10.0/24",
 				},
 			},
 			Want: `
@@ -55,7 +56,7 @@ func TestNodeStore(t *testing.T) {
 				# TYPE kube_node_info gauge
 				# TYPE kube_node_labels gauge
 				# TYPE kube_node_spec_unschedulable gauge
-				kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",provider_id="provider://i-uniqueid"} 1
+				kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",pod_cidr="172.24.10.0/24",provider_id="provider://i-uniqueid"} 1
 				kube_node_labels{node="127.0.0.1"} 1
 				kube_node_spec_unschedulable{node="127.0.0.1"} 0
 			`,
@@ -74,6 +75,7 @@ func TestNodeStore(t *testing.T) {
 				Spec: v1.NodeSpec{
 					Unschedulable: true,
 					ProviderID:    "provider://i-randomidentifier",
+					PodCIDR:       "172.24.10.0/24",
 				},
 				Status: v1.NodeStatus{
 					NodeInfo: v1.NodeSystemInfo{
@@ -129,7 +131,7 @@ func TestNodeStore(t *testing.T) {
 		# TYPE kube_node_status_capacity_memory_bytes gauge
 		# TYPE kube_node_status_capacity_pods gauge
 		kube_node_created{node="127.0.0.1"} 1.5e+09
-        kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",provider_id="provider://i-randomidentifier"} 1
+        kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",pod_cidr="172.24.10.0/24",provider_id="provider://i-randomidentifier"} 1
 		kube_node_labels{label_node_role_kubernetes_io_master="",node="127.0.0.1"} 1
 		kube_node_role{node="127.0.0.1",role="master"} 1
         kube_node_spec_unschedulable{node="127.0.0.1"} 1


### PR DESCRIPTION
**What this PR does / why we need it**:

It can be helpful to know the PodCIDR of nodes in order to predict IP
space utilization. In GKE for example, one typically uses a Secondary
Alias IP range that doles out PodCIDRs dynamically. When this is
exhausted, nodes will fail to boot with messages such as:

```
Instance 'gke-test-ingre-43fd70d6-9v77' creation failed: IP space of 'projects/network-project/regions/us-central1/subnetworks/pod-alias-b85f82b0bca36afa' is exhausted.
```

Although not comprehensive, on could use this label to construct a query
such as:

```
count(kube_node_info(pod_cidr~="/24")) * 256
```

