### PR TITLE
Fix e2e tests when minikube driver is not "none"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ TAG_PREFIX = v
 VERSION = $(shell cat VERSION)
 TAG = $(TAG_PREFIX)$(VERSION)
 LATEST_RELEASE_BRANCH := release-$(shell grep -ohE "[0-9]+.[0-9]+" VERSION)
+DOCKER_CLI ?= docker
 PKGS = $(shell go list ./... | grep -v /vendor/ | grep -v /tests/e2e)
 ARCH ?= $(shell go env GOARCH)
 BuildDate = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
@@ -61,14 +62,16 @@ doccheck: generate
 build-local: clean
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) CGO_ENABLED=0 go build -ldflags "-s -w -X ${PKG}/version.Release=${TAG} -X ${PKG}/version.Commit=${Commit} -X ${PKG}/version.BuildDate=${BuildDate}" -o kube-state-metrics
 
-build: clean
-	docker run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics golang:${GO_VERSION} make build-local
+build: clean kube-state-metrics
+
+kube-state-metrics:
+	${DOCKER_CLI} run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics golang:${GO_VERSION} make build-local
 
 test-unit: clean build
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(TESTENVVAR) go test --race $(FLAGS) $(PKGS)
 
 shellcheck:
-	docker run -v "${PWD}:/mnt" koalaman/shellcheck:stable $(shell find . -type f -name "*.sh" -not -path "*vendor*")
+	${DOCKER_CLI} run -v "${PWD}:/mnt" koalaman/shellcheck:stable $(shell find . -type f -name "*.sh" -not -path "*vendor*")
 
 # Runs benchmark tests on the current git ref and the last release and compares
 # the two.
@@ -91,26 +94,25 @@ all-container: $(addprefix sub-container-,$(ALL_ARCH))
 all-push: $(addprefix sub-push-,$(ALL_ARCH))
 
 container: .container-$(ARCH)
-.container-$(ARCH):
-	docker run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics -e GOOS=linux -e GOARCH=$(ARCH) -e CGO_ENABLED=0 golang:${GO_VERSION} go build -ldflags "-s -w -X ${PKG}/version.Release=${TAG} -X ${PKG}/version.Commit=${Commit} -X ${PKG}/version.BuildDate=${BuildDate}" -o kube-state-metrics
+.container-$(ARCH): kube-state-metrics
 	cp -r * "${TEMP_DIR}"
-	docker build -t $(MULTI_ARCH_IMG):$(TAG) "${TEMP_DIR}"
-	docker tag $(MULTI_ARCH_IMG):$(TAG) $(MULTI_ARCH_IMG):latest
+	${DOCKER_CLI} build -t $(MULTI_ARCH_IMG):$(TAG) "${TEMP_DIR}"
+	${DOCKER_CLI} tag $(MULTI_ARCH_IMG):$(TAG) $(MULTI_ARCH_IMG):latest
 	rm -rf "${TEMP_DIR}"
 
 ifeq ($(ARCH), amd64)
 	# Adding check for amd64
-	docker tag $(MULTI_ARCH_IMG):$(TAG) $(IMAGE):$(TAG)
-	docker tag $(MULTI_ARCH_IMG):$(TAG) $(IMAGE):latest
+	${DOCKER_CLI} tag $(MULTI_ARCH_IMG):$(TAG) $(IMAGE):$(TAG)
+	${DOCKER_CLI} tag $(MULTI_ARCH_IMG):$(TAG) $(IMAGE):latest
 endif
 
 quay-push: .quay-push-$(ARCH)
 .quay-push-$(ARCH): .container-$(ARCH)
-	docker push $(MULTI_ARCH_IMG):$(TAG)
-	docker push $(MULTI_ARCH_IMG):latest
+	${DOCKER_CLI} push $(MULTI_ARCH_IMG):$(TAG)
+	${DOCKER_CLI} push $(MULTI_ARCH_IMG):latest
 ifeq ($(ARCH), amd64)
-	docker push $(IMAGE):$(TAG)
-	docker push $(IMAGE):latest
+	${DOCKER_CLI} push $(IMAGE):$(TAG)
+	${DOCKER_CLI} push $(IMAGE):latest
 endif
 
 push: .push-$(ARCH)

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -27,6 +27,7 @@ E2E_SETUP_PROMTOOL=${E2E_SETUP_PROMTOOL:-}
 MINIKUBE_VERSION=v1.3.1
 MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-virtualbox}
 SUDO=${SUDO:-}
+MINIKUBE_PROFILE=${MINIKUBE_PROFILE:-ksm-e2e}
 
 OS=$(uname -s | awk '{print tolower($0)}')
 OS=${OS:-linux}
@@ -77,9 +78,16 @@ mkdir "${HOME}"/.kube || true
 touch "${HOME}"/.kube/config
 
 export KUBECONFIG=$HOME/.kube/config
-${SUDO} minikube start --vm-driver="${MINIKUBE_DRIVER}" --kubernetes-version=${KUBERNETES_VERSION} --logtostderr
 
-minikube update-context
+if [[ "$MINIKUBE_DRIVER" != "none" ]]; then 
+  export MINIKUBE_PROFILE_ARG=" --profile ${MINIKUBE_PROFILE}"
+else
+  export MINIKUBE_PROFILE_ARG=''
+fi
+
+${SUDO} minikube start --vm-driver="${MINIKUBE_DRIVER}"${MINIKUBE_PROFILE_ARG} --kubernetes-version=${KUBERNETES_VERSION} --logtostderr
+
+minikube update-context${MINIKUBE_PROFILE_ARG}
 
 set +e
 
@@ -98,7 +106,7 @@ for _ in {1..90}; do # timeout for 3 minutes
 done
 
 if [[ ${is_kube_running} == "false" ]]; then
-   minikube logs
+   minikube logs${MINIKUBE_PROFILE_ARG}
    echo "Kubernetes does not start within 3 minutes"
    exit 1
 fi
@@ -107,8 +115,11 @@ set -e
 
 kubectl version
 
+# Build binary
+make build
+
 # ensure that we build docker image in minikube
-[[ "$MINIKUBE_DRIVER" != "none" ]] && eval "$(minikube docker-env)"
+[[ "$MINIKUBE_DRIVER" != "none" ]] && eval "$(minikube docker-env${MINIKUBE_PROFILE_ARG})" && export DOCKER_CLI='docker'
 
 # query kube-state-metrics image tag
 make container


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes e2e tests, failing when `MINIKUBE_DRIVER` is not `none`.
To do that, `make container` is refactored to use the binary built by `make build`:
- `make build` builds the binary `kube-state-metrics` using local Docker engine, with `$(pwd)` mounted as a volume;
- then `eval "$(minikube docker-env)"` is executed, to switch to the Docker daemon of the Minikube VM;
- then `make container` builds the docker image, which is then available in Minikube.

This PR also adds useful customizations:

- make it possible to use a docker-compatible tool instead of docker (e.g. podman), with environment variable `DOCKER_CLI` (except when using Minikube docker daemon)
- it also uses a separate profile for Minikube, when possible (i.e. not when the minikube driver is `none`)

**Which issue(s) this PR fixes**:
Fixes #771 (closed as `lifecycle/rotten` but still valid)

