### PR TITLE
update telemetry port to 8081

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See the [`docs`](docs) directory for more information on the exposed metrics.
 
 ### Kube-state-metrics self metrics
 
-kube-state-metrics exposes its own general process metrics under `--telemetry-host` and `--telemetry-port` (default 81).
+kube-state-metrics exposes its own general process metrics under `--telemetry-host` and `--telemetry-port` (default 8081).
 
 kube-state-metrics also exposes list and watch success and error metrics. These can be used to calculate the error rate of list or watch resources.
 If you encounter those errors in the metrics, it is most likely a configuration or permission issue, and the next thing to investigate would be looking


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Update telemetry port to 8081 in README.
This was missing in PR https://github.com/kubernetes/kube-state-metrics/pull/1005

