### PR TITLE
Build with same golang version as defined in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.14 as builder
+ARG GOVERSION=1.14
+FROM golang:${GOVERSION} as builder
 ARG GOARCH
 ENV GOARCH=${GOARCH}
 WORKDIR /go/src/k8s.io/kube-state-metrics/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BuildDate = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 Commit = $(shell git rev-parse --short HEAD)
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 PKG = k8s.io/kube-state-metrics/pkg
-GO_VERSION = 1.14.6
+GO_VERSION = 1.14.7
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell go env GOPATH)))
 BENCHCMP_BINARY := $(FIRST_GOPATH)/bin/benchcmp
 GOLANGCI_VERSION := v1.29.0
@@ -88,7 +88,7 @@ all: all-container
 container: container-$(ARCH)
 
 container-%:
-	${DOCKER_CLI} build --pull -t $(IMAGE)-$*:$(TAG) --build-arg GOARCH=$* .
+	${DOCKER_CLI} build --pull -t $(IMAGE)-$*:$(TAG) --build-arg GOVERSION=$(GO_VERSION) --build-arg GOARCH=$* .
 
 sub-container-%:
 	$(MAKE) --no-print-directory ARCH=$* container

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -45,7 +45,7 @@ function finish() {
 }
 
 function setup_kind() {
-    curl -sLo kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-"${OS}"-amd64 \
+    curl -sLo kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${OS}-${ARCH}" \
         && chmod +x kind \
         && ${SUDO} mv kind /usr/local/bin/
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
Small fixes:
* Build with same golang version as defined in Makefile
* Bump golang version to 1.14.7
* Fetch the matching kind binary for the arch e2e are executed on


@tariq1890 @lilic 
