### PR TITLE
Add the possibility to provide “custom” metric-store to the builder

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -68,7 +68,6 @@ type Builder struct {
 // NewBuilder returns a new builder.
 func NewBuilder() *Builder {
 	b := &Builder{}
-	b.buildStoreFunc = b.buildStore
 	return b
 }
 
@@ -126,9 +125,14 @@ func (b *Builder) WithWhiteBlackList(l ksmtypes.WhiteBlackLister) {
 	b.whiteBlackList = l
 }
 
-// WithCustomGenerateStoreFunc configures a constom generate store function
-func (b *Builder) WithCustomGenerateStoreFunc(f ksmtypes.BuildStoreFunc) {
+// WithGenerateStoreFunc configures a constom generate store function
+func (b *Builder) WithGenerateStoreFunc(f ksmtypes.BuildStoreFunc) {
 	b.buildStoreFunc = f
+}
+
+// DefaultGenerateStoreFunc returns default buildStore function
+func (b *Builder) DefaultGenerateStoreFunc() ksmtypes.BuildStoreFunc {
+	return b.buildStore
 }
 
 // Build initializes and registers all enabled stores.

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
+	ksmtypes "k8s.io/kube-state-metrics/pkg/builder/types"
 	"k8s.io/kube-state-metrics/pkg/listwatch"
 	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
@@ -48,17 +49,6 @@ import (
 	"k8s.io/kube-state-metrics/pkg/sharding"
 	"k8s.io/kube-state-metrics/pkg/watch"
 )
-
-type whiteBlackLister interface {
-	IsIncluded(string) bool
-	IsExcluded(string) bool
-}
-
-// BuildStoreFunc function signature that is use to returns a cache.Store
-type BuildStoreFunc func(metricFamilies []generator.FamilyGenerator,
-	expectedType interface{},
-	listWatchFunc func(kubeClient clientset.Interface, ns string) cache.ListerWatcher,
-) cache.Store
 
 // Builder helps to build store. It follows the builder pattern
 // (https://en.wikipedia.org/wiki/Builder_pattern).
@@ -68,11 +58,11 @@ type Builder struct {
 	namespaces       options.NamespaceList
 	ctx              context.Context
 	enabledResources []string
-	whiteBlackList   whiteBlackLister
+	whiteBlackList   ksmtypes.WhiteBlackLister
 	metrics          *watch.ListWatchMetrics
 	shard            int32
 	totalShards      int
-	buildStoreFunc   BuildStoreFunc
+	buildStoreFunc   ksmtypes.BuildStoreFunc
 }
 
 // NewBuilder returns a new builder.
@@ -132,12 +122,12 @@ func (b *Builder) WithVPAClient(c vpaclientset.Interface) {
 
 // WithWhiteBlackList configures the white or blacklisted metric to be exposed
 // by the store build by the Builder.
-func (b *Builder) WithWhiteBlackList(l whiteBlackLister) {
+func (b *Builder) WithWhiteBlackList(l ksmtypes.WhiteBlackLister) {
 	b.whiteBlackList = l
 }
 
 // WithCustomGenerateStoreFunc configures a constom generate store function
-func (b *Builder) WithCustomGenerateStoreFunc(f BuildStoreFunc) {
+func (b *Builder) WithCustomGenerateStoreFunc(f ksmtypes.BuildStoreFunc) {
 	b.buildStoreFunc = f
 }
 

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/klog"
 
 	"k8s.io/kube-state-metrics/pkg/listwatch"
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
 	"k8s.io/kube-state-metrics/pkg/options"
 	"k8s.io/kube-state-metrics/pkg/sharding"
@@ -55,7 +55,7 @@ type whiteBlackLister interface {
 }
 
 // BuildStoreFunc function signature that is use to returns a cache.Store
-type BuildStoreFunc func(metricFamilies []metric.FamilyGenerator,
+type BuildStoreFunc func(metricFamilies []generator.FamilyGenerator,
 	expectedType interface{},
 	listWatchFunc func(kubeClient clientset.Interface, ns string) cache.ListerWatcher,
 ) cache.Store
@@ -321,14 +321,14 @@ func (b *Builder) buildVPAStore() cache.Store {
 }
 
 func (b *Builder) buildStore(
-	metricFamilies []metric.FamilyGenerator,
+	metricFamilies []generator.FamilyGenerator,
 	expectedType interface{},
 	listWatchFunc func(kubeClient clientset.Interface, ns string) cache.ListerWatcher,
 ) cache.Store {
-	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, metricFamilies)
-	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+	filteredMetricFamilies := generator.FilterMetricFamilies(b.whiteBlackList, metricFamilies)
+	composedMetricGenFuncs := generator.ComposeMetricGenFuncs(filteredMetricFamilies)
 
-	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+	familyHeaders := generator.ExtractMetricFamilyHeaders(filteredMetricFamilies)
 
 	store := metricsstore.NewMetricsStore(
 		familyHeaders,

--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	certv1beta1 "k8s.io/api/certificates/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +33,7 @@ var (
 	descCSRLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descCSRLabelsDefaultLabels = []string{"certificatesigningrequest"}
 
-	csrMetricFamilies = []metric.FamilyGenerator{
+	csrMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: descCSRLabelsName,
 			Type: metric.Gauge,

--- a/internal/store/certificatesigningrequest_test.go
+++ b/internal/store/certificatesigningrequest_test.go
@@ -23,7 +23,7 @@ import (
 	certv1beta1 "k8s.io/api/certificates/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestCsrStore(t *testing.T) {
@@ -212,8 +212,8 @@ func TestCsrStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(csrMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(csrMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(csrMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(csrMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected error when collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -25,12 +25,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
 	descConfigMapLabelsDefaultLabels = []string{"namespace", "configmap"}
 
-	configMapMetricFamilies = []metric.FamilyGenerator{
+	configMapMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_configmap_info",
 			Type: metric.Gauge,

--- a/internal/store/configmap_test.go
+++ b/internal/store/configmap_test.go
@@ -22,7 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestConfigMapStore(t *testing.T) {
@@ -72,8 +72,8 @@ func TestConfigMapStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(configMapMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(configMapMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(configMapMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(configMapMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -36,7 +37,7 @@ var (
 	descCronJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descCronJobLabelsDefaultLabels = []string{"namespace", "cronjob"}
 
-	cronJobMetricFamilies = []metric.FamilyGenerator{
+	cronJobMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: descCronJobLabelsName,
 			Type: metric.Gauge,

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -26,7 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -243,8 +243,8 @@ func TestCronJobStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(cronJobMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(cronJobMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(cronJobMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(cronJobMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -32,7 +33,7 @@ var (
 	descDaemonSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descDaemonSetLabelsDefaultLabels = []string{"namespace", "daemonset"}
 
-	daemonSetMetricFamilies = []metric.FamilyGenerator{
+	daemonSetMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_daemonset_created",
 			Type: metric.Gauge,

--- a/internal/store/daemonset_test.go
+++ b/internal/store/daemonset_test.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestDaemonSetStore(t *testing.T) {
@@ -217,8 +217,8 @@ func TestDaemonSetStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(daemonSetMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(daemonSetMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(daemonSetMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(daemonSetMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +34,7 @@ var (
 	descDeploymentLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
 
-	deploymentMetricFamilies = []metric.FamilyGenerator{
+	deploymentMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_deployment_created",
 			Type: metric.Gauge,

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -183,8 +183,8 @@ func TestDeploymentStore(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(deploymentMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(deploymentMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(deploymentMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(deploymentMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -32,7 +33,7 @@ var (
 	descEndpointLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descEndpointLabelsDefaultLabels = []string{"namespace", "endpoint"}
 
-	endpointMetricFamilies = []metric.FamilyGenerator{
+	endpointMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_endpoint_info",
 			Type: metric.Gauge,

--- a/internal/store/endpoint_test.go
+++ b/internal/store/endpoint_test.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestEndpointStore(t *testing.T) {
@@ -93,8 +93,8 @@ func TestEndpointStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(endpointMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(endpointMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(endpointMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(endpointMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/hpa.go
+++ b/internal/store/hpa.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 type MetricTargetType int
@@ -50,7 +51,7 @@ var (
 
 	targetMetricLabels = []string{"metric_name", "metric_target_type"}
 
-	hpaMetricFamilies = []metric.FamilyGenerator{
+	hpaMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_hpa_metadata_generation",
 			Type: metric.Gauge,

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -188,8 +188,8 @@ func TestHPAStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(hpaMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(hpaMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(hpaMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(hpaMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	"k8s.io/api/extensions/v1beta1"
 
@@ -33,7 +34,7 @@ var (
 	descIngressLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descIngressLabelsDefaultLabels = []string{"namespace", "ingress"}
 
-	ingressMetricFamilies = []metric.FamilyGenerator{
+	ingressMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_ingress_info",
 			Type: metric.Gauge,

--- a/internal/store/ingress_test.go
+++ b/internal/store/ingress_test.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestIngressStore(t *testing.T) {
@@ -169,8 +169,8 @@ func TestIngressStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(ingressMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(ingressMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(ingressMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(ingressMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	v1batch "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +35,7 @@ var (
 	descJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descJobLabelsDefaultLabels = []string{"namespace", "job_name"}
 
-	jobMetricFamilies = []metric.FamilyGenerator{
+	jobMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: descJobLabelsName,
 			Type: metric.Gauge,

--- a/internal/store/job_test.go
+++ b/internal/store/job_test.go
@@ -24,7 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -254,8 +254,8 @@ func TestJobStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(jobMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(jobMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(jobMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(jobMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/limitrange.go
+++ b/internal/store/limitrange.go
@@ -25,12 +25,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
 	descLimitRangeLabelsDefaultLabels = []string{"namespace", "limitrange"}
 
-	limitRangeMetricFamilies = []metric.FamilyGenerator{
+	limitRangeMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_limitrange",
 			Type: metric.Gauge,

--- a/internal/store/limitrange_test.go
+++ b/internal/store/limitrange_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestLimitRangeStore(t *testing.T) {
@@ -81,8 +81,8 @@ func TestLimitRangeStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(limitRangeMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(limitRangeMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(limitRangeMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(limitRangeMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -25,13 +25,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
 	descMutatingWebhookConfigurationHelp          = "Kubernetes labels converted to Prometheus labels."
 	descMutatingWebhookConfigurationDefaultLabels = []string{"namespace", "mutatingwebhookconfiguration"}
 
-	mutatingWebhookConfigurationMetricFamilies = []metric.FamilyGenerator{
+	mutatingWebhookConfigurationMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_mutatingwebhookconfiguration_info",
 			Type: metric.Gauge,

--- a/internal/store/mutatingwebhookconfiguration_test.go
+++ b/internal/store/mutatingwebhookconfiguration_test.go
@@ -22,7 +22,7 @@ import (
 	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestMutatingWebhookConfigurationStore(t *testing.T) {
@@ -72,8 +72,8 @@ func TestMutatingWebhookConfigurationStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(mutatingWebhookConfigurationMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(mutatingWebhookConfigurationMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(mutatingWebhookConfigurationMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(mutatingWebhookConfigurationMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +33,7 @@ var (
 	descNamespaceLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descNamespaceLabelsDefaultLabels = []string{"namespace"}
 
-	namespaceMetricFamilies = []metric.FamilyGenerator{
+	namespaceMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_namespace_created",
 			Type: metric.Gauge,

--- a/internal/store/namespace_test.go
+++ b/internal/store/namespace_test.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestNamespaceStore(t *testing.T) {
@@ -158,8 +158,8 @@ func TestNamespaceStore(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(namespaceMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(namespaceMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(namespaceMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(namespaceMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/networkpolicy.go
+++ b/internal/store/networkpolicy.go
@@ -25,12 +25,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
 	descNetworkPolicyLabelsDefaultLabels = []string{"namespace", "networkpolicy"}
 
-	networkpolicyMetricFamilies = []metric.FamilyGenerator{
+	networkpolicyMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_networkpolicy_created",
 			Type: metric.Gauge,

--- a/internal/store/networkpolicy_test.go
+++ b/internal/store/networkpolicy_test.go
@@ -22,7 +22,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestNetworkPolicyStore(t *testing.T) {
@@ -68,7 +68,7 @@ func TestNetworkPolicyStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(networkpolicyMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(networkpolicyMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %dth run:\n%s", i, err)
 		}

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kube-state-metrics/pkg/constant"
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ var (
 	descNodeLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descNodeLabelsDefaultLabels = []string{"node"}
 
-	nodeMetricFamilies = []metric.FamilyGenerator{
+	nodeMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_node_info",
 			Type: metric.Gauge,

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestNodeStore(t *testing.T) {
@@ -349,8 +349,8 @@ func TestNodeStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(nodeMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(nodeMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(nodeMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(nodeMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +33,7 @@ var (
 	descPersistentVolumeLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descPersistentVolumeLabelsDefaultLabels = []string{"persistentvolume"}
 
-	persistentVolumeMetricFamilies = []metric.FamilyGenerator{
+	persistentVolumeMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: descPersistentVolumeLabelsName,
 			Type: metric.Gauge,

--- a/internal/store/persistentvolume_test.go
+++ b/internal/store/persistentvolume_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestPersistentVolumeStore(t *testing.T) {
@@ -231,8 +231,8 @@ func TestPersistentVolumeStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(persistentVolumeMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(persistentVolumeMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(persistentVolumeMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(persistentVolumeMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +33,7 @@ var (
 	descPersistentVolumeClaimLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descPersistentVolumeClaimLabelsDefaultLabels = []string{"namespace", "persistentvolumeclaim"}
 
-	persistentVolumeClaimMetricFamilies = []metric.FamilyGenerator{
+	persistentVolumeClaimMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: descPersistentVolumeClaimLabelsName,
 			Type: metric.Gauge,

--- a/internal/store/persistentvolumeclaim_test.go
+++ b/internal/store/persistentvolumeclaim_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestPersistentVolumeClaimStore(t *testing.T) {
@@ -183,8 +183,8 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(persistentVolumeClaimMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(persistentVolumeClaimMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(persistentVolumeClaimMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(persistentVolumeClaimMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kube-state-metrics/pkg/constant"
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +38,7 @@ var (
 	containerWaitingReasons    = []string{"ContainerCreating", "CrashLoopBackOff", "CreateContainerConfigError", "ErrImagePull", "ImagePullBackOff", "CreateContainerError", "InvalidImageName"}
 	containerTerminatedReasons = []string{"OOMKilled", "Completed", "Error", "ContainerCannotRun", "DeadlineExceeded", "Evicted"}
 
-	podMetricFamilies = []metric.FamilyGenerator{
+	podMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_pod_info",
 			Type: metric.Gauge,

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestPodStore(t *testing.T) {
@@ -1507,8 +1507,8 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 	}
 
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(podMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(podMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(podMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(podMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}
@@ -1518,7 +1518,7 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 func BenchmarkPodStore(b *testing.B) {
 	b.ReportAllocs()
 
-	f := metric.ComposeMetricGenFuncs(podMetricFamilies)
+	f := generator.ComposeMetricGenFuncs(podMetricFamilies)
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -25,12 +25,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
 	descPodDisruptionBudgetLabelsDefaultLabels = []string{"namespace", "poddisruptionbudget"}
 
-	podDisruptionBudgetMetricFamilies = []metric.FamilyGenerator{
+	podDisruptionBudgetMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_poddisruptionbudget_created",
 			Type: metric.Gauge,

--- a/internal/store/poddisruptionbudget_test.go
+++ b/internal/store/poddisruptionbudget_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestPodDisruptionBudgetStore(t *testing.T) {
@@ -94,8 +94,8 @@ func TestPodDisruptionBudgetStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(podDisruptionBudgetMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(podDisruptionBudgetMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(podDisruptionBudgetMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(podDisruptionBudgetMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +35,7 @@ var (
 	descReplicaSetLabelsName          = "kube_replicaset_labels"
 	descReplicaSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 
-	replicaSetMetricFamilies = []metric.FamilyGenerator{
+	replicaSetMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_replicaset_created",
 			Type: metric.Gauge,

--- a/internal/store/replicaset_test.go
+++ b/internal/store/replicaset_test.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -130,8 +130,8 @@ func TestReplicaSetStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(replicaSetMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(replicaSetMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(replicaSetMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(replicaSetMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -25,12 +25,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
 	descReplicationControllerLabelsDefaultLabels = []string{"namespace", "replicationcontroller"}
 
-	replicationControllerMetricFamilies = []metric.FamilyGenerator{
+	replicationControllerMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_replicationcontroller_created",
 			Type: metric.Gauge,

--- a/internal/store/replicationcontroller_test.go
+++ b/internal/store/replicationcontroller_test.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -113,8 +113,8 @@ func TestReplicationControllerStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(replicationControllerMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(replicationControllerMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(replicationControllerMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(replicationControllerMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/resourcequota.go
+++ b/internal/store/resourcequota.go
@@ -25,12 +25,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
 	descResourceQuotaLabelsDefaultLabels = []string{"namespace", "resourcequota"}
 
-	resourceQuotaMetricFamilies = []metric.FamilyGenerator{
+	resourceQuotaMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_resourcequota_created",
 			Type: metric.Gauge,

--- a/internal/store/resourcequota_test.go
+++ b/internal/store/resourcequota_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestResourceQuotaStore(t *testing.T) {
@@ -134,8 +134,8 @@ func TestResourceQuotaStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(resourceQuotaMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(resourceQuotaMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(resourceQuotaMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(resourceQuotaMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -32,7 +33,7 @@ var (
 	descSecretLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descSecretLabelsDefaultLabels = []string{"namespace", "secret"}
 
-	secretMetricFamilies = []metric.FamilyGenerator{
+	secretMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_secret_info",
 			Type: metric.Gauge,

--- a/internal/store/secret_test.go
+++ b/internal/store/secret_test.go
@@ -22,7 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestSecretStore(t *testing.T) {
@@ -117,8 +117,8 @@ func TestSecretStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(secretMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(secretMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(secretMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(secretMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -32,7 +33,7 @@ var (
 	descServiceLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descServiceLabelsDefaultLabels = []string{"namespace", "service"}
 
-	serviceMetricFamilies = []metric.FamilyGenerator{
+	serviceMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_service_info",
 			Type: metric.Gauge,

--- a/internal/store/service_test.go
+++ b/internal/store/service_test.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestServiceStore(t *testing.T) {
@@ -209,8 +209,8 @@ func TestServiceStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(serviceMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(serviceMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(serviceMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(serviceMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +33,7 @@ var (
 	descStatefulSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descStatefulSetLabelsDefaultLabels = []string{"namespace", "statefulset"}
 
-	statefulSetMetricFamilies = []metric.FamilyGenerator{
+	statefulSetMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_statefulset_created",
 			Type: metric.Gauge,

--- a/internal/store/statefulset_test.go
+++ b/internal/store/statefulset_test.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -241,8 +241,8 @@ func TestStatefulSetStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(statefulSetMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(statefulSetMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(statefulSetMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(statefulSetMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -15,6 +15,7 @@ package store
 
 import (
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -32,7 +33,7 @@ var (
 	defaultReclaimPolicy                = v1.PersistentVolumeReclaimDelete
 	defaultVolumeBindingMode            = storagev1.VolumeBindingImmediate
 
-	storageClassMetricFamilies = []metric.FamilyGenerator{
+	storageClassMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_storageclass_info",
 			Type: metric.Gauge,

--- a/internal/store/storageclass_test.go
+++ b/internal/store/storageclass_test.go
@@ -20,7 +20,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestStorageClassStore(t *testing.T) {
@@ -108,8 +108,8 @@ func TestStorageClassStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(storageClassMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(storageClassMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(storageClassMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(storageClassMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -34,7 +34,7 @@ type generateMetricsTestCase struct {
 	MetricNames []string
 	Want        string
 	Headers     []string
-	Func        func(interface{}) []*metric.Family
+	Func        func(interface{}) []metric.FamilityInterface
 }
 
 func (testCase *generateMetricsTestCase) run() error {

--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
+	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
 type generateMetricsTestCase struct {
@@ -34,7 +34,7 @@ type generateMetricsTestCase struct {
 	MetricNames []string
 	Want        string
 	Headers     []string
-	Func        func(interface{}) []metricsstore.FamilyByteSlicer
+	Func        func(interface{}) []*metric.Family
 }
 
 func (testCase *generateMetricsTestCase) run() error {

--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -34,7 +34,7 @@ type generateMetricsTestCase struct {
 	MetricNames []string
 	Want        string
 	Headers     []string
-	Func        func(interface{}) []metric.FamilityInterface
+	Func        func(interface{}) []metric.FamilyInterface
 }
 
 func (testCase *generateMetricsTestCase) run() error {

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -25,13 +25,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
 	descValidatingWebhookConfigurationHelp          = "Kubernetes labels converted to Prometheus labels."
 	descValidatingWebhookConfigurationDefaultLabels = []string{"namespace", "validatingwebhookconfiguration"}
 
-	validatingWebhookConfigurationMetricFamilies = []metric.FamilyGenerator{
+	validatingWebhookConfigurationMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: "kube_validatingwebhookconfiguration_info",
 			Type: metric.Gauge,

--- a/internal/store/validatingwebhookconfiguration_test.go
+++ b/internal/store/validatingwebhookconfiguration_test.go
@@ -22,7 +22,7 @@ import (
 	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestValidatingWebhookConfigurationStore(t *testing.T) {
@@ -72,8 +72,8 @@ func TestValidatingWebhookConfigurationStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(validatingWebhookConfigurationMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(validatingWebhookConfigurationMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(validatingWebhookConfigurationMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(validatingWebhookConfigurationMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/verticalpodautoscaler.go
+++ b/internal/store/verticalpodautoscaler.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/kube-state-metrics/pkg/constant"
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -35,7 +36,7 @@ var (
 	descVerticalPodAutoscalerLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descVerticalPodAutoscalerLabelsDefaultLabels = []string{"namespace", "verticalpodautoscaler", "target_api_version", "target_kind", "target_name"}
 
-	vpaMetricFamilies = []metric.FamilyGenerator{
+	vpaMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: descVerticalPodAutoscalerLabelsName,
 			Type: metric.Gauge,

--- a/internal/store/verticalpodautoscaler_test.go
+++ b/internal/store/verticalpodautoscaler_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	autoscaling "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestVPAStore(t *testing.T) {
@@ -133,8 +133,8 @@ func TestVPAStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(vpaMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(vpaMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(vpaMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(vpaMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/volumeattachment.go
+++ b/internal/store/volumeattachment.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 var (
@@ -32,7 +33,7 @@ var (
 	descVolumeAttachmentLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descVolumeAttachmentLabelsDefaultLabels = []string{"volumeattachment"}
 
-	volumeAttachmentMetricFamilies = []metric.FamilyGenerator{
+	volumeAttachmentMetricFamilies = []generator.FamilyGenerator{
 		{
 			Name: descVolumeAttachmentLabelsName,
 			Type: metric.Gauge,

--- a/internal/store/volumeattachment_test.go
+++ b/internal/store/volumeattachment_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package store
 
 import (
+	"testing"
+
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"testing"
-
-	"k8s.io/kube-state-metrics/pkg/metric"
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
 )
 
 func TestVolumeAttachmentStore(t *testing.T) {
@@ -87,8 +87,8 @@ func TestVolumeAttachmentStore(t *testing.T) {
 		}
 	)
 	for i, c := range cases {
-		c.Func = metric.ComposeMetricGenFuncs(volumeAttachmentMetricFamilies)
-		c.Headers = metric.ExtractMetricFamilyHeaders(volumeAttachmentMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(volumeAttachmentMetricFamilies)
+		c.Headers = generator.ExtractMetricFamilyHeaders(volumeAttachmentMetricFamilies)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/main.go
+++ b/main.go
@@ -140,6 +140,8 @@ func main() {
 
 	storeBuilder.WithWhiteBlackList(whiteBlackList)
 
+	storeBuilder.WithGenerateStoreFunc(storeBuilder.DefaultGenerateStoreFunc())
+
 	proc.StartReaper()
 
 	kubeClient, vpaClient, err := createKubeClient(opts.Apiserver, opts.Kubeconfig)

--- a/main_test.go
+++ b/main_test.go
@@ -66,6 +66,7 @@ func BenchmarkKubeStateMetrics(b *testing.B) {
 	builder.WithSharding(0, 1)
 	builder.WithContext(ctx)
 	builder.WithNamespaces(options.DefaultNamespaces)
+	builder.WithGenerateStoreFunc(builder.DefaultGenerateStoreFunc())
 
 	l, err := whiteblacklist.New(map[string]struct{}{}, map[string]struct{}{})
 	if err != nil {
@@ -128,6 +129,7 @@ func TestFullScrapeCycle(t *testing.T) {
 	builder.WithEnabledResources(options.DefaultCollectors.AsSlice())
 	builder.WithKubeClient(kubeClient)
 	builder.WithNamespaces(options.DefaultNamespaces)
+	builder.WithGenerateStoreFunc(builder.DefaultGenerateStoreFunc())
 
 	l, err := whiteblacklist.New(map[string]struct{}{}, map[string]struct{}{})
 	if err != nil {
@@ -367,6 +369,7 @@ func TestShardingEquivalenceScrapeCycle(t *testing.T) {
 	unshardedBuilder.WithKubeClient(kubeClient)
 	unshardedBuilder.WithNamespaces(options.DefaultNamespaces)
 	unshardedBuilder.WithWhiteBlackList(l)
+	unshardedBuilder.WithGenerateStoreFunc(unshardedBuilder.DefaultGenerateStoreFunc())
 
 	unshardedHandler := metricshandler.New(&options.Options{}, kubeClient, unshardedBuilder, false)
 	unshardedHandler.ConfigureSharding(ctx, 0, 1)
@@ -378,6 +381,7 @@ func TestShardingEquivalenceScrapeCycle(t *testing.T) {
 	shardedBuilder1.WithKubeClient(kubeClient)
 	shardedBuilder1.WithNamespaces(options.DefaultNamespaces)
 	shardedBuilder1.WithWhiteBlackList(l)
+	shardedBuilder1.WithGenerateStoreFunc(shardedBuilder1.DefaultGenerateStoreFunc())
 
 	shardedHandler1 := metricshandler.New(&options.Options{}, kubeClient, shardedBuilder1, false)
 	shardedHandler1.ConfigureSharding(ctx, 0, 2)
@@ -389,6 +393,7 @@ func TestShardingEquivalenceScrapeCycle(t *testing.T) {
 	shardedBuilder2.WithKubeClient(kubeClient)
 	shardedBuilder2.WithNamespaces(options.DefaultNamespaces)
 	shardedBuilder2.WithWhiteBlackList(l)
+	shardedBuilder2.WithGenerateStoreFunc(shardedBuilder2.DefaultGenerateStoreFunc())
 
 	shardedHandler2 := metricshandler.New(&options.Options{}, kubeClient, shardedBuilder2, false)
 	shardedHandler2.ConfigureSharding(ctx, 1, 2)

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	vpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	internalstore "k8s.io/kube-state-metrics/internal/store"
+	ksmtypes "k8s.io/kube-state-metrics/pkg/builder/types"
+	"k8s.io/kube-state-metrics/pkg/options"
+)
+
+// Builder helps to build store. It follows the builder pattern
+// (https://en.wikipedia.org/wiki/Builder_pattern).
+type Builder struct {
+	internal ksmtypes.BuilderInterface
+}
+
+// NewBuilder returns a new builder.
+func NewBuilder() *Builder {
+	b := &Builder{
+		internal: internalstore.NewBuilder(),
+	}
+	return b
+}
+
+// WithMetrics sets the metrics property of a Builder.
+func (b *Builder) WithMetrics(r *prometheus.Registry) {
+	b.internal.WithMetrics(r)
+}
+
+// WithEnabledResources sets the enabledResources property of a Builder.
+func (b *Builder) WithEnabledResources(c []string) error {
+	return b.internal.WithEnabledResources(c)
+}
+
+// WithNamespaces sets the namespaces property of a Builder.
+func (b *Builder) WithNamespaces(n options.NamespaceList) {
+	b.internal.WithNamespaces(n)
+}
+
+// WithSharding sets the shard and totalShards property of a Builder.
+func (b *Builder) WithSharding(shard int32, totalShards int) {
+	b.internal.WithSharding(shard, totalShards)
+}
+
+// WithContext sets the ctx property of a Builder.
+func (b *Builder) WithContext(ctx context.Context) {
+	b.internal.WithContext(ctx)
+}
+
+// WithKubeClient sets the kubeClient property of a Builder.
+func (b *Builder) WithKubeClient(c clientset.Interface) {
+	b.internal.WithKubeClient(c)
+}
+
+// WithVPAClient sets the vpaClient property of a Builder so that the verticalpodautoscaler collector can query VPA objects.
+func (b *Builder) WithVPAClient(c vpaclientset.Interface) {
+	b.internal.WithVPAClient(c)
+}
+
+// WithWhiteBlackList configures the white or blacklisted metric to be exposed
+// by the store build by the Builder.
+func (b *Builder) WithWhiteBlackList(l ksmtypes.WhiteBlackLister) {
+	b.internal.WithWhiteBlackList(l)
+}
+
+// WithCustomGenerateStoreFunc configures a constom generate store function
+func (b *Builder) WithCustomGenerateStoreFunc(f ksmtypes.BuildStoreFunc) {
+	b.internal.WithCustomGenerateStoreFunc(f)
+}
+
+// Build initializes and registers all enabled stores.
+func (b *Builder) Build() []cache.Store {
+	return b.internal.Build()
+}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -84,9 +84,14 @@ func (b *Builder) WithWhiteBlackList(l ksmtypes.WhiteBlackLister) {
 	b.internal.WithWhiteBlackList(l)
 }
 
-// WithCustomGenerateStoreFunc configures a constom generate store function
-func (b *Builder) WithCustomGenerateStoreFunc(f ksmtypes.BuildStoreFunc) {
-	b.internal.WithCustomGenerateStoreFunc(f)
+// WithGenerateStoreFunc configures a constom generate store function
+func (b *Builder) WithGenerateStoreFunc(f ksmtypes.BuildStoreFunc) {
+	b.internal.WithGenerateStoreFunc(f)
+}
+
+// DefaultGenerateStoreFunc returns default buildStore function
+func (b *Builder) DefaultGenerateStoreFunc() ksmtypes.BuildStoreFunc {
+	return b.internal.DefaultGenerateStoreFunc()
 }
 
 // Build initializes and registers all enabled stores.

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors All rights reserved.
+Copyright 2019 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -38,7 +38,8 @@ type BuilderInterface interface {
 	WithKubeClient(c clientset.Interface)
 	WithVPAClient(c vpaclientset.Interface)
 	WithWhiteBlackList(l WhiteBlackLister)
-	WithCustomGenerateStoreFunc(f BuildStoreFunc)
+	WithGenerateStoreFunc(f BuildStoreFunc)
+	DefaultGenerateStoreFunc() BuildStoreFunc
 	Build() []cache.Store
 }
 

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	vpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
+	"k8s.io/kube-state-metrics/pkg/options"
+)
+
+// BuilderInterface represent all methods that a Builder should implements
+type BuilderInterface interface {
+	WithMetrics(r *prometheus.Registry)
+	WithEnabledResources(c []string) error
+	WithNamespaces(n options.NamespaceList)
+	WithSharding(shard int32, totalShards int)
+	WithContext(ctx context.Context)
+	WithKubeClient(c clientset.Interface)
+	WithVPAClient(c vpaclientset.Interface)
+	WithWhiteBlackList(l WhiteBlackLister)
+	WithCustomGenerateStoreFunc(f BuildStoreFunc)
+	Build() []cache.Store
+}
+
+// BuildStoreFunc function signature that is use to returns a cache.Store
+type BuildStoreFunc func(metricFamilies []generator.FamilyGenerator,
+	expectedType interface{},
+	listWatchFunc func(kubeClient clientset.Interface, ns string) cache.ListerWatcher,
+) cache.Store
+
+// WhiteBlackLister interface for WhiteBlack lister that can allow or exclude metrics by there names
+type WhiteBlackLister interface {
+	IsIncluded(string) bool
+	IsExcluded(string) bool
+}

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors All rights reserved.
+Copyright 2019 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/metric/family.go
+++ b/pkg/metric/family.go
@@ -23,6 +23,7 @@ import (
 // Family represents a set of metrics with the same name and help text.
 type Family struct {
 	Name    string
+	Type    Type
 	Metrics []*Metric
 }
 

--- a/pkg/metric/family.go
+++ b/pkg/metric/family.go
@@ -20,11 +20,22 @@ import (
 	"strings"
 )
 
+// FamilityInterface interface for a family
+type FamilityInterface interface {
+	Inspect(inspect func(Family))
+	ByteSlice() []byte
+}
+
 // Family represents a set of metrics with the same name and help text.
 type Family struct {
 	Name    string
 	Type    Type
 	Metrics []*Metric
+}
+
+// Inspect use to instact the inside of a Family
+func (f Family) Inspect(inspect func(Family)) {
+	inspect(f)
 }
 
 // ByteSlice returns the given Family in its string representation.

--- a/pkg/metric/family.go
+++ b/pkg/metric/family.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 )
 
-// FamilityInterface interface for a family
-type FamilityInterface interface {
+// FamilyInterface interface for a family
+type FamilyInterface interface {
 	Inspect(inspect func(Family))
 	ByteSlice() []byte
 }

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metric
+package generator
 
 import (
 	"strings"
 
-	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
+	"k8s.io/kube-state-metrics/pkg/metric"
 )
 
 // FamilyGenerator provides everything needed to generate a metric family with a
@@ -27,15 +27,15 @@ import (
 type FamilyGenerator struct {
 	Name         string
 	Help         string
-	Type         Type
-	GenerateFunc func(obj interface{}) *Family
+	Type         metric.Type
+	GenerateFunc func(obj interface{}) *metric.Family
 }
 
 // Generate calls the FamilyGenerator.GenerateFunc and gives the family its
 // name. The reasoning behind injecting the name at such a late point in time is
 // deduplication in the code, preventing typos made by developers as
 // well as saving memory.
-func (g *FamilyGenerator) Generate(obj interface{}) *Family {
+func (g *FamilyGenerator) Generate(obj interface{}) *metric.Family {
 	family := g.GenerateFunc(obj)
 	family.Name = g.Name
 	return family
@@ -70,9 +70,9 @@ func ExtractMetricFamilyHeaders(families []FamilyGenerator) []string {
 
 // ComposeMetricGenFuncs takes a slice of metric families and returns a function
 // that composes their metric generation functions into a single one.
-func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []metricsstore.FamilyByteSlicer {
-	return func(obj interface{}) []metricsstore.FamilyByteSlicer {
-		families := make([]metricsstore.FamilyByteSlicer, len(familyGens))
+func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []*metric.Family {
+	return func(obj interface{}) []*metric.Family {
+		families := make([]*metric.Family, len(familyGens))
 
 		for i, gen := range familyGens {
 			families[i] = gen.Generate(obj)

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -71,9 +71,9 @@ func ExtractMetricFamilyHeaders(families []FamilyGenerator) []string {
 
 // ComposeMetricGenFuncs takes a slice of metric families and returns a function
 // that composes their metric generation functions into a single one.
-func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []*metric.Family {
-	return func(obj interface{}) []*metric.Family {
-		families := make([]*metric.Family, len(familyGens))
+func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []metric.FamilityInterface {
+	return func(obj interface{}) []metric.FamilityInterface {
+		families := make([]metric.FamilityInterface, len(familyGens))
 
 		for i, gen := range familyGens {
 			families[i] = gen.Generate(obj)

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -38,6 +38,7 @@ type FamilyGenerator struct {
 func (g *FamilyGenerator) Generate(obj interface{}) *metric.Family {
 	family := g.GenerateFunc(obj)
 	family.Name = g.Name
+	family.Type = g.Type
 	return family
 }
 

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -71,9 +71,9 @@ func ExtractMetricFamilyHeaders(families []FamilyGenerator) []string {
 
 // ComposeMetricGenFuncs takes a slice of metric families and returns a function
 // that composes their metric generation functions into a single one.
-func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []metric.FamilityInterface {
-	return func(obj interface{}) []metric.FamilityInterface {
-		families := make([]metric.FamilityInterface, len(familyGens))
+func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []metric.FamilyInterface {
+	return func(obj interface{}) []metric.FamilyInterface {
+		families := make([]metric.FamilyInterface, len(familyGens))
 
 		for i, gen := range familyGens {
 			families[i] = gen.Generate(obj)

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -44,11 +44,11 @@ type MetricsStore struct {
 
 	// generateMetricsFunc generates metrics based on a given Kubernetes object
 	// and returns them grouped by metric family.
-	generateMetricsFunc func(interface{}) []*metric.Family
+	generateMetricsFunc func(interface{}) []metric.FamilityInterface
 }
 
 // NewMetricsStore returns a new MetricsStore
-func NewMetricsStore(headers []string, generateFunc func(interface{}) []*metric.Family) *MetricsStore {
+func NewMetricsStore(headers []string, generateFunc func(interface{}) []metric.FamilityInterface) *MetricsStore {
 	return &MetricsStore{
 		generateMetricsFunc: generateFunc,
 		headers:             headers,

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -22,13 +22,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
-)
 
-// FamilyByteSlicer represents a metric family that can be converted to its string
-// representation.
-type FamilyByteSlicer interface {
-	ByteSlice() []byte
-}
+	"k8s.io/kube-state-metrics/pkg/metric"
+)
 
 // MetricsStore implements the k8s.io/client-go/tools/cache.Store
 // interface. Instead of storing entire Kubernetes objects, it stores metrics
@@ -48,11 +44,11 @@ type MetricsStore struct {
 
 	// generateMetricsFunc generates metrics based on a given Kubernetes object
 	// and returns them grouped by metric family.
-	generateMetricsFunc func(interface{}) []FamilyByteSlicer
+	generateMetricsFunc func(interface{}) []*metric.Family
 }
 
 // NewMetricsStore returns a new MetricsStore
-func NewMetricsStore(headers []string, generateFunc func(interface{}) []FamilyByteSlicer) *MetricsStore {
+func NewMetricsStore(headers []string, generateFunc func(interface{}) []*metric.Family) *MetricsStore {
 	return &MetricsStore{
 		generateMetricsFunc: generateFunc,
 		headers:             headers,

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -44,11 +44,11 @@ type MetricsStore struct {
 
 	// generateMetricsFunc generates metrics based on a given Kubernetes object
 	// and returns them grouped by metric family.
-	generateMetricsFunc func(interface{}) []metric.FamilityInterface
+	generateMetricsFunc func(interface{}) []metric.FamilyInterface
 }
 
 // NewMetricsStore returns a new MetricsStore
-func NewMetricsStore(headers []string, generateFunc func(interface{}) []metric.FamilityInterface) *MetricsStore {
+func NewMetricsStore(headers []string, generateFunc func(interface{}) []metric.FamilyInterface) *MetricsStore {
 	return &MetricsStore{
 		generateMetricsFunc: generateFunc,
 		headers:             headers,

--- a/pkg/metrics_store/metrics_store_test.go
+++ b/pkg/metrics_store/metrics_store_test.go
@@ -43,7 +43,7 @@ func (f *metricFamily) ByteSlice() []byte {
 func TestObjectsSameNameDifferentNamespaces(t *testing.T) {
 	serviceIDS := []string{"a", "b"}
 
-	genFunc := func(obj interface{}) []*metric.Family {
+	genFunc := func(obj interface{}) []metric.FamilityInterface {
 		o, err := meta.Accessor(obj)
 		if err != nil {
 			t.Fatal(err)
@@ -60,7 +60,7 @@ func TestObjectsSameNameDifferentNamespaces(t *testing.T) {
 			},
 		}
 
-		return []*metric.Family{&metricFamily}
+		return []metric.FamilityInterface{&metricFamily}
 	}
 
 	ms := NewMetricsStore([]string{"Information about service."}, genFunc)

--- a/pkg/metrics_store/metrics_store_test.go
+++ b/pkg/metrics_store/metrics_store_test.go
@@ -43,7 +43,7 @@ func (f *metricFamily) ByteSlice() []byte {
 func TestObjectsSameNameDifferentNamespaces(t *testing.T) {
 	serviceIDS := []string{"a", "b"}
 
-	genFunc := func(obj interface{}) []metric.FamilityInterface {
+	genFunc := func(obj interface{}) []metric.FamilyInterface {
 		o, err := meta.Accessor(obj)
 		if err != nil {
 			t.Fatal(err)
@@ -60,7 +60,7 @@ func TestObjectsSameNameDifferentNamespaces(t *testing.T) {
 			},
 		}
 
-		return []metric.FamilityInterface{&metricFamily}
+		return []metric.FamilyInterface{&metricFamily}
 	}
 
 	ms := NewMetricsStore([]string{"Information about service."}, genFunc)

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -50,7 +50,7 @@ type MetricsHandler struct {
 
 	// mtx protects stores, curShard, and curTotalShards
 	mtx            *sync.RWMutex
-	stores         []*metricsstore.MetricsStore
+	stores         []cache.Store
 	curShard       int32
 	curTotalShards int
 }
@@ -199,7 +199,8 @@ func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, s := range m.stores {
-		s.WriteAll(w)
+		ms := s.(*metricsstore.MetricsStore)
+		ms.WriteAll(w)
 	}
 
 	// In case we gzipped the response, we have to close the writer.

--- a/tests/lib/lib_test.go
+++ b/tests/lib/lib_test.go
@@ -82,7 +82,7 @@ func serviceCollector(kubeClient clientset.Interface) *metricsstore.MetricsStore
 	return store
 }
 
-func generateServiceMetrics(obj interface{}) []*metric.Family {
+func generateServiceMetrics(obj interface{}) []metric.FamilityInterface {
 	sPointer := obj.(*v1.Service)
 	s := *sPointer
 
@@ -97,5 +97,5 @@ func generateServiceMetrics(obj interface{}) []*metric.Family {
 		Metrics: []*metric.Metric{&m},
 	}
 
-	return []*metric.Family{&family}
+	return []metric.FamilityInterface{&family}
 }

--- a/tests/lib/lib_test.go
+++ b/tests/lib/lib_test.go
@@ -82,7 +82,7 @@ func serviceCollector(kubeClient clientset.Interface) *metricsstore.MetricsStore
 	return store
 }
 
-func generateServiceMetrics(obj interface{}) []metric.FamilityInterface {
+func generateServiceMetrics(obj interface{}) []metric.FamilyInterface {
 	sPointer := obj.(*v1.Service)
 	s := *sPointer
 
@@ -97,5 +97,5 @@ func generateServiceMetrics(obj interface{}) []metric.FamilityInterface {
 		Metrics: []*metric.Metric{&m},
 	}
 
-	return []metric.FamilityInterface{&family}
+	return []metric.FamilyInterface{&family}
 }

--- a/tests/lib/lib_test.go
+++ b/tests/lib/lib_test.go
@@ -82,7 +82,7 @@ func serviceCollector(kubeClient clientset.Interface) *metricsstore.MetricsStore
 	return store
 }
 
-func generateServiceMetrics(obj interface{}) []metricsstore.FamilyByteSlicer {
+func generateServiceMetrics(obj interface{}) []*metric.Family {
 	sPointer := obj.(*v1.Service)
 	s := *sPointer
 
@@ -97,5 +97,5 @@ func generateServiceMetrics(obj interface{}) []metricsstore.FamilyByteSlicer {
 		Metrics: []*metric.Metric{&m},
 	}
 
-	return []metricsstore.FamilyByteSlicer{&family}
+	return []*metric.Family{&family}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PullRequest allows a third-party project to reuse the kube-state-metrics `collectors` by adding a way to configure a custom `cache.Store` generator function in the `store.Builder`.

In summary, the modifications are:
* Use `cache.Store` interface in “Builder”. It is a lot of code changes, but it is mainly a one to one replacement.
* Remove the FamilyByteSlicer interface and provide access to “metrics.Family” directly. Also, I have to split into two packages “metrics” package (creation of “metrics generator”) package to solve a cyclic import issue.
* To keep all the logic in the internal package, I created a public package that implements a kind of “bridge” pattern and also an interface for the Builder.


**Which issue(s) this PR fixes**

Fixes #973

