### PR TITLE
Controller labels

### DIFF
--- a/docs/job-metrics.md
+++ b/docs/job-metrics.md
@@ -5,6 +5,7 @@
 | kube_job_info | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
 | kube_job_labels | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; <br> `label_JOB_LABEL`=&lt;JOB_LABEL&gt;  | STABLE |
 | kube_job_owner | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  | STABLE |
+| kube_job_controller | Gauge | `job`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; <br> &lt;lowercase owner kind&gt;=&lt;owner name&gt; | STABLE |
 | kube_job_spec_parallelism | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
 | kube_job_spec_completions | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
 | kube_job_spec_active_deadline_seconds | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |

--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -6,6 +6,7 @@
 | kube_pod_start_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; |
 | kube_pod_completion_time | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_owner | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  | STABLE |
+| kube_pod_controller | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> &lt;lowercase owner kind&gt;=&lt;owner name&gt; | STABLE |
 | kube_pod_labels | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `label_POD_LABEL`=&lt;POD_LABEL&gt;  | STABLE |
 | kube_pod_status_phase | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `phase`=&lt;Pending\|Running\|Succeeded\|Failed\|Unknown&gt; | STABLE |
 | kube_pod_status_ready | Gauge |  `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; | STABLE |

--- a/docs/replicaset-metrics.md
+++ b/docs/replicaset-metrics.md
@@ -11,3 +11,4 @@
 | kube_replicaset_labels | Gauge | `replicaset`=&lt;replicaset-name&gt; <br> `namespace`=&lt;replicaset-namespace&gt; | STABLE |
 | kube_replicaset_created | Gauge | `replicaset`=&lt;replicaset-name&gt; <br> `namespace`=&lt;replicaset-namespace&gt; | STABLE |
 | kube_replicaset_owner | Gauge | `replicaset`=&lt;replicaset-name&gt; <br> `namespace`=&lt;replicaset-namespace&gt; <br> `owner_kind`=&lt;owner kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `owner_is_controller`=&lt;whether owner is controller&gt;  | STABLE |
+| kube_replicaset_controller | Gauge | `replicaset`=&lt;replicaset-name&gt; <br> `namespace`=&lt;replicaset-namespace&gt; <br> &lt;lowercase owner kind&gt;=&lt;owner name&gt; | STABLE |

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -307,6 +307,14 @@ var (
 				}
 			}),
 		},
+		{
+			Name: "kube_job_controller",
+			Type: metric.Gauge,
+			Help: "Information about the Job's controller",
+			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				return controllerInfo(j)
+			}),
+		},
 	}
 )
 

--- a/internal/store/job_test.go
+++ b/internal/store/job_test.go
@@ -52,6 +52,8 @@ func TestJobStore(t *testing.T) {
 		# TYPE kube_job_created gauge
 		# HELP kube_job_owner Information about the Job's owner.
 		# TYPE kube_job_owner gauge
+		# TYPE kube_job_controller gauge
+		# HELP kube_job_controller Information about the Job's controller
 		# HELP kube_job_complete The job has completed its execution.
 		# TYPE kube_job_complete gauge
 		# HELP kube_job_failed The job has failed its execution.
@@ -111,6 +113,7 @@ func TestJobStore(t *testing.T) {
 			},
 			Want: metadata + `
 				kube_job_owner{job_name="RunningJob1",namespace="ns1",owner_is_controller="true",owner_kind="CronJob",owner_name="cronjob-name"} 1
+				kube_job_controller{cronjob="cronjob-name",job_name="RunningJob1",namespace="ns1"} 1
 				kube_job_created{job_name="RunningJob1",namespace="ns1"} 1.5e+09
 				kube_job_info{job_name="RunningJob1",namespace="ns1"} 1
 				kube_job_labels{job_name="RunningJob1",label_app="example-running-1",namespace="ns1"} 1

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -161,6 +161,14 @@ var (
 			}),
 		},
 		{
+			Name: "kube_pod_controller",
+			Type: metric.Gauge,
+			Help: "Information about the Pod's controller",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				return controllerInfo(p)
+			}),
+		},
+		{
 			Name: "kube_pod_labels",
 			Type: metric.Gauge,
 			Help: "Kubernetes labels converted to Prometheus labels.",

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1603,7 +1603,7 @@ func BenchmarkPodStore(b *testing.B) {
 		},
 	}
 
-	expectedFamilies := 38
+	expectedFamilies := 39
 	for n := 0; n < b.N; n++ {
 		families := f(pod)
 		if len(families) != expectedFamilies {

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -187,6 +187,14 @@ var (
 			}),
 		},
 		{
+			Name: "kube_replicaset_controller",
+			Type: metric.Gauge,
+			Help: "Information about the ReplicaSet's controller",
+			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+				return controllerInfo(r)
+			}),
+		},
+		{
 			Name: descReplicaSetLabelsName,
 			Type: metric.Gauge,
 			Help: descReplicaSetLabelsHelp,

--- a/internal/store/replicaset_test.go
+++ b/internal/store/replicaset_test.go
@@ -38,7 +38,7 @@ func TestReplicaSetStore(t *testing.T) {
 	const metadata = `
 		# HELP kube_replicaset_created Unix creation timestamp
 		# TYPE kube_replicaset_created gauge
-	  # HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
+		# HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
 		# TYPE kube_replicaset_metadata_generation gauge
 		# HELP kube_replicaset_status_replicas The number of replicas per ReplicaSet.
 		# TYPE kube_replicaset_status_replicas gauge
@@ -52,6 +52,8 @@ func TestReplicaSetStore(t *testing.T) {
 		# TYPE kube_replicaset_spec_replicas gauge
 		# HELP kube_replicaset_owner Information about the ReplicaSet's owner.
 		# TYPE kube_replicaset_owner gauge
+		# HELP kube_replicaset_controller Information about the ReplicaSet's controller
+		# TYPE kube_replicaset_controller gauge
 		# HELP kube_replicaset_labels Kubernetes labels converted to Prometheus labels.
 		# TYPE kube_replicaset_labels gauge
 	`
@@ -94,6 +96,7 @@ func TestReplicaSetStore(t *testing.T) {
 				kube_replicaset_status_ready_replicas{namespace="ns1",replicaset="rs1"} 5
 				kube_replicaset_spec_replicas{namespace="ns1",replicaset="rs1"} 5
 				kube_replicaset_owner{namespace="ns1",owner_is_controller="true",owner_kind="Deployment",owner_name="dp-name",replicaset="rs1"} 1
+				kube_replicaset_controller{deployment="dp-name",namespace="ns1",replicaset="rs1"} 1
 `,
 		},
 		{

--- a/main_test.go
+++ b/main_test.go
@@ -309,8 +309,6 @@ kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod
 # TYPE kube_pod_overhead gauge`
 
 	expectedSplit := strings.Split(strings.TrimSpace(expected), "\n")
-	sort.Strings(expectedSplit)
-
 	gotSplit := strings.Split(strings.TrimSpace(string(body)), "\n")
 
 	gotFiltered := []string{}
@@ -320,15 +318,25 @@ kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod
 		}
 	}
 
-	sort.Strings(gotFiltered)
-
-	if len(expectedSplit) != len(gotFiltered) {
-		t.Fatalf("expected different output length, expected %d got %d", len(expectedSplit), len(gotFiltered))
+	expectedMap := make(map[string]bool)
+	for _, s := range expectedSplit {
+		expectedMap[s] = true
 	}
 
-	for i := 0; i < len(expectedSplit); i++ {
-		if expectedSplit[i] != gotFiltered[i] {
-			t.Fatalf("expected:\n\n%v, but got:\n\n%v", expectedSplit[i], gotFiltered[i])
+	gotMap := make(map[string]bool)
+	for _, s := range gotFiltered {
+		gotMap[s] = true
+	}
+
+	for exp := range expectedMap {
+		if _, ok := gotMap[exp]; !ok {
+			t.Errorf("Did not get expected line: %v", exp)
+		}
+	}
+
+	for got := range gotMap {
+		if _, ok := expectedMap[got]; !ok {
+			t.Errorf("Got unexpected line: %v", got)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -165,6 +165,8 @@ kube_pod_info{namespace="default",pod="pod0",host_ip="1.1.1.1",pod_ip="1.2.3.4",
 # HELP kube_pod_owner Information about the Pod's owner.
 # TYPE kube_pod_owner gauge
 kube_pod_owner{namespace="default",pod="pod0",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+# HELP kube_pod_controller Information about the Pod's controller
+# TYPE kube_pod_controller gauge
 # HELP kube_pod_labels Kubernetes labels converted to Prometheus labels.
 # TYPE kube_pod_labels gauge
 kube_pod_labels{namespace="default",pod="pod0"} 1


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `kube_*_controller` metrics. They are similar to `kube_*_owner` (effectively expose the same data) except for two crucial differences:

1. They only report the controller owner
2. The owner kind is returned in the label name, not in its own owner_kind label. This makes PromQL joins significantly easier.

Example: get the sum of memory limits for all deployments with the label app=nginx

**`owner` labels**

You need to use `label_replace` to make the label names line up to join on them:

```
sum(
kube_pod_container_resource_limits_memory_bytes and on(namespace, pod)
(label_replace(kube_pod_owner{owner_kind="ReplicaSet"}, "replicaset", "$1", "owner_name", "(.+)") and on (namespace, replicaset) 
(label_replace(kube_replicaset_owner{owner_kind="Deployment"}, "deployment", "$1", "owner_name", "(.+)") and on (namespace, deployment) 
kube_deployment_labels{label_app="nginx"})))
```

**`controller` labels**

No relabelling needed:

```
sum(
kube_pod_container_resource_limits_memory_bytes and on(namespace, pod) 
(kube_pod_controller and on (namespace, replicaset)
(kube_replicaset_controller and on (namespace, deployment) 
kube_deployment_labels{label_app="nginx"})))
```