### PR TITLE
jsonnet/kube-state-metrics-mixin: add default KSM selector

### DIFF
--- a/jsonnet/kube-state-metrics-mixin/alerts.libsonnet
+++ b/jsonnet/kube-state-metrics-mixin/alerts.libsonnet
@@ -1,7 +1,4 @@
 {
-  _config+:: {
-    kubeStateMetricsSelector: error 'must provide selector for kube-state-metrics',
-  },
   prometheusAlerts+:: {
     groups+: [
       {

--- a/jsonnet/kube-state-metrics-mixin/config.libsonnet
+++ b/jsonnet/kube-state-metrics-mixin/config.libsonnet
@@ -1,0 +1,6 @@
+{
+  _config+:: {
+    // Select the metrics coming from the kube state metrics.
+    kubeStateMetricsSelector: 'job="kube-state-metrics"',
+  },
+}

--- a/jsonnet/kube-state-metrics-mixin/mixin.libsonnet
+++ b/jsonnet/kube-state-metrics-mixin/mixin.libsonnet
@@ -1,1 +1,2 @@
+(import 'config.libsonnet') +
 (import 'alerts.libsonnet')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Enable easier onboarding when using KSM mixin and align with other mixins.

/cc @brancz @lilic 

