### PR TITLE
Fix various CI issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PKG = k8s.io/kube-state-metrics/pkg
 GO_VERSION = 1.14.1
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell go env GOPATH)))
 BENCHCMP_BINARY := $(FIRST_GOPATH)/bin/benchcmp
-GOLANGCI_VERSION := v1.22.2
+GOLANGCI_VERSION := v1.24.0
 HAS_GOLANGCI := $(shell which golangci-lint)
 
 IMAGE = $(REGISTRY)/kube-state-metrics

--- a/docs/volumeattachment-metrics.md
+++ b/docs/volumeattachment-metrics.md
@@ -2,7 +2,7 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
-| kube_volumeattachment_info | Gauge | `volumeattachment`=&lt;volumeattachment-name&gt; <br> `attacher`=&lt;attacher-name&gt; <br> `nodeName`=&lt;node-name&gt; | EXPERIMENTAL |
+| kube_volumeattachment_info | Gauge | `volumeattachment`=&lt;volumeattachment-name&gt; <br> `attacher`=&lt;attacher-name&gt; <br> `node`=&lt;node-name&gt; | EXPERIMENTAL |
 | kube_volumeattachment_created | Gauge | `volumeattachment`=&lt;volumeattachment-name&gt; | EXPERIMENTAL |
 | kube_volumeattachment_labels | Gauge | `volumeattachment`=&lt;volumeattachment-name&gt; <br> `label_VOLUMEATTACHMENT_LABEL`=&lt;VOLUMEATTACHMENT_LABEL&gt;  | EXPERIMENTAL |
 | kube_volumeattachment_spec_source_persistentvolume | Gauge | `volumeattachment`=&lt;volumeattachment-name&gt; <br> `volumename`=&lt;persistentvolume-name&gt; | EXPERIMENTAL |

--- a/internal/store/volumeattachment.go
+++ b/internal/store/volumeattachment.go
@@ -59,7 +59,7 @@ var (
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   []string{"attacher", "nodeName"},
+							LabelKeys:   []string{"attacher", "node"},
 							LabelValues: []string{va.Spec.Attacher, va.Spec.NodeName},
 							Value:       1,
 						},

--- a/internal/store/volumeattachment_test.go
+++ b/internal/store/volumeattachment_test.go
@@ -69,7 +69,7 @@ func TestVolumeAttachmentStore(t *testing.T) {
 					},
 				},
 				Want: metadata + `
-		        kube_volumeattachment_info{attacher="cinder.csi.openstack.org",nodeName="node1",volumeattachment="csi-5ff16a1ad085261021e21c6cb3a6defb979a8794f25a4f90f6285664cff37224"} 1
+		        kube_volumeattachment_info{attacher="cinder.csi.openstack.org",node="node1",volumeattachment="csi-5ff16a1ad085261021e21c6cb3a6defb979a8794f25a4f90f6285664cff37224"} 1
         		kube_volumeattachment_labels{label_app="foobar",volumeattachment="csi-5ff16a1ad085261021e21c6cb3a6defb979a8794f25a4f90f6285664cff37224"} 1
 		        kube_volumeattachment_spec_source_persistentvolume{volumeattachment="csi-5ff16a1ad085261021e21c6cb3a6defb979a8794f25a4f90f6285664cff37224",volumename="pvc-44f6ff3f-ba9b-49c4-9b95-8b01c4bd4bab"} 1
 		        kube_volumeattachment_status_attached{volumeattachment="csi-5ff16a1ad085261021e21c6cb3a6defb979a8794f25a4f90f6285664cff37224"} 1

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -68,14 +68,14 @@ touch "${HOME}"/.kube/config
 export KUBECONFIG=$HOME/.kube/config
 
 if [[ "$MINIKUBE_DRIVER" != "none" ]]; then 
-  export MINIKUBE_PROFILE_ARG=" --profile ${MINIKUBE_PROFILE}"
+  export MINIKUBE_PROFILE_ARG="--profile ${MINIKUBE_PROFILE}"
 else
   export MINIKUBE_PROFILE_ARG=''
 fi
 
-${SUDO} minikube start --vm-driver="${MINIKUBE_DRIVER}"${MINIKUBE_PROFILE_ARG} --kubernetes-version=${KUBERNETES_VERSION} --logtostderr
+${SUDO} minikube start --vm-driver="${MINIKUBE_DRIVER}" "${MINIKUBE_PROFILE_ARG}" --kubernetes-version=${KUBERNETES_VERSION} --logtostderr
 
-minikube update-context${MINIKUBE_PROFILE_ARG}
+minikube update-context "${MINIKUBE_PROFILE_ARG}"
 
 set +e
 
@@ -94,7 +94,7 @@ for _ in {1..90}; do # timeout for 3 minutes
 done
 
 if [[ ${is_kube_running} == "false" ]]; then
-   minikube logs${MINIKUBE_PROFILE_ARG}
+   minikube logs "${MINIKUBE_PROFILE_ARG}"
    echo "Kubernetes does not start within 3 minutes"
    exit 1
 fi
@@ -107,7 +107,7 @@ kubectl version
 make build
 
 # ensure that we build docker image in minikube
-[[ "$MINIKUBE_DRIVER" != "none" ]] && eval "$(minikube docker-env${MINIKUBE_PROFILE_ARG})" && export DOCKER_CLI='docker'
+[[ "$MINIKUBE_DRIVER" != "none" ]] && eval "$(minikube docker-env "${MINIKUBE_PROFILE_ARG}")" && export DOCKER_CLI='docker'
 
 # query kube-state-metrics image tag
 make container


### PR DESCRIPTION
**What this PR does / why we need it**:

CI caught a violation of the label name being `nodeName` (camelCase) rather than snake_case, however, this is actually a case of another violation, which is the kubernetes instrumentation guideline says, that this label should have always been `node` to begin with, to allow for joining without label_replace. This metric is experimental anyways, so we're free to change this.

~We're not sure yet why PR CI didn't catch this.~

Travis CI not reporting seems to have magically fixed itself (possibly by either @lilic or myself logging in to Travis refreshing something?).

To get CI into a working state, I fixed the remaining issues as well.

@lilic @tariq1890 
