### PR TITLE
docs/pod-metrics.md: add missing condition label

### DIFF
--- a/docs/job-metrics.md
+++ b/docs/job-metrics.md
@@ -13,6 +13,6 @@
 | kube_job_status_failed | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
 | kube_job_status_start_time | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
 | kube_job_status_completion_time | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
-| kube_job_complete | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
-| kube_job_failed | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |
+| kube_job_complete | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; | STABLE |
+| kube_job_failed | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; <br> `condition`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_job_created | Gauge | `job_name`=&lt;job-name&gt; <br> `namespace`=&lt;job-namespace&gt; | STABLE |


### PR DESCRIPTION
The condition label of the [kube_job_complete](https://github.com/kubernetes/kube-state-metrics/blob/315824ab81ff123c6c3bf016917c4d387f0d435f/internal/store/job.go#L194-L216) and [kube_job_failed](https://github.com/kubernetes/kube-state-metrics/blob/315824ab81ff123c6c3bf016917c4d387f0d435f/internal/store/job.go#L217-L240) metrics
were forgotten in the documentation.