### PR TITLE
internal/store/hpa.go: Set kube_hpa_status_current_metrics_average_value metric for the External metric source

### DIFF
--- a/internal/store/hpa.go
+++ b/internal/store/hpa.go
@@ -255,6 +255,8 @@ var (
 						}
 					} else if intVal, canFastConvert := value.AsInt64(); canFastConvert {
 						metricValue = float64(intVal)
+					} else if c.Type == autoscaling.ExternalMetricSourceType {
+						metricValue = float64(value.MilliValue()) / 1000.0
 					} else {
 						// Skip unsupported metric value format
 						continue

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -290,6 +290,7 @@ func TestHPAStore(t *testing.T) {
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="unknown"} 0
 				kube_hpa_status_current_metrics_average_utilization{hpa="hpa2",namespace="ns1"} 28
 				kube_hpa_status_current_metrics_average_utilization{hpa="hpa2",namespace="ns1"} 6
+				kube_hpa_status_current_metrics_average_value{hpa="hpa2",namespace="ns1"} 2.9
 				kube_hpa_status_current_metrics_average_value{hpa="hpa2",namespace="ns1"} 0.062
 				kube_hpa_status_current_metrics_average_value{hpa="hpa2",namespace="ns1"} 8.47775744e+08
 				kube_hpa_status_current_replicas{hpa="hpa2",namespace="ns1"} 2


### PR DESCRIPTION
We were not setting the kube_hpa_status_current_metrics_average_value when the metric source was External.

@tariq1890 @brancz 