### PR TITLE
fix nil panics parsing hpa cpu current metrics

### DIFF
--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -146,7 +146,7 @@ func TestHPAStore(t *testing.T) {
 							Resource: &autoscaling.ResourceMetricStatus{
 								Name:                      "cpu",
 								CurrentAverageUtilization: new(int32),
-								CurrentAverageValue:       resource.MustParse("10"),
+								CurrentAverageValue:       resource.MustParse("7m"),
 							},
 						},
 					},
@@ -170,7 +170,7 @@ func TestHPAStore(t *testing.T) {
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="unknown"} 0
 				kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
 				kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
-				kube_hpa_status_current_metrics_average_value{hpa="hpa1",namespace="ns1"} 10
+				kube_hpa_status_current_metrics_average_value{hpa="hpa1",namespace="ns1"} 0.007
 				kube_hpa_status_current_metrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
 			`,
 			MetricNames: []string{


### PR DESCRIPTION
This PR fixes a nil de-referencing issue [here](https://github.com/kubernetes/kube-state-metrics/blob/4e4a49fe935318adff0c6ed0c3f044e5e7686875/internal/store/hpa.go#L285).

The root cause of this issue is a nil metric element being added to the metric family slice. These nil metrics are added when parsing `kube_hpa_status_current_metrics_average_value` CPU metrics. This is because CPU metrics need to be handled differently owing to the fact that they are scaled metrics.