### PR TITLE
Added a kube_hpa_target_metric metric that publishes all of a HPA's target metrics.

### DIFF
--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -6,6 +6,7 @@
 | kube_hpa_metadata_generation      | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_hpa_spec_max_replicas        | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_hpa_spec_min_replicas        | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_hpa_spec_target_metric       | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
 | kube_hpa_status_condition         | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_hpa_status_current_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_hpa_status_currentmetrics_average_utilization | Gauge     | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | EXPERIMENTAL |

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -102,6 +102,13 @@ func TestHPAStore(t *testing.T) {
 								TargetAverageValue:       resourcePtr(resource.MustParse("800Ki")),
 							},
 						},
+						// No targets, this metric should be ignored
+						{
+							Type: autoscaling.ResourceMetricSourceType,
+							Resource: &autoscaling.ResourceMetricSource{
+								Name: "disk",
+							},
+						},
 						{
 							Type: autoscaling.ExternalMetricSourceType,
 							External: &autoscaling.ExternalMetricSource{


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
kube-state-metrics currently publishes only part of a Horizontal Pod Autoscaler's spec, specifically the Minimum and Maximum Replicas values. This PR aims to add the HPA's target metric values to the list metrics to be published.

**Which issue(s) this PR fixes**
Fixes #768 

