### PR TITLE
internal/store/mutatingwebhookconfiguration.go: Switch to v1

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	admissionregistration "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -241,7 +241,7 @@ func (b *Builder) buildLimitRangeStore() cache.Store {
 }
 
 func (b *Builder) buildMutatingWebhookConfigurationStore() cache.Store {
-	return b.buildStoreFunc(mutatingWebhookConfigurationMetricFamilies, &admissionregistration.MutatingWebhookConfiguration{}, createMutatingWebhookConfigurationListWatch)
+	return b.buildStoreFunc(mutatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.MutatingWebhookConfiguration{}, createMutatingWebhookConfigurationListWatch)
 }
 
 func (b *Builder) buildNamespaceStore() cache.Store {
@@ -305,7 +305,7 @@ func (b *Builder) buildCsrStore() cache.Store {
 }
 
 func (b *Builder) buildValidatingWebhookConfigurationStore() cache.Store {
-	return b.buildStoreFunc(validatingWebhookConfigurationMetricFamilies, &admissionregistration.ValidatingWebhookConfiguration{}, createValidatingWebhookConfigurationListWatch)
+	return b.buildStoreFunc(validatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.ValidatingWebhookConfiguration{}, createValidatingWebhookConfigurationListWatch)
 }
 
 func (b *Builder) buildVolumeAttachmentStore() cache.Store {

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -17,7 +17,7 @@ limitations under the License.
 package store
 
 import (
-	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -37,7 +37,7 @@ var (
 			Name: "kube_mutatingwebhookconfiguration_info",
 			Type: metric.Gauge,
 			Help: "Information about the MutatingWebhookConfiguration.",
-			GenerateFunc: wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistration.MutatingWebhookConfiguration) *metric.Family {
+			GenerateFunc: wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -51,7 +51,7 @@ var (
 			Name: "kube_mutatingwebhookconfiguration_created",
 			Type: metric.Gauge,
 			Help: "Unix creation timestamp.",
-			GenerateFunc: wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistration.MutatingWebhookConfiguration) *metric.Family {
+			GenerateFunc: wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !mwc.CreationTimestamp.IsZero() {
@@ -68,7 +68,7 @@ var (
 			Name: "kube_mutatingwebhookconfiguration_metadata_resource_version",
 			Type: metric.Gauge,
 			Help: "Resource version representing a specific version of the MutatingWebhookConfiguration.",
-			GenerateFunc: wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistration.MutatingWebhookConfiguration) *metric.Family {
+			GenerateFunc: wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
 					Metrics: resourceVersionMetric(mwc.ObjectMeta.ResourceVersion),
 				}
@@ -80,17 +80,17 @@ var (
 func createMutatingWebhookConfigurationListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(opts)
+			return kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Watch(opts)
+			return kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Watch(opts)
 		},
 	}
 }
 
-func wrapMutatingWebhookConfigurationFunc(f func(*admissionregistration.MutatingWebhookConfiguration) *metric.Family) func(interface{}) *metric.Family {
+func wrapMutatingWebhookConfigurationFunc(f func(*admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {
-		mutatingWebhookConfiguration := obj.(*admissionregistration.MutatingWebhookConfiguration)
+		mutatingWebhookConfiguration := obj.(*admissionregistrationv1.MutatingWebhookConfiguration)
 
 		metricFamily := f(mutatingWebhookConfiguration)
 

--- a/internal/store/mutatingwebhookconfiguration_test.go
+++ b/internal/store/mutatingwebhookconfiguration_test.go
@@ -19,7 +19,7 @@ package store
 import (
 	"testing"
 
-	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
@@ -31,7 +31,7 @@ func TestMutatingWebhookConfigurationStore(t *testing.T) {
 
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &admissionregistration.MutatingWebhookConfiguration{
+			Obj: &admissionregistrationv1.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "mutatingwebhookconfiguration1",
 					Namespace:       "ns1",
@@ -49,7 +49,7 @@ func TestMutatingWebhookConfigurationStore(t *testing.T) {
 			MetricNames: []string{"kube_mutatingwebhookconfiguration_info", "kube_mutatingwebhookconfiguration_metadata_resource_version"},
 		},
 		{
-			Obj: &admissionregistration.MutatingWebhookConfiguration{
+			Obj: &admissionregistrationv1.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "mutatingwebhookconfiguration2",
 					Namespace:         "ns2",

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -17,7 +17,7 @@ limitations under the License.
 package store
 
 import (
-	admissionregistration "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -37,7 +37,7 @@ var (
 			Name: "kube_validatingwebhookconfiguration_info",
 			Type: metric.Gauge,
 			Help: "Information about the ValidatingWebhookConfiguration.",
-			GenerateFunc: wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistration.ValidatingWebhookConfiguration) *metric.Family {
+			GenerateFunc: wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -51,7 +51,7 @@ var (
 			Name: "kube_validatingwebhookconfiguration_created",
 			Type: metric.Gauge,
 			Help: "Unix creation timestamp.",
-			GenerateFunc: wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistration.ValidatingWebhookConfiguration) *metric.Family {
+			GenerateFunc: wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !vwc.CreationTimestamp.IsZero() {
@@ -68,7 +68,7 @@ var (
 			Name: "kube_validatingwebhookconfiguration_metadata_resource_version",
 			Type: metric.Gauge,
 			Help: "Resource version representing a specific version of the ValidatingWebhookConfiguration.",
-			GenerateFunc: wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistration.ValidatingWebhookConfiguration) *metric.Family {
+			GenerateFunc: wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
 					Metrics: resourceVersionMetric(vwc.ObjectMeta.ResourceVersion),
 				}
@@ -88,9 +88,9 @@ func createValidatingWebhookConfigurationListWatch(kubeClient clientset.Interfac
 	}
 }
 
-func wrapValidatingWebhookConfigurationFunc(f func(*admissionregistration.ValidatingWebhookConfiguration) *metric.Family) func(interface{}) *metric.Family {
+func wrapValidatingWebhookConfigurationFunc(f func(*admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {
-		mutatingWebhookConfiguration := obj.(*admissionregistration.ValidatingWebhookConfiguration)
+		mutatingWebhookConfiguration := obj.(*admissionregistrationv1.ValidatingWebhookConfiguration)
 
 		metricFamily := f(mutatingWebhookConfiguration)
 

--- a/internal/store/validatingwebhookconfiguration_test.go
+++ b/internal/store/validatingwebhookconfiguration_test.go
@@ -19,7 +19,7 @@ package store
 import (
 	"testing"
 
-	admissionregistration "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	generator "k8s.io/kube-state-metrics/pkg/metric_generator"
@@ -31,7 +31,7 @@ func TestValidatingWebhookConfigurationStore(t *testing.T) {
 
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &admissionregistration.ValidatingWebhookConfiguration{
+			Obj: &admissionregistrationv1.ValidatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "validatingwebhookconfiguration1",
 					Namespace:       "ns1",
@@ -49,7 +49,7 @@ func TestValidatingWebhookConfigurationStore(t *testing.T) {
 			MetricNames: []string{"kube_validatingwebhookconfiguration_info", "kube_validatingwebhookconfiguration_metadata_resource_version"},
 		},
 		{
-			Obj: &admissionregistration.ValidatingWebhookConfiguration{
+			Obj: &admissionregistrationv1.ValidatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "validatingwebhookconfiguration2",
 					Namespace:         "ns2",

--- a/tests/manifests/mutatingwebhookconfiguration.yaml
+++ b/tests/manifests/mutatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: example-mutatingwebhookconfiguration
@@ -11,6 +11,9 @@ webhooks:
       namespace: apples
       path: /apple
     caBundle: "YXBwbGVz"
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5
   namespaceSelector:
     matchExpressions:
     - key: production


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch mutatingWebhookConfiguration to use v1 api

**Which issue(s) this PR fixes**:
Fixes #1142 

