### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ At most, 5 kube-state-metrics and 5 [kubernetes releases](https://github.com/kub
 | **v1.6.0**         |         ✓           |         -           |          -           |          -           |          -           |
 | **v1.7.2**         |         ✓           |         ✓           |          -           |          -           |          -           |
 | **v1.8.0**         |         ✓           |         ✓           |          ✓           |          -           |          -           |
-| **v1.9.5**         |         ✓           |         ✓           |          ✓           |          ✓           |          -           |
-| **master**         |         ✓           |         ✓           |          ✓           |          ✓           |          ✓           |
+| **v1.9.5**         |         -           |         -           |          -           |          ✓           |          -           |
+| **master**         |         -           |         -           |          -           |          ✓           |          ✓           |
 - `✓` Fully supported version range.
-- `-` The Kubernetes cluster has features the client-go library can't use (additional API objects, etc).
+- `-` The Kubernetes cluster has features the client-go library can't use (additional API objects, deprecated APIs, etc).
 
 #### Resource group version compatibility
 Resources in Kubernetes can evolve, i.e., the group version for a resource may change from alpha to beta and finally GA


### PR DESCRIPTION
This update is to address https://github.com/kubernetes/kube-state-metrics/issues/1090. Since K8s 1.9 - 1.15 uses the v1beta1 version of admissionregistration, where as 1.16 and newer use v1 of the admissionregistration API, the 1.9.5 release of kube-state-metrics is not backwards compatible with kubernetes 1.15 or older. 

These versions are from https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#prerequisites

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

