### PR TITLE
Rename kube_pod_deleted to kube_pod_deletion_timestamp

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -197,7 +197,7 @@ var (
 			}),
 		},
 		{
-			Name: "kube_pod_deleted",
+			Name: "kube_pod_deletion_timestamp",
 			Type: metric.Gauge,
 			Help: "Unix deletion timestamp",
 			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -883,11 +883,11 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				},
 			},
 			Want: `
-				# HELP kube_pod_deleted Unix deletion timestamp
-				# TYPE kube_pod_deleted gauge
-				kube_pod_deleted{namespace="ns1",pod="pod1"} 1.8e+09
+				# HELP kube_pod_deletion_timestamp Unix deletion timestamp
+				# TYPE kube_pod_deletion_timestamp gauge
+				kube_pod_deletion_timestamp{namespace="ns1",pod="pod1"} 1.8e+09
 `,
-			MetricNames: []string{"kube_pod_deleted"},
+			MetricNames: []string{"kube_pod_deletion_timestamp"},
 		},
 		{
 			Obj: &v1.Pod{

--- a/main_test.go
+++ b/main_test.go
@@ -171,8 +171,8 @@ kube_pod_labels{namespace="default",pod="pod0"} 1
 # HELP kube_pod_created Unix creation timestamp
 # TYPE kube_pod_created gauge
 kube_pod_created{namespace="default",pod="pod0"} 1.5e+09
-# HELP kube_pod_deleted Unix deletion timestamp
-# TYPE kube_pod_deleted gauge
+# HELP kube_pod_deletion_timestamp Unix deletion timestamp
+# TYPE kube_pod_deletion_timestamp gauge
 # HELP kube_pod_restart_policy Describes the restart policy in use by this pod.
 # TYPE kube_pod_restart_policy gauge
 kube_pod_restart_policy{namespace="default",pod="pod0",type="Always"} 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Rename `kube_pod_deleted` to `kube_pod_deletion_timestamp`, to fix an inconsistency.

**Which issue(s) this PR fixes** :
Fixes #1068

