### PR TITLE
cloudbuild.yaml: Add builds for k8s.gcr.io

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,12 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+    entrypoint: make
+    env:
+    - GIT_TAG=$_PULL_BASE_REF
+    - GIT_COMMIT=$_PULL_BASE_SHA
+    args:
+    - push


### PR DESCRIPTION
I do not know if I am doing correctly, we have push make target, which should do the trick but not sure about the name part?

@serathius Marek do you mind having a look, thanks so much!

Background -> https://github.com/kubernetes/kube-state-metrics/issues/1089
