### PR TITLE
v2: Renamed --namespace flag to --namespaces

### DIFF
--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -39,7 +39,7 @@ Usage of ./kube-state-metrics:
       --logtostderr                      log to standard error instead of files (default true)
       --metric-allowlist string          Comma-separated list of metrics to be exposed. This list comprises of exact metric names and/or regex patterns. The allowlist and denylist are mutually exclusive.
       --metric-denylist string           Comma-separated list of metrics not to be enabled. This list comprises of exact metric names and/or regex patterns. The allowlist and denylist are mutually exclusive.
-      --namespace string                 Comma-separated list of namespaces to be enabled. Defaults to ""
+      --namespaces string                Comma-separated list of namespaces to be enabled. Defaults to ""
       --pod string                       Name of the pod that contains the kube-state-metrics container. When set, it is expected that --pod and --pod-namespace are both set. Most likely this should be passed via the downward API. This is used for auto-detecting sharding. If set, this has preference over statically configured sharding. This is experimental, it may be removed without notice.
       --pod-namespace string             Name of the namespace of the pod specified by --pod. When set, it is expected that --pod and --pod-namespace are both set. Most likely this should be passed via the downward API. This is used for auto-detecting sharding. If set, this has preference over statically configured sharding. This is experimental, it may be removed without notice.
       --port int                         Port to expose metrics on. (default 8080)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -83,7 +83,7 @@ func (o *Options) AddFlags() {
 	o.flags.IntVar(&o.TelemetryPort, "telemetry-port", 8081, `Port to expose kube-state-metrics self metrics on.`)
 	o.flags.StringVar(&o.TelemetryHost, "telemetry-host", "0.0.0.0", `Host to expose kube-state-metrics self metrics on.`)
 	o.flags.Var(&o.Resources, "resources", fmt.Sprintf("Comma-separated list of Resources to be enabled. Defaults to %q", &DefaultResources))
-	o.flags.Var(&o.Namespaces, "namespace", fmt.Sprintf("Comma-separated list of namespaces to be enabled. Defaults to %q", &DefaultNamespaces))
+	o.flags.Var(&o.Namespaces, "namespaces", fmt.Sprintf("Comma-separated list of namespaces to be enabled. Defaults to %q", &DefaultNamespaces))
 	o.flags.Var(&o.MetricAllowlist, "metric-allowlist", "Comma-separated list of metrics to be exposed. This list comprises of exact metric names and/or regex patterns. The allowlist and denylist are mutually exclusive.")
 	o.flags.Var(&o.MetricDenylist, "metric-denylist", "Comma-separated list of metrics not to be enabled. This list comprises of exact metric names and/or regex patterns. The allowlist and denylist are mutually exclusive.")
 	o.flags.Int32Var(&o.Shard, "shard", int32(0), "The instances shard nominal (zero indexed) within the total number of shards. (default 0)")

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -36,8 +36,8 @@ func TestOptionsParse(t *testing.T) {
 			RecoverInvoked: false,
 		},
 		{
-			Desc:           "namespace command line argument",
-			Args:           []string{"./kube-state-metrics", "--namespace=default,kube-system"},
+			Desc:           "namespaces command line argument",
+			Args:           []string{"./kube-state-metrics", "--namespaces=default,kube-system"},
 			RecoverInvoked: false,
 		},
 	}


### PR DESCRIPTION
What this PR does / why we need it:
This PR renames --namespace flag to --namespaces
Which issue(s) this PR fixes *
Fixes #978