### PR TITLE
internal/store/: Remove hpa metric kube_hpa_status_current_metrics_av…

### DIFF
--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -9,6 +9,4 @@
 | kube_hpa_spec_target_metric       | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
 | kube_hpa_status_condition         | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_hpa_status_current_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
-| kube_hpa_status_current_metrics_average_utilization | Gauge     | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | EXPERIMENTAL |
-| kube_hpa_status_current_metrics_average_value | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | EXPERIMENTAL |
 | kube_hpa_status_desired_replicas  | Gauge       | `hpa`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |

--- a/internal/store/hpa.go
+++ b/internal/store/hpa.go
@@ -18,8 +18,6 @@ package store
 
 import (
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -218,55 +216,6 @@ var (
 					}
 				}
 
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		},
-
-		{
-			Name: "kube_hpa_status_current_metrics_average_value",
-			Type: metric.Gauge,
-			Help: "Average metric value observed by the autoscaler.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-				ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
-				for _, c := range a.Status.CurrentMetrics {
-					var value *resource.Quantity
-					switch c.Type {
-					case autoscaling.ResourceMetricSourceType:
-						value = &c.Resource.CurrentAverageValue
-					case autoscaling.PodsMetricSourceType:
-						value = &c.Pods.CurrentAverageValue
-					case autoscaling.ObjectMetricSourceType:
-						value = c.Object.AverageValue
-					case autoscaling.ExternalMetricSourceType:
-						value = c.External.CurrentAverageValue
-					default:
-						// Skip unsupported metric type
-						continue
-					}
-					if value == nil {
-						// Some types might have a nil value (e.g. External.CurrentAverageValue can be nil)
-						continue
-					}
-					var metricValue float64
-					if c.Type == autoscaling.ResourceMetricSourceType {
-						switch c.Resource.Name {
-						case corev1.ResourceCPU:
-							metricValue = float64(value.MilliValue()) / 1000.0
-						case corev1.ResourceMemory:
-							metricValue = float64(value.Value())
-						}
-					} else if intVal, canFastConvert := value.AsInt64(); canFastConvert {
-						metricValue = float64(intVal)
-					} else {
-						// Skip unsupported metric value format
-						continue
-					}
-					ms = append(ms, &metric.Metric{
-						Value: metricValue,
-					})
-				}
 				return &metric.Family{
 					Metrics: ms,
 				}

--- a/internal/store/hpa.go
+++ b/internal/store/hpa.go
@@ -221,24 +221,6 @@ var (
 				}
 			}),
 		},
