### PR TITLE
Makefile: Bump golangci-lint to 1.29.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PKG = k8s.io/kube-state-metrics/pkg
 GO_VERSION = 1.14.2
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell go env GOPATH)))
 BENCHCMP_BINARY := $(FIRST_GOPATH)/bin/benchcmp
-GOLANGCI_VERSION := v1.25.0
+GOLANGCI_VERSION := v1.29.0
 HAS_GOLANGCI := $(shell which golangci-lint)
 
 IMAGE = $(REGISTRY)/kube-state-metrics

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GO_VERSION = 1.14.2
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell go env GOPATH)))
 BENCHCMP_BINARY := $(FIRST_GOPATH)/bin/benchcmp
 GOLANGCI_VERSION := v1.29.0
-HAS_GOLANGCI := $(shell which golangci-lint)
+HAS_GOLANGCI := $(shell command -v golangci-lint)
 
 IMAGE = $(REGISTRY)/kube-state-metrics
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps golangci-lint from 1.25.0 to 1.29.0
Use shell built-in command instead of which to find golangci-lint
