### PR TITLE
Move resource version from metric label to metric number value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v1.9.0-rc.0 / 2019-12-04
 
+* [BUGFIX] Move resource version from metric label to metric number value #997
+
+## v1.9.0-rc.0 / 2019-12-04
+
 * [CHANGE] Add tools as go modules #927
 * [FEATURE] Add `kube_hpa_spec_target_metric` metric. #966
 * [FEATURE] Add hpa stats for current utilization and average value. #961

--- a/docs/configmap-metrics.md
+++ b/docs/configmap-metrics.md
@@ -4,4 +4,4 @@
 | ---------- | ----------- | ----------- | ----------- |
 | kube_configmap_info | Gauge | `configmap`=&lt;configmap-name&gt; <br> `namespace`=&lt;configmap-namespace&gt; | STABLE |
 | kube_configmap_created  | Gauge | `configmap`=&lt;configmap-name&gt; <br> `namespace`=&lt;configmap-namespace&gt; | STABLE |
-| kube_configmap_metadata_resource_version | Gauge | `configmap`=&lt;configmap-name&gt; <br> `namespace`=&lt;configmap-namespace&gt; <br> `resource_version`=&lt;configmap-resource-version&gt; | STABLE |
+| kube_configmap_metadata_resource_version | Gauge | `configmap`=&lt;configmap-name&gt; <br> `namespace`=&lt;configmap-namespace&gt; | EXPERIMENTAL |

--- a/docs/ingress-metrics.md
+++ b/docs/ingress-metrics.md
@@ -5,6 +5,6 @@
 | kube_ingress_info | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; | STABLE |
 | kube_ingress_labels | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `label_INGRESS_LABEL`=&lt;INGRESS_LABEL&gt; | STABLE |
 | kube_ingress_created  | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; | STABLE |
-| kube_ingress_metadata_resource_version  | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `resource_version`=&lt;ingress-resource-version&gt; | STABLE |
+| kube_ingress_metadata_resource_version  | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; | EXPERIMENTAL |
 | kube_ingress_path | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `host`=&lt;ingress-host&gt; <br> `path`=&lt;ingress-path&gt; <br> `service_name`=&lt;service name for the path&gt; <br> `service_port`=&lt;service port for hte path&gt; | STABLE |
 | kube_ingress_tls | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `tls_host`=&lt;tls hostname&gt; <br> `secret`=&lt;tls secret name&gt;| STABLE |

--- a/docs/mutatingwebhookconfiguration.md
+++ b/docs/mutatingwebhookconfiguration.md
@@ -4,4 +4,4 @@
 | ---------- | ----------- | ----------- | ----------- |
 | kube_mutatingwebhookconfiguration_info | Gauge | `mutatingwebhookconfiguration`=&lt;mutatingwebhookconfiguration-name&gt; <br> `namespace`=&lt;mutatingwebhookconfiguration-namespace&gt; | EXPERIMENTAL |
 | kube_mutatingwebhookconfiguration_created  | Gauge | `mutatingwebhookconfiguration`=&lt;mutatingwebhookconfiguration-name&gt; <br> `namespace`=&lt;mutatingwebhookconfiguration-namespace&gt; | EXPERIMENTAL |
-| kube_mutatingwebhookconfiguration_metadata_resource_version | Gauge | `mutatingwebhookconfiguration`=&lt;mutatingwebhookconfiguration-name&gt; <br> `namespace`=&lt;mutatingwebhookconfiguration-namespace&gt; <br> `resource_version`=&lt;mutatingwebhookconfiguration-resource-version&gt; | EXPERIMENTAL |
+| kube_mutatingwebhookconfiguration_metadata_resource_version | Gauge | `mutatingwebhookconfiguration`=&lt;mutatingwebhookconfiguration-name&gt; <br> `namespace`=&lt;mutatingwebhookconfiguration-namespace&gt; | EXPERIMENTAL |

--- a/docs/secret-metrics.md
+++ b/docs/secret-metrics.md
@@ -6,4 +6,4 @@
 | kube_secret_type | Gauge | `secret`=&lt;secret-name&gt; <br> `namespace`=&lt;secret-namespace&gt; <br> `type`=&lt;secret-type&gt; | STABLE |
 | kube_secret_labels | Gauge | `secret`=&lt;secret-name&gt; <br> `namespace`=&lt;secret-namespace&gt; <br> `label_SECRET_LABEL`=&lt;SECRET_LABEL&gt; | STABLE |
 | kube_secret_created  | Gauge | `secret`=&lt;secret-name&gt; <br> `namespace`=&lt;secret-namespace&gt; | STABLE |
