### PR TITLE
Backport Container Build Changes to Release 1.9

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-*
-!kube-state-metrics

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ jobs:
     - name: Build
       script: make build
     - name: End to end tests
-      script: make e2e
+      script: REGISTRY="quay.io/coreos" make e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
-FROM gcr.io/distroless/static
+FROM golang:1.14 as builder
+ARG GOARCH
+ENV GOARCH=${GOARCH}
+WORKDIR /go/src/k8s.io/kube-state-metrics/
+COPY . /go/src/k8s.io/kube-state-metrics/
 
-COPY kube-state-metrics /
+RUN make build-local
+
+FROM gcr.io/distroless/static:latest
+COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 USER nobody
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as builder
+FROM golang:1.13 as builder
 ARG GOARCH
 ENV GOARCH=${GOARCH}
 WORKDIR /go/src/k8s.io/kube-state-metrics/

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,13 @@ doccheck: generate
 	@cd docs; for doc in *.md; do if [ "$$doc" != "README.md" ] && ! grep -q "$$doc" *.md; then echo "ERROR: No link to documentation file $${doc} detected"; exit 1; fi; done
 	@echo OK
 
-build-local: clean
+build-local:
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) CGO_ENABLED=0 go build -ldflags "-s -w -X ${PKG}/version.Release=${TAG} -X ${PKG}/version.Commit=${Commit} -X ${PKG}/version.BuildDate=${BuildDate}" -o kube-state-metrics
 
-build: clean
-	docker run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics golang:${GO_VERSION} make build-local
+build: kube-state-metrics
+
+kube-state-metrics:
+	${DOCKER_CLI} run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics golang:${GO_VERSION} make build-local
 
 test-unit: clean build
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(TESTENVVAR) go test --race $(FLAGS) $(PKGS)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FLAGS =
 TESTENVVAR =
-REGISTRY = quay.io/coreos
+REGISTRY ?= gcr.io/k8s-staging-kube-state-metrics
 TAG_PREFIX = v
 VERSION = $(shell cat VERSION)
 TAG = $(TAG_PREFIX)$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,6 @@ test-benchmark-compare: $(BENCHCMP_BINARY)
 	./tests/compare_benchmarks.sh master
 	./tests/compare_benchmarks.sh ${LATEST_RELEASE_BRANCH}
 
-TEMP_DIR := $(shell mktemp -d)
-
 all: all-container
 
 sub-container-%:
@@ -92,11 +90,8 @@ all-push: $(addprefix sub-push-,$(ALL_ARCH))
 
 container: .container-$(ARCH)
 .container-$(ARCH):
-	docker run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics -e GOOS=linux -e GOARCH=$(ARCH) -e CGO_ENABLED=0 golang:${GO_VERSION} go build -ldflags "-s -w -X ${PKG}/version.Release=${TAG} -X ${PKG}/version.Commit=${Commit} -X ${PKG}/version.BuildDate=${BuildDate}" -o kube-state-metrics
-	cp -r * "${TEMP_DIR}"
-	docker build -t $(MULTI_ARCH_IMG):$(TAG) "${TEMP_DIR}"
-	docker tag $(MULTI_ARCH_IMG):$(TAG) $(MULTI_ARCH_IMG):latest
-	rm -rf "${TEMP_DIR}"
+	${DOCKER_CLI} build -t $(MULTI_ARCH_IMG):$(TAG) --build-arg GOARCH=$(ARCH) .
+	${DOCKER_CLI} tag $(MULTI_ARCH_IMG):$(TAG) $(MULTI_ARCH_IMG):latest
 
 ifeq ($(ARCH), amd64)
 	# Adding check for amd64

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -27,6 +27,7 @@ E2E_SETUP_PROMTOOL=${E2E_SETUP_PROMTOOL:-}
 MINIKUBE_VERSION=v1.3.1
 MINIKUBE_DRIVER=${MINIKUBE_DRIVER:-virtualbox}
 SUDO=${SUDO:-}
+MINIKUBE_PROFILE=${MINIKUBE_PROFILE:-ksm-e2e}
 
 OS=$(uname -s | awk '{print tolower($0)}')
 OS=${OS:-linux}
