### PR TITLE
v2: Rename hpa metrics to use full horizontalpodautoscaler n…

### DIFF
--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -2,11 +2,11 @@
 
 | Metric name                       | Metric type | Labels/tags                                                   | Status |
 | --------------------------------  | ----------- | ------------------------------------------------------------- | ------ |
-| kube_hpa_labels                   | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
-| kube_hpa_metadata_generation      | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
-| kube_hpa_spec_max_replicas        | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
-| kube_hpa_spec_min_replicas        | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
-| kube_hpa_spec_target_metric       | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
-| kube_hpa_status_condition         | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
-| kube_hpa_status_current_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
-| kube_hpa_status_desired_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_horizontalpodautoscaler_labels                   | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_horizontalpodautoscaler_metadata_generation      | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_horizontalpodautoscaler_spec_max_replicas        | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_horizontalpodautoscaler_spec_min_replicas        | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_horizontalpodautoscaler_spec_target_metric       | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
+| kube_horizontalpodautoscaler_status_condition         | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
+| kube_horizontalpodautoscaler_status_current_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_horizontalpodautoscaler_status_desired_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -43,15 +43,15 @@ func (m MetricTargetType) String() string {
 }
 
 var (
-	descHorizontalPodAutoscalerLabelsName          = "kube_hpa_labels"
+	descHorizontalPodAutoscalerLabelsName          = "kube_horizontalpodautoscaler_labels"
 	descHorizontalPodAutoscalerLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descHorizontalPodAutoscalerLabelsDefaultLabels = []string{"namespace", "hpa"}
+	descHorizontalPodAutoscalerLabelsDefaultLabels = []string{"namespace", "horizontalpodautoscaler"}
 
 	targetMetricLabels = []string{"metric_name", "metric_target_type"}
 
 	hpaMetricFamilies = []generator.FamilyGenerator{
 		{
-			Name: "kube_hpa_metadata_generation",
+			Name: "kube_horizontalpodautoscaler_metadata_generation",
 			Type: metric.Gauge,
 			Help: "The generation observed by the HorizontalPodAutoscaler controller.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
@@ -65,7 +65,7 @@ var (
 			}),
 		},
 		{
-			Name: "kube_hpa_spec_max_replicas",
+			Name: "kube_horizontalpodautoscaler_spec_max_replicas",
 			Type: metric.Gauge,
 			Help: "Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
@@ -79,7 +79,7 @@ var (
 			}),
 		},
 		{
-			Name: "kube_hpa_spec_min_replicas",
+			Name: "kube_horizontalpodautoscaler_spec_min_replicas",
 			Type: metric.Gauge,
 			Help: "Lower limit for the number of pods that can be set by the autoscaler, default 1.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
@@ -93,7 +93,7 @@ var (
 			}),
 		},
 		{
-			Name: "kube_hpa_spec_target_metric",
+			Name: "kube_horizontalpodautoscaler_spec_target_metric",
 			Type: metric.Gauge,
 			Help: "The metric specifications used by this autoscaler when calculating the desired replica count.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
@@ -155,7 +155,7 @@ var (
 			}),
 		},
 		{
-			Name: "kube_hpa_status_current_replicas",
+			Name: "kube_horizontalpodautoscaler_status_current_replicas",
 			Type: metric.Gauge,
 			Help: "Current number of replicas of pods managed by this autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
@@ -169,7 +169,7 @@ var (
 			}),
 		},
 		{
-			Name: "kube_hpa_status_desired_replicas",
+			Name: "kube_horizontalpodautoscaler_status_desired_replicas",
 			Type: metric.Gauge,
 			Help: "Desired number of replicas of pods managed by this autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
@@ -200,7 +200,7 @@ var (
 			}),
 		},
 		{
-			Name: "kube_hpa_status_condition",
+			Name: "kube_horizontalpodautoscaler_status_condition",
 			Type: metric.Gauge,
 			Help: "The condition of this autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -35,22 +35,22 @@ func TestHPAStore(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
-		# HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
-		# HELP kube_hpa_metadata_generation The generation observed by the HorizontalPodAutoscaler controller.
-		# HELP kube_hpa_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
-		# HELP kube_hpa_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
-		# HELP kube_hpa_spec_target_metric The metric specifications used by this autoscaler when calculating the desired replica count.
-		# HELP kube_hpa_status_condition The condition of this autoscaler.
-		# HELP kube_hpa_status_current_replicas Current number of replicas of pods managed by this autoscaler.
-		# HELP kube_hpa_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
-		# TYPE kube_hpa_labels gauge
-		# TYPE kube_hpa_metadata_generation gauge
-		# TYPE kube_hpa_spec_max_replicas gauge
-		# TYPE kube_hpa_spec_min_replicas gauge
-		# TYPE kube_hpa_spec_target_metric gauge
-		# TYPE kube_hpa_status_condition gauge
-		# TYPE kube_hpa_status_current_replicas gauge
-		# TYPE kube_hpa_status_desired_replicas gauge
+		# HELP kube_horizontalpodautoscaler_labels Kubernetes labels converted to Prometheus labels.
+		# HELP kube_horizontalpodautoscaler_metadata_generation The generation observed by the HorizontalPodAutoscaler controller.
+		# HELP kube_horizontalpodautoscaler_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+		# HELP kube_horizontalpodautoscaler_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
+		# HELP kube_horizontalpodautoscaler_spec_target_metric The metric specifications used by this autoscaler when calculating the desired replica count.
+		# HELP kube_horizontalpodautoscaler_status_condition The condition of this autoscaler.
+		# HELP kube_horizontalpodautoscaler_status_current_replicas Current number of replicas of pods managed by this autoscaler.
+		# HELP kube_horizontalpodautoscaler_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
+		# TYPE kube_horizontalpodautoscaler_labels gauge
+		# TYPE kube_horizontalpodautoscaler_metadata_generation gauge
+		# TYPE kube_horizontalpodautoscaler_spec_max_replicas gauge
+		# TYPE kube_horizontalpodautoscaler_spec_min_replicas gauge
+		# TYPE kube_horizontalpodautoscaler_spec_target_metric gauge
+		# TYPE kube_horizontalpodautoscaler_status_condition gauge
+		# TYPE kube_horizontalpodautoscaler_status_current_replicas gauge
+		# TYPE kube_horizontalpodautoscaler_status_desired_replicas gauge
 	`
 	cases := []generateMetricsTestCase{
 		{
@@ -157,33 +157,33 @@ func TestHPAStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_hpa_labels{hpa="hpa1",label_app="foobar",namespace="ns1"} 1
-				kube_hpa_metadata_generation{hpa="hpa1",namespace="ns1"} 2
-				kube_hpa_spec_max_replicas{hpa="hpa1",namespace="ns1"} 4
-				kube_hpa_spec_min_replicas{hpa="hpa1",namespace="ns1"} 2
-				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
-				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="events",metric_target_type="average",namespace="ns1"} 30
-				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="hits",metric_target_type="average",namespace="ns1"} 12
-				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="hits",metric_target_type="value",namespace="ns1"} 10
-				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 819200
-				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
-				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="sqs_jobs",metric_target_type="value",namespace="ns1"} 30
-				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="transactions_processed",metric_target_type="average",namespace="ns1"} 33
-				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="false"} 0
-				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="true"} 1
-				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="unknown"} 0
-				kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
-				kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
+				kube_horizontalpodautoscaler_labels{horizontalpodautoscaler="hpa1",label_app="foobar",namespace="ns1"} 1
+				kube_horizontalpodautoscaler_metadata_generation{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
+				kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 4
+				kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="events",metric_target_type="average",namespace="ns1"} 30
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="hits",metric_target_type="average",namespace="ns1"} 12
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="hits",metric_target_type="value",namespace="ns1"} 10
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 819200
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="sqs_jobs",metric_target_type="value",namespace="ns1"} 30
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="transactions_processed",metric_target_type="average",namespace="ns1"} 33
+				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="false"} 0
+				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="true"} 1
+				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="unknown"} 0
+				kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
+				kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
 			`,
 			MetricNames: []string{
-				"kube_hpa_metadata_generation",
-				"kube_hpa_spec_max_replicas",
-				"kube_hpa_spec_min_replicas",
-				"kube_hpa_spec_target_metric",
-				"kube_hpa_status_current_replicas",
-				"kube_hpa_status_desired_replicas",
-				"kube_hpa_status_condition",
-				"kube_hpa_labels",
+				"kube_horizontalpodautoscaler_metadata_generation",
+				"kube_horizontalpodautoscaler_spec_max_replicas",
+				"kube_horizontalpodautoscaler_spec_min_replicas",
+				"kube_horizontalpodautoscaler_spec_target_metric",
+				"kube_horizontalpodautoscaler_status_current_replicas",
+				"kube_horizontalpodautoscaler_status_desired_replicas",
+				"kube_horizontalpodautoscaler_status_condition",
+				"kube_horizontalpodautoscaler_labels",
 			},
 		},
 		{
@@ -282,29 +282,29 @@ func TestHPAStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_hpa_labels{hpa="hpa2",label_app="foobar",namespace="ns1"} 1
-				kube_hpa_metadata_generation{hpa="hpa2",namespace="ns1"} 2
-				kube_hpa_spec_max_replicas{hpa="hpa2",namespace="ns1"} 4
-				kube_hpa_spec_min_replicas{hpa="hpa2",namespace="ns1"} 2
-				kube_hpa_spec_target_metric{hpa="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
-				kube_hpa_spec_target_metric{hpa="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 75
-				kube_hpa_spec_target_metric{hpa="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 100
-				kube_hpa_spec_target_metric{hpa="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 100
-				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="false"} 0
-				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="true"} 1
-				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="unknown"} 0
-				kube_hpa_status_current_replicas{hpa="hpa2",namespace="ns1"} 2
-				kube_hpa_status_desired_replicas{hpa="hpa2",namespace="ns1"} 2
+				kube_horizontalpodautoscaler_labels{horizontalpodautoscaler="hpa2",label_app="foobar",namespace="ns1"} 1
+				kube_horizontalpodautoscaler_metadata_generation{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
+				kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 4
+				kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 75
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 100
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 100
+				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="false"} 0
+				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="true"} 1
+				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="unknown"} 0
+				kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
+				kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
 			`,
 			MetricNames: []string{
-				"kube_hpa_metadata_generation",
-				"kube_hpa_spec_max_replicas",
-				"kube_hpa_spec_min_replicas",
-				"kube_hpa_spec_target_metric",
-				"kube_hpa_status_current_replicas",
-				"kube_hpa_status_desired_replicas",
-				"kube_hpa_status_condition",
-				"kube_hpa_labels",
+				"kube_horizontalpodautoscaler_metadata_generation",
+				"kube_horizontalpodautoscaler_spec_max_replicas",
+				"kube_horizontalpodautoscaler_spec_min_replicas",
+				"kube_horizontalpodautoscaler_spec_target_metric",
+				"kube_horizontalpodautoscaler_status_current_replicas",
+				"kube_horizontalpodautoscaler_status_desired_replicas",
+				"kube_horizontalpodautoscaler_status_condition",
+				"kube_horizontalpodautoscaler_labels",
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Rename hpa metrics to use full horizontalpodautoscaler nomenclature for v2.0.0
**Which issue(s) this PR fixes** :
Fixes #977

