### PR TITLE
pod: add gauges for pod overhead

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -21,6 +21,7 @@
 | kube_pod_container_status_restarts_total | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; | STABLE |
 | kube_pod_container_resource_requests | Gauge | `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt; <br> `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; | STABLE |
 | kube_pod_container_resource_limits | Gauge | `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt; <br> `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; | STABLE |
+| kube_pod_overhead | Gauge | `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
 | kube_pod_created | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_deleted | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
 | kube_pod_restart_policy | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `type`=&lt;Always|Never|OnFailure&gt; | STABLE |

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -991,6 +991,41 @@ var (
 				}
 			}),
 		},
+		{
+			Name: "kube_pod_overhead",
+			Type: metric.Gauge,
+			Help: "The pod overhead associated with running a pod.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if p.Spec.Overhead != nil {
+					for resourceName, val := range p.Spec.Overhead {
+						switch resourceName {
+						case v1.ResourceCPU:
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+								Value:       float64(val.MilliValue()) / 1000,
+							})
+
+						case v1.ResourceMemory:
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								Value:       float64(val.Value()),
+							})
+						}
+					}
+
+				}
+
+				for _, metric := range ms {
+					metric.LabelKeys = []string{"resource", "unit"}
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
 	}
 )
 

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1605,7 +1605,7 @@ func BenchmarkPodStore(b *testing.B) {
 		},
 	}
 
-	expectedFamilies := 37
+	expectedFamilies := 38
 	for n := 0; n < b.N; n++ {
 		families := f(pod)
 		if len(families) != expectedFamilies {

--- a/main_test.go
+++ b/main_test.go
@@ -304,7 +304,9 @@ kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
 # TYPE kube_pod_spec_volumes_persistentvolumeclaims_info gauge
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_readonly Describes whether a persistentvolumeclaim is mounted read only.
-# TYPE kube_pod_spec_volumes_persistentvolumeclaims_readonly gauge`
+# TYPE kube_pod_spec_volumes_persistentvolumeclaims_readonly gauge
+# HELP kube_pod_overhead The pod overhead associated with running a pod.
+# TYPE kube_pod_overhead gauge`
 
 	expectedSplit := strings.Split(strings.TrimSpace(expected), "\n")
 	sort.Strings(expectedSplit)


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds two metrics for observability of the PodOverhead feature:
kube_pod_overhead_mcpu_cores
kube_pod_overhead_memory_bytes

Using these metrics allows end-users to quickly verify that the PodOverhead feature is being utilized.

When combined with the kube_pod_status_phase, end-users can use tools like grafana to quickly assess how pods running with overhead are behaving compared to non-overhead pods.


This addresses https://github.com/kubernetes/kubernetes/issues/87259