-| kube_secret_metadata_resource_version  | Gauge | `secret`=&lt;secret-name&gt; <br> `namespace`=&lt;secret-namespace&gt; <br> `resource_version`=&lt;secret-resource-version&gt; | STABLE |
+| kube_secret_metadata_resource_version  | Gauge | `secret`=&lt;secret-name&gt; <br> `namespace`=&lt;secret-namespace&gt; | EXPERIMENTAL |

--- a/docs/validatingwebhookconfiguration.md
+++ b/docs/validatingwebhookconfiguration.md
@@ -4,4 +4,4 @@
 | ---------- | ----------- | ----------- | ----------- |
 | kube_validatingwebhookconfiguration_info | Gauge | `validatingwebhookconfiguration`=&lt;validatingwebhookconfiguration-name&gt; <br> `namespace`=&lt;validatingwebhookconfiguration-namespace&gt; | EXPERIMENTAL |
 | kube_validatingwebhookconfiguration_created  | Gauge | `validatingwebhookconfiguration`=&lt;validatingwebhookconfiguration-name&gt; <br> `namespace`=&lt;validatingwebhookconfiguration-namespace&gt; | EXPERIMENTAL |
-| kube_validatingwebhookconfiguration_metadata_resource_version | Gauge | `validatingwebhookconfiguration`=&lt;validatingwebhookconfiguration-name&gt; <br> `namespace`=&lt;validatingwebhookconfiguration-namespace&gt; <br> `resource_version`=&lt;validatingwebhookconfiguration-resource-version&gt; | EXPERIMENTAL |
+| kube_validatingwebhookconfiguration_metadata_resource_version | Gauge | `validatingwebhookconfiguration`=&lt;validatingwebhookconfiguration-name&gt; <br> `namespace`=&lt;validatingwebhookconfiguration-namespace&gt; | EXPERIMENTAL |

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -71,13 +71,7 @@ var (
 			Help: "Resource version representing a specific version of the configmap.",
 			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{"resource_version"},
-							LabelValues: []string{c.ObjectMeta.ResourceVersion},
-							Value:       1,
-						},
-					},
+					Metrics: resourceVersionMetric(c.ObjectMeta.ResourceVersion),
 				}
 			}),
 		},

--- a/internal/store/configmap_test.go
+++ b/internal/store/configmap_test.go
@@ -35,7 +35,7 @@ func TestConfigMapStore(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "configmap1",
 					Namespace:       "ns1",
-					ResourceVersion: "123456",
+					ResourceVersion: "BBBBB",
 				},
 			},
 			Want: `
@@ -44,7 +44,6 @@ func TestConfigMapStore(t *testing.T) {
 				# TYPE kube_configmap_info gauge
 				# TYPE kube_configmap_metadata_resource_version gauge
 				kube_configmap_info{configmap="configmap1",namespace="ns1"} 1
-				kube_configmap_metadata_resource_version{configmap="configmap1",namespace="ns1",resource_version="123456"} 1
 `,
 			MetricNames: []string{"kube_configmap_info", "kube_configmap_metadata_resource_version"},
 		},
