### PR TITLE
Adds new pod metric kube_pod_container_state_started

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -14,6 +14,7 @@
 | kube_pod_container_status_waiting | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_container_status_waiting_reason | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `reason`=&lt;ContainerCreating\|CrashLoopBackOff\|ErrImagePull\|ImagePullBackOff\|CreateContainerConfigError\|InvalidImageName\|CreateContainerError&gt; | STABLE |
 | kube_pod_container_status_running | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
+| kube_pod_container_state_started | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_container_status_terminated | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_container_status_terminated_reason | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `reason`=&lt;OOMKilled\|Error\|Completed\|ContainerCannotRun\|DeadlineExceeded&gt; | STABLE |
 | kube_pod_container_status_last_terminated_reason | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `reason`=&lt;OOMKilled\|Error\|Completed\|ContainerCannotRun\|DeadlineExceeded&gt; | STABLE |

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -81,6 +81,27 @@ var (
 						Value:       float64((p.Status.StartTime).Unix()),
 					})
 				}
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		},
+		{
+			Name: "kube_pod_container_state_started",
+			Type: metric.Gauge,
+			Help: "Start time in unix timestamp for a pod container.",
+			GenerateFunc: wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				for _, cs := range p.Status.ContainerStatuses {
+					if cs.State.Running != nil {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container"},
+							LabelValues: []string{cs.Name},
+							Value:       float64((cs.State.Running.StartedAt).Unix()),
+						})
+					}
+				}
 
 				return &metric.Family{
 					Metrics: ms,

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -291,7 +291,11 @@ func TestPodStore(t *testing.T) {
 						{
 							Name: "container1",
 							State: v1.ContainerState{
-								Running: &v1.ContainerStateRunning{},
+								Running: &v1.ContainerStateRunning{
+									StartedAt: metav1.Time{
+										Time: time.Unix(1501777018, 0),
+									},
+								},
 							},
 						},
 					},
@@ -307,6 +311,7 @@ func TestPodStore(t *testing.T) {
 			},
 			Want: `
 				# HELP kube_pod_container_status_running Describes whether the container is currently in running state.
+				# HELP kube_pod_container_state_started Start time in unix timestamp for a pod container.
 				# HELP kube_pod_container_status_terminated Describes whether the container is currently in terminated state.
 				# HELP kube_pod_container_status_terminated_reason Describes the reason the container is currently in terminated state.
 				# HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
@@ -317,6 +322,7 @@ func TestPodStore(t *testing.T) {
 				# HELP kube_pod_init_container_status_waiting Describes whether the init container is currently in waiting state.
 				# HELP kube_pod_init_container_status_waiting_reason Describes the reason the init container is currently in waiting state.
 				# TYPE kube_pod_container_status_running gauge
+				# TYPE kube_pod_container_state_started gauge
 				# TYPE kube_pod_container_status_terminated gauge
 				# TYPE kube_pod_container_status_terminated_reason gauge
 				# TYPE kube_pod_container_status_waiting gauge
@@ -327,6 +333,7 @@ func TestPodStore(t *testing.T) {
 				# TYPE kube_pod_init_container_status_waiting gauge
 				# TYPE kube_pod_init_container_status_waiting_reason gauge
 				kube_pod_container_status_running{container="container1",namespace="ns1",pod="pod1"} 1
+				kube_pod_container_state_started{container="container1",namespace="ns1",pod="pod1"} 1.501777018e+09
 				kube_pod_container_status_terminated_reason{container="container1",namespace="ns1",pod="pod1",reason="Completed"} 0
                 kube_pod_container_status_terminated_reason{container="container1",namespace="ns1",pod="pod1",reason="ContainerCannotRun"} 0
 				kube_pod_container_status_terminated_reason{container="container1",namespace="ns1",pod="pod1",reason="Error"} 0
@@ -361,6 +368,7 @@ func TestPodStore(t *testing.T) {
 			`,
 			MetricNames: []string{
 				"kube_pod_container_status_running",
+				"kube_pod_container_state_started",
 				"kube_pod_container_status_waiting",
 				"kube_pod_container_status_waiting_reason",
 				"kube_pod_container_status_terminated",
@@ -537,7 +545,11 @@ kube_pod_container_status_last_terminated_reason{container="container4",namespac
 						{
 							Name: "container7",
 							State: v1.ContainerState{
-								Running: &v1.ContainerStateRunning{},
+								Running: &v1.ContainerStateRunning{
+									StartedAt: metav1.Time{
+										Time: time.Unix(1501777018, 0),
+									},
+								},
 							},
 							LastTerminationState: v1.ContainerState{
 								Terminated: &v1.ContainerStateTerminated{
@@ -555,13 +567,16 @@ kube_pod_container_status_last_terminated_reason{container="container4",namespac
 				# HELP kube_pod_container_status_terminated_reason Describes the reason the container is currently in terminated state.
 				# HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
 				# HELP kube_pod_container_status_waiting_reason Describes the reason the container is currently in waiting state.
+				# HELP kube_pod_container_state_started Start time in unix timestamp for a pod container.
 				# TYPE kube_pod_container_status_last_terminated_reason gauge
 				# TYPE kube_pod_container_status_running gauge
 				# TYPE kube_pod_container_status_terminated gauge
 				# TYPE kube_pod_container_status_terminated_reason gauge
 				# TYPE kube_pod_container_status_waiting gauge
 				# TYPE kube_pod_container_status_waiting_reason gauge
+				# TYPE kube_pod_container_state_started gauge
 				kube_pod_container_status_running{container="container7",namespace="ns6",pod="pod6"} 1
+				kube_pod_container_state_started{container="container7",namespace="ns6",pod="pod6"} 1.501777018e+09
 				kube_pod_container_status_terminated{container="container7",namespace="ns6",pod="pod6"} 0
 kube_pod_container_status_terminated_reason{container="container7",namespace="ns6",pod="pod6",reason="Completed"} 0
 				kube_pod_container_status_terminated_reason{container="container7",namespace="ns6",pod="pod6",reason="ContainerCannotRun"} 0
@@ -587,6 +602,7 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			MetricNames: []string{
 				"kube_pod_container_status_last_terminated_reason",
 				"kube_pod_container_status_running",
+				"kube_pod_container_state_started",
 				"kube_pod_container_status_terminated",
 				"kube_pod_container_status_terminated_reason",
 				"kube_pod_container_status_waiting",
@@ -604,7 +620,11 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 						{
 							Name: "container7",
 							State: v1.ContainerState{
-								Running: &v1.ContainerStateRunning{},
+								Running: &v1.ContainerStateRunning{
+									StartedAt: metav1.Time{
+										Time: time.Unix(1501777018, 0),
+									},
+								},
 							},
 							LastTerminationState: v1.ContainerState{
 								Terminated: &v1.ContainerStateTerminated{
@@ -618,17 +638,20 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			Want: `
 				# HELP kube_pod_container_status_last_terminated_reason Describes the last reason the container was in terminated state.
 				# HELP kube_pod_container_status_running Describes whether the container is currently in running state.
+				# HELP kube_pod_container_state_started Start time in unix timestamp for a pod container.
 				# HELP kube_pod_container_status_terminated Describes whether the container is currently in terminated state.
 				# HELP kube_pod_container_status_terminated_reason Describes the reason the container is currently in terminated state.
 				# HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
 				# HELP kube_pod_container_status_waiting_reason Describes the reason the container is currently in waiting state.
 				# TYPE kube_pod_container_status_last_terminated_reason gauge
 				# TYPE kube_pod_container_status_running gauge
+				# TYPE kube_pod_container_state_started gauge
 				# TYPE kube_pod_container_status_terminated gauge
 				# TYPE kube_pod_container_status_terminated_reason gauge
 				# TYPE kube_pod_container_status_waiting gauge
 				# TYPE kube_pod_container_status_waiting_reason gauge
 				kube_pod_container_status_running{container="container7",namespace="ns7",pod="pod7"} 1
+				kube_pod_container_state_started{container="container7",namespace="ns7",pod="pod7"} 1.501777018e+09
 				kube_pod_container_status_terminated{container="container7",namespace="ns7",pod="pod7"} 0
 kube_pod_container_status_terminated_reason{container="container7",namespace="ns7",pod="pod7",reason="Completed"} 0
 				kube_pod_container_status_terminated_reason{container="container7",namespace="ns7",pod="pod7",reason="ContainerCannotRun"} 0
@@ -653,6 +676,7 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 			`,
 			MetricNames: []string{
 				"kube_pod_container_status_running",
+				"kube_pod_container_state_started",
 				"kube_pod_container_status_terminated",
 				"kube_pod_container_status_terminated_reason",
 				"kube_pod_container_status_waiting",

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1695,7 +1695,7 @@ func BenchmarkPodStore(b *testing.B) {
 		},
 	}
 
-	expectedFamilies := 56
+	expectedFamilies := 57
 	for n := 0; n < b.N; n++ {
 		families := f(pod)
 		if len(families) != expectedFamilies {

--- a/main_test.go
+++ b/main_test.go
@@ -160,6 +160,8 @@ func TestFullScrapeCycle(t *testing.T) {
 kube_pod_info{namespace="default",pod="pod0",host_ip="1.1.1.1",pod_ip="1.2.3.4",uid="abc-0",node="node1",created_by_kind="<none>",created_by_name="<none>",priority_class="",host_network="false"} 1
 # HELP kube_pod_start_time Start time in unix timestamp for a pod.
 # TYPE kube_pod_start_time gauge
+# HELP kube_pod_container_state_started Start time in unix timestamp for a pod container.
+# TYPE kube_pod_container_state_started gauge
 # HELP kube_pod_completion_time Completion time in unix timestamp for a pod.
 # TYPE kube_pod_completion_time gauge
 # HELP kube_pod_owner Information about the Pod's owner.


### PR DESCRIPTION
What this PR does / why we need it:
This adds a new metric kube_pod_container_state_started under POD metrics

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

Fixes #1167 

