### PR TITLE
Added kube_pod_status_condition and kube_pod_status_condition_last_transition_time metric

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -4,6 +4,8 @@
 | ---------- | ----------- | ----------- | ----------- |
 | kube_pod_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `host_ip`=&lt;host-ip&gt; <br> `pod_ip`=&lt;pod-ip&gt; <br> `node`=&lt;node-name&gt;<br> `created_by_kind`=&lt;created_by_kind&gt;<br> `created_by_name`=&lt;created_by_name&gt;<br> `uid`=&lt;pod-uid&gt;<br> `priority_class`=&lt;priority_class&gt;<br> `host_network`=&lt;host_network&gt;| STABLE |
 | kube_pod_start_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `uid`=&lt;pod-uid&gt; | STABLE |
+| kube_pod_status_condition | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition_type`=&lt;condition-type&gt; | EXPERIMENTAL |
+| kube_pod_status_condition_last_transition_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition_type`=&lt;condition-type&gt; | EXPERIMENTAL |
 | kube_pod_completion_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `uid`=&lt;pod-uid&gt; | STABLE |
 | kube_pod_owner | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt; <br> `uid`=&lt;pod-uid&gt;  | STABLE |
 | kube_pod_labels | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `label_POD_LABEL`=&lt;POD_LABEL&gt; <br> `uid`=&lt;pod-uid&gt; | STABLE |

--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -4,8 +4,7 @@
 | ---------- | ----------- | ----------- | ----------- |
 | kube_pod_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `host_ip`=&lt;host-ip&gt; <br> `pod_ip`=&lt;pod-ip&gt; <br> `node`=&lt;node-name&gt;<br> `created_by_kind`=&lt;created_by_kind&gt;<br> `created_by_name`=&lt;created_by_name&gt;<br> `uid`=&lt;pod-uid&gt;<br> `priority_class`=&lt;priority_class&gt;<br> `host_network`=&lt;host_network&gt;| STABLE |
 | kube_pod_start_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `uid`=&lt;pod-uid&gt; | STABLE |
-| kube_pod_status_condition | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition_type`=&lt;condition-type&gt; | EXPERIMENTAL |
-| kube_pod_status_condition_last_transition_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition_type`=&lt;condition-type&gt; | EXPERIMENTAL |
+| kube_pod_status_condition_last_transition_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition_type`=&lt;condition-type&gt; <br> `uid`=&lt;pod-uid&gt; | EXPERIMENTAL |
 | kube_pod_completion_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `uid`=&lt;pod-uid&gt; | STABLE |
 | kube_pod_owner | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt; <br> `uid`=&lt;pod-uid&gt;  | STABLE |
 | kube_pod_labels | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `label_POD_LABEL`=&lt;POD_LABEL&gt; <br> `uid`=&lt;pod-uid&gt; | STABLE |

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -91,7 +91,6 @@ func podMetricFamilies(allowLabelsList []string) []generator.FamilyGenerator {
 		createPodStatusScheduledFamilyGenerator(),
 		createPodStatusScheduledTimeFamilyGenerator(),
 		createPodStatusUnschedulableFamilyGenerator(),
-		createPodStatusConditionFamilyGenerator(),
 		createPodStatusConditionLastTransitionTimeFamilyGenerator(),
 	}
 }
@@ -1408,39 +1407,6 @@ func createPodStatusPhaseFamilyGenerator() generator.FamilyGenerator {
 					LabelKeys:   []string{"phase"},
 					LabelValues: []string{p.n},
 					Value:       boolFloat64(p.v),
-				}
-			}
-
-			return &metric.Family{
-				Metrics: ms,
-			}
-		}),
-	)
-}
-
-func createPodStatusConditionFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
-		"kube_pod_status_condition",
-		"The pods conditions.",
-		metric.Gauge,
-		"",
-		wrapPodFunc(func(p *v1.Pod) *metric.Family {
-			conditions := p.Status.Conditions
-
-			ms := make([]*metric.Metric, len(conditions))
-
-			for i, condition := range conditions {
-				conditionType := string(condition.Type)
-				conditionStatusStr := string(condition.Status)
-				conditionStatus, err := strconv.ParseBool(conditionStatusStr)
-				if err != nil {
-					return nil
-				}
-				ms[i] = &metric.Metric{
-
-					LabelKeys:   []string{"condition_type"},
-					LabelValues: []string{conditionType},
-					Value:       boolFloat64(conditionStatus),
 				}
 			}
 

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1289,16 +1289,12 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				},
 			},
 			Want: `
