### PR TITLE
fixing some issues missed during previous code reviews

### DIFF
--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -9,6 +9,6 @@
 | kube_hpa_spec_target_metric       | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
 | kube_hpa_status_condition         | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_hpa_status_current_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
-| kube_hpa_status_currentmetrics_average_utilization | Gauge     | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | EXPERIMENTAL |
-| kube_hpa_status_currentmetrics_average_value | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | EXPERIMENTAL |
+| kube_hpa_status_current_metrics_average_utilization | Gauge     | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | EXPERIMENTAL |
+| kube_hpa_status_current_metrics_average_value | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | EXPERIMENTAL |
 | kube_hpa_status_desired_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |

--- a/docs/namespace-metrics.md
+++ b/docs/namespace-metrics.md
@@ -2,7 +2,7 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
-| kube_namespace_status_phase| Gauge | `namespace`=&lt;namespace-name&gt; <br> `status`=&lt;Active\|Terminating&gt; | STABLE |
-| kube_namespace_labels | Gauge | `namespace`=&lt;namespace-name&gt; <br> `label_NS_LABEL`=&lt;NS_LABEL&gt; | STABLE |
 | kube_namespace_created | Gauge | `namespace`=&lt;namespace-name&gt; | STABLE |
+| kube_namespace_labels | Gauge | `namespace`=&lt;namespace-name&gt; <br> `label_NS_LABEL`=&lt;NS_LABEL&gt; | STABLE |
 | kube_namespace_status_condition | Gauge | `namespace`=&lt;namespace-name&gt; <br> `condition`=&lt;NamespaceDeletionDiscoveryFailure\|NamespaceDeletionContentFailure\|NamespaceDeletionGroupVersionParsingFailure&gt;  <br> `status`=&lt;true\|false\|unknown&gt; | EXPERIMENTAL |
+| kube_namespace_status_phase| Gauge | `namespace`=&lt;namespace-name&gt; <br> `status`=&lt;Active\|Terminating&gt; | STABLE |

--- a/internal/store/hpa.go
+++ b/internal/store/hpa.go
@@ -223,7 +223,7 @@ var (
 			}),
 		},
 		{
-			Name: "kube_hpa_status_currentmetrics_average_value",
+			Name: "kube_hpa_status_current_metrics_average_value",
 			Type: metric.Gauge,
 			Help: "Average metric value observed by the autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
@@ -255,7 +255,7 @@ var (
 			}),
 		},
 		{
-			Name: "kube_hpa_status_currentmetrics_average_utilization",
+			Name: "kube_hpa_status_current_metrics_average_utilization",
 			Type: metric.Gauge,
 			Help: "Average metric utilization observed by the autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -51,10 +51,10 @@ func TestHPAStore(t *testing.T) {
         # TYPE kube_hpa_status_condition gauge
         # HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
         # TYPE kube_hpa_labels gauge
-        # HELP kube_hpa_status_currentmetrics_average_value Average metric value observed by the autoscaler.
-        # TYPE kube_hpa_status_currentmetrics_average_value gauge
-        # HELP kube_hpa_status_currentmetrics_average_utilization Average metric utilization observed by the autoscaler.
-        # TYPE kube_hpa_status_currentmetrics_average_utilization gauge
+        # HELP kube_hpa_status_current_metrics_average_value Average metric value observed by the autoscaler.
+        # TYPE kube_hpa_status_current_metrics_average_value gauge
+        # HELP kube_hpa_status_current_metrics_average_utilization Average metric utilization observed by the autoscaler.
+        # TYPE kube_hpa_status_current_metrics_average_utilization gauge
 	`
 	cases := []generateMetricsTestCase{
 		{
@@ -170,8 +170,8 @@ func TestHPAStore(t *testing.T) {
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="unknown"} 0
 				kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
 				kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
-				kube_hpa_status_currentmetrics_average_value{hpa="hpa1",namespace="ns1"} 10
-				kube_hpa_status_currentmetrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
+				kube_hpa_status_current_metrics_average_value{hpa="hpa1",namespace="ns1"} 10
+				kube_hpa_status_current_metrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
 			`,
 			MetricNames: []string{
 				"kube_hpa_metadata_generation",
@@ -182,8 +182,8 @@ func TestHPAStore(t *testing.T) {
 				"kube_hpa_status_desired_replicas",
 				"kube_hpa_status_condition",
 				"kube_hpa_labels",
-				"kube_hpa_status_currentmetrics_average_value",
-				"kube_hpa_status_currentmetrics_average_utilization",
+				"kube_hpa_status_current_metrics_average_value",
+				"kube_hpa_status_current_metrics_average_utilization",
 			},
 		},
 	}


### PR DESCRIPTION
This PR fixes the following:

i) `s/currentmetrics/current_metrics` in `hpa.go`
ii) sort namespace metrics names in `doc/namespace-metrics.md`