### PR TITLE
[Backport-1.9] Multi-Arch Images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ HAS_GOLANGCI := $(shell which golangci-lint)
 IMAGE = $(REGISTRY)/kube-state-metrics
 MULTI_ARCH_IMG = $(IMAGE)-$(ARCH)
 
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
 validate-modules:
 	@echo "- Verifying that the dependencies have expected content..."
 	go mod verify


### PR DESCRIPTION
**What this PR does / why we need it**:
Backporting those changes to the 1.9 branch, so a release could be made from there.
@lilic 


See also: https://github.com/kubernetes/kube-state-metrics/issues/1089

