### PR TITLE
Update README: revert to --resources and mention v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ the raw metrics.
 
 ### Versioning
 
+> **WARNING**: Please be aware that `master` branch is targeting an upcoming version v2
+> of kube-state-metrics, which includes breaking changes. Documentation for the latest
+> released version (`1.9.5`) is available in the [release-1.9](https://github.com/kubernetes/kube-state-metrics/tree/release-1.9/docs) branch.
+
 #### Kubernetes Version
 
 kube-state-metrics uses [`client-go`](https://github.com/kubernetes/client-go) to talk with

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ subjects:
     namespace: your-namespace-where-kube-state-metrics-will-deployed
 ```
 
-- then specify a set of namespaces (using the `--namespace` option) and a set of kubernetes objects (using the `--collectors`) that your serviceaccount has access to in the `kube-state-metrics` deployment configuration
+- then specify a set of namespaces (using the `--namespace` option) and a set of kubernetes objects (using the `--resources`) that your serviceaccount has access to in the `kube-state-metrics` deployment configuration
 
 ```yaml
 spec:
@@ -268,7 +268,7 @@ spec:
       containers:
       - name: kube-state-metrics
         args:
-          - '--collectors=pods'
+          - '--resources=pods'
           - '--namespace=project1'
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Reverts #1059, which replaced by error `--resources` by `--collectors`. Collectors have been renamed _resources_ in #1006.
- Add a note in README to explain that master branch is targeting v2 (at least #915, #1059 and #1081 were made because of this confusion)

**Which issue(s) this PR fixes** :
N/A

