### PR TITLE
internal/store/hpa.go: fix nil panics when parsing hpa memory current metrics

### DIFF
--- a/internal/store/hpa.go
+++ b/internal/store/hpa.go
@@ -245,8 +245,13 @@ var (
 						continue
 					}
 					var metricValue float64
-					if c.Type == autoscaling.ResourceMetricSourceType && c.Resource.Name == corev1.ResourceCPU {
-						metricValue = float64(value.MilliValue()) / 1000
+					if c.Type == autoscaling.ResourceMetricSourceType {
+						switch c.Resource.Name {
+						case corev1.ResourceCPU:
+							metricValue = float64(value.MilliValue()) / 1000.0
+						case corev1.ResourceMemory:
+							metricValue = float64(value.Value())
+						}
 					} else if intVal, canFastConvert := value.AsInt64(); canFastConvert {
 						metricValue = float64(intVal)
 					} else {

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -149,6 +149,14 @@ func TestHPAStore(t *testing.T) {
 								CurrentAverageValue:       resource.MustParse("7m"),
 							},
 						},
+						{
+							Type: "Resource",
+							Resource: &autoscaling.ResourceMetricStatus{
+								Name:                      "memory",
+								CurrentAverageUtilization: new(int32),
+								CurrentAverageValue:       resource.MustParse("26335914666m"),
+							},
+						},
 					},
 				},
 			},
@@ -171,7 +179,9 @@ func TestHPAStore(t *testing.T) {
 				kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
 				kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
 				kube_hpa_status_current_metrics_average_value{hpa="hpa1",namespace="ns1"} 0.007
+                kube_hpa_status_current_metrics_average_value{hpa="hpa1",namespace="ns1"} 2.6335915e+07
 				kube_hpa_status_current_metrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
+	            kube_hpa_status_current_metrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
 			`,
 			MetricNames: []string{
 				"kube_hpa_metadata_generation",


### PR DESCRIPTION
Fixes #1012 

This is a follow-up to the PR #993 where we had only addressed the case for parsing Resource CPU metrics and not Resource Memory metrics.