### PR TITLE
document the new pod-cidr dimension

### DIFF
--- a/docs/node-metrics.md
+++ b/docs/node-metrics.md
@@ -2,7 +2,7 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
-| kube_node_info | Gauge | `node`=&lt;node-address&gt; <br> `kernel_version`=&lt;kernel-version&gt; <br> `os_image`=&lt;os-image-name&gt; <br> `container_runtime_version`=&lt;container-runtime-and-version-combination&gt; <br> `kubelet_version`=&lt;kubelet-version&gt; <br> `kubeproxy_version`=&lt;kubeproxy-version&gt; <br> `provider_id`=&lt;provider-id&gt; | STABLE |
+| kube_node_info | Gauge | `node`=&lt;node-address&gt; <br> `kernel_version`=&lt;kernel-version&gt; <br> `os_image`=&lt;os-image-name&gt; <br> `container_runtime_version`=&lt;container-runtime-and-version-combination&gt; <br> `kubelet_version`=&lt;kubelet-version&gt; <br> `kubeproxy_version`=&lt;kubeproxy-version&gt; <br> `pod_cidr`=&lt;pod-cidr&gt; <br> `provider_id`=&lt;provider-id&gt; | STABLE |
 | kube_node_labels | Gauge | `node`=&lt;node-address&gt; <br> `label_NODE_LABEL`=&lt;NODE_LABEL&gt;  | STABLE |
 | kube_node_role | Gauge | `node`=&lt;node-address&gt; <br> `role`=&lt;NODE_ROLE&gt; | EXPERIMENTAL |
 | kube_node_spec_unschedulable | Gauge | `node`=&lt;node-address&gt;|


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubernetes/kube-state-metrics/pull/963 was recently merged. I neglected to document this new dimension.
