### PR TITLE
Dockerfile,Makefile: Fix building for k8s.gcr.io images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ doccheck: generate
 	@cd docs; for doc in *.md; do if [ "$$doc" != "README.md" ] && ! grep -q "$$doc" *.md; then echo "ERROR: No link to documentation file $${doc} detected"; exit 1; fi; done
 	@echo OK
 
-build-local: clean
+build-local:
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) CGO_ENABLED=0 go build -ldflags "-s -w -X ${PKG}/version.Release=${TAG} -X ${PKG}/version.Commit=${Commit} -X ${PKG}/version.BuildDate=${BuildDate}" -o kube-state-metrics
 
-build: clean kube-state-metrics
+build: kube-state-metrics
 
 kube-state-metrics:
 	${DOCKER_CLI} run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics golang:${GO_VERSION} make build-local


### PR DESCRIPTION
Building fails as we run clean target afterwards as git does not exist.
There is not need for clean anyways.

See error here -> https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kube-state-metrics-push-images/1285961432038379522

cc @brancz @tariq1890 if you have other suggestions how to fix it, I thought this was the smoothest approach, the local should be kept for local building when you want cleanup to happen with git clean and removal of the binary.