### PR TITLE
Makefile: Set default registry name to gcr.io/k8s-staging-kube-state-…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ jobs:
     - name: Build
       script: make build
     - name: End to end tests
-      script: make e2e
+      script: REGISTRY="quay.io/coreos" make e2e

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FLAGS =
 TESTENVVAR =
-REGISTRY = quay.io/coreos
+REGISTRY ?= gcr.io/k8s-staging-kube-state-metrics
 TAG_PREFIX = v
 VERSION = $(shell cat VERSION)
 TAG = $(TAG_PREFIX)$(VERSION)


### PR DESCRIPTION
So we seem to building correctly but were using quay.io/coreos as the default registry which made push part fail.

cc @brancz PTAL