### PR TITLE
fix e2e test run when the minikube_driver is not none

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -68,7 +68,7 @@ touch "${HOME}"/.kube/config
 export KUBECONFIG=$HOME/.kube/config
 
 if [[ "$MINIKUBE_DRIVER" != "none" ]]; then 
-  export MINIKUBE_PROFILE_ARG="--profile ${MINIKUBE_PROFILE}"
+  export MINIKUBE_PROFILE_ARG=" --profile ${MINIKUBE_PROFILE}"
 else
   export MINIKUBE_PROFILE_ARG=''
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes the e2e test run when the minikube_driver is not none.
This was introduced here: https://github.com/kubernetes/kube-state-metrics/pull/1117/files#diff-44bdf2bf033618abcd6345950e4ed565R71 see line 71
The reason last PR build (https://travis-ci.org/github/kubernetes/kube-state-metrics/jobs/672429529) was successful because it was only running for the case when minikube_driver is none see line 186 and 250 in the logs.

@lilic @tariq1890 @brancz It might be a good idea to cover both the cases while running the e2e tests in future so that we do not miss these cases?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

