### PR TITLE
Regenerate alerting rule examples

### DIFF
--- a/examples/prometheus-alerting-rules/alerts.yaml
+++ b/examples/prometheus-alerting-rules/alerts.yaml
@@ -3,9 +3,8 @@ groups:
   rules:
   - alert: KubeStateMetricsListErrors
     annotations:
-      message: kube-state-metrics is experiencing errors at an elevated rate in list
-        operations. This is likely causing it to not be able to expose metrics about
-        Kubernetes objects correctly or at all.
+      description: kube-state-metrics is experiencing errors at an elevated rate in list operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.
+      summary: kube-state-metrics is experiencing errors in list operations.
     expr: |
       (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m]))
         /
@@ -16,9 +15,8 @@ groups:
       severity: critical
   - alert: KubeStateMetricsWatchErrors
     annotations:
-      message: kube-state-metrics is experiencing errors at an elevated rate in watch
-        operations. This is likely causing it to not be able to expose metrics about
-        Kubernetes objects correctly or at all.
+      description: kube-state-metrics is experiencing errors at an elevated rate in watch operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.
+      summary: kube-state-metrics is experiencing errors in watch operations.
     expr: |
       (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m]))
         /


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
A follow-up to https://github.com/kubernetes/kube-state-metrics/pull/1202 as PR was auto merged even when CI was red.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

