### PR TITLE
Makefile: Enable experimental Docker CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ HAS_GOLANGCI := $(shell command -v golangci-lint)
 IMAGE = $(REGISTRY)/kube-state-metrics
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
 validate-modules:
 	@echo "- Verifying that the dependencies have expected content..."
 	go mod verify


### PR DESCRIPTION
**What this PR does / why we need it**:
So the `docker manifest` command is supported
see also: https://github.com/kubernetes-sigs/metrics-server/blob/master/Makefile#L15


@lilic I had that enabled on my machine, this should resolve the issue for google cloud as well since metrics-server is built on prow and doesn't have additional `gcloud` calls.

Follow up from: https://github.com/kubernetes/kube-state-metrics/pull/1190 