### PR TITLE
add new service metric, kube_service_spec_selectors, to export servic…

### DIFF
--- a/docs/service-metrics.md
+++ b/docs/service-metrics.md
@@ -5,6 +5,7 @@
 | kube_service_info | Gauge | `service`=&lt;service-name&gt; <br> `namespace`=&lt;service-namespace&gt; <br> `cluster_ip`=&lt;service cluster ip&gt; <br> `external_name`=&lt;service external name&gt; <btr> `load_balancer_ip`=&lt;service load balancer ip&gt; | STABLE |
 | kube_service_labels | Gauge | `service`=&lt;service-name&gt; <br> `namespace`=&lt;service-namespace&gt; <br> `label_SERVICE_LABEL`=&lt;SERVICE_LABEL&gt;  | STABLE |
 | kube_service_created | Gauge | `service`=&lt;service-name&gt; <br> `namespace`=&lt;service-namespace&gt; | STABLE |
+| kube_service_spec_selectors | Gauge | `service`=&lt;service-name&gt; <br> `namespace`=&lt;service-namespace&gt; <br> `selector_SERVICE_SPEC_SELECTOR`=&lt;SERVICE_SPEC_SELECTOR&gt;  | STABLE |
 | kube_service_spec_type | Gauge | `service`=&lt;service-name&gt; <br> `namespace`=&lt;service-namespace&gt; <br> `type`=&lt;ClusterIP\|NodePort\|LoadBalancer\|ExternalName&gt; | STABLE |
 | kube_service_spec_external_ip | Gauge | `service`=&lt;service-name&gt; <br> `namespace`=&lt;service-namespace&gt; <br> `external_ip`=&lt;external-ip&gt; | STABLE |
 | kube_service_status_load_balancer_ingress | Gauge | `service`=&lt;service-name&gt; <br> `namespace`=&lt;service-namespace&gt; <br> `ip`=&lt;load-balancer-ingress-ip&gt; <br> `hostname`=&lt;load-balancer-ingress-hostname&gt; | STABLE |

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -93,6 +93,20 @@ var (
 			}),
 		},
 		{
+			Name: "kube_service_spec_selectors",
+			Type: metric.Gauge,
+			Help: "Kubernetes selectors converted to Prometheus selectors.",
+			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+				selectorKeys, selectorValues := kubeSelectorsToPrometheusSelectors(s.Spec.Selector)
+				m := metric.Metric{
+					LabelKeys:   selectorKeys,
+					LabelValues: selectorValues,
+					Value:       1,
+				}
+				return &metric.Family{Metrics: []*metric.Metric{&m}}
+			}),
+		},
+		{
 			Name: "kube_service_spec_external_ip",
 			Type: metric.Gauge,
 			Help: "Service external ips. One series for each ip",

--- a/internal/store/service_test.go
+++ b/internal/store/service_test.go
@@ -36,6 +36,8 @@ func TestServiceStore(t *testing.T) {
 		# TYPE kube_service_created gauge
 		# HELP kube_service_labels Kubernetes labels converted to Prometheus labels.
 		# TYPE kube_service_labels gauge
+		# HELP kube_service_spec_selectors Kubernetes selectors converted to Prometheus selectors.
+		# TYPE kube_service_spec_selectors gauge
 		# HELP kube_service_spec_type Type about service.
 		# TYPE kube_service_spec_type gauge
 		# HELP kube_service_spec_external_ip Service external ips. One series for each ip
@@ -57,26 +59,33 @@ func TestServiceStore(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					ClusterIP: "1.2.3.4",
 					Type:      v1.ServiceTypeClusterIP,
+					Selector: map[string]string{
+						"app.kubernetes.io/name": "selector1",
+					},
 				},
 			},
 			Want: `
 				# HELP kube_service_created Unix creation timestamp
 				# HELP kube_service_info Information about service.
 				# HELP kube_service_labels Kubernetes labels converted to Prometheus labels.
+				# HELP kube_service_spec_selectors Kubernetes selectors converted to Prometheus selectors.
 				# HELP kube_service_spec_type Type about service.
 				# TYPE kube_service_created gauge
 				# TYPE kube_service_info gauge
 				# TYPE kube_service_labels gauge
+				# TYPE kube_service_spec_selectors gauge
 				# TYPE kube_service_spec_type gauge
 				kube_service_created{namespace="default",service="test-service1"} 1.5e+09
 				kube_service_info{cluster_ip="1.2.3.4",external_name="",load_balancer_ip="",namespace="default",service="test-service1"} 1
 				kube_service_labels{label_app="example1",namespace="default",service="test-service1"} 1
+				kube_service_spec_selectors{selector_app_kubernetes_io_name="selector1",namespace="default",service="test-service1"} 1
 				kube_service_spec_type{namespace="default",service="test-service1",type="ClusterIP"} 1
 `,
 			MetricNames: []string{
 				"kube_service_created",
 				"kube_service_info",
 				"kube_service_labels",
+				"kube_service_spec_selectors",
 				"kube_service_spec_type",
 			},
 		},
