### PR TITLE
*: Remove non-identifying labels from pod metrics

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -787,7 +787,7 @@ var (
 						switch resourceName {
 						case v1.ResourceCPU:
 							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
 								Value:       float64(val.MilliValue()) / 1000,
 							})
 						case v1.ResourceStorage:
@@ -796,25 +796,25 @@ var (
 							fallthrough
 						case v1.ResourceMemory:
 							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 								Value:       float64(val.Value()),
 							})
 						default:
 							if isHugePageResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 									Value:       float64(val.Value()),
 								})
 							}
 							if isAttachableVolumeResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 									Value:       float64(val.Value()),
 								})
 							}
 							if isExtendedResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+									LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
 									Value:       float64(val.Value()),
 								})
 							}
@@ -823,7 +823,7 @@ var (
 				}
 
 				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+					metric.LabelKeys = []string{"container", "resource", "unit"}
 				}
 
 				return &metric.Family{
@@ -846,7 +846,7 @@ var (
 						case v1.ResourceCPU:
 							ms = append(ms, &metric.Metric{
 								Value:       float64(val.MilliValue()) / 1000,
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
 							})
 						case v1.ResourceStorage:
 							fallthrough
@@ -854,26 +854,26 @@ var (
 							fallthrough
 						case v1.ResourceMemory:
 							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 								Value:       float64(val.Value()),
 							})
 						default:
 							if isHugePageResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 									Value:       float64(val.Value()),
 								})
 							}
 							if isAttachableVolumeResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
 									Value:       float64(val.Value()),
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 								})
 							}
 							if isExtendedResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
 									Value:       float64(val.Value()),
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+									LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
 								})
 							}
 						}
@@ -881,7 +881,7 @@ var (
 				}
 
 				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+					metric.LabelKeys = []string{"container", "resource", "unit"}
 				}
 
 				return &metric.Family{
@@ -904,7 +904,7 @@ var (
 						case v1.ResourceCPU:
 							ms = append(ms, &metric.Metric{
 								Value:       float64(val.MilliValue()) / 1000,
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
 							})
 						case v1.ResourceStorage:
 							fallthrough
@@ -912,26 +912,26 @@ var (
 							fallthrough
 						case v1.ResourceMemory:
 							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 								Value:       float64(val.Value()),
 							})
 						default:
 							if isHugePageResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 									Value:       float64(val.Value()),
 								})
 							}
 							if isAttachableVolumeResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
 									Value:       float64(val.Value()),
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 								})
 							}
 							if isExtendedResourceName(resourceName) {
 								ms = append(ms, &metric.Metric{
 									Value:       float64(val.Value()),
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+									LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
 								})
 							}
 						}
