### PR TITLE
Add kube_replicationcontroller_owner

### DIFF
--- a/docs/replicationcontroller-metrics.md
+++ b/docs/replicationcontroller-metrics.md
@@ -10,3 +10,4 @@
 | kube_replicationcontroller_spec_replicas | Gauge | `replicationcontroller`=&lt;replicationcontroller-name&gt; <br> `namespace`=&lt;replicationcontroller-namespace&gt; | STABLE |
 | kube_replicationcontroller_metadata_generation | Gauge | `replicationcontroller`=&lt;replicationcontroller-name&gt; <br> `namespace`=&lt;replicationcontroller-namespace&gt; | STABLE |
 | kube_replicationcontroller_created | Gauge | `replicationcontroller`=&lt;replicationcontroller-name&gt; <br> `namespace`=&lt;replicationcontroller-namespace&gt; | STABLE |
+| kube_replicationcontroller_owner | Gauge | `replicationcontroller`=&lt;replicationcontroller-name&gt; <br> `namespace`=&lt;replicationcontroller-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  | EXPERIMENTAL |

--- a/internal/store/replicationcontroller_test.go
+++ b/internal/store/replicationcontroller_test.go
@@ -29,9 +29,12 @@ import (
 var (
 	rc1Replicas int32 = 5
 	rc2Replicas int32
+	rc3Replicas int32
 )
 
 func TestReplicationControllerStore(t *testing.T) {
+	var trueValue = true
+
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
@@ -39,6 +42,8 @@ func TestReplicationControllerStore(t *testing.T) {
 		# TYPE kube_replicationcontroller_created gauge
 		# HELP kube_replicationcontroller_metadata_generation Sequence number representing a specific generation of the desired state.
 		# TYPE kube_replicationcontroller_metadata_generation gauge
+		# HELP kube_replicationcontroller_owner Information about the ReplicationController's owner.
+		# TYPE kube_replicationcontroller_owner gauge
 		# HELP kube_replicationcontroller_status_replicas The number of replicas per ReplicationController.
 		# TYPE kube_replicationcontroller_status_replicas gauge
 		# HELP kube_replicationcontroller_status_fully_labeled_replicas The number of fully labeled replicas per ReplicationController.
@@ -60,6 +65,13 @@ func TestReplicationControllerStore(t *testing.T) {
 					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 					Namespace:         "ns1",
 					Generation:        21,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "DeploymentConfig",
+							Name:       "dc-name",
+							Controller: &trueValue,
+						},
+					},
 				},
 				Status: v1.ReplicationControllerStatus{
 					Replicas:             5,
@@ -75,6 +87,7 @@ func TestReplicationControllerStore(t *testing.T) {
 			Want: metadata + `
 				kube_replicationcontroller_created{namespace="ns1",replicationcontroller="rc1"} 1.5e+09
 				kube_replicationcontroller_metadata_generation{namespace="ns1",replicationcontroller="rc1"} 21
+				kube_replicationcontroller_owner{namespace="ns1",owner_is_controller="true",owner_kind="DeploymentConfig",owner_name="dc-name",replicationcontroller="rc1"} 1
 				kube_replicationcontroller_status_replicas{namespace="ns1",replicationcontroller="rc1"} 5
 				kube_replicationcontroller_status_observed_generation{namespace="ns1",replicationcontroller="rc1"} 1
 				kube_replicationcontroller_status_fully_labeled_replicas{namespace="ns1",replicationcontroller="rc1"} 10
@@ -103,12 +116,49 @@ func TestReplicationControllerStore(t *testing.T) {
 			},
 			Want: metadata + `
 				kube_replicationcontroller_metadata_generation{namespace="ns2",replicationcontroller="rc2"} 14
+				kube_replicationcontroller_owner{namespace="ns2",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>",replicationcontroller="rc2"} 1
 				kube_replicationcontroller_status_replicas{namespace="ns2",replicationcontroller="rc2"} 0
 				kube_replicationcontroller_status_observed_generation{namespace="ns2",replicationcontroller="rc2"} 5
 				kube_replicationcontroller_status_fully_labeled_replicas{namespace="ns2",replicationcontroller="rc2"} 5
 				kube_replicationcontroller_status_ready_replicas{namespace="ns2",replicationcontroller="rc2"} 0
 				kube_replicationcontroller_status_available_replicas{namespace="ns2",replicationcontroller="rc2"} 0
 				kube_replicationcontroller_spec_replicas{namespace="ns2",replicationcontroller="rc2"} 0
+`,
+		},
+		{
+			Obj: &v1.ReplicationController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "rc3",
+					Namespace:  "ns3",
+					Generation: 5,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "DeploymentConfig",
+							Name:       "dc-test",
+							Controller: nil,
+						},
+					},
+				},
+				Status: v1.ReplicationControllerStatus{
+					Replicas:             1,
+					FullyLabeledReplicas: 5,
+					ReadyReplicas:        2,
+					AvailableReplicas:    1,
+					ObservedGeneration:   1,
+				},
+				Spec: v1.ReplicationControllerSpec{
+					Replicas: &rc3Replicas,
+				},
+			},
+			Want: metadata + `
+				kube_replicationcontroller_metadata_generation{namespace="ns3",replicationcontroller="rc3"} 5
+				kube_replicationcontroller_owner{namespace="ns3",owner_is_controller="false",owner_kind="DeploymentConfig",owner_name="dc-test",replicationcontroller="rc3"} 1
+				kube_replicationcontroller_status_replicas{namespace="ns3",replicationcontroller="rc3"} 1
+				kube_replicationcontroller_status_observed_generation{namespace="ns3",replicationcontroller="rc3"} 1
+				kube_replicationcontroller_status_fully_labeled_replicas{namespace="ns3",replicationcontroller="rc3"} 5
+				kube_replicationcontroller_status_ready_replicas{namespace="ns3",replicationcontroller="rc3"} 2
+				kube_replicationcontroller_status_available_replicas{namespace="ns3",replicationcontroller="rc3"} 1
+				kube_replicationcontroller_spec_replicas{namespace="ns3",replicationcontroller="rc3"} 0
 `,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add metric for owner of ReplicationController - `kube_replicationcontroller_owner`

**Which issue(s) this PR fixes**:
Fixes #1055