@@ -54,7 +53,7 @@ func TestConfigMapStore(t *testing.T) {
 					Name:              "configmap2",
 					Namespace:         "ns2",
 					CreationTimestamp: metav1StartTime,
-					ResourceVersion:   "abcdef",
+					ResourceVersion:   "10596",
 				},
 			},
 			Want: `
@@ -66,7 +65,7 @@ func TestConfigMapStore(t *testing.T) {
 				# TYPE kube_configmap_metadata_resource_version gauge
 				kube_configmap_info{configmap="configmap2",namespace="ns2"} 1
 				kube_configmap_created{configmap="configmap2",namespace="ns2"} 1.501569018e+09
-				kube_configmap_metadata_resource_version{configmap="configmap2",namespace="ns2",resource_version="abcdef"} 1
+				kube_configmap_metadata_resource_version{configmap="configmap2",namespace="ns2"} 10596
 				`,
 			MetricNames: []string{"kube_configmap_info", "kube_configmap_created", "kube_configmap_metadata_resource_version"},
 		},

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -88,13 +88,8 @@ var (
 			Help: "Resource version representing a specific version of ingress.",
 			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
 				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{"resource_version"},
-							LabelValues: []string{i.ObjectMeta.ResourceVersion},
-							Value:       1,
-						},
-					}}
+					Metrics: resourceVersionMetric(i.ObjectMeta.ResourceVersion),
+				}
 			}),
 		},
 		{

--- a/internal/store/ingress_test.go
+++ b/internal/store/ingress_test.go
@@ -57,7 +57,7 @@ func TestIngressStore(t *testing.T) {
 			},
 			Want: metadata + `
 				kube_ingress_info{namespace="ns1",ingress="ingress1"} 1
-				kube_ingress_metadata_resource_version{namespace="ns1",resource_version="000000",ingress="ingress1"} 1
+				kube_ingress_metadata_resource_version{namespace="ns1",ingress="ingress1"} 0
 				kube_ingress_labels{namespace="ns1",ingress="ingress1"} 1
 `,
 			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_tls"},
@@ -74,7 +74,7 @@ func TestIngressStore(t *testing.T) {
 			Want: metadata + `
 				kube_ingress_info{namespace="ns2",ingress="ingress2"} 1
 				kube_ingress_created{namespace="ns2",ingress="ingress2"} 1.501569018e+09
-				kube_ingress_metadata_resource_version{namespace="ns2",resource_version="123456",ingress="ingress2"} 1
+				kube_ingress_metadata_resource_version{namespace="ns2",ingress="ingress2"} 123456
 				kube_ingress_labels{namespace="ns2",ingress="ingress2"} 1
 				`,
 			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_tls"},
@@ -92,7 +92,6 @@ func TestIngressStore(t *testing.T) {
 			Want: metadata + `
 				kube_ingress_info{namespace="ns3",ingress="ingress3"} 1
 				kube_ingress_created{namespace="ns3",ingress="ingress3"} 1.501569018e+09
-				kube_ingress_metadata_resource_version{namespace="ns3",resource_version="abcdef",ingress="ingress3"} 1
 				kube_ingress_labels{label_test_3="test-3",namespace="ns3",ingress="ingress3"} 1
 `,
 			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_tls"},
@@ -133,7 +132,6 @@ func TestIngressStore(t *testing.T) {
 			Want: metadata + `
 				kube_ingress_info{namespace="ns4",ingress="ingress4"} 1
 				kube_ingress_created{namespace="ns4",ingress="ingress4"} 1.501569018e+09
-				kube_ingress_metadata_resource_version{namespace="ns4",resource_version="abcdef",ingress="ingress4"} 1
 				kube_ingress_labels{label_test_4="test-4",namespace="ns4",ingress="ingress4"} 1
 				kube_ingress_path{namespace="ns4",ingress="ingress4",host="somehost",path="/somepath",service_name="someservice",service_port="1234"} 1
 `,
@@ -160,7 +158,6 @@ func TestIngressStore(t *testing.T) {
 			Want: metadata + `
 				kube_ingress_info{namespace="ns5",ingress="ingress5"} 1
 				kube_ingress_created{namespace="ns5",ingress="ingress5"} 1.501569018e+09
-				kube_ingress_metadata_resource_version{namespace="ns5",resource_version="abcdef",ingress="ingress5"} 1
 				kube_ingress_labels{label_test_5="test-5",namespace="ns5",ingress="ingress5"} 1
 				kube_ingress_tls{namespace="ns5",ingress="ingress5",tls_host="somehost1",secret="somesecret"} 1
 				kube_ingress_tls{namespace="ns5",ingress="ingress5",tls_host="somehost2",secret="somesecret"} 1

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -69,13 +69,7 @@ var (
 			Help: "Resource version representing a specific version of the MutatingWebhookConfiguration.",
 			GenerateFunc: wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistration.MutatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{"resource_version"},
-							LabelValues: []string{mwc.ObjectMeta.ResourceVersion},
-							Value:       1,
-						},
-					},
+					Metrics: resourceVersionMetric(mwc.ObjectMeta.ResourceVersion),
 				}
 			}),
 		},

--- a/internal/store/mutatingwebhookconfiguration_test.go
+++ b/internal/store/mutatingwebhookconfiguration_test.go
@@ -44,7 +44,7 @@ func TestMutatingWebhookConfigurationStore(t *testing.T) {
 				# TYPE kube_mutatingwebhookconfiguration_info gauge
 				# TYPE kube_mutatingwebhookconfiguration_metadata_resource_version gauge
 				kube_mutatingwebhookconfiguration_info{mutatingwebhookconfiguration="mutatingwebhookconfiguration1",namespace="ns1"} 1
-				kube_mutatingwebhookconfiguration_metadata_resource_version{mutatingwebhookconfiguration="mutatingwebhookconfiguration1",namespace="ns1",resource_version="123456"} 1
+				kube_mutatingwebhookconfiguration_metadata_resource_version{mutatingwebhookconfiguration="mutatingwebhookconfiguration1",namespace="ns1"} 123456
 				`,
 			MetricNames: []string{"kube_mutatingwebhookconfiguration_info", "kube_mutatingwebhookconfiguration_metadata_resource_version"},
 		},
@@ -66,7 +66,6 @@ func TestMutatingWebhookConfigurationStore(t *testing.T) {
 			# TYPE kube_mutatingwebhookconfiguration_metadata_resource_version gauge
 			kube_mutatingwebhookconfiguration_created{mutatingwebhookconfiguration="mutatingwebhookconfiguration2",namespace="ns2"} 1.501569018e+09
 			kube_mutatingwebhookconfiguration_info{mutatingwebhookconfiguration="mutatingwebhookconfiguration2",namespace="ns2"} 1
-			kube_mutatingwebhookconfiguration_metadata_resource_version{mutatingwebhookconfiguration="mutatingwebhookconfiguration2",namespace="ns2",resource_version="abcdef"} 1
 			`,
 			MetricNames: []string{"kube_mutatingwebhookconfiguration_created", "kube_mutatingwebhookconfiguration_info", "kube_mutatingwebhookconfiguration_metadata_resource_version"},
 		},

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -105,13 +105,7 @@ var (
 			Help: "Resource version representing a specific version of secret.",
 			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{"resource_version"},
-							LabelValues: []string{s.ObjectMeta.ResourceVersion},
-							Value:       1,
-						},
-					},
+					Metrics: resourceVersionMetric(s.ObjectMeta.ResourceVersion),
 				}
 			}),
 		},

--- a/internal/store/secret_test.go
+++ b/internal/store/secret_test.go
@@ -51,7 +51,7 @@ func TestSecretStore(t *testing.T) {
 				# TYPE kube_secret_type gauge
 				kube_secret_info{namespace="ns1",secret="secret1"} 1
 				kube_secret_type{namespace="ns1",secret="secret1",type="Opaque"} 1
-				kube_secret_metadata_resource_version{namespace="ns1",resource_version="000000",secret="secret1"} 1
+				kube_secret_metadata_resource_version{namespace="ns1",secret="secret1"} 0
 				kube_secret_labels{namespace="ns1",secret="secret1"} 1
 `,
 			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},
@@ -62,7 +62,7 @@ func TestSecretStore(t *testing.T) {
 					Name:              "secret2",
 					Namespace:         "ns2",
 					CreationTimestamp: metav1StartTime,
-					ResourceVersion:   "123456",
+					ResourceVersion:   "123456B",
 				},
 				Type: v1.SecretTypeServiceAccountToken,
 			},
@@ -80,7 +80,6 @@ func TestSecretStore(t *testing.T) {
 				kube_secret_info{namespace="ns2",secret="secret2"} 1
 				kube_secret_type{namespace="ns2",secret="secret2",type="kubernetes.io/service-account-token"} 1
 				kube_secret_created{namespace="ns2",secret="secret2"} 1.501569018e+09
-				kube_secret_metadata_resource_version{namespace="ns2",resource_version="123456",secret="secret2"} 1
 				kube_secret_labels{namespace="ns2",secret="secret2"} 1
 				`,
 			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},
@@ -92,7 +91,7 @@ func TestSecretStore(t *testing.T) {
 					Namespace:         "ns3",
 					CreationTimestamp: metav1StartTime,
 					Labels:            map[string]string{"test-3": "test-3"},
-					ResourceVersion:   "abcdef",
+					ResourceVersion:   "0",
 				},
 				Type: v1.SecretTypeDockercfg,
 			},
@@ -110,7 +109,7 @@ func TestSecretStore(t *testing.T) {
 				kube_secret_info{namespace="ns3",secret="secret3"} 1
 				kube_secret_type{namespace="ns3",secret="secret3",type="kubernetes.io/dockercfg"} 1
 				kube_secret_created{namespace="ns3",secret="secret3"} 1.501569018e+09
-				kube_secret_metadata_resource_version{namespace="ns3",resource_version="abcdef",secret="secret3"} 1
+				kube_secret_metadata_resource_version{namespace="ns3",secret="secret3"} 0
 				kube_secret_labels{label_test_3="test-3",namespace="ns3",secret="secret3"} 1
 `,
 			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -33,6 +34,20 @@ var (
 	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 	conditionStatuses  = []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionUnknown}
 )
+
+func resourceVersionMetric(rv string) []*metric.Metric {
+	v, err := strconv.ParseFloat(rv, 64)
+	if err != nil {
+		return []*metric.Metric{}
+	}
+
+	return []*metric.Metric{
+		{
+			Value: v,
+		},
+	}
+
+}
 
 func boolFloat64(b bool) float64 {
 	if b {

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -69,13 +69,7 @@ var (
 			Help: "Resource version representing a specific version of the ValidatingWebhookConfiguration.",
 			GenerateFunc: wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistration.ValidatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{"resource_version"},
-							LabelValues: []string{vwc.ObjectMeta.ResourceVersion},
-							Value:       1,
-						},
-					},
+					Metrics: resourceVersionMetric(vwc.ObjectMeta.ResourceVersion),
 				}
 			}),
 		},

--- a/internal/store/validatingwebhookconfiguration_test.go
+++ b/internal/store/validatingwebhookconfiguration_test.go
@@ -44,7 +44,7 @@ func TestValidatingWebhookConfigurationStore(t *testing.T) {
 				# TYPE kube_validatingwebhookconfiguration_info gauge
 				# TYPE kube_validatingwebhookconfiguration_metadata_resource_version gauge
 				kube_validatingwebhookconfiguration_info{validatingwebhookconfiguration="validatingwebhookconfiguration1",namespace="ns1"} 1
-				kube_validatingwebhookconfiguration_metadata_resource_version{validatingwebhookconfiguration="validatingwebhookconfiguration1",namespace="ns1",resource_version="123456"} 1
+				kube_validatingwebhookconfiguration_metadata_resource_version{validatingwebhookconfiguration="validatingwebhookconfiguration1",namespace="ns1"} 123456
 				`,
 			MetricNames: []string{"kube_validatingwebhookconfiguration_info", "kube_validatingwebhookconfiguration_metadata_resource_version"},
 		},
@@ -66,7 +66,6 @@ func TestValidatingWebhookConfigurationStore(t *testing.T) {
 			# TYPE kube_validatingwebhookconfiguration_metadata_resource_version gauge
 			kube_validatingwebhookconfiguration_created{validatingwebhookconfiguration="validatingwebhookconfiguration2",namespace="ns2"} 1.501569018e+09
 			kube_validatingwebhookconfiguration_info{validatingwebhookconfiguration="validatingwebhookconfiguration2",namespace="ns2"} 1
-			kube_validatingwebhookconfiguration_metadata_resource_version{validatingwebhookconfiguration="validatingwebhookconfiguration2",namespace="ns2",resource_version="abcdef"} 1
 			`,
 			MetricNames: []string{"kube_validatingwebhookconfiguration_created", "kube_validatingwebhookconfiguration_info", "kube_validatingwebhookconfiguration_metadata_resource_version"},
 		},


### PR DESCRIPTION
These metrics expose the resource version as a string in the label. This value can change often and would therefore create huge cardinality. This PR changes it to be the number value of the metric itself instead.

I checked with API team and while formally it is not guaranteed that this is always a numerical value, majority of the ecosystem assumes this is the case.

cc @tariq1890 @brancz 

Fixes https://github.com/kubernetes/kube-state-metrics/issues/982