### PR TITLE
Build binary fully in container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-*
-!kube-state-metrics

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
-FROM gcr.io/distroless/static
+FROM golang:1.14 as builder
+ARG GOARCH
+ENV GOARCH=${GOARCH}
+WORKDIR /go/src/k8s.io/kube-state-metrics/
+COPY . /go/src/k8s.io/kube-state-metrics/
 
-COPY kube-state-metrics /
+RUN make build-local
+
+FROM gcr.io/distroless/static:latest
+COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 USER nobody
 

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,6 @@ test-benchmark-compare: $(BENCHCMP_BINARY)
 	./tests/compare_benchmarks.sh master
 	./tests/compare_benchmarks.sh ${LATEST_RELEASE_BRANCH}
 
-TEMP_DIR := $(shell mktemp -d)
-
 all: all-container
 
 sub-container-%:
@@ -94,11 +92,9 @@ all-container: $(addprefix sub-container-,$(ALL_ARCH))
 all-push: $(addprefix sub-push-,$(ALL_ARCH))
 
 container: .container-$(ARCH)
-.container-$(ARCH): kube-state-metrics
-	cp -r * "${TEMP_DIR}"
-	${DOCKER_CLI} build -t $(MULTI_ARCH_IMG):$(TAG) "${TEMP_DIR}"
+.container-$(ARCH):
+	${DOCKER_CLI} build -t $(MULTI_ARCH_IMG):$(TAG) --build-arg GOARCH=$(ARCH) .
 	${DOCKER_CLI} tag $(MULTI_ARCH_IMG):$(TAG) $(MULTI_ARCH_IMG):latest
-	rm -rf "${TEMP_DIR}"
 
 ifeq ($(ARCH), amd64)
 	# Adding check for amd64


### PR DESCRIPTION
**What this PR does / why we need it**:
As a first step towards https://github.com/kubernetes/kube-state-metrics/issues/1089, this now builds the kube-state-metrics binary fully in Docker. I'm not sure how images are build via the image-promoter, in order to build correctly there, the image-promoter would need to set a build arg for the arch it needs to build for.

FYI @paulfantom @lilic @tariq1890 