### PR TITLE
internal/store/hpa: Fix segfault in hpa metrics

### DIFF
--- a/internal/store/hpa.go
+++ b/internal/store/hpa.go
@@ -205,16 +205,16 @@ var (
 			Type: metric.Gauge,
 			Help: "The condition of this autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-				ms := make([]*metric.Metric, len(a.Status.Conditions)*len(conditionStatuses))
+				ms := make([]*metric.Metric, 0, len(a.Status.Conditions)*len(conditionStatuses))
 
-				for i, c := range a.Status.Conditions {
+				for _, c := range a.Status.Conditions {
 					metrics := addConditionMetrics(c.Status)
 
-					for j, m := range metrics {
+					for _, m := range metrics {
 						metric := m
 						metric.LabelKeys = []string{"condition", "status"}
 						metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
-						ms[i*len(conditionStatuses)+j] = metric
+						ms = append(ms, metric)
 					}
 				}
 
@@ -223,13 +223,14 @@ var (
 				}
 			}),
 		},
+
 		{
 			Name: "kube_hpa_status_current_metrics_average_value",
 			Type: metric.Gauge,
 			Help: "Average metric value observed by the autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-				ms := make([]*metric.Metric, len(a.Status.CurrentMetrics))
-				for i, c := range a.Status.CurrentMetrics {
+				ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
+				for _, c := range a.Status.CurrentMetrics {
 					var value *resource.Quantity
 					switch c.Type {
 					case autoscaling.ResourceMetricSourceType:
@@ -258,9 +259,9 @@ var (
 						// Skip unsupported metric value format
 						continue
 					}
-					ms[i] = &metric.Metric{
+					ms = append(ms, &metric.Metric{
 						Value: metricValue,
-					}
+					})
 				}
 				return &metric.Family{
 					Metrics: ms,
@@ -272,12 +273,12 @@ var (
 			Type: metric.Gauge,
 			Help: "Average metric utilization observed by the autoscaler.",
 			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-				ms := make([]*metric.Metric, len(a.Status.CurrentMetrics))
-				for i, c := range a.Status.CurrentMetrics {
+				ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
+				for _, c := range a.Status.CurrentMetrics {
 					if c.Type == autoscaling.ResourceMetricSourceType {
-						ms[i] = &metric.Metric{
+						ms = append(ms, &metric.Metric{
 							Value: float64(*c.Resource.CurrentAverageUtilization),
-						}
+						})
 					}
 				}
 				return &metric.Family{

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -196,6 +196,118 @@ func TestHPAStore(t *testing.T) {
 				"kube_hpa_status_current_metrics_average_utilization",
 			},
 		},
+		{
+			// Verify populating base metric.
+			Obj: &autoscaling.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 2,
+					Name:       "hpa2",
+					Namespace:  "ns1",
+					Labels: map[string]string{
+						"app": "foobar",
+					},
+				},
+				Spec: autoscaling.HorizontalPodAutoscalerSpec{
+					MaxReplicas: 4,
+					MinReplicas: &hpa1MinReplicas,
+					Metrics: []autoscaling.MetricSpec{
+						{
+							Type: autoscaling.ResourceMetricSourceType,
+							Resource: &autoscaling.ResourceMetricSource{
+								Name:                     "memory",
+								TargetAverageUtilization: int32ptr(75),
+							},
+						},
+						{
+							Type: autoscaling.ResourceMetricSourceType,
+							Resource: &autoscaling.ResourceMetricSource{
+								Name:                     "cpu",
+								TargetAverageUtilization: int32ptr(80),
+							},
+						},
+						{
+							Type: autoscaling.ExternalMetricSourceType,
+							External: &autoscaling.ExternalMetricSource{
+								MetricName:  "traefik_backend_requests_per_second",
+								TargetValue: resourcePtr(resource.MustParse("100")),
+							},
+						},
+					},
+					ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "deployment1",
+					},
+				},
+				Status: autoscaling.HorizontalPodAutoscalerStatus{
+					CurrentReplicas: 2,
+					DesiredReplicas: 2,
+					Conditions: []autoscaling.HorizontalPodAutoscalerCondition{
+						{
+							Type:   autoscaling.AbleToScale,
+							Status: v1.ConditionTrue,
+							Reason: "reason",
+						},
+					},
+					CurrentMetrics: []autoscaling.MetricStatus{
+						{
+							Type: "Resource",
+							Resource: &autoscaling.ResourceMetricStatus{
+								Name:                      "memory",
+								CurrentAverageUtilization: int32ptr(28),
+								CurrentAverageValue:       resource.MustParse("847775744"),
+							},
+						},
+						{
+							Type: "Resource",
+							Resource: &autoscaling.ResourceMetricStatus{
+								Name:                      "cpu",
+								CurrentAverageUtilization: int32ptr(6),
+								CurrentAverageValue:       resource.MustParse("62m"),
+							},
+						},
+						{
+							Type: "External",
+							External: &autoscaling.ExternalMetricStatus{
+								MetricName:          "traefik_backend_requests_per_second",
+								CurrentValue:        resource.MustParse("0"),
+								CurrentAverageValue: resourcePtr(resource.MustParse("2900m")),
+							},
+						},
+					},
+				},
+			},
+			Want: metadata + `
+				kube_hpa_labels{hpa="hpa2",label_app="foobar",namespace="ns1"} 1
+				kube_hpa_metadata_generation{hpa="hpa2",namespace="ns1"} 2
+				kube_hpa_spec_max_replicas{hpa="hpa2",namespace="ns1"} 4
+				kube_hpa_spec_min_replicas{hpa="hpa2",namespace="ns1"} 2
+				kube_hpa_spec_target_metric{hpa="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
+				kube_hpa_spec_target_metric{hpa="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 75
+				kube_hpa_spec_target_metric{hpa="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 100
+				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="false"} 0
+				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="true"} 1
+				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="unknown"} 0
+				kube_hpa_status_current_metrics_average_utilization{hpa="hpa2",namespace="ns1"} 28
+				kube_hpa_status_current_metrics_average_utilization{hpa="hpa2",namespace="ns1"} 6
+				kube_hpa_status_current_metrics_average_value{hpa="hpa2",namespace="ns1"} 0.062
+				kube_hpa_status_current_metrics_average_value{hpa="hpa2",namespace="ns1"} 8.47775744e+08
+				kube_hpa_status_current_replicas{hpa="hpa2",namespace="ns1"} 2
+				kube_hpa_status_desired_replicas{hpa="hpa2",namespace="ns1"} 2
+			`,
+			MetricNames: []string{
+				"kube_hpa_metadata_generation",
+				"kube_hpa_spec_max_replicas",
+				"kube_hpa_spec_min_replicas",
+				"kube_hpa_spec_target_metric",
+				"kube_hpa_status_current_replicas",
+				"kube_hpa_status_desired_replicas",
+				"kube_hpa_status_condition",
+				"kube_hpa_labels",
+				"kube_hpa_status_current_metrics_average_value",
+				"kube_hpa_status_current_metrics_average_utilization",
+			},
+		},
 	}
 	for i, c := range cases {
 		c.Func = metric.ComposeMetricGenFuncs(hpaMetricFamilies)


### PR DESCRIPTION
This fixes https://github.com/kubernetes/kube-state-metrics/issues/1012, also adds a test case based on the example @lawliet89 provided. Thanks for that!

@lawliet89 Do you mind verifying this if you have time in your cluster, if this fix works for you?

cc @tariq1890 @brancz 