@@ -939,7 +939,7 @@ var (
 				}
 
 				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+					metric.LabelKeys = []string{"container", "resource", "unit"}
 				}
 
 				return &metric.Family{

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1269,7 +1269,6 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 					Namespace: "ns1",
 				},
 				Spec: v1.PodSpec{
-					NodeName: "node1",
 					Containers: []v1.Container{
 						{
 							Name: "pod1_con1",
@@ -1336,25 +1335,25 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				# TYPE kube_pod_container_resource_requests gauge
 				# TYPE kube_pod_init_container_resource_limits gauge
 				# TYPE kube_pod_init_container_status_last_terminated_reason gauge
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.2
-				kube_pod_container_resource_requests{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.3
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 1e+08
-				kube_pod_container_resource_requests{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 2e+08
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="storage",unit="byte"} 4e+08
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.2
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
-				kube_pod_container_resource_limits{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.3
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 1e+08
-				kube_pod_container_resource_limits{container="pod1_con2",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 2e+08
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="storage",unit="byte"} 4e+08
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",node="node1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="cpu",unit="core"} 0.2
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="memory",unit="byte"} 1e+08
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
-                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",node="node1",pod="pod1",resource="storage",unit="byte"} 4e+08
+				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",pod="pod1",resource="cpu",unit="core"} 0.2
+				kube_pod_container_resource_requests{container="pod1_con2",namespace="ns1",pod="pod1",resource="cpu",unit="core"} 0.3
+				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
+				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",pod="pod1",resource="memory",unit="byte"} 1e+08
+				kube_pod_container_resource_requests{container="pod1_con2",namespace="ns1",pod="pod1",resource="memory",unit="byte"} 2e+08
+				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",pod="pod1",resource="storage",unit="byte"} 4e+08
+				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
+				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",pod="pod1",resource="cpu",unit="core"} 0.2
+				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
+				kube_pod_container_resource_limits{container="pod1_con2",namespace="ns1",pod="pod1",resource="cpu",unit="core"} 0.3
+				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",pod="pod1",resource="memory",unit="byte"} 1e+08
+				kube_pod_container_resource_limits{container="pod1_con2",namespace="ns1",pod="pod1",resource="memory",unit="byte"} 2e+08
+				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",pod="pod1",resource="storage",unit="byte"} 4e+08
+				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
+                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",pod="pod1",resource="cpu",unit="core"} 0.2
+                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
+                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",pod="pod1",resource="memory",unit="byte"} 1e+08
+                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
+                kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",pod="pod1",resource="storage",unit="byte"} 4e+08
 		`,
 			MetricNames: []string{
 				"kube_pod_container_resource_requests",
@@ -1371,7 +1370,6 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 					Namespace: "ns2",
 				},
 				Spec: v1.PodSpec{
-					NodeName: "node2",
 					Containers: []v1.Container{
 						{
 							Name: "pod2_con1",
@@ -1428,16 +1426,16 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				# TYPE kube_pod_container_resource_limits gauge
 				# TYPE kube_pod_container_resource_requests gauge
 				# TYPE kube_pod_init_container_resource_limits gauge
-				kube_pod_container_resource_requests{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.4
-				kube_pod_container_resource_requests{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.5
-				kube_pod_container_resource_requests{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 3e+08
-				kube_pod_container_resource_requests{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 4e+08
-				kube_pod_container_resource_limits{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.4
-				kube_pod_container_resource_limits{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.5
-				kube_pod_container_resource_limits{container="pod2_con1",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 3e+08
-				kube_pod_container_resource_limits{container="pod2_con2",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 4e+08
-                kube_pod_init_container_resource_limits{container="pod2_initcon1",namespace="ns2",node="node2",pod="pod2",resource="cpu",unit="core"} 0.4
-                kube_pod_init_container_resource_limits{container="pod2_initcon1",namespace="ns2",node="node2",pod="pod2",resource="memory",unit="byte"} 3e+08
+				kube_pod_container_resource_requests{container="pod2_con1",namespace="ns2",pod="pod2",resource="cpu",unit="core"} 0.4
+				kube_pod_container_resource_requests{container="pod2_con2",namespace="ns2",pod="pod2",resource="cpu",unit="core"} 0.5
+				kube_pod_container_resource_requests{container="pod2_con1",namespace="ns2",pod="pod2",resource="memory",unit="byte"} 3e+08
+				kube_pod_container_resource_requests{container="pod2_con2",namespace="ns2",pod="pod2",resource="memory",unit="byte"} 4e+08
+				kube_pod_container_resource_limits{container="pod2_con1",namespace="ns2",pod="pod2",resource="cpu",unit="core"} 0.4
+				kube_pod_container_resource_limits{container="pod2_con2",namespace="ns2",pod="pod2",resource="cpu",unit="core"} 0.5
+				kube_pod_container_resource_limits{container="pod2_con1",namespace="ns2",pod="pod2",resource="memory",unit="byte"} 3e+08
+				kube_pod_container_resource_limits{container="pod2_con2",namespace="ns2",pod="pod2",resource="memory",unit="byte"} 4e+08
+                kube_pod_init_container_resource_limits{container="pod2_initcon1",namespace="ns2",pod="pod2",resource="cpu",unit="core"} 0.4
+                kube_pod_init_container_resource_limits{container="pod2_initcon1",namespace="ns2",pod="pod2",resource="memory",unit="byte"} 3e+08
 		`,
 			MetricNames: []string{
 				"kube_pod_container_resource_requests",

--- a/main_test.go
+++ b/main_test.go
@@ -283,24 +283,24 @@ kube_pod_container_status_restarts_total{namespace="default",pod="pod0",containe
 # TYPE kube_pod_init_container_status_restarts_total counter
 # HELP kube_pod_container_resource_requests The number of requested request resource by a container.
 # TYPE kube_pod_container_resource_requests gauge
-kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="nvidia_com_gpu",unit="integer"} 1
-kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="cpu",unit="core"} 0.2
-kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="memory",unit="byte"} 1e+08
-kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="ephemeral_storage",unit="byte"} 3e+08
-kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="storage",unit="byte"} 4e+08
-kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="cpu",unit="core"} 0.3
-kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="memory",unit="byte"} 2e+08
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",resource="nvidia_com_gpu",unit="integer"} 1
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",resource="cpu",unit="core"} 0.2
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",resource="memory",unit="byte"} 1e+08
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",resource="ephemeral_storage",unit="byte"} 3e+08
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",resource="storage",unit="byte"} 4e+08
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con2",resource="cpu",unit="core"} 0.3
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con2",resource="memory",unit="byte"} 2e+08
 # HELP kube_pod_init_container_resource_limits The number of requested limit resource by the init container.
 # TYPE kube_pod_init_container_resource_limits gauge
 # HELP kube_pod_container_resource_limits The number of requested limit resource by a container.
 # TYPE kube_pod_container_resource_limits gauge
-kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="nvidia_com_gpu",unit="integer"} 1
-kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="cpu",unit="core"} 0.2
-kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="memory",unit="byte"} 1e+08
-kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="ephemeral_storage",unit="byte"} 3e+08
-kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="storage",unit="byte"} 4e+08
-kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="memory",unit="byte"} 2e+08
-kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="cpu",unit="core"} 0.3
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",resource="nvidia_com_gpu",unit="integer"} 1
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",resource="cpu",unit="core"} 0.2
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",resource="memory",unit="byte"} 1e+08
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",resource="ephemeral_storage",unit="byte"} 3e+08
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",resource="storage",unit="byte"} 4e+08
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con2",resource="memory",unit="byte"} 2e+08
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con2",resource="cpu",unit="core"} 0.3
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
 # TYPE kube_pod_spec_volumes_persistentvolumeclaims_info gauge
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_readonly Describes whether a persistentvolumeclaim is mounted read only.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #979

@LiliC I made a start on this and I can't see anything else that I would consider "non-identifying" labels.

I also wondered about the removal of node name from metrics re cpu/mem usage, perhaps it is still valid there? 