### PR TITLE
internal/store: convert k8s labels to snake case

### DIFF
--- a/internal/store/utils_test.go
+++ b/internal/store/utils_test.go
@@ -214,6 +214,34 @@ func TestKubeLabelsToPrometheusLabels(t *testing.T) {
 				"underscore",
 			},
 		},
+		{
+			kubeLabels: map[string]string{
+				"camelCase": "camel_case",
+			},
+			expectKeys:   []string{"label_camel_case"},
+			expectValues: []string{"camel_case"},
+		},
+		{
+			kubeLabels: map[string]string{
+				"snake_camelCase": "snake_and_camel_case",
+			},
+			expectKeys:   []string{"label_snake_camel_case"},
+			expectValues: []string{"snake_and_camel_case"},
+		},
+		{
+			kubeLabels: map[string]string{
+				"conflicting_camelCase":  "camel_case",
+				"conflicting_camel_case": "snake_case",
+			},
+			expectKeys: []string{
+				"label_conflicting_camel_case_conflict1",
+				"label_conflicting_camel_case_conflict2",
+			},
+			expectValues: []string{
+				"camel_case",
+				"snake_case",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/store/volumeattachment_test.go
+++ b/internal/store/volumeattachment_test.go
@@ -73,7 +73,7 @@ func TestVolumeAttachmentStore(t *testing.T) {
         		kube_volumeattachment_labels{label_app="foobar",volumeattachment="csi-5ff16a1ad085261021e21c6cb3a6defb979a8794f25a4f90f6285664cff37224"} 1
 		        kube_volumeattachment_spec_source_persistentvolume{volumeattachment="csi-5ff16a1ad085261021e21c6cb3a6defb979a8794f25a4f90f6285664cff37224",volumename="pvc-44f6ff3f-ba9b-49c4-9b95-8b01c4bd4bab"} 1
 		        kube_volumeattachment_status_attached{volumeattachment="csi-5ff16a1ad085261021e21c6cb3a6defb979a8794f25a4f90f6285664cff37224"} 1
-		        kube_volumeattachment_status_attachment_metadata{metadata_DevicePath="/dev/sdd",volumeattachment="csi-5ff16a1ad085261021e21c6cb3a6defb979a8794f25a4f90f6285664cff37224"} 1
+		        kube_volumeattachment_status_attachment_metadata{metadata_device_path="/dev/sdd",volumeattachment="csi-5ff16a1ad085261021e21c6cb3a6defb979a8794f25a4f90f6285664cff37224"} 1
 			`,
 				MetricNames: []string{
 					"kube_volumeattachment_labels",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

As mentioned in the linked issue, when a Kubernetes label in camel case is mapped to a Prometheus label by kube-state-metrics, the resulting label is written in camel case. However, according to Prometheus best practices, labels should be written in snake case.
Thus, this PR intends to lint these labels by mapping Kubernetes labels written in camel case to Prometheus labels written in snake case.

**Which issue(s) this PR fixes**
Fixes #1162 

