### PR TITLE
Add observedGeneration metric for DaemonSets

### DIFF
--- a/docs/daemonset-metrics.md
+++ b/docs/daemonset-metrics.md
@@ -9,6 +9,7 @@
 | kube_daemonset_status_number_misscheduled | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; | STABLE |
 | kube_daemonset_status_number_ready | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; | STABLE |
 | kube_daemonset_status_number_unavailable | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; | STABLE |
+| kube_daemonset_status_observed_generation | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; | STABLE |
 | kube_daemonset_updated_number_scheduled | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; | STABLE |
 | kube_daemonset_metadata_generation | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; | STABLE |
 | kube_daemonset_labels | Gauge | `daemonset`=&lt;daemonset-name&gt; <br> `namespace`=&lt;daemonset-namespace&gt; <br> `label_DAEMONSET_LABEL`=&lt;DAEMONSET_LABEL&gt; | STABLE |

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -151,6 +151,22 @@ var (
 			}),
 		},
 		{
+			Name: "kube_daemonset_status_observed_generation",
+			Type: metric.Gauge,
+			Help: "The most recent generation observed by the daemon set controller.",
+			GenerateFunc: wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   []string{},
+							LabelValues: []string{},
+							Value:       float64(d.Status.ObservedGeneration),
+						},
+					},
+				}
+			}),
+		},
+		{
 			Name: "kube_daemonset_updated_number_scheduled",
 			Type: metric.Gauge,
 			Help: "The total number of nodes that are running updated daemon pod",

--- a/internal/store/daemonset_test.go
+++ b/internal/store/daemonset_test.go
@@ -43,6 +43,7 @@ func TestDaemonSetStore(t *testing.T) {
 					NumberMisscheduled:     10,
 					DesiredNumberScheduled: 5,
 					NumberReady:            5,
+					ObservedGeneration:     2,
 				},
 			},
 			Want: `
@@ -54,6 +55,7 @@ func TestDaemonSetStore(t *testing.T) {
 				# HELP kube_daemonset_status_number_misscheduled The number of nodes running a daemon pod but are not supposed to.
 				# HELP kube_daemonset_status_number_ready The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
 				# HELP kube_daemonset_status_number_unavailable The number of nodes that should be running the daemon pod and have none of the daemon pod running and available
+				# HELP kube_daemonset_status_observed_generation The most recent generation observed by the daemon set controller.
 				# HELP kube_daemonset_updated_number_scheduled The total number of nodes that are running updated daemon pod
 				# TYPE kube_daemonset_labels gauge
 				# TYPE kube_daemonset_metadata_generation gauge
@@ -63,6 +65,7 @@ func TestDaemonSetStore(t *testing.T) {
 				# TYPE kube_daemonset_status_number_misscheduled gauge
 				# TYPE kube_daemonset_status_number_ready gauge
 				# TYPE kube_daemonset_status_number_unavailable gauge
+				# TYPE kube_daemonset_status_observed_generation gauge
 				# TYPE kube_daemonset_updated_number_scheduled gauge
 				kube_daemonset_metadata_generation{daemonset="ds1",namespace="ns1"} 21
 				kube_daemonset_status_current_number_scheduled{daemonset="ds1",namespace="ns1"} 15
@@ -71,6 +74,7 @@ func TestDaemonSetStore(t *testing.T) {
 				kube_daemonset_status_number_misscheduled{daemonset="ds1",namespace="ns1"} 10
 				kube_daemonset_status_number_ready{daemonset="ds1",namespace="ns1"} 5
 				kube_daemonset_status_number_unavailable{daemonset="ds1",namespace="ns1"} 0
+				kube_daemonset_status_observed_generation{daemonset="ds1",namespace="ns1"} 2
 				kube_daemonset_updated_number_scheduled{daemonset="ds1",namespace="ns1"} 0
 				kube_daemonset_labels{daemonset="ds1",label_app="example1",namespace="ns1"} 1
 `,
@@ -83,6 +87,7 @@ func TestDaemonSetStore(t *testing.T) {
 				"kube_daemonset_status_number_misscheduled",
 				"kube_daemonset_status_number_ready",
 				"kube_daemonset_status_number_unavailable",
+				"kube_daemonset_status_observed_generation",
 				"kube_daemonset_updated_number_scheduled",
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This adds a new metric from DaemonSet status

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1176 