@@ -77,9 +78,16 @@ mkdir "${HOME}"/.kube || true
 touch "${HOME}"/.kube/config
 
 export KUBECONFIG=$HOME/.kube/config
-${SUDO} minikube start --vm-driver="${MINIKUBE_DRIVER}" --kubernetes-version=${KUBERNETES_VERSION} --logtostderr
 
-minikube update-context
+if [[ "$MINIKUBE_DRIVER" != "none" ]]; then 
+  export MINIKUBE_PROFILE_ARG=" --profile ${MINIKUBE_PROFILE}"
+else
+  export MINIKUBE_PROFILE_ARG=''
+fi
+
+${SUDO} minikube start --vm-driver="${MINIKUBE_DRIVER}"${MINIKUBE_PROFILE_ARG} --kubernetes-version=${KUBERNETES_VERSION} --logtostderr
+
+minikube update-context${MINIKUBE_PROFILE_ARG}
 
 set +e
 
@@ -98,7 +106,7 @@ for _ in {1..90}; do # timeout for 3 minutes
 done
 
 if [[ ${is_kube_running} == "false" ]]; then
-   minikube logs
+   minikube logs${MINIKUBE_PROFILE_ARG}
    echo "Kubernetes does not start within 3 minutes"
    exit 1
 fi
@@ -107,8 +115,11 @@ set -e
 
 kubectl version
 
+# Build binary
+make build
+
 # ensure that we build docker image in minikube
-[[ "$MINIKUBE_DRIVER" != "none" ]] && eval "$(minikube docker-env)"
+[[ "$MINIKUBE_DRIVER" != "none" ]] && eval "$(minikube docker-env${MINIKUBE_PROFILE_ARG})" && export DOCKER_CLI='docker'
 
 # query kube-state-metrics image tag
 make container

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -80,14 +80,14 @@ touch "${HOME}"/.kube/config
 export KUBECONFIG=$HOME/.kube/config
 
 if [[ "$MINIKUBE_DRIVER" != "none" ]]; then 
-  export MINIKUBE_PROFILE_ARG=" --profile ${MINIKUBE_PROFILE}"
+  export MINIKUBE_PROFILE_ARG="--profile ${MINIKUBE_PROFILE}"
 else
   export MINIKUBE_PROFILE_ARG=''
 fi
 
-${SUDO} minikube start --vm-driver="${MINIKUBE_DRIVER}"${MINIKUBE_PROFILE_ARG} --kubernetes-version=${KUBERNETES_VERSION} --logtostderr
+${SUDO} minikube start --vm-driver="${MINIKUBE_DRIVER}" "${MINIKUBE_PROFILE_ARG}" --kubernetes-version=${KUBERNETES_VERSION} --logtostderr
 
-minikube update-context${MINIKUBE_PROFILE_ARG}
+minikube update-context "${MINIKUBE_PROFILE_ARG}"
 
 set +e
 
@@ -106,7 +106,7 @@ for _ in {1..90}; do # timeout for 3 minutes
 done
 
 if [[ ${is_kube_running} == "false" ]]; then
-   minikube logs${MINIKUBE_PROFILE_ARG}
+   minikube logs "${MINIKUBE_PROFILE_ARG}"
    echo "Kubernetes does not start within 3 minutes"
    exit 1
 fi
@@ -119,7 +119,7 @@ kubectl version
 make build
 
 # ensure that we build docker image in minikube
-[[ "$MINIKUBE_DRIVER" != "none" ]] && eval "$(minikube docker-env${MINIKUBE_PROFILE_ARG})" && export DOCKER_CLI='docker'
+[[ "$MINIKUBE_DRIVER" != "none" ]] && eval "$(minikube docker-env "${MINIKUBE_PROFILE_ARG}")" && export DOCKER_CLI='docker'
 
 # query kube-state-metrics image tag
 make container


### PR DESCRIPTION
**What this PR does / why we need it**:
@lilic @serathius backporting the changes for https://github.com/kubernetes/kube-state-metrics/issues/1089 so a new release can be cut.

