### PR TITLE
Fix maxUnavailable to round down instead up

### DIFF
--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -184,7 +184,7 @@ var (
 					return &metric.Family{}
 				}
 
-				maxUnavailable, err := intstr.GetValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*d.Spec.Replicas), true)
+				maxUnavailable, err := intstr.GetValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*d.Spec.Replicas), false)
 				if err != nil {
 					panic(err)
 				}

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -33,7 +33,7 @@ var (
 	depl2Replicas int32 = 5
 
 	depl1MaxUnavailable = intstr.FromInt(10)
-	depl2MaxUnavailable = intstr.FromString("20%")
+	depl2MaxUnavailable = intstr.FromString("25%")
 
 	depl1MaxSurge = intstr.FromInt(10)
 	depl2MaxSurge = intstr.FromString("20%")


### PR DESCRIPTION
**What this PR does / why we need it**:
kube-state-metrics rounding logic should match Kubernetes rounding logic

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1075 

