### PR TITLE
[release 1.9] cloudbuild.yaml: Add builds for k8s.gcr.io

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,12 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+    entrypoint: make
+    env:
+    - GIT_TAG=$_PULL_BASE_REF
+    - GIT_COMMIT=$_PULL_BASE_SHA
+    args:
+    - push


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport the change from @lilic to the 1.9 release branch, so we can have multi-arch container images as @paulfantom mentioned in https://github.com/kubernetes/kube-state-metrics/pull/1130#issuecomment-651033447


I hope this is the right way to do it, if not please let me know.