### PR TITLE
jsonnet/kube-state-metrics-mixin/alerts.libsonnet: Fix selector typo

### DIFF
--- a/jsonnet/kube-state-metrics-mixin/alerts.libsonnet
+++ b/jsonnet/kube-state-metrics-mixin/alerts.libsonnet
@@ -1,6 +1,6 @@
 {
   _config+:: {
-    kubeStateMetricsSelectmr: error 'must provide selector for kube-state-metrics',
+    kubeStateMetricsSelector: error 'must provide selector for kube-state-metrics',
   },
   prometheusAlerts+:: {
     groups+: [


### PR DESCRIPTION
(cherry picked from commit e4e9d325caf51b990b31628465db37d60030281e)