-				# HELP kube_pod_status_condition The pods conditions.
-				# TYPE kube_pod_status_condition gauge
 				# HELP kube_pod_status_condition_last_transition_time The last transition time of each pod condition.
 				# TYPE kube_pod_status_condition_last_transition_time gauge
-				kube_pod_status_condition{namespace="ns2",pod="pod2",condition_type="PodScheduled",uid="uid2"} 1
-				kube_pod_status_condition{namespace="ns2",pod="pod2",condition_type="Ready",uid="uid2"} 0
 				kube_pod_status_condition_last_transition_time{namespace="ns2",pod="pod2",condition_type="PodScheduled",uid="uid2"} 1.501666018e+09
 				kube_pod_status_condition_last_transition_time{namespace="ns2",pod="pod2",condition_type="Ready",uid="uid2"} 1.501666018e+09
 			`,
-			MetricNames: []string{"kube_pod_status_condition", "kube_pod_status_condition_last_transition_time"},
+			MetricNames: []string{"kube_pod_status_condition_last_transition_time"},
 		},
 		{
 			Obj: &v1.Pod{
@@ -1311,12 +1307,10 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				},
 			},
 			Want: `
-				# HELP kube_pod_status_condition The pods conditions.
-				# TYPE kube_pod_status_condition gauge
 				# HELP kube_pod_status_condition_last_transition_time The last transition time of each pod condition.
 				# TYPE kube_pod_status_condition_last_transition_time gauge
 			`,
-			MetricNames: []string{"kube_pod_status_condition", "kube_pod_status_condition_last_transition_time"},
+			MetricNames: []string{"kube_pod_status_condition_last_transition_time"},
 		},
 		{
 			Obj: &v1.Pod{
@@ -1774,7 +1768,7 @@ func BenchmarkPodStore(b *testing.B) {
 		},
 	}
 
-	expectedFamilies := 52
+	expectedFamilies := 51
 	for n := 0; n < b.N; n++ {
 		families := f(pod)
 		if len(families) != expectedFamilies {

--- a/main_test.go
+++ b/main_test.go
@@ -209,7 +209,6 @@ func TestFullScrapeCycle(t *testing.T) {
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_readonly Describes whether a persistentvolumeclaim is mounted read only.
 # HELP kube_pod_start_time Start time in unix timestamp for a pod.
-# HELP kube_pod_status_condition The pods conditions.
 # HELP kube_pod_status_condition_last_transition_time The last transition time of each pod condition.
 # HELP kube_pod_status_phase The pods current phase.
 # HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
@@ -261,7 +260,6 @@ func TestFullScrapeCycle(t *testing.T) {
 # TYPE kube_pod_spec_volumes_persistentvolumeclaims_info gauge
 # TYPE kube_pod_spec_volumes_persistentvolumeclaims_readonly gauge
 # TYPE kube_pod_start_time gauge
-# TYPE kube_pod_status_condition gauge
 # TYPE kube_pod_status_condition_last_transition_time gauge
 # TYPE kube_pod_status_phase gauge
 # TYPE kube_pod_status_ready gauge

--- a/main_test.go
+++ b/main_test.go
@@ -209,6 +209,8 @@ func TestFullScrapeCycle(t *testing.T) {
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_readonly Describes whether a persistentvolumeclaim is mounted read only.
 # HELP kube_pod_start_time Start time in unix timestamp for a pod.
+# HELP kube_pod_status_condition The pods conditions.
+# HELP kube_pod_status_condition_last_transition_time The last transition time of each pod condition.
 # HELP kube_pod_status_phase The pods current phase.
 # HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
 # HELP kube_pod_status_reason The pod status reasons
@@ -259,6 +261,8 @@ func TestFullScrapeCycle(t *testing.T) {
 # TYPE kube_pod_spec_volumes_persistentvolumeclaims_info gauge
 # TYPE kube_pod_spec_volumes_persistentvolumeclaims_readonly gauge
 # TYPE kube_pod_start_time gauge
+# TYPE kube_pod_status_condition gauge
+# TYPE kube_pod_status_condition_last_transition_time gauge
 # TYPE kube_pod_status_phase gauge
 # TYPE kube_pod_status_ready gauge
 # TYPE kube_pod_status_reason gauge


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

- ~~Provides `kube_pod_status_ready_time`, which tells when a pod has become Ready, allowing us to see how much time it took to spin up and accept connections.~~
- Provides kube_pod_status_condition, which shows a pod's conditions. 
- Provides kube_pod_status_condition_last_transition_time, which shows the transition time of each condition.


