### PR TITLE
Version label should not contain any additional prefix

### DIFF
--- a/examples/autosharding/cluster-role-binding.yaml
+++ b/examples/autosharding/cluster-role-binding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/examples/autosharding/cluster-role.yaml
+++ b/examples/autosharding/cluster-role.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/examples/autosharding/role-binding.yaml
+++ b/examples/autosharding/role-binding.yaml
@@ -3,7 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/examples/autosharding/role.yaml
+++ b/examples/autosharding/role.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
   namespace: kube-system
 rules:

--- a/examples/autosharding/service-account.yaml
+++ b/examples/autosharding/service-account.yaml
@@ -3,6 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
   namespace: kube-system

--- a/examples/autosharding/service.yaml
+++ b/examples/autosharding/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
   namespace: kube-system
 spec:

--- a/examples/autosharding/statefulset.yaml
+++ b/examples/autosharding/statefulset.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
   namespace: kube-system
 spec:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: v1.9.4
+        app.kubernetes.io/version: 1.9.4
     spec:
       containers:
       - args:

--- a/examples/standard/cluster-role-binding.yaml
+++ b/examples/standard/cluster-role-binding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/examples/standard/cluster-role.yaml
+++ b/examples/standard/cluster-role.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/examples/standard/deployment.yaml
+++ b/examples/standard/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
   namespace: kube-system
 spec:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: v1.9.4
+        app.kubernetes.io/version: 1.9.4
     spec:
       containers:
       - image: quay.io/coreos/kube-state-metrics:v1.9.4

--- a/examples/standard/service-account.yaml
+++ b/examples/standard/service-account.yaml
@@ -3,6 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
   namespace: kube-system

--- a/examples/standard/service.yaml
+++ b/examples/standard/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: v1.9.4
+    app.kubernetes.io/version: 1.9.4
   name: kube-state-metrics
   namespace: kube-system
 spec:

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -9,7 +9,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
   commonLabels:: {
     'app.kubernetes.io/name': 'kube-state-metrics',
-    'app.kubernetes.io/version': 'v' + ksm.version,
+    'app.kubernetes.io/version': ksm.version,
   },
 
   podLabels:: {


### PR DESCRIPTION
**What this PR does / why we need it**: Remove prefix from version label *app.kubernetes.io/version*

**Which issue(s) this PR fixes**: as discussed with @brancz  [here](https://github.com/coreos/kube-prometheus/pull/404#discussion_r376506668) the **v** prefix should be removed from version label. 