### PR TITLE
Update docs to point to new gcr registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,6 @@ The latest container image can be found at:
 * `quay.io/coreos/kube-state-metrics:v1.9.7`
 * `k8s.gcr.io/kube-state-metrics:v1.9.7`
 
-**Note**:
-The recommended docker registry for kube-state-metrics is `quay.io`. kube-state-metrics on
-`gcr.io` is only maintained on best effort as it requires external help from Google employees.
-
 ### Metrics Documentation
 
 There are many more metrics we could report, but this first pass is focused on

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,9 +15,9 @@ Maintaining the release branches for older minor releases happens on a best effo
 ## Prepare your release
 
 * Bump the version in the `VERSION` file in the root of the repository.
-* Run `make examples`, which will re-generate all example manifests to use the the new version.
+* Run `make examples`, which will re-generate all example manifests to use the new version.
 * Make a PR to update:
-  * kube-state-metrics image tag for both `quay.io` and `staging-k8s.gcr.io`.
+  * kube-state-metrics image tag for both `quay.io` and `gcr.io/k8s-staging-kube-state-metrics`.
   * [Compatibility matrix](README.md#compatibility-matrix)
   * Changelog entry
     * Only include user relevant changes
@@ -32,8 +32,9 @@ Maintaining the release branches for older minor releases happens on a best effo
   * kube-state-metrics image tag used in Kubernetes deployment yaml config.
 * Cut the new release branch, i.e., `release-1.2`, or merge/cherry-pick changes onto the minor release branch you intend to tag the release on
 * Cut the new release tag, i.e., `v1.2.0-rc.0`
-* Create issue requesting for image release to `k8s.gcr.io` (or to `staging-k8s.gcr.io` in case of release candidates) and assign it to one of Googlers (@serathius, @loburm)
-* Build and push newest image to `quay.io`(@brancz)
+* New images are automatically built and pushed to `gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics`
+* Promote image by sending a PR to kubernetes/k8s.io repo.
+* Build and push newest image to `quay.io/coreos`(@brancz, @lilic)
 
 ## Stable release
 


### PR DESCRIPTION
With the image building and push to `gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics` working, I edited the docs.

cc @serathius can you double check this is correct now from your side, we no longer need to ping you so removing that part. :)