### PR TITLE
[e2e] Remove redundant bash test + upgrade Minikube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
   global:
       - E2E_SETUP_MINIKUBE=yes
       - E2E_SETUP_KUBECTL=yes
-      - E2E_SETUP_PROMTOOL=yes
       - MINIKUBE_DRIVER=none
       - SUDO=sudo
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,9 +2,9 @@
 
 This folder contains simple e2e tests.
 When launched it spins up a kubernetes cluster using minikube, creates several kubernetes resources and launches a kube-state-metrics deployment.
-Then, it downloads kube-state-metrics' metrics and examines validity using `promtool` tool.
+Then, it runs verification tests: check metrics' presence, lint metrics, check service health, etc.
 
-The testsuite is run automatically using Travis.
+The test suite is run automatically using Travis.
 
 ## Running locally
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove metrics linting using `promtool`, since it is now done in go tests since #907.
- Upgrade minikube to latest version

**Which issue(s) this PR fixes** :
Related to #875

