### PR TITLE
v2: Rename storage class labels reclaimPolicy to reclaim_policy and volumeBindingMode to volume_binding_mode

### DIFF
--- a/docs/storageclass-metrics.md
+++ b/docs/storageclass-metrics.md
@@ -2,6 +2,6 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
-| kube_storageclass_info | Gauge | `storageclass`=&lt;storageclass-name&gt; <br> `provisioner`=&lt;storageclass-provisioner&gt; <br> `reclaimPolicy`=&lt;storageclass-reclaimPolicy&gt; <br> `volumeBindingMode`=&lt;storageclass-volumeBindingMode&gt; | STABLE |
+| kube_storageclass_info | Gauge | `storageclass`=&lt;storageclass-name&gt; <br> `provisioner`=&lt;storageclass-provisioner&gt; <br> `reclaim_policy`=&lt;storageclass-reclaimPolicy&gt; <br> `volume_binding_mode`=&lt;storageclass-volumeBindingMode&gt; | STABLE |
 | kube_storageclass_labels | Gauge | `storageclass`=&lt;storageclass-name&gt; <br> `label_STORAGECLASS_LABEL`=&lt;STORAGECLASS_LABEL&gt; | STABLE |
 | kube_storageclass_created  | Gauge | `storageclass`=&lt;storageclass-name&gt; | STABLE |

--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -50,7 +50,7 @@ var (
 				}
 
 				m := metric.Metric{
-					LabelKeys:   []string{"provisioner", "reclaimPolicy", "volumeBindingMode"},
+					LabelKeys:   []string{"provisioner", "reclaim_policy", "volume_binding_mode"},
 					LabelValues: []string{s.Provisioner, string(*s.ReclaimPolicy), string(*s.VolumeBindingMode)},
 					Value:       1,
 				}

--- a/internal/store/storageclass_test.go
+++ b/internal/store/storageclass_test.go
@@ -42,7 +42,7 @@ func TestStorageClassStore(t *testing.T) {
 			Want: `
 					# HELP kube_storageclass_info Information about storageclass.
 					# TYPE kube_storageclass_info gauge
-					kube_storageclass_info{storageclass="test_storageclass-info",provisioner="kubernetes.io/rbd",reclaimPolicy="Delete",volumeBindingMode="Immediate"} 1
+					kube_storageclass_info{storageclass="test_storageclass-info",provisioner="kubernetes.io/rbd",reclaim_policy="Delete",volume_binding_mode="Immediate"} 1
 				`,
 			MetricNames: []string{
 				"kube_storageclass_info",
@@ -60,7 +60,7 @@ func TestStorageClassStore(t *testing.T) {
 			Want: `
 					# HELP kube_storageclass_info Information about storageclass.
 					# TYPE kube_storageclass_info gauge
-					kube_storageclass_info{storageclass="test_storageclass-default-info",provisioner="kubernetes.io/rbd",reclaimPolicy="Delete",volumeBindingMode="Immediate"} 1
+					kube_storageclass_info{storageclass="test_storageclass-default-info",provisioner="kubernetes.io/rbd",reclaim_policy="Delete",volume_binding_mode="Immediate"} 1
 				`,
 			MetricNames: []string{
 				"kube_storageclass_info",


### PR DESCRIPTION
**What this PR does / why we need it**:
Raising new PR as exiting one [ #996 ] has no progress from last 3 months.
This PR renames storage class labels `reclaimPolicy` to `reclaim_policy` and `volumeBindingMode` to `volume_binding_mode`
 
**Which issue(s) this PR fixes** 
Fixes #981 

