### PR TITLE
Avoid conflicts when mapping Kubernetes labels to Prometheus labels

### DIFF
--- a/internal/store/utils_test.go
+++ b/internal/store/utils_test.go
@@ -176,6 +176,44 @@ func TestKubeLabelsToPrometheusLabels(t *testing.T) {
 			expectKeys:   []string{"label_an", "label_order", "label_test"},
 			expectValues: []string{"", "", ""},
 		},
+		{
+			kubeLabels: map[string]string{
+				"conflicting_label1": "underscore",
+				"conflicting.label1": "dot",
+				"conflicting-label1": "hyphen",
+
+				"conflicting.label2": "dot",
+				"conflicting-label2": "hyphen",
+				"conflicting_label2": "underscore",
+
+				"conflicting-label3": "hyphen",
+				"conflicting_label3": "underscore",
+				"conflicting.label3": "dot",
+			},
+			// keys are sorted alphabetically during sanitization
+			expectKeys: []string{
+				"label_conflicting_label1_conflict1",
+				"label_conflicting_label2_conflict1",
+				"label_conflicting_label3_conflict1",
+				"label_conflicting_label1_conflict2",
+				"label_conflicting_label2_conflict2",
+				"label_conflicting_label3_conflict2",
+				"label_conflicting_label1_conflict3",
+				"label_conflicting_label2_conflict3",
+				"label_conflicting_label3_conflict3",
+			},
+			expectValues: []string{
+				"hyphen",
+				"hyphen",
+				"hyphen",
+				"dot",
+				"dot",
+				"dot",
+				"underscore",
+				"underscore",
+				"underscore",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:

Prometheus 2.16.0 introduced a breaking change that prevents _any_ metrics from being ingested from a target in case _even a single_ metric has duplicate labels.

See https://github.com/prometheus/prometheus/pull/6664

This becomes a problem for ksm as Kubernetes label naming is less restrictive than Prometheus label naming, so we have a "sanitization" process that replaces unsupported characters with an underscore.

A side effect of this process is that it can produce duplicate labels, e.g. Kubernetes labels "foo.bar", "foo-bar" and "foo_bar" are mapped to the same Prometheus label "foo_bar".

Based on the discussion in #1141, we've decided to sort and then automatically rename conflicting labels, so "foo-bar" and "foo_bar" will become "label_foo_bar_conflict1" and "label_foo_bar_conflict2" correspondingly.

If you'd like to have more control over how this conflict is resolved, you should consider addressing this on a different level of the stack, e.g. by standardizing Kubernetes labels using Admission Webhook that ensures that there are no possible conflicts.

**Which issue(s) this PR fixes**:
Fixes #1115