### PR TITLE
Add DeprecatedVersion to struct FamilyGenerator and func NewFamilyGenerator

### DIFF
--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -36,11 +36,12 @@ var (
 	descCSRLabelsDefaultLabels = []string{"certificatesigningrequest"}
 
 	csrMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: descCSRLabelsName,
-			Type: metric.Gauge,
-			Help: descCSRLabelsHelp,
-			GenerateFunc: wrapCSRFunc(func(j *certv1beta1.CertificateSigningRequest) *metric.Family {
+		*generator.NewFamilyGenerator(
+			descCSRLabelsName,
+			descCSRLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapCSRFunc(func(j *certv1beta1.CertificateSigningRequest) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -52,12 +53,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_certificatesigningrequest_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapCSRFunc(func(csr *certv1beta1.CertificateSigningRequest) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_certificatesigningrequest_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapCSRFunc(func(csr *certv1beta1.CertificateSigningRequest) *metric.Family {
 				ms := []*metric.Metric{}
 				if !csr.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
@@ -71,22 +73,24 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_certificatesigningrequest_condition",
-			Type: metric.Gauge,
-			Help: "The number of each certificatesigningrequest condition",
-			GenerateFunc: wrapCSRFunc(func(csr *certv1beta1.CertificateSigningRequest) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_certificatesigningrequest_condition",
+			"The number of each certificatesigningrequest condition",
+			metric.Gauge,
+			"",
+			wrapCSRFunc(func(csr *certv1beta1.CertificateSigningRequest) *metric.Family {
 				return &metric.Family{
 					Metrics: addCSRConditionMetrics(csr.Status),
 				}
 			}),
-		},
-		{
-			Name: "kube_certificatesigningrequest_cert_length",
-			Type: metric.Gauge,
-			Help: "Length of the issued cert",
-			GenerateFunc: wrapCSRFunc(func(csr *certv1beta1.CertificateSigningRequest) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_certificatesigningrequest_cert_length",
+			"Length of the issued cert",
+			metric.Gauge,
+			"",
+			wrapCSRFunc(func(csr *certv1beta1.CertificateSigningRequest) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -97,7 +101,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -34,11 +34,12 @@ var (
 	descConfigMapLabelsDefaultLabels = []string{"namespace", "configmap"}
 
 	configMapMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_configmap_info",
-			Type: metric.Gauge,
-			Help: "Information about configmap.",
-			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_configmap_info",
+			"Information about configmap.",
+			metric.Gauge,
+			"",
+			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{{
 						LabelKeys:   []string{},
@@ -47,12 +48,13 @@ var (
 					}},
 				}
 			}),
-		},
-		{
-			Name: "kube_configmap_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_configmap_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !c.CreationTimestamp.IsZero() {
@@ -67,17 +69,18 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_configmap_metadata_resource_version",
-			Type: metric.Gauge,
-			Help: "Resource version representing a specific version of the configmap.",
-			GenerateFunc: wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_configmap_metadata_resource_version",
+			"Resource version representing a specific version of the configmap.",
+			metric.Gauge,
+			"",
+			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				return &metric.Family{
 					Metrics: resourceVersionMetric(c.ObjectMeta.ResourceVersion),
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -39,11 +39,12 @@ var (
 	descCronJobLabelsDefaultLabels = []string{"namespace", "cronjob"}
 
 	cronJobMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: descCronJobLabelsName,
-			Type: metric.Gauge,
-			Help: descCronJobLabelsHelp,
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+		*generator.NewFamilyGenerator(
+			descCronJobLabelsName,
+			descCronJobLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -55,12 +56,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_cronjob_info",
-			Type: metric.Gauge,
-			Help: "Info about cronjob.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_info",
+			"Info about cronjob.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -71,12 +73,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_cronjob_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 				if !j.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
@@ -90,12 +93,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_cronjob_status_active",
-			Type: metric.Gauge,
-			Help: "Active holds pointers to currently running jobs.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_status_active",
+			"Active holds pointers to currently running jobs.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -106,12 +110,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_cronjob_status_last_schedule_time",
-			Type: metric.Gauge,
-			Help: "LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_status_last_schedule_time",
+			"LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Status.LastScheduleTime != nil {
@@ -126,12 +131,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_cronjob_spec_suspend",
-			Type: metric.Gauge,
-			Help: "Suspend flag tells the controller to suspend subsequent executions.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_spec_suspend",
+			"Suspend flag tells the controller to suspend subsequent executions.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.Suspend != nil {
@@ -146,12 +152,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_cronjob_spec_starting_deadline_seconds",
-			Type: metric.Gauge,
-			Help: "Deadline in seconds for starting the job if it misses scheduled time for any reason.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_spec_starting_deadline_seconds",
+			"Deadline in seconds for starting the job if it misses scheduled time for any reason.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.StartingDeadlineSeconds != nil {
@@ -167,12 +174,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_cronjob_next_schedule_time",
-			Type: metric.Gauge,
-			Help: "Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
-			GenerateFunc: wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_cronjob_next_schedule_time",
+			"Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// If the cron job is suspended, don't track the next scheduled time
@@ -191,7 +199,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -36,11 +36,12 @@ var (
 	descDaemonSetLabelsDefaultLabels = []string{"namespace", "daemonset"}
 
 	daemonSetMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_daemonset_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_daemonset_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !d.CreationTimestamp.IsZero() {
@@ -55,12 +56,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_daemonset_status_current_number_scheduled",
-			Type: metric.Gauge,
-			Help: "The number of nodes running at least one daemon pod and are supposed to.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_daemonset_status_current_number_scheduled",
+			"The number of nodes running at least one daemon pod and are supposed to.",
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -71,12 +73,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_daemonset_status_desired_number_scheduled",
-			Type: metric.Gauge,
-			Help: "The number of nodes that should be running the daemon pod.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_daemonset_status_desired_number_scheduled",
+			"The number of nodes that should be running the daemon pod.",
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -87,12 +90,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_daemonset_status_number_available",
-			Type: metric.Gauge,
-			Help: "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_daemonset_status_number_available",
+			"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -103,12 +107,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_daemonset_status_number_misscheduled",
-			Type: metric.Gauge,
-			Help: "The number of nodes running a daemon pod but are not supposed to.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_daemonset_status_number_misscheduled",
+			"The number of nodes running a daemon pod but are not supposed to.",
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -119,12 +124,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_daemonset_status_number_ready",
-			Type: metric.Gauge,
-			Help: "The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_daemonset_status_number_ready",
+			"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -135,12 +141,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_daemonset_status_number_unavailable",
-			Type: metric.Gauge,
-			Help: "The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_daemonset_status_number_unavailable",
+			"The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -151,12 +158,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_daemonset_status_observed_generation",
-			Type: metric.Gauge,
-			Help: "The most recent generation observed by the daemon set controller.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_daemonset_status_observed_generation",
+			"The most recent generation observed by the daemon set controller.",
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -167,12 +175,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_daemonset_status_updated_number_scheduled",
-			Type: metric.Gauge,
-			Help: "The total number of nodes that are running updated daemon pod",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_daemonset_status_updated_number_scheduled",
+			"The total number of nodes that are running updated daemon pod",
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -181,12 +190,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_daemonset_metadata_generation",
-			Type: metric.Gauge,
-			Help: "Sequence number representing a specific generation of the desired state.",
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_daemonset_metadata_generation",
+			"Sequence number representing a specific generation of the desired state.",
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -197,12 +207,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: descDaemonSetLabelsName,
-			Type: metric.Gauge,
-			Help: descDaemonSetLabelsHelp,
-			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descDaemonSetLabelsName,
+			descDaemonSetLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.ObjectMeta.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -214,7 +225,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -37,11 +37,12 @@ var (
 	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
 
 	deploymentMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_deployment_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_deployment_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !d.CreationTimestamp.IsZero() {
@@ -54,12 +55,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_status_replicas",
-			Type: metric.Gauge,
-			Help: "The number of replicas per deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_status_replicas",
+			"The number of replicas per deployment.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -68,12 +70,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_status_replicas_available",
-			Type: metric.Gauge,
-			Help: "The number of available replicas per deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_status_replicas_available",
+			"The number of available replicas per deployment.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -82,12 +85,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_status_replicas_unavailable",
-			Type: metric.Gauge,
-			Help: "The number of unavailable replicas per deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_status_replicas_unavailable",
+			"The number of unavailable replicas per deployment.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -96,12 +100,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_status_replicas_updated",
-			Type: metric.Gauge,
-			Help: "The number of updated replicas per deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_status_replicas_updated",
+			"The number of updated replicas per deployment.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -110,12 +115,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_status_observed_generation",
-			Type: metric.Gauge,
-			Help: "The generation observed by the deployment controller.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_status_observed_generation",
+			"The generation observed by the deployment controller.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -124,12 +130,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_status_condition",
-			Type: metric.Gauge,
-			Help: "The current status conditions of a deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_status_condition",
+			"The current status conditions of a deployment.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := make([]*metric.Metric, len(d.Status.Conditions)*len(conditionStatuses))
 
 				for i, c := range d.Status.Conditions {
@@ -148,12 +155,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_spec_replicas",
-			Type: metric.Gauge,
-			Help: "Number of desired pods for a deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_spec_replicas",
+			"Number of desired pods for a deployment.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -162,12 +170,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_spec_paused",
-			Type: metric.Gauge,
-			Help: "Whether the deployment is paused and will not be processed by the deployment controller.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_spec_paused",
+			"Whether the deployment is paused and will not be processed by the deployment controller.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -176,12 +185,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_spec_strategy_rollingupdate_max_unavailable",
-			Type: metric.Gauge,
-			Help: "Maximum number of unavailable replicas during a rolling update of a deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
+			"Maximum number of unavailable replicas during a rolling update of a deployment.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.Spec.Strategy.RollingUpdate == nil {
 					return &metric.Family{}
 				}
@@ -199,12 +209,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_spec_strategy_rollingupdate_max_surge",
-			Type: metric.Gauge,
-			Help: "Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_spec_strategy_rollingupdate_max_surge",
+			"Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.Spec.Strategy.RollingUpdate == nil {
 					return &metric.Family{}
 				}
@@ -222,12 +233,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_deployment_metadata_generation",
-			Type: metric.Gauge,
-			Help: "Sequence number representing a specific generation of the desired state.",
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_metadata_generation",
+			"Sequence number representing a specific generation of the desired state.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -236,12 +248,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: descDeploymentLabelsName,
-			Type: metric.Gauge,
-			Help: descDeploymentLabelsHelp,
-			GenerateFunc: wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descDeploymentLabelsName,
+			descDeploymentLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -253,7 +266,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -36,11 +36,12 @@ var (
 	descEndpointLabelsDefaultLabels = []string{"namespace", "endpoint"}
 
 	endpointMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_endpoint_info",
-			Type: metric.Gauge,
-			Help: "Information about endpoint.",
-			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_endpoint_info",
+			"Information about endpoint.",
+			metric.Gauge,
+			"",
+			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -49,12 +50,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_endpoint_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_endpoint_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !e.CreationTimestamp.IsZero() {
@@ -68,12 +70,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: descEndpointLabelsName,
-			Type: metric.Gauge,
-			Help: descEndpointLabelsHelp,
-			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descEndpointLabelsName,
+			descEndpointLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(e.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -85,12 +88,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_endpoint_address_available",
-			Type: metric.Gauge,
-			Help: "Number of addresses available in endpoint.",
-			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_endpoint_address_available",
+			"Number of addresses available in endpoint.",
+			metric.Gauge,
+			"",
+			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				var available int
 				for _, s := range e.Subsets {
 					available += len(s.Addresses) * len(s.Ports)
@@ -104,12 +108,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_endpoint_address_not_ready",
-			Type: metric.Gauge,
-			Help: "Number of addresses not ready in endpoint",
-			GenerateFunc: wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_endpoint_address_not_ready",
+			"Number of addresses not ready in endpoint",
+			metric.Gauge,
+			"",
+			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				var notReady int
 				for _, s := range e.Subsets {
 					notReady += len(s.NotReadyAddresses) * len(s.Ports)
@@ -122,7 +127,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -52,11 +52,12 @@ var (
 	targetMetricLabels = []string{"metric_name", "metric_target_type"}
 
 	hpaMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_horizontalpodautoscaler_metadata_generation",
-			Type: metric.Gauge,
-			Help: "The generation observed by the HorizontalPodAutoscaler controller.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_metadata_generation",
+			"The generation observed by the HorizontalPodAutoscaler controller.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -65,12 +66,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_horizontalpodautoscaler_spec_max_replicas",
-			Type: metric.Gauge,
-			Help: "Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_spec_max_replicas",
+			"Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -79,12 +81,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_horizontalpodautoscaler_spec_min_replicas",
-			Type: metric.Gauge,
-			Help: "Lower limit for the number of pods that can be set by the autoscaler, default 1.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_spec_min_replicas",
+			"Lower limit for the number of pods that can be set by the autoscaler, default 1.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -93,12 +96,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_horizontalpodautoscaler_spec_target_metric",
-			Type: metric.Gauge,
-			Help: "The metric specifications used by this autoscaler when calculating the desired replica count.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_spec_target_metric",
+			"The metric specifications used by this autoscaler when calculating the desired replica count.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				ms := make([]*metric.Metric, 0, len(a.Spec.Metrics))
 				for _, m := range a.Spec.Metrics {
 					var metricName string
@@ -155,12 +159,13 @@ var (
 				}
 				return &metric.Family{Metrics: ms}
 			}),
-		},
-		{
-			Name: "kube_horizontalpodautoscaler_status_current_replicas",
-			Type: metric.Gauge,
-			Help: "Current number of replicas of pods managed by this autoscaler.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_status_current_replicas",
+			"Current number of replicas of pods managed by this autoscaler.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -169,12 +174,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_horizontalpodautoscaler_status_desired_replicas",
-			Type: metric.Gauge,
-			Help: "Desired number of replicas of pods managed by this autoscaler.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_status_desired_replicas",
+			"Desired number of replicas of pods managed by this autoscaler.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -183,12 +189,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: descHorizontalPodAutoscalerLabelsName,
-			Type: metric.Gauge,
-			Help: descHorizontalPodAutoscalerLabelsHelp,
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descHorizontalPodAutoscalerLabelsName,
+			descHorizontalPodAutoscalerLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(a.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -200,12 +207,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_horizontalpodautoscaler_status_condition",
-			Type: metric.Gauge,
-			Help: "The condition of this autoscaler.",
-			GenerateFunc: wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_status_condition",
+			"The condition of this autoscaler.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				ms := make([]*metric.Metric, 0, len(a.Status.Conditions)*len(conditionStatuses))
 
 				for _, c := range a.Status.Conditions {
@@ -223,7 +231,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -37,11 +37,12 @@ var (
 	descIngressLabelsDefaultLabels = []string{"namespace", "ingress"}
 
 	ingressMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_ingress_info",
-			Type: metric.Gauge,
-			Help: "Information about ingress.",
-			GenerateFunc: wrapIngressFunc(func(s *v1beta1.Ingress) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_ingress_info",
+			"Information about ingress.",
+			metric.Gauge,
+			"",
+			wrapIngressFunc(func(s *v1beta1.Ingress) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -49,12 +50,13 @@ var (
 						},
 					}}
 			}),
-		},
-		{
-			Name: descIngressLabelsName,
-			Type: metric.Gauge,
-			Help: descIngressLabelsHelp,
-			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descIngressLabelsName,
+			descIngressLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(i.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -66,12 +68,13 @@ var (
 					}}
 
 			}),
-		},
-		{
-			Name: "kube_ingress_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_ingress_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !i.CreationTimestamp.IsZero() {
@@ -84,22 +87,24 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_ingress_metadata_resource_version",
-			Type: metric.Gauge,
-			Help: "Resource version representing a specific version of ingress.",
-			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_ingress_metadata_resource_version",
+			"Resource version representing a specific version of ingress.",
+			metric.Gauge,
+			"",
+			wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
 				return &metric.Family{
 					Metrics: resourceVersionMetric(i.ObjectMeta.ResourceVersion),
 				}
 			}),
-		},
-		{
-			Name: "kube_ingress_path",
-			Type: metric.Gauge,
-			Help: "Ingress host, paths and backend service information.",
-			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_ingress_path",
+			"Ingress host, paths and backend service information.",
+			metric.Gauge,
+			"",
+			wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
 				ms := []*metric.Metric{}
 				for _, rule := range i.Spec.Rules {
 					if rule.HTTP != nil {
@@ -116,12 +121,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_ingress_tls",
-			Type: metric.Gauge,
-			Help: "Ingress TLS host and secret information.",
-			GenerateFunc: wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_ingress_tls",
+			"Ingress TLS host and secret information.",
+			metric.Gauge,
+			"",
+			wrapIngressFunc(func(i *v1beta1.Ingress) *metric.Family {
 				ms := []*metric.Metric{}
 				for _, tls := range i.Spec.TLS {
 					for _, host := range tls.Hosts {
@@ -136,7 +142,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -37,11 +37,12 @@ var (
 	descJobLabelsDefaultLabels = []string{"namespace", "job_name"}
 
 	jobMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: descJobLabelsName,
-			Type: metric.Gauge,
-			Help: descJobLabelsHelp,
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		*generator.NewFamilyGenerator(
+			descJobLabelsName,
+			descJobLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(j.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -53,12 +54,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_job_info",
-			Type: metric.Gauge,
-			Help: "Information about job.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_info",
+			"Information about job.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -67,12 +69,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_job_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !j.CreationTimestamp.IsZero() {
@@ -85,12 +88,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_job_spec_parallelism",
-			Type: metric.Gauge,
-			Help: "The maximum desired number of pods the job should run at any given time.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_spec_parallelism",
+			"The maximum desired number of pods the job should run at any given time.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.Parallelism != nil {
@@ -103,12 +107,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_job_spec_completions",
-			Type: metric.Gauge,
-			Help: "The desired number of successfully finished pods the job should be run with.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_spec_completions",
+			"The desired number of successfully finished pods the job should be run with.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.Completions != nil {
@@ -121,12 +126,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_job_spec_active_deadline_seconds",
-			Type: metric.Gauge,
-			Help: "The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_spec_active_deadline_seconds",
+			"The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.ActiveDeadlineSeconds != nil {
@@ -139,12 +145,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_job_status_succeeded",
-			Type: metric.Gauge,
-			Help: "The number of pods which reached Phase Succeeded.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_status_succeeded",
+			"The number of pods which reached Phase Succeeded.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -153,12 +160,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_job_status_failed",
-			Type: metric.Gauge,
-			Help: "The number of pods which reached Phase Failed.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_status_failed",
+			"The number of pods which reached Phase Failed.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -167,12 +175,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_job_status_active",
-			Type: metric.Gauge,
-			Help: "The number of actively running pods.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_status_active",
+			"The number of actively running pods.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -181,12 +190,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_job_complete",
-			Type: metric.Gauge,
-			Help: "The job has completed its execution.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_complete",
+			"The job has completed its execution.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 				for _, c := range j.Status.Conditions {
 					if c.Type == v1batch.JobComplete {
@@ -203,12 +213,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_job_failed",
-			Type: metric.Gauge,
-			Help: "The job has failed its execution.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_failed",
+			"The job has failed its execution.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range j.Status.Conditions {
@@ -226,12 +237,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_job_status_start_time",
-			Type: metric.Gauge,
-			Help: "StartTime represents time when the job was acknowledged by the Job Manager.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_status_start_time",
+			"StartTime represents time when the job was acknowledged by the Job Manager.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Status.StartTime != nil {
@@ -245,12 +257,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_job_status_completion_time",
-			Type: metric.Gauge,
-			Help: "CompletionTime represents time when the job was completed.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_status_completion_time",
+			"CompletionTime represents time when the job was completed.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 				if j.Status.CompletionTime != nil {
 					ms = append(ms, &metric.Metric{
@@ -263,12 +276,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_job_owner",
-			Type: metric.Gauge,
-			Help: "Information about the Job's owner.",
-			GenerateFunc: wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_job_owner",
+			"Information about the Job's owner.",
+			metric.Gauge,
+			"",
+			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
 
 				owners := j.GetOwnerReferences()
@@ -307,7 +321,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -34,11 +34,12 @@ var (
 	descLeaseLabelsDefaultLabels = []string{"lease"}
 
 	leaseMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_lease_owner",
-			Type: metric.Gauge,
-			Help: "Information about the Lease's owner.",
-			GenerateFunc: wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_lease_owner",
+			"Information about the Lease's owner.",
+			metric.Gauge,
+			"",
+			wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name"}
 
 				owners := l.GetOwnerReferences()
@@ -67,12 +68,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_lease_renew_time",
-			Type: metric.Gauge,
-			Help: "Kube lease renew time.",
-			GenerateFunc: wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_lease_renew_time",
+			"Kube lease renew time.",
+			metric.Gauge,
+			"",
+			wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !l.Spec.RenewTime.IsZero() {
@@ -84,7 +86,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/limitrange.go
+++ b/internal/store/limitrange.go
@@ -34,11 +34,12 @@ var (
 	descLimitRangeLabelsDefaultLabels = []string{"namespace", "limitrange"}
 
 	limitRangeMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_limitrange",
-			Type: metric.Gauge,
-			Help: "Information about limit range.",
-			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_limitrange",
+			"Information about limit range.",
+			metric.Gauge,
+			"",
+			wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
 				ms := []*metric.Metric{}
 
 				rawLimitRanges := r.Spec.Limits
@@ -87,12 +88,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_limitrange_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_limitrange_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !r.CreationTimestamp.IsZero() {
@@ -106,7 +108,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -35,11 +35,12 @@ var (
 	descMutatingWebhookConfigurationDefaultLabels = []string{"namespace", "mutatingwebhookconfiguration"}
 
 	mutatingWebhookConfigurationMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_mutatingwebhookconfiguration_info",
-			Type: metric.Gauge,
-			Help: "Information about the MutatingWebhookConfiguration.",
-			GenerateFunc: wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_mutatingwebhookconfiguration_info",
+			"Information about the MutatingWebhookConfiguration.",
+			metric.Gauge,
+			"",
+			wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -48,12 +49,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_mutatingwebhookconfiguration_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp.",
-			GenerateFunc: wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_mutatingwebhookconfiguration_created",
+			"Unix creation timestamp.",
+			metric.Gauge,
+			"",
+			wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !mwc.CreationTimestamp.IsZero() {
@@ -65,17 +67,18 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_mutatingwebhookconfiguration_metadata_resource_version",
-			Type: metric.Gauge,
-			Help: "Resource version representing a specific version of the MutatingWebhookConfiguration.",
-			GenerateFunc: wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_mutatingwebhookconfiguration_metadata_resource_version",
+			"Resource version representing a specific version of the MutatingWebhookConfiguration.",
+			metric.Gauge,
+			"",
+			wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
 					Metrics: resourceVersionMetric(mwc.ObjectMeta.ResourceVersion),
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -36,11 +36,12 @@ var (
 	descNamespaceLabelsDefaultLabels = []string{"namespace"}
 
 	namespaceMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_namespace_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_namespace_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := []*metric.Metric{}
 				if !n.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
@@ -52,12 +53,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: descNamespaceLabelsName,
-			Type: metric.Gauge,
-			Help: descNamespaceLabelsHelp,
-			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descNamespaceLabelsName,
+			descNamespaceLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -69,12 +71,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_namespace_status_phase",
-			Type: metric.Gauge,
-			Help: "kubernetes namespace status phase.",
-			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_namespace_status_phase",
+			"kubernetes namespace status phase.",
+			metric.Gauge,
+			"",
+			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := []*metric.Metric{
 					{
 						LabelValues: []string{string(v1.NamespaceActive)},
@@ -94,12 +97,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_namespace_status_condition",
-			Type: metric.Gauge,
-			Help: "The condition of a namespace.",
-			GenerateFunc: wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_namespace_status_condition",
+			"The condition of a namespace.",
+			metric.Gauge,
+			"",
+			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := make([]*metric.Metric, len(n.Status.Conditions)*len(conditionStatuses))
 				for i, c := range n.Status.Conditions {
 					conditionMetrics := addConditionMetrics(c.Status)
@@ -118,7 +122,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/networkpolicy.go
+++ b/internal/store/networkpolicy.go
@@ -34,11 +34,12 @@ var (
 	descNetworkPolicyLabelsDefaultLabels = []string{"namespace", "networkpolicy"}
 
 	networkpolicyMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_networkpolicy_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp of network policy",
-			GenerateFunc: wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_networkpolicy_created",
+			"Unix creation timestamp of network policy",
+			metric.Gauge,
+			"",
+			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -49,12 +50,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_networkpolicy_labels",
-			Type: metric.Gauge,
-			Help: "Kubernetes labels converted to Prometheus labels",
-			GenerateFunc: wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_networkpolicy_labels",
+			"Kubernetes labels converted to Prometheus labels",
+			metric.Gauge,
+			"",
+			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -66,12 +68,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_networkpolicy_spec_ingress_rules",
-			Type: metric.Gauge,
-			Help: "Number of ingress rules on the networkpolicy",
-			GenerateFunc: wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_networkpolicy_spec_ingress_rules",
+			"Number of ingress rules on the networkpolicy",
+			metric.Gauge,
+			"",
+			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -82,12 +85,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_networkpolicy_spec_egress_rules",
-			Type: metric.Gauge,
-			Help: "Number of egress rules on the networkpolicy",
-			GenerateFunc: wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_networkpolicy_spec_egress_rules",
+			"Number of egress rules on the networkpolicy",
+			metric.Gauge,
+			"",
+			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -98,7 +102,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -38,11 +38,12 @@ var (
 	descNodeLabelsDefaultLabels = []string{"node"}
 
 	nodeMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_node_info",
-			Type: metric.Gauge,
-			Help: "Information about a cluster node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_node_info",
+			"Information about a cluster node.",
+			metric.Gauge,
+			"",
+			wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				labelKeys := []string{
 					"kernel_version",
 					"os_image",
@@ -81,12 +82,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_node_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_node_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !n.CreationTimestamp.IsZero() {
@@ -100,12 +102,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: descNodeLabelsName,
-			Type: metric.Gauge,
-			Help: descNodeLabelsHelp,
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descNodeLabelsName,
+			descNodeLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(n.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -117,12 +120,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_node_role",
-			Type: metric.Gauge,
-			Help: "The role of a cluster node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_node_role",
+			"The role of a cluster node.",
+			metric.Gauge,
+			"",
+			wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				const prefix = "node-role.kubernetes.io/"
 				ms := []*metric.Metric{}
 				for lbl := range n.Labels {
@@ -138,12 +142,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_node_spec_unschedulable",
-			Type: metric.Gauge,
-			Help: "Whether a node can schedule new pods.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_node_spec_unschedulable",
+			"Whether a node can schedule new pods.",
+			metric.Gauge,
+			"",
+			wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -152,12 +157,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_node_spec_taint",
-			Type: metric.Gauge,
-			Help: "The taint of a cluster node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_node_spec_taint",
+			"The taint of a cluster node.",
+			metric.Gauge,
+			"",
+			wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := make([]*metric.Metric, len(n.Spec.Taints))
 
 				for i, taint := range n.Spec.Taints {
@@ -175,16 +181,17 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 		// This all-in-one metric family contains all conditions for extensibility.
 		// Third party plugin may report customized condition for cluster node
 		// (e.g. node-problem-detector), and Kubernetes may add new core
 		// conditions in future.
-		{
-			Name: "kube_node_status_condition",
-			Type: metric.Gauge,
-			Help: "The condition of a cluster node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_node_status_condition",
+			"The condition of a cluster node.",
+			metric.Gauge,
+			"",
+			wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := make([]*metric.Metric, len(n.Status.Conditions)*len(conditionStatuses))
 
 				// Collect node conditions and while default to false.
@@ -205,12 +212,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_node_status_capacity",
-			Type: metric.Gauge,
-			Help: "The capacity for different resources of a node.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_node_status_capacity",
+			"The capacity for different resources of a node.",
+			metric.Gauge,
+			"",
+			wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				capacity := n.Status.Capacity
@@ -283,12 +291,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_node_status_allocatable",
-			Type: metric.Gauge,
-			Help: "The allocatable for different resources of a node that are available for scheduling.",
-			GenerateFunc: wrapNodeFunc(func(n *v1.Node) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_node_status_allocatable",
+			"The allocatable for different resources of a node that are available for scheduling.",
+			metric.Gauge,
+			"",
+			wrapNodeFunc(func(n *v1.Node) *metric.Family {
 				ms := []*metric.Metric{}
 
 				allocatable := n.Status.Allocatable
@@ -362,7 +371,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -36,11 +36,12 @@ var (
 	descPersistentVolumeLabelsDefaultLabels = []string{"persistentvolume"}
 
 	persistentVolumeMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: descPersistentVolumeLabelsName,
-			Type: metric.Gauge,
-			Help: descPersistentVolumeLabelsHelp,
-			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+		*generator.NewFamilyGenerator(
+			descPersistentVolumeLabelsName,
+			descPersistentVolumeLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -52,12 +53,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_persistentvolume_status_phase",
-			Type: metric.Gauge,
-			Help: "The phase indicates if a volume is available, bound to a claim, or released by a claim.",
-			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_persistentvolume_status_phase",
+			"The phase indicates if a volume is available, bound to a claim, or released by a claim.",
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				phase := p.Status.Phase
 
 				if phase == "" {
@@ -98,12 +100,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_persistentvolume_info",
-			Type: metric.Gauge,
-			Help: "Information about persistentvolume.",
-			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_persistentvolume_info",
+			"Information about persistentvolume.",
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				var gcePDDiskName, ebsVolumeID string
 				switch {
 				case p.Spec.PersistentVolumeSource.GCEPersistentDisk != nil:
@@ -130,12 +133,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_persistentvolume_capacity_bytes",
-			Type: metric.Gauge,
-			Help: "Persistentvolume capacity in bytes.",
-			GenerateFunc: wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_persistentvolume_capacity_bytes",
+			"Persistentvolume capacity in bytes.",
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				storage := p.Spec.Capacity[v1.ResourceStorage]
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -145,7 +149,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -36,11 +36,12 @@ var (
 	descPersistentVolumeClaimLabelsDefaultLabels = []string{"namespace", "persistentvolumeclaim"}
 
 	persistentVolumeClaimMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: descPersistentVolumeClaimLabelsName,
-			Type: metric.Gauge,
-			Help: descPersistentVolumeClaimLabelsHelp,
-			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+		*generator.NewFamilyGenerator(
+			descPersistentVolumeClaimLabelsName,
+			descPersistentVolumeClaimLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -52,12 +53,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_persistentvolumeclaim_info",
-			Type: metric.Gauge,
-			Help: "Information about persistent volume claim.",
-			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_persistentvolumeclaim_info",
+			"Information about persistent volume claim.",
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				storageClassName := getPersistentVolumeClaimClass(p)
 				volumeName := p.Spec.VolumeName
 				return &metric.Family{
@@ -70,12 +72,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_persistentvolumeclaim_status_phase",
-			Type: metric.Gauge,
-			Help: "The phase the persistent volume claim is currently in.",
-			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_persistentvolumeclaim_status_phase",
+			"The phase the persistent volume claim is currently in.",
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				phase := p.Status.Phase
 
 				if phase == "" {
@@ -108,12 +111,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_persistentvolumeclaim_resource_requests_storage_bytes",
-			Type: metric.Gauge,
-			Help: "The capacity of storage requested by the persistent volume claim.",
-			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_persistentvolumeclaim_resource_requests_storage_bytes",
+			"The capacity of storage requested by the persistent volume claim.",
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if storage, ok := p.Spec.Resources.Requests[v1.ResourceStorage]; ok {
@@ -126,12 +130,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_persistentvolumeclaim_access_mode",
-			Type: metric.Gauge,
-			Help: "The access mode(s) specified by the persistent volume claim.",
-			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_persistentvolumeclaim_access_mode",
+			"The access mode(s) specified by the persistent volume claim.",
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Spec.AccessModes))
 
 				for i, mode := range p.Spec.AccessModes {
@@ -146,12 +151,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_persistentvolumeclaim_status_condition",
-			Help: "Information about status of different conditions of persistent volume claim.",
-			Type: metric.Gauge,
-			GenerateFunc: wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_persistentvolumeclaim_status_condition",
+			"Information about status of different conditions of persistent volume claim.",
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.Conditions)*len(conditionStatuses))
 
 				for i, c := range p.Status.Conditions {
@@ -171,7 +177,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -39,11 +39,12 @@ var (
 	podStatusReasons           = []string{"NodeLost", "Evicted", "UnexpectedAdmissionError"}
 
 	podMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_pod_info",
-			Type: metric.Gauge,
-			Help: "Information about pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_pod_info",
+			"Information about pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				createdBy := metav1.GetControllerOf(p)
 				createdByKind := "<none>"
 				createdByName := "<none>"
@@ -67,12 +68,13 @@ var (
 					Metrics: []*metric.Metric{&m},
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_start_time",
-			Type: metric.Gauge,
-			Help: "Start time in unix timestamp for a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_start_time",
+			"Start time in unix timestamp for a pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if p.Status.StartTime != nil {
@@ -86,12 +88,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_state_started",
-			Type: metric.Gauge,
-			Help: "Start time in unix timestamp for a pod container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_state_started",
+			"Start time in unix timestamp for a pod container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, cs := range p.Status.ContainerStatuses {
@@ -108,12 +111,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_completion_time",
-			Type: metric.Gauge,
-			Help: "Completion time in unix timestamp for a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_completion_time",
+			"Completion time in unix timestamp for a pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				var lastFinishTime float64
@@ -138,12 +142,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_owner",
-			Type: metric.Gauge,
-			Help: "Information about the Pod's owner.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_owner",
+			"Information about the Pod's owner.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
 
 				owners := p.GetOwnerReferences()
@@ -181,12 +186,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_labels",
-			Type: metric.Gauge,
-			Help: "Kubernetes labels converted to Prometheus labels.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_labels",
+			"Kubernetes labels converted to Prometheus labels.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(p.Labels)
 				m := metric.Metric{
 					LabelKeys:   labelKeys,
@@ -197,12 +203,13 @@ var (
 					Metrics: []*metric.Metric{&m},
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !p.CreationTimestamp.IsZero() {
@@ -217,12 +224,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_deletion_timestamp",
-			Type: metric.Gauge,
-			Help: "Unix deletion timestamp",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_deletion_timestamp",
+			"Unix deletion timestamp",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if p.DeletionTimestamp != nil && !p.DeletionTimestamp.IsZero() {
@@ -237,12 +245,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_restart_policy",
-			Type: metric.Gauge,
-			Help: "Describes the restart policy in use by this pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_restart_policy",
+			"Describes the restart policy in use by this pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -253,12 +262,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_status_scheduled_time",
-			Type: metric.Gauge,
-			Help: "Unix timestamp when pod moved into scheduled status",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_status_scheduled_time",
+			"Unix timestamp when pod moved into scheduled status",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Status.Conditions {
@@ -278,12 +288,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_status_unschedulable",
-			Type: metric.Gauge,
-			Help: "Describes the unschedulable status for the pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_status_unschedulable",
+			"Describes the unschedulable status for the pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Status.Conditions {
@@ -303,12 +314,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_status_phase",
-			Type: metric.Gauge,
-			Help: "The pods current phase.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_status_phase",
+			"The pods current phase.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				phase := p.Status.Phase
 				if phase == "" {
 					return &metric.Family{
@@ -342,12 +354,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_status_ready",
-			Type: metric.Gauge,
-			Help: "Describes whether the pod is ready to serve requests.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_status_ready",
+			"Describes whether the pod is ready to serve requests.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Status.Conditions {
@@ -367,12 +380,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_status_scheduled",
-			Type: metric.Gauge,
-			Help: "Describes the status of the scheduling process for the pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_status_scheduled",
+			"Describes the status of the scheduling process for the pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Status.Conditions {
@@ -392,12 +406,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_status_reason",
-			Type: metric.Gauge,
-			Help: "The pod status reasons",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_status_reason",
+			"The pod status reasons",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, reason := range podStatusReasons {
@@ -416,12 +431,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_info",
-			Type: metric.Gauge,
-			Help: "Information about a container in a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_info",
+			"Information about a container in a pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 				labelKeys := []string{"container", "image", "image_id", "container_id"}
 
@@ -437,12 +453,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_info",
-			Type: metric.Gauge,
-			Help: "Information about an init container in a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_info",
+			"Information about an init container in a pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 				labelKeys := []string{"container", "image", "image_id", "container_id"}
 
@@ -458,12 +475,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_status_waiting",
-			Type: metric.Gauge,
-			Help: "Describes whether the container is currently in waiting state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_status_waiting",
+			"Describes whether the container is currently in waiting state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 				for i, cs := range p.Status.ContainerStatuses {
@@ -478,12 +496,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_status_waiting",
-			Type: metric.Gauge,
-			Help: "Describes whether the init container is currently in waiting state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_status_waiting",
+			"Describes whether the init container is currently in waiting state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 				for i, cs := range p.Status.InitContainerStatuses {
@@ -498,12 +517,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_status_waiting_reason",
-			Type: metric.Gauge,
-			Help: "Describes the reason the container is currently in waiting state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_status_waiting_reason",
+			"Describes the reason the container is currently in waiting state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerWaitingReasons))
 
 				for i, cs := range p.Status.ContainerStatuses {
@@ -520,12 +540,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_status_waiting_reason",
-			Type: metric.Gauge,
-			Help: "Describes the reason the init container is currently in waiting state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_status_waiting_reason",
+			"Describes the reason the init container is currently in waiting state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses)*len(containerWaitingReasons))
 
 				for i, cs := range p.Status.InitContainerStatuses {
@@ -542,12 +563,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_status_running",
-			Type: metric.Gauge,
-			Help: "Describes whether the container is currently in running state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_status_running",
+			"Describes whether the container is currently in running state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 				for i, cs := range p.Status.ContainerStatuses {
@@ -562,12 +584,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_status_running",
-			Type: metric.Gauge,
-			Help: "Describes whether the init container is currently in running state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_status_running",
+			"Describes whether the init container is currently in running state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 				for i, cs := range p.Status.InitContainerStatuses {
@@ -582,12 +605,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_status_terminated",
-			Type: metric.Gauge,
-			Help: "Describes whether the container is currently in terminated state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_status_terminated",
+			"Describes whether the container is currently in terminated state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 				for i, cs := range p.Status.ContainerStatuses {
@@ -602,12 +626,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_status_terminated",
-			Type: metric.Gauge,
-			Help: "Describes whether the init container is currently in terminated state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_status_terminated",
+			"Describes whether the init container is currently in terminated state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 				for i, cs := range p.Status.InitContainerStatuses {
@@ -622,12 +647,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_status_terminated_reason",
-			Type: metric.Gauge,
-			Help: "Describes the reason the container is currently in terminated state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_status_terminated_reason",
+			"Describes the reason the container is currently in terminated state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerTerminatedReasons))
 
 				for i, cs := range p.Status.ContainerStatuses {
@@ -644,12 +670,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_status_terminated_reason",
-			Type: metric.Gauge,
-			Help: "Describes the reason the init container is currently in terminated state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_status_terminated_reason",
+			"Describes the reason the init container is currently in terminated state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses)*len(containerTerminatedReasons))
 
 				for i, cs := range p.Status.InitContainerStatuses {
@@ -666,12 +693,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_status_last_terminated_reason",
-			Type: metric.Gauge,
-			Help: "Describes the last reason the container was in terminated state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_status_last_terminated_reason",
+			"Describes the last reason the container was in terminated state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerTerminatedReasons))
 
 				for i, cs := range p.Status.ContainerStatuses {
@@ -688,12 +716,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_status_last_terminated_reason",
-			Type: metric.Gauge,
-			Help: "Describes the last reason the init container was in terminated state.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_status_last_terminated_reason",
+			"Describes the last reason the init container was in terminated state.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses)*len(containerTerminatedReasons))
 
 				for i, cs := range p.Status.InitContainerStatuses {
@@ -710,12 +739,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_status_ready",
-			Type: metric.Gauge,
-			Help: "Describes whether the containers readiness check succeeded.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_status_ready",
+			"Describes whether the containers readiness check succeeded.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 				for i, cs := range p.Status.ContainerStatuses {
@@ -730,12 +760,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_status_ready",
-			Type: metric.Gauge,
-			Help: "Describes whether the init containers readiness check succeeded.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_status_ready",
+			"Describes whether the init containers readiness check succeeded.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 				for i, cs := range p.Status.InitContainerStatuses {
@@ -750,12 +781,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_status_restarts_total",
-			Type: metric.Counter,
-			Help: "The number of container restarts per container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_status_restarts_total",
+			"The number of container restarts per container.",
+			metric.Counter,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 				for i, cs := range p.Status.ContainerStatuses {
@@ -770,12 +802,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_status_restarts_total",
-			Type: metric.Counter,
-			Help: "The number of restarts for the init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_status_restarts_total",
+			"The number of restarts for the init container.",
+			metric.Counter,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 				for i, cs := range p.Status.InitContainerStatuses {
@@ -790,12 +823,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_resource_requests_cpu_cores",
-			Type: metric.Gauge,
-			Help: "The number of CPU cores requested by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_requests_cpu_cores",
+			"The number of CPU cores requested by a container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -816,12 +850,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_resource_requests_memory_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of memory requested by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_requests_memory_bytes",
+			"Bytes of memory requested by a container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -842,12 +877,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_resource_requests_storage_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of storage requested by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_requests_storage_bytes",
+			"Bytes of storage requested by a container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -868,12 +904,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_resource_requests_ephemeral_storage_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of ephemeral-storage requested by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_requests_ephemeral_storage_bytes",
+			"Bytes of ephemeral-storage requested by a container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -894,12 +931,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_resource_requests",
-			Type: metric.Gauge,
-			Help: "The number of requested request resource by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_requests",
+			"The number of requested request resource by a container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -935,12 +973,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_resource_limits_cpu_cores",
-			Type: metric.Gauge,
-			Help: "The number of CPU cores requested limit by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_limits_cpu_cores",
+			"The number of CPU cores requested limit by a container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -961,12 +1000,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_resource_limits_memory_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of memory requested limit by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_limits_memory_bytes",
+			"Bytes of memory requested limit by a container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -987,12 +1027,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_resource_limits_storage_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of storage requested limit by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_limits_storage_bytes",
+			"Bytes of storage requested limit by a container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -1013,12 +1054,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_resource_limits_ephemeral_storage_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of ephemeral-storage requested limit by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_limits_ephemeral_storage_bytes",
+			"Bytes of ephemeral-storage requested limit by a container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -1039,12 +1081,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_container_resource_limits",
-			Type: metric.Gauge,
-			Help: "The number of requested limit resource by a container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_limits",
+			"The number of requested limit resource by a container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.Containers {
@@ -1080,12 +1123,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_resource_requests_cpu_cores",
-			Type: metric.Gauge,
-			Help: "The number of CPU cores requested by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_resource_requests_cpu_cores",
+			"The number of CPU cores requested by an init container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.InitContainers {
@@ -1106,12 +1150,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_resource_requests_memory_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of memory requested by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_resource_requests_memory_bytes",
+			"Bytes of memory requested by an init container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.InitContainers {
@@ -1132,12 +1177,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_resource_requests_storage_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of storage requested by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_resource_requests_storage_bytes",
+			"Bytes of storage requested by an init container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.InitContainers {
@@ -1158,12 +1204,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_resource_requests_ephemeral_storage_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of ephemeral-storage requested by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_resource_requests_ephemeral_storage_bytes",
+			"Bytes of ephemeral-storage requested by an init container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.InitContainers {
@@ -1184,12 +1231,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_resource_requests",
-			Type: metric.Gauge,
-			Help: "The number of requested request resource by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_resource_requests",
+			"The number of requested request resource by an init container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.InitContainers {
@@ -1225,12 +1273,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_resource_limits_cpu_cores",
-			Type: metric.Gauge,
-			Help: "The number of CPU cores requested limit by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_resource_limits_cpu_cores",
+			"The number of CPU cores requested limit by an init container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.InitContainers {
@@ -1251,12 +1300,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_resource_limits_memory_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of memory requested limit by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_resource_limits_memory_bytes",
+			"Bytes of memory requested limit by an init container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.InitContainers {
@@ -1277,12 +1327,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_resource_limits_storage_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of storage requested limit by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_resource_limits_storage_bytes",
+			"Bytes of storage requested limit by an init container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.InitContainers {
@@ -1303,12 +1354,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_resource_limits_ephemeral_storage_bytes",
-			Type: metric.Gauge,
-			Help: "Bytes of ephemeral-storage requested limit by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_resource_limits_ephemeral_storage_bytes",
+			"Bytes of ephemeral-storage requested limit by an init container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.InitContainers {
@@ -1329,12 +1381,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_init_container_resource_limits",
-			Type: metric.Gauge,
-			Help: "The number of requested limit resource by an init container.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_init_container_resource_limits",
+			"The number of requested limit resource by an init container.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, c := range p.Spec.InitContainers {
@@ -1370,12 +1423,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_spec_volumes_persistentvolumeclaims_info",
-			Type: metric.Gauge,
-			Help: "Information about persistentvolumeclaim volumes in a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_spec_volumes_persistentvolumeclaims_info",
+			"Information about persistentvolumeclaim volumes in a pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, v := range p.Spec.Volumes {
@@ -1392,12 +1446,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_spec_volumes_persistentvolumeclaims_readonly",
-			Type: metric.Gauge,
-			Help: "Describes whether a persistentvolumeclaim is mounted read only.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_spec_volumes_persistentvolumeclaims_readonly",
+			"Describes whether a persistentvolumeclaim is mounted read only.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for _, v := range p.Spec.Volumes {
@@ -1414,12 +1469,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_overhead_cpu_cores",
-			Type: metric.Gauge,
-			Help: "The pod overhead in regards to cpu cores associated with running a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_overhead_cpu_cores",
+			"The pod overhead in regards to cpu cores associated with running a pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if p.Spec.Overhead != nil {
@@ -1436,12 +1492,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_pod_overhead_memory_bytes",
-			Type: metric.Gauge,
-			Help: "The pod overhead in regards to memory associated with running a pod.",
-			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_overhead_memory_bytes",
+			"The pod overhead in regards to memory associated with running a pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if p.Spec.Overhead != nil {
@@ -1458,7 +1515,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -34,11 +34,12 @@ var (
 	descPodDisruptionBudgetLabelsDefaultLabels = []string{"namespace", "poddisruptionbudget"}
 
 	podDisruptionBudgetMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_poddisruptionbudget_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !p.CreationTimestamp.IsZero() {
@@ -51,12 +52,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_poddisruptionbudget_status_current_healthy",
-			Type: metric.Gauge,
-			Help: "Current number of healthy pods",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_status_current_healthy",
+			"Current number of healthy pods",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -65,12 +67,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_poddisruptionbudget_status_desired_healthy",
-			Type: metric.Gauge,
-			Help: "Minimum desired number of healthy pods",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_status_desired_healthy",
+			"Minimum desired number of healthy pods",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -79,12 +82,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_poddisruptionbudget_status_pod_disruptions_allowed",
-			Type: metric.Gauge,
-			Help: "Number of pod disruptions that are currently allowed",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_status_pod_disruptions_allowed",
+			"Number of pod disruptions that are currently allowed",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -93,12 +97,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_poddisruptionbudget_status_expected_pods",
-			Type: metric.Gauge,
-			Help: "Total number of pods counted by this disruption budget",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_status_expected_pods",
+			"Total number of pods counted by this disruption budget",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -107,12 +112,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_poddisruptionbudget_status_observed_generation",
-			Type: metric.Gauge,
-			Help: "Most recent generation observed when updating this PDB status",
-			GenerateFunc: wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_poddisruptionbudget_status_observed_generation",
+			"Most recent generation observed when updating this PDB status",
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -121,7 +127,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -37,11 +37,12 @@ var (
 	descReplicaSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 
 	replicaSetMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_replicaset_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_replicaset_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !r.CreationTimestamp.IsZero() {
@@ -55,12 +56,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_replicaset_status_replicas",
-			Type: metric.Gauge,
-			Help: "The number of replicas per ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicaset_status_replicas",
+			"The number of replicas per ReplicaSet.",
+			metric.Gauge,
+			"",
+			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -69,12 +71,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicaset_status_fully_labeled_replicas",
-			Type: metric.Gauge,
-			Help: "The number of fully labeled replicas per ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicaset_status_fully_labeled_replicas",
+			"The number of fully labeled replicas per ReplicaSet.",
+			metric.Gauge,
+			"",
+			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -83,12 +86,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicaset_status_ready_replicas",
-			Type: metric.Gauge,
-			Help: "The number of ready replicas per ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicaset_status_ready_replicas",
+			"The number of ready replicas per ReplicaSet.",
+			metric.Gauge,
+			"",
+			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -97,12 +101,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicaset_status_observed_generation",
-			Type: metric.Gauge,
-			Help: "The generation observed by the ReplicaSet controller.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicaset_status_observed_generation",
+			"The generation observed by the ReplicaSet controller.",
+			metric.Gauge,
+			"",
+			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -111,12 +116,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicaset_spec_replicas",
-			Type: metric.Gauge,
-			Help: "Number of desired pods for a ReplicaSet.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicaset_spec_replicas",
+			"Number of desired pods for a ReplicaSet.",
+			metric.Gauge,
+			"",
+			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if r.Spec.Replicas != nil {
@@ -129,12 +135,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_replicaset_metadata_generation",
-			Type: metric.Gauge,
-			Help: "Sequence number representing a specific generation of the desired state.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicaset_metadata_generation",
+			"Sequence number representing a specific generation of the desired state.",
+			metric.Gauge,
+			"",
+			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -143,12 +150,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicaset_owner",
-			Type: metric.Gauge,
-			Help: "Information about the ReplicaSet's owner.",
-			GenerateFunc: wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicaset_owner",
+			"Information about the ReplicaSet's owner.",
+			metric.Gauge,
+			"",
+			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				owners := r.GetOwnerReferences()
 
 				if len(owners) == 0 {
@@ -186,12 +194,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: descReplicaSetLabelsName,
-			Type: metric.Gauge,
-			Help: descReplicaSetLabelsHelp,
-			GenerateFunc: wrapReplicaSetFunc(func(d *v1.ReplicaSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descReplicaSetLabelsName,
+			descReplicaSetLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapReplicaSetFunc(func(d *v1.ReplicaSet) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -203,7 +212,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -35,11 +35,12 @@ var (
 	descReplicationControllerLabelsDefaultLabels = []string{"namespace", "replicationcontroller"}
 
 	replicationControllerMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_replicationcontroller_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_replicationcontroller_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !r.CreationTimestamp.IsZero() {
@@ -52,12 +53,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_replicationcontroller_status_replicas",
-			Type: metric.Gauge,
-			Help: "The number of replicas per ReplicationController.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicationcontroller_status_replicas",
+			"The number of replicas per ReplicationController.",
+			metric.Gauge,
+			"",
+			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -66,12 +68,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicationcontroller_status_fully_labeled_replicas",
-			Type: metric.Gauge,
-			Help: "The number of fully labeled replicas per ReplicationController.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicationcontroller_status_fully_labeled_replicas",
+			"The number of fully labeled replicas per ReplicationController.",
+			metric.Gauge,
+			"",
+			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -80,12 +83,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicationcontroller_status_ready_replicas",
-			Type: metric.Gauge,
-			Help: "The number of ready replicas per ReplicationController.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicationcontroller_status_ready_replicas",
+			"The number of ready replicas per ReplicationController.",
+			metric.Gauge,
+			"",
+			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -94,12 +98,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicationcontroller_status_available_replicas",
-			Type: metric.Gauge,
-			Help: "The number of available replicas per ReplicationController.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicationcontroller_status_available_replicas",
+			"The number of available replicas per ReplicationController.",
+			metric.Gauge,
+			"",
+			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -108,12 +113,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicationcontroller_status_observed_generation",
-			Type: metric.Gauge,
-			Help: "The generation observed by the ReplicationController controller.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicationcontroller_status_observed_generation",
+			"The generation observed by the ReplicationController controller.",
+			metric.Gauge,
+			"",
+			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -122,12 +128,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicationcontroller_spec_replicas",
-			Type: metric.Gauge,
-			Help: "Number of desired pods for a ReplicationController.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicationcontroller_spec_replicas",
+			"Number of desired pods for a ReplicationController.",
+			metric.Gauge,
+			"",
+			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if r.Spec.Replicas != nil {
@@ -140,12 +147,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_replicationcontroller_metadata_generation",
-			Type: metric.Gauge,
-			Help: "Sequence number representing a specific generation of the desired state.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicationcontroller_metadata_generation",
+			"Sequence number representing a specific generation of the desired state.",
+			metric.Gauge,
+			"",
+			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -154,12 +162,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_replicationcontroller_owner",
-			Type: metric.Gauge,
-			Help: "Information about the ReplicationController's owner.",
-			GenerateFunc: wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_replicationcontroller_owner",
+			"Information about the ReplicationController's owner.",
+			metric.Gauge,
+			"",
+			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
 				ms := []*metric.Metric{}
 
@@ -189,7 +198,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/resourcequota.go
+++ b/internal/store/resourcequota.go
@@ -34,11 +34,12 @@ var (
 	descResourceQuotaLabelsDefaultLabels = []string{"namespace", "resourcequota"}
 
 	resourceQuotaMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_resourcequota_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_resourcequota_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !r.CreationTimestamp.IsZero() {
@@ -52,12 +53,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_resourcequota",
-			Type: metric.Gauge,
-			Help: "Information about resource quota.",
-			GenerateFunc: wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_resourcequota",
+			"Information about resource quota.",
+			metric.Gauge,
+			"",
+			wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
 				ms := []*metric.Metric{}
 
 				for res, qty := range r.Status.Hard {
@@ -81,7 +83,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -36,11 +36,12 @@ var (
 	descSecretLabelsDefaultLabels = []string{"namespace", "secret"}
 
 	secretMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_secret_info",
-			Type: metric.Gauge,
-			Help: "Information about secret.",
-			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_secret_info",
+			"Information about secret.",
+			metric.Gauge,
+			"",
+			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -49,12 +50,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_secret_type",
-			Type: metric.Gauge,
-			Help: "Type about secret.",
-			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_secret_type",
+			"Type about secret.",
+			metric.Gauge,
+			"",
+			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -65,12 +67,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: descSecretLabelsName,
-			Type: metric.Gauge,
-			Help: descSecretLabelsHelp,
-			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descSecretLabelsName,
+			descSecretLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -83,12 +86,13 @@ var (
 				}
 
 			}),
-		},
-		{
-			Name: "kube_secret_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_secret_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !s.CreationTimestamp.IsZero() {
@@ -101,17 +105,18 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_secret_metadata_resource_version",
-			Type: metric.Gauge,
-			Help: "Resource version representing a specific version of secret.",
-			GenerateFunc: wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_secret_metadata_resource_version",
+			"Resource version representing a specific version of secret.",
+			metric.Gauge,
+			"",
+			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				return &metric.Family{
 					Metrics: resourceVersionMetric(s.ObjectMeta.ResourceVersion),
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -36,11 +36,12 @@ var (
 	descServiceLabelsDefaultLabels = []string{"namespace", "service"}
 
 	serviceMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_service_info",
-			Type: metric.Gauge,
-			Help: "Information about service.",
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_service_info",
+			"Information about service.",
+			metric.Gauge,
+			"",
+			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				m := metric.Metric{
 					LabelKeys:   []string{"cluster_ip", "external_name", "load_balancer_ip"},
 					LabelValues: []string{s.Spec.ClusterIP, s.Spec.ExternalName, s.Spec.LoadBalancerIP},
@@ -48,12 +49,13 @@ var (
 				}
 				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
-		},
-		{
-			Name: "kube_service_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_service_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if !s.CreationTimestamp.IsZero() {
 					m := metric.Metric{
 						LabelKeys:   nil,
@@ -64,12 +66,13 @@ var (
 				}
 				return &metric.Family{Metrics: []*metric.Metric{}}
 			}),
-		},
-		{
-			Name: "kube_service_spec_type",
-			Type: metric.Gauge,
-			Help: "Type about service.",
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_service_spec_type",
+			"Type about service.",
+			metric.Gauge,
+			"",
+			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				m := metric.Metric{
 
 					LabelKeys:   []string{"type"},
@@ -78,12 +81,13 @@ var (
 				}
 				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
-		},
-		{
-			Name: descServiceLabelsName,
-			Type: metric.Gauge,
-			Help: descServiceLabelsHelp,
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descServiceLabelsName,
+			descServiceLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
 				m := metric.Metric{
 
@@ -93,12 +97,13 @@ var (
 				}
 				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
-		},
-		{
-			Name: "kube_service_spec_external_ip",
-			Type: metric.Gauge,
-			Help: "Service external ips. One series for each ip",
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_service_spec_external_ip",
+			"Service external ips. One series for each ip",
+			metric.Gauge,
+			"",
+			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if len(s.Spec.ExternalIPs) == 0 {
 					return &metric.Family{
 						Metrics: []*metric.Metric{},
@@ -119,12 +124,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_service_status_load_balancer_ingress",
-			Type: metric.Gauge,
-			Help: "Service load balancer ingress status",
-			GenerateFunc: wrapSvcFunc(func(s *v1.Service) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_service_status_load_balancer_ingress",
+			"Service load balancer ingress status",
+			metric.Gauge,
+			"",
+			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if len(s.Status.LoadBalancer.Ingress) == 0 {
 					return &metric.Family{
 						Metrics: []*metric.Metric{},
@@ -145,7 +151,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -36,11 +36,12 @@ var (
 	descStatefulSetLabelsDefaultLabels = []string{"namespace", "statefulset"}
 
 	statefulSetMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_statefulset_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_statefulset_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !s.CreationTimestamp.IsZero() {
@@ -53,12 +54,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_statefulset_status_replicas",
-			Type: metric.Gauge,
-			Help: "The number of replicas per StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_statefulset_status_replicas",
+			"The number of replicas per StatefulSet.",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -67,12 +69,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_statefulset_status_replicas_current",
-			Type: metric.Gauge,
-			Help: "The number of current replicas per StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_statefulset_status_replicas_current",
+			"The number of current replicas per StatefulSet.",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -81,12 +84,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_statefulset_status_replicas_ready",
-			Type: metric.Gauge,
-			Help: "The number of ready replicas per StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_statefulset_status_replicas_ready",
+			"The number of ready replicas per StatefulSet.",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -95,12 +99,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_statefulset_status_replicas_updated",
-			Type: metric.Gauge,
-			Help: "The number of updated replicas per StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_statefulset_status_replicas_updated",
+			"The number of updated replicas per StatefulSet.",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -109,12 +114,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_statefulset_status_observed_generation",
-			Type: metric.Gauge,
-			Help: "The generation observed by the StatefulSet controller.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_statefulset_status_observed_generation",
+			"The generation observed by the StatefulSet controller.",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -123,12 +129,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_statefulset_replicas",
-			Type: metric.Gauge,
-			Help: "Number of desired pods for a StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_statefulset_replicas",
+			"Number of desired pods for a StatefulSet.",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if s.Spec.Replicas != nil {
@@ -141,12 +148,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_statefulset_metadata_generation",
-			Type: metric.Gauge,
-			Help: "Sequence number representing a specific generation of the desired state for the StatefulSet.",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_statefulset_metadata_generation",
+			"Sequence number representing a specific generation of the desired state for the StatefulSet.",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -155,12 +163,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: descStatefulSetLabelsName,
-			Type: metric.Gauge,
-			Help: descStatefulSetLabelsHelp,
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descStatefulSetLabelsName,
+			descStatefulSetLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -172,12 +181,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_statefulset_status_current_revision",
-			Type: metric.Gauge,
-			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_statefulset_status_current_revision",
+			"Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -188,12 +198,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_statefulset_status_update_revision",
-			Type: metric.Gauge,
-			Help: "Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
-			GenerateFunc: wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_statefulset_status_update_revision",
+			"Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -204,7 +215,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -36,11 +36,12 @@ var (
 	defaultVolumeBindingMode            = storagev1.VolumeBindingImmediate
 
 	storageClassMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_storageclass_info",
-			Type: metric.Gauge,
-			Help: "Information about storageclass.",
-			GenerateFunc: wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_storageclass_info",
+			"Information about storageclass.",
+			metric.Gauge,
+			"",
+			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 
 				// Add default values if missing.
 				if s.ReclaimPolicy == nil {
@@ -58,12 +59,13 @@ var (
 				}
 				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
-		},
-		{
-			Name: "kube_storageclass_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_storageclass_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 				ms := []*metric.Metric{}
 				if !s.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
@@ -74,12 +76,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: descStorageClassLabelsName,
-			Type: metric.Gauge,
-			Help: descStorageClassLabelsHelp,
-			GenerateFunc: wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			descStorageClassLabelsName,
+			descStorageClassLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(s.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -91,7 +94,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -35,11 +35,12 @@ var (
 	descValidatingWebhookConfigurationDefaultLabels = []string{"namespace", "validatingwebhookconfiguration"}
 
 	validatingWebhookConfigurationMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: "kube_validatingwebhookconfiguration_info",
-			Type: metric.Gauge,
-			Help: "Information about the ValidatingWebhookConfiguration.",
-			GenerateFunc: wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
+		*generator.NewFamilyGenerator(
+			"kube_validatingwebhookconfiguration_info",
+			"Information about the ValidatingWebhookConfiguration.",
+			metric.Gauge,
+			"",
+			wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -48,12 +49,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_validatingwebhookconfiguration_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp.",
-			GenerateFunc: wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_validatingwebhookconfiguration_created",
+			"Unix creation timestamp.",
+			metric.Gauge,
+			"",
+			wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !vwc.CreationTimestamp.IsZero() {
@@ -65,17 +67,18 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_validatingwebhookconfiguration_metadata_resource_version",
-			Type: metric.Gauge,
-			Help: "Resource version representing a specific version of the ValidatingWebhookConfiguration.",
-			GenerateFunc: wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_validatingwebhookconfiguration_metadata_resource_version",
+			"Resource version representing a specific version of the ValidatingWebhookConfiguration.",
+			metric.Gauge,
+			"",
+			wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
 					Metrics: resourceVersionMetric(vwc.ObjectMeta.ResourceVersion),
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/verticalpodautoscaler.go
+++ b/internal/store/verticalpodautoscaler.go
@@ -39,11 +39,12 @@ var (
 	descVerticalPodAutoscalerLabelsDefaultLabels = []string{"namespace", "verticalpodautoscaler", "target_api_version", "target_kind", "target_name"}
 
 	vpaMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: descVerticalPodAutoscalerLabelsName,
-			Type: metric.Gauge,
-			Help: descVerticalPodAutoscalerLabelsHelp,
-			GenerateFunc: wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
+		*generator.NewFamilyGenerator(
+			descVerticalPodAutoscalerLabelsName,
+			descVerticalPodAutoscalerLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(a.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -55,12 +56,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_verticalpodautoscaler_spec_updatepolicy_updatemode",
-			Type: metric.Gauge,
-			Help: "Update mode of the VerticalPodAutoscaler.",
-			GenerateFunc: wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_verticalpodautoscaler_spec_updatepolicy_updatemode",
+			"Update mode of the VerticalPodAutoscaler.",
+			metric.Gauge,
+			"",
+			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if a.Spec.UpdatePolicy == nil || a.Spec.UpdatePolicy.UpdateMode == nil {
@@ -92,12 +94,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed",
-			Type: metric.Gauge,
-			Help: "Minimum resources the VerticalPodAutoscaler can set for containers matching the name.",
-			GenerateFunc: wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed",
+			"Minimum resources the VerticalPodAutoscaler can set for containers matching the name.",
+			metric.Gauge,
+			"",
+			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Spec.ResourcePolicy == nil || a.Spec.ResourcePolicy.ContainerPolicies == nil {
 					return &metric.Family{
@@ -113,12 +116,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed",
-			Type: metric.Gauge,
-			Help: "Maximum resources the VerticalPodAutoscaler can set for containers matching the name.",
-			GenerateFunc: wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed",
+			"Maximum resources the VerticalPodAutoscaler can set for containers matching the name.",
+			metric.Gauge,
+			"",
+			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Spec.ResourcePolicy == nil || a.Spec.ResourcePolicy.ContainerPolicies == nil {
 					return &metric.Family{
@@ -133,12 +137,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound",
-			Type: metric.Gauge,
-			Help: "Minimum resources the container can use before the VerticalPodAutoscaler updater evicts it.",
-			GenerateFunc: wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound",
+			"Minimum resources the container can use before the VerticalPodAutoscaler updater evicts it.",
+			metric.Gauge,
+			"",
+			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
 					return &metric.Family{
@@ -153,12 +158,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound",
-			Type: metric.Gauge,
-			Help: "Maximum resources the container can use before the VerticalPodAutoscaler updater evicts it.",
-			GenerateFunc: wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound",
+			"Maximum resources the container can use before the VerticalPodAutoscaler updater evicts it.",
+			metric.Gauge,
+			"",
+			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
 					return &metric.Family{
@@ -173,12 +179,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target",
-			Type: metric.Gauge,
-			Help: "Target resources the VerticalPodAutoscaler recommends for the container.",
-			GenerateFunc: wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target",
+			"Target resources the VerticalPodAutoscaler recommends for the container.",
+			metric.Gauge,
+			"",
+			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
 					return &metric.Family{
@@ -192,12 +199,13 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
-		{
-			Name: "kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget",
-			Type: metric.Gauge,
-			Help: "Target resources the VerticalPodAutoscaler recommends for the container ignoring bounds.",
-			GenerateFunc: wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget",
+			"Target resources the VerticalPodAutoscaler recommends for the container ignoring bounds.",
+			metric.Gauge,
+			"",
+			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
 					return &metric.Family{
@@ -211,7 +219,7 @@ var (
 					Metrics: ms,
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/internal/store/volumeattachment.go
+++ b/internal/store/volumeattachment.go
@@ -36,11 +36,12 @@ var (
 	descVolumeAttachmentLabelsDefaultLabels = []string{"volumeattachment"}
 
 	volumeAttachmentMetricFamilies = []generator.FamilyGenerator{
-		{
-			Name: descVolumeAttachmentLabelsName,
-			Type: metric.Gauge,
-			Help: descVolumeAttachmentLabelsHelp,
-			GenerateFunc: wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
+		*generator.NewFamilyGenerator(
+			descVolumeAttachmentLabelsName,
+			descVolumeAttachmentLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				labelKeys, labelValues := kubeLabelsToPrometheusLabels(va.Labels)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -52,12 +53,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_volumeattachment_info",
-			Type: metric.Gauge,
-			Help: "Information about volumeattachment.",
-			GenerateFunc: wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_volumeattachment_info",
+			"Information about volumeattachment.",
+			metric.Gauge,
+			"",
+			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -68,12 +70,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_volumeattachment_created",
-			Type: metric.Gauge,
-			Help: "Unix creation timestamp",
-			GenerateFunc: wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_volumeattachment_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			"",
+			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				if !va.CreationTimestamp.IsZero() {
 					m := metric.Metric{
 						LabelKeys:   nil,
@@ -84,12 +87,13 @@ var (
 				}
 				return &metric.Family{Metrics: []*metric.Metric{}}
 			}),
-		},
-		{
-			Name: "kube_volumeattachment_spec_source_persistentvolume",
-			Type: metric.Gauge,
-			Help: "PersistentVolume source reference.",
-			GenerateFunc: wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_volumeattachment_spec_source_persistentvolume",
+			"PersistentVolume source reference.",
+			metric.Gauge,
+			"",
+			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				if va.Spec.Source.PersistentVolumeName != nil {
 					return &metric.Family{
 						Metrics: []*metric.Metric{
@@ -103,12 +107,13 @@ var (
 				}
 				return &metric.Family{}
 			}),
-		},
-		{
-			Name: "kube_volumeattachment_status_attached",
-			Type: metric.Gauge,
-			Help: "Information about volumeattachment.",
-			GenerateFunc: wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_volumeattachment_status_attached",
+			"Information about volumeattachment.",
+			metric.Gauge,
+			"",
+			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -119,12 +124,13 @@ var (
 					},
 				}
 			}),
-		},
-		{
-			Name: "kube_volumeattachment_status_attachment_metadata",
-			Type: metric.Gauge,
-			Help: "volumeattachment metadata.",
-			GenerateFunc: wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
+		),
+		*generator.NewFamilyGenerator(
+			"kube_volumeattachment_status_attachment_metadata",
+			"volumeattachment metadata.",
+			metric.Gauge,
+			"",
+			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				labelKeys, labelValues := mapToPrometheusLabels(va.Status.AttachmentMetadata, "metadata")
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -136,7 +142,7 @@ var (
 					},
 				}
 			}),
-		},
+		),
 	}
 )
 

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package generator
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/kube-state-metrics/pkg/metric"
@@ -24,11 +25,29 @@ import (
 
 // FamilyGenerator provides everything needed to generate a metric family with a
 // Kubernetes object.
+// DeprecatedVersion is defined only if the metric for which this options applies is,
+// in fact, deprecated.
 type FamilyGenerator struct {
-	Name         string
-	Help         string
-	Type         metric.Type
-	GenerateFunc func(obj interface{}) *metric.Family
+	Name              string
+	Help              string
+	Type              metric.Type
+	DeprecatedVersion string
+	GenerateFunc      func(obj interface{}) *metric.Family
+}
+
+// NewFamilyGenerator creates new FamilyGenerator instances.
+func NewFamilyGenerator(name string, help string, metricType metric.Type, deprecatedVersion string, generateFunc func(obj interface{}) *metric.Family) *FamilyGenerator {
+	f := &FamilyGenerator{
+		Name:              name,
+		Type:              metricType,
+		Help:              help,
+		DeprecatedVersion: deprecatedVersion,
+		GenerateFunc:      generateFunc,
+	}
+	if deprecatedVersion != "" {
+		f.Help = fmt.Sprintf("(Deprecated since %s) %s", deprecatedVersion, help)
+	}
+	return f
 }
 
 // Generate calls the FamilyGenerator.GenerateFunc and gives the family its


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Currently, in kube-state-metrics, deprecated metrics is managed just in document. And also there are many docs about metrics(node-metrics.md, pod-metrics.md, ...)
This PR adds a new field "DeprecatedVersion" to struct FamilyGenerator and new func "NewFamilyGenerator" which generate struct FamilyGenerator. In NewFamilyGenerator, if the metrics is deprecated, "(Deprecated since x.x)" will be added at the begining of help string. It makes easier to manage deprecated metrics.

Also see:
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/metrics/opts.go#L198
```
type SummaryOpts struct {
	Namespace         string
	Subsystem         string
	Name              string
	Help              string
	ConstLabels       map[string]string
	Objectives        map[float64]float64
	MaxAge            time.Duration
	AgeBuckets        uint32
	BufCap            uint32
	DeprecatedVersion string <---
	deprecateOnce     sync.Once
	annotateOnce      sync.Once
	StabilityLevel    StabilityLevel
}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

