### PR TITLE
[Pod] remove kubctl logic in kube_pod_status_phase

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -31,8 +31,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const nodeUnreachablePodReason = "NodeLost"
-
 var (
 	descPodLabelsDefaultLabels = []string{"namespace", "pod"}
 	containerWaitingReasons    = []string{"ContainerCreating", "CrashLoopBackOff", "CreateContainerConfigError", "ErrImagePull", "ImagePullBackOff", "CreateContainerError", "InvalidImageName"}
@@ -303,10 +301,8 @@ var (
 					{phase == v1.PodPending, string(v1.PodPending)},
 					{phase == v1.PodSucceeded, string(v1.PodSucceeded)},
 					{phase == v1.PodFailed, string(v1.PodFailed)},
-					// This logic is directly copied from: https://github.com/kubernetes/kubernetes/blob/d39bfa0d138368bbe72b0eaf434501dcb4ec9908/pkg/printers/internalversion/printers.go#L597-L601
-					// For more info, please go to: https://github.com/kubernetes/kube-state-metrics/issues/410
-					{phase == v1.PodRunning && !(p.DeletionTimestamp != nil && p.Status.Reason == nodeUnreachablePodReason), string(v1.PodRunning)},
-					{phase == v1.PodUnknown || (p.DeletionTimestamp != nil && p.Status.Reason == nodeUnreachablePodReason), string(v1.PodUnknown)},
+					{phase == v1.PodUnknown, string(v1.PodUnknown)},
+					{phase == v1.PodRunning, string(v1.PodRunning)},
 				}
 
 				ms := make([]*metric.Metric, len(phases))

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1076,7 +1076,7 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				},
 				Status: v1.PodStatus{
 					Phase:  v1.PodRunning,
-					Reason: nodeUnreachablePodReason,
+					Reason: "NodeLost",
 				},
 			},
 			Want: `
@@ -1086,9 +1086,9 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				# TYPE kube_pod_status_reason gauge
 				kube_pod_status_phase{namespace="ns4",phase="Failed",pod="pod4"} 0
 				kube_pod_status_phase{namespace="ns4",phase="Pending",pod="pod4"} 0
-				kube_pod_status_phase{namespace="ns4",phase="Running",pod="pod4"} 0
+				kube_pod_status_phase{namespace="ns4",phase="Running",pod="pod4"} 1
 				kube_pod_status_phase{namespace="ns4",phase="Succeeded",pod="pod4"} 0
-				kube_pod_status_phase{namespace="ns4",phase="Unknown",pod="pod4"} 1
+				kube_pod_status_phase{namespace="ns4",phase="Unknown",pod="pod4"} 0
 				kube_pod_status_reason{namespace="ns4",pod="pod4",reason="Evicted"} 0
 				kube_pod_status_reason{namespace="ns4",pod="pod4",reason="NodeLost"} 1
 `,


### PR DESCRIPTION
**What this PR does / why we need it**:

As explained in the doc: "kube-state-metrics exposes raw data
unmodified from the Kubernetes API".

The goal of this change is to remove the kubctl logic introduced to
get the `Unknown` phase in `kube_pod_status_phase` metric.

With the introduction of `kube_pod_deleted` metric, it is now possible
to get the same result with a promQL query. (more info in this #1013).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

