### PR TITLE
remove client-go column from support version matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ All additional compatibility is only best effort, or happens to still/already be
 #### Compatibility matrix
 At most, 5 kube-state-metrics and 5 [kubernetes releases](https://github.com/kubernetes/kubernetes/releases) will be recorded below.
 
-| kube-state-metrics | client-go  | **Kubernetes 1.11** | **Kubernetes 1.12** | **Kubernetes 1.13** | **Kubernetes 1.14** |  **Kubernetes 1.15** |
-|--------------------|------------|---------------------|---------------------|---------------------|---------------------|----------------------|
-| **v1.4.0**         |  v8.0.0    |         ✓           |         ✓           |         -           |         -           |          -           |
-| **v1.5.0**         |  v8.0.0    |         ✓           |         ✓           |         -           |         -           |          -           |
-| **v1.6.0**         |  v11.0.0   |         ✓           |         ✓           |         ✓           |         ✓           |          -           |
-| **v1.7.2**         |  v12.0.0   |         ✓           |         ✓           |         ✓           |         ✓           |          ✓           |
-| **v1.8.0**         |  v12.0.0   |         ✓           |         ✓           |         ✓           |         ✓           |          ✓           |
-| **master**         |  v12.0.0   |         ✓           |         ✓           |         ✓           |         ✓           |          ✓           |
+| kube-state-metrics | **Kubernetes 1.11** | **Kubernetes 1.12** | **Kubernetes 1.13** | **Kubernetes 1.14** |  **Kubernetes 1.15** |
+|--------------------|---------------------|---------------------|---------------------|---------------------|----------------------|
+| **v1.4.0**         |         ✓           |         ✓           |         -           |         -           |          -           |
+| **v1.5.0**         |         ✓           |         ✓           |         -           |         -           |          -           |
+| **v1.6.0**         |         ✓           |         ✓           |         ✓           |         ✓           |          -           |
+| **v1.7.2**         |         ✓           |         ✓           |         ✓           |         ✓           |          ✓           |
+| **v1.8.0**         |         ✓           |         ✓           |         ✓           |         ✓           |          ✓           |
+| **master**         |         ✓           |         ✓           |         ✓           |         ✓           |          ✓           |
 - `✓` Fully supported version range.
 - `-` The Kubernetes cluster has features the client-go library can't use (additional API objects, etc).
 


### PR DESCRIPTION
The Kubernetes-dev team have decided to stop the v10.0.0+ conventions for `client-go` since the release of Kubernetes 1.16. Since the cadence of `client-go` updates matches that of the general Kubernetes dependencies in kube-state-metrics, recording `client-go` versions becomes redundant.