@@ -94,12 +103,16 @@ func TestServiceStore(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					ClusterIP: "1.2.3.5",
 					Type:      v1.ServiceTypeNodePort,
+					Selector: map[string]string{
+						"app.kubernetes.io/name": "selector2",
+					},
 				},
 			},
 			Want: metadata + `
 				kube_service_created{namespace="default",service="test-service2"} 1.5e+09
 				kube_service_info{cluster_ip="1.2.3.5",external_name="",load_balancer_ip="",namespace="default",service="test-service2"} 1
 				kube_service_labels{label_app="example2",namespace="default",service="test-service2"} 1
+				kube_service_spec_selectors{selector_app_kubernetes_io_name="selector2",namespace="default",service="test-service2"} 1
 				kube_service_spec_type{namespace="default",service="test-service2",type="NodePort"} 1
 `,
 		},
@@ -117,12 +130,16 @@ func TestServiceStore(t *testing.T) {
 					ClusterIP:      "1.2.3.6",
 					LoadBalancerIP: "1.2.3.7",
 					Type:           v1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{
+						"app.kubernetes.io/name": "selector3",
+					},
 				},
 			},
 			Want: metadata + `
 				kube_service_created{namespace="default",service="test-service3"} 1.5e+09
 				kube_service_info{cluster_ip="1.2.3.6",external_name="",load_balancer_ip="1.2.3.7",namespace="default",service="test-service3"} 1
 				kube_service_labels{label_app="example3",namespace="default",service="test-service3"} 1
+				kube_service_spec_selectors{selector_app_kubernetes_io_name="selector3",namespace="default",service="test-service3"} 1
 				kube_service_spec_type{namespace="default",service="test-service3",type="LoadBalancer"} 1
 `,
 		},
@@ -139,12 +156,16 @@ func TestServiceStore(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					ExternalName: "www.example.com",
 					Type:         v1.ServiceTypeExternalName,
+					Selector: map[string]string{
+						"app.kubernetes.io/name": "selector4",
+					},
 				},
 			},
 			Want: metadata + `
 				kube_service_created{namespace="default",service="test-service4"} 1.5e+09
 				kube_service_info{cluster_ip="",external_name="www.example.com",load_balancer_ip="",namespace="default",service="test-service4"} 1
 				kube_service_labels{label_app="example4",namespace="default",service="test-service4"} 1
+				kube_service_spec_selectors{selector_app_kubernetes_io_name="selector4",namespace="default",service="test-service4"} 1
 				kube_service_spec_type{namespace="default",service="test-service4",type="ExternalName"} 1
 			`,
 		},
@@ -160,6 +181,9 @@ func TestServiceStore(t *testing.T) {
 				},
 				Spec: v1.ServiceSpec{
 					Type: v1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{
+						"app.kubernetes.io/name": "selector5",
+					},
 				},
 				Status: v1.ServiceStatus{
 					LoadBalancer: v1.LoadBalancerStatus{
@@ -176,6 +200,7 @@ func TestServiceStore(t *testing.T) {
 				kube_service_created{namespace="default",service="test-service5"} 1.5e+09
 				kube_service_info{cluster_ip="",external_name="",load_balancer_ip="",namespace="default",service="test-service5"} 1
 				kube_service_labels{label_app="example5",namespace="default",service="test-service5"} 1
+				kube_service_spec_selectors{selector_app_kubernetes_io_name="selector5",namespace="default",service="test-service5"} 1
 				kube_service_spec_type{namespace="default",service="test-service5",type="LoadBalancer"} 1
 				kube_service_status_load_balancer_ingress{hostname="www.example.com",ip="1.2.3.8",namespace="default",service="test-service5"} 1
 			`,
@@ -196,12 +221,16 @@ func TestServiceStore(t *testing.T) {
 						"1.2.3.9",
 						"1.2.3.10",
 					},
+					Selector: map[string]string{
+						"app.kubernetes.io/name": "selector6",
+					},
 				},
 			},
 			Want: metadata + `
 				kube_service_created{namespace="default",service="test-service6"} 1.5e+09
 				kube_service_info{cluster_ip="",external_name="",load_balancer_ip="",namespace="default",service="test-service6"} 1
 				kube_service_labels{label_app="example6",namespace="default",service="test-service6"} 1
+				kube_service_spec_selectors{selector_app_kubernetes_io_name="selector6",namespace="default",service="test-service6"} 1
 				kube_service_spec_type{namespace="default",service="test-service6",type="ClusterIP"} 1
 				kube_service_spec_external_ip{external_ip="1.2.3.9",namespace="default",service="test-service6"} 1
 				kube_service_spec_external_ip{external_ip="1.2.3.10",namespace="default",service="test-service6"} 1

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -76,6 +76,10 @@ func kubeLabelsToPrometheusLabels(labels map[string]string) ([]string, []string)
 	return mapToPrometheusLabels(labels, "label")
 }
 
+func kubeSelectorsToPrometheusSelectors(selectors map[string]string) ([]string, []string) {
+	return mapToPrometheusLabels(selectors, "selector")
+}
+
 func mapToPrometheusLabels(labels map[string]string, prefix string) ([]string, []string) {
 	labelKeys := make([]string, 0, len(labels))
 	for k := range labels {


### PR DESCRIPTION
…e selector info

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR extends the current set of metrics exported for a service.  More specifically, it introduces a new metric (kube_service_spec_selectors) to export service spec selector information.  Service selectors facilitate the connection of services to pods (or vice-versa).  Without this information, one cannot make such connections with the current set of metrics.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