-		{
-			Name: "kube_hpa_status_current_metrics_average_utilization",
-			Type: metric.Gauge,
-			Help: "Average metric utilization observed by the autoscaler.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-				ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
-				for _, c := range a.Status.CurrentMetrics {
-					if c.Type == autoscaling.ResourceMetricSourceType {
-						ms = append(ms, &metric.Metric{
-							Value: float64(*c.Resource.CurrentAverageUtilization),
-						})
-					}
-				}
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		},
 	}
 )
 

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -35,26 +35,24 @@ func TestHPAStore(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
 		# HELP kube_hpa_metadata_generation The generation observed by the HorizontalPodAutoscaler controller.
-		# TYPE kube_hpa_metadata_generation gauge
 		# HELP kube_hpa_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
-		# TYPE kube_hpa_spec_max_replicas gauge
 		# HELP kube_hpa_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
-		# TYPE kube_hpa_spec_min_replicas gauge
 		# HELP kube_hpa_spec_target_metric The metric specifications used by this autoscaler when calculating the desired replica count.
-		# TYPE kube_hpa_spec_target_metric gauge
+		# HELP kube_hpa_status_condition The condition of this autoscaler.
+		# HELP kube_hpa_status_current_metrics_average_utilization Average metric utilization observed by the autoscaler.
 		# HELP kube_hpa_status_current_replicas Current number of replicas of pods managed by this autoscaler.
-		# TYPE kube_hpa_status_current_replicas gauge
 		# HELP kube_hpa_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
+		# TYPE kube_hpa_labels gauge
+		# TYPE kube_hpa_metadata_generation gauge
+		# TYPE kube_hpa_spec_max_replicas gauge
+		# TYPE kube_hpa_spec_min_replicas gauge
+		# TYPE kube_hpa_spec_target_metric gauge
+		# TYPE kube_hpa_status_condition gauge
+		# TYPE kube_hpa_status_current_metrics_average_utilization gauge
+		# TYPE kube_hpa_status_current_replicas gauge
 		# TYPE kube_hpa_status_desired_replicas gauge
-        # HELP kube_hpa_status_condition The condition of this autoscaler.
-        # TYPE kube_hpa_status_condition gauge
-        # HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
-        # TYPE kube_hpa_labels gauge
-        # HELP kube_hpa_status_current_metrics_average_value Average metric value observed by the autoscaler.
-        # TYPE kube_hpa_status_current_metrics_average_value gauge
-        # HELP kube_hpa_status_current_metrics_average_utilization Average metric utilization observed by the autoscaler.
-        # TYPE kube_hpa_status_current_metrics_average_utilization gauge
 	`
 	cases := []generateMetricsTestCase{
 		{
@@ -165,23 +163,21 @@ func TestHPAStore(t *testing.T) {
 				kube_hpa_metadata_generation{hpa="hpa1",namespace="ns1"} 2
 				kube_hpa_spec_max_replicas{hpa="hpa1",namespace="ns1"} 4
 				kube_hpa_spec_min_replicas{hpa="hpa1",namespace="ns1"} 2
-				kube_hpa_spec_target_metric{hpa="hpa1",namespace="ns1",metric_name="hits",metric_target_type="value"} 10
-				kube_hpa_spec_target_metric{hpa="hpa1",namespace="ns1",metric_name="hits",metric_target_type="average"} 12
-				kube_hpa_spec_target_metric{hpa="hpa1",namespace="ns1",metric_name="transactions_processed",metric_target_type="average"} 33
-				kube_hpa_spec_target_metric{hpa="hpa1",namespace="ns1",metric_name="cpu",metric_target_type="utilization"} 80
-				kube_hpa_spec_target_metric{hpa="hpa1",namespace="ns1",metric_name="memory",metric_target_type="utilization"} 80
-				kube_hpa_spec_target_metric{hpa="hpa1",namespace="ns1",metric_name="memory",metric_target_type="average"} 819200
-				kube_hpa_spec_target_metric{hpa="hpa1",namespace="ns1",metric_name="sqs_jobs",metric_target_type="value"} 30
-				kube_hpa_spec_target_metric{hpa="hpa1",namespace="ns1",metric_name="events",metric_target_type="average"} 30
+				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
+				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="events",metric_target_type="average",namespace="ns1"} 30
+				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="hits",metric_target_type="average",namespace="ns1"} 12
+				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="hits",metric_target_type="value",namespace="ns1"} 10
+				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 819200
+				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
+				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="sqs_jobs",metric_target_type="value",namespace="ns1"} 30
+				kube_hpa_spec_target_metric{hpa="hpa1",metric_name="transactions_processed",metric_target_type="average",namespace="ns1"} 33
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="false"} 0
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="true"} 1
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="unknown"} 0
+				kube_hpa_status_current_metrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
+				kube_hpa_status_current_metrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
 				kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
 				kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
-				kube_hpa_status_current_metrics_average_value{hpa="hpa1",namespace="ns1"} 0.007
-                kube_hpa_status_current_metrics_average_value{hpa="hpa1",namespace="ns1"} 2.6335915e+07
-				kube_hpa_status_current_metrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
-	            kube_hpa_status_current_metrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
 			`,
 			MetricNames: []string{
 				"kube_hpa_metadata_generation",
@@ -192,7 +188,6 @@ func TestHPAStore(t *testing.T) {
 				"kube_hpa_status_desired_replicas",
 				"kube_hpa_status_condition",
 				"kube_hpa_labels",
-				"kube_hpa_status_current_metrics_average_value",
 				"kube_hpa_status_current_metrics_average_utilization",
 			},
 		},
@@ -305,8 +300,6 @@ func TestHPAStore(t *testing.T) {
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="unknown"} 0
 				kube_hpa_status_current_metrics_average_utilization{hpa="hpa2",namespace="ns1"} 28
 				kube_hpa_status_current_metrics_average_utilization{hpa="hpa2",namespace="ns1"} 6
-				kube_hpa_status_current_metrics_average_value{hpa="hpa2",namespace="ns1"} 0.062
-				kube_hpa_status_current_metrics_average_value{hpa="hpa2",namespace="ns1"} 8.47775744e+08
 				kube_hpa_status_current_replicas{hpa="hpa2",namespace="ns1"} 2
 				kube_hpa_status_desired_replicas{hpa="hpa2",namespace="ns1"} 2
 			`,
@@ -319,7 +312,6 @@ func TestHPAStore(t *testing.T) {
 				"kube_hpa_status_desired_replicas",
 				"kube_hpa_status_condition",
 				"kube_hpa_labels",
-				"kube_hpa_status_current_metrics_average_value",
 				"kube_hpa_status_current_metrics_average_utilization",
 			},
 		},

--- a/internal/store/hpa_test.go
+++ b/internal/store/hpa_test.go
@@ -41,7 +41,6 @@ func TestHPAStore(t *testing.T) {
 		# HELP kube_hpa_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
 		# HELP kube_hpa_spec_target_metric The metric specifications used by this autoscaler when calculating the desired replica count.
 		# HELP kube_hpa_status_condition The condition of this autoscaler.
-		# HELP kube_hpa_status_current_metrics_average_utilization Average metric utilization observed by the autoscaler.
 		# HELP kube_hpa_status_current_replicas Current number of replicas of pods managed by this autoscaler.
 		# HELP kube_hpa_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
 		# TYPE kube_hpa_labels gauge
@@ -50,7 +49,6 @@ func TestHPAStore(t *testing.T) {
 		# TYPE kube_hpa_spec_min_replicas gauge
 		# TYPE kube_hpa_spec_target_metric gauge
 		# TYPE kube_hpa_status_condition gauge
-		# TYPE kube_hpa_status_current_metrics_average_utilization gauge
 		# TYPE kube_hpa_status_current_replicas gauge
 		# TYPE kube_hpa_status_desired_replicas gauge
 	`
@@ -174,8 +172,6 @@ func TestHPAStore(t *testing.T) {
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="false"} 0
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="true"} 1
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa1",namespace="ns1",status="unknown"} 0
-				kube_hpa_status_current_metrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
-				kube_hpa_status_current_metrics_average_utilization{hpa="hpa1",namespace="ns1"} 0
 				kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
 				kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
 			`,
@@ -188,7 +184,6 @@ func TestHPAStore(t *testing.T) {
 				"kube_hpa_status_desired_replicas",
 				"kube_hpa_status_condition",
 				"kube_hpa_labels",
-				"kube_hpa_status_current_metrics_average_utilization",
 			},
 		},
 		{
@@ -298,8 +293,6 @@ func TestHPAStore(t *testing.T) {
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="false"} 0
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="true"} 1
 				kube_hpa_status_condition{condition="AbleToScale",hpa="hpa2",namespace="ns1",status="unknown"} 0
-				kube_hpa_status_current_metrics_average_utilization{hpa="hpa2",namespace="ns1"} 28
-				kube_hpa_status_current_metrics_average_utilization{hpa="hpa2",namespace="ns1"} 6
 				kube_hpa_status_current_replicas{hpa="hpa2",namespace="ns1"} 2
 				kube_hpa_status_desired_replicas{hpa="hpa2",namespace="ns1"} 2
 			`,
@@ -312,7 +305,6 @@ func TestHPAStore(t *testing.T) {
 				"kube_hpa_status_desired_replicas",
 				"kube_hpa_status_condition",
 				"kube_hpa_labels",
-				"kube_hpa_status_current_metrics_average_utilization",
 			},
 		},
 	}


### PR DESCRIPTION
…erage_value

due to unhandled edge cases and precision loss. Because we are not
handling nil cases correctly we often experience segfault in various edge
case scenarios.

cc @tariq1890 @brancz 