### PR TITLE
feat(persistentvolume): claimRef info to labels

### DIFF
--- a/docs/persistentvolume-metrics.md
+++ b/docs/persistentvolume-metrics.md
@@ -4,6 +4,7 @@
 | ---------- | ----------- | ----------- | ----------- |
 | kube_persistentvolume_capacity_bytes | Gauge | `persistentvolume`=&lt;pv-name&gt; | STABLE |
 | kube_persistentvolume_status_phase | Gauge | `persistentvolume`=&lt;pv-name&gt; <br>`phase`=&lt;Bound\|Failed\|Pending\|Available\|Released&gt;| STABLE |
+| kube_persistentvolume_claim_ref | Gauge | `persistentvolume`=&lt;pv-name&gt; <br>`claim_namespace`=&lt;<namespace>&gt; <br>`name`=&lt;<name>&gt; | STABLE |
 | kube_persistentvolume_labels | Gauge | `persistentvolume`=&lt;persistentvolume-name&gt; <br> `label_PERSISTENTVOLUME_LABEL`=&lt;PERSISTENTVOLUME_LABEL&gt;  | STABLE |
 | kube_persistentvolume_info | Gauge | `persistentvolume`=&lt;pv-name&gt; <br> `storageclass`=&lt;storageclass-name&gt; <br> `gce_persistent_disk_name`=&lt;pd-name&gt; <br> `ebs_volume_id`=&lt;ebs-volume-id&gt; <br> `fc_wwids`=&lt;fc-wwids-comma-separated&gt; <br> `fc_lun`=&lt;fc-lun&gt; <br> `fc_target_wwns`=&lt;fc-target-wwns-comma-separated&gt; <br> `iscsi_target_portal`=&lt;iscsi-target-portal&gt; <br> `iscsi_iqn`=&lt;iscsi-iqn&gt; <br> `iscsi_lun`=&lt;iscsi-lun&gt; <br> `iscsi_initiator_name`=&lt;iscsi-initiator-name&gt; <br> `nfs_server`=&lt;nfs-server&gt; <br> `nfs_path`=&lt;nfs-path&gt; | STABLE |
 

--- a/internal/store/persistentvolume_test.go
+++ b/internal/store/persistentvolume_test.go
@@ -402,6 +402,46 @@ func TestPersistentVolumeStore(t *testing.T) {
 		{
 			Obj: &v1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-claimed-pv",
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumePending,
+				},
+				Spec: v1.PersistentVolumeSpec{
+					StorageClassName: "test",
+					ClaimRef: &v1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "PersistentVolumeClaim",
+						Name:       "pv-claim",
+						Namespace:  "default",
+					},
+				},
+			},
+			Want: `
+					# HELP kube_persistentvolume_claim_ref Information about the Persitant Volume Claim Reference.
+					# TYPE kube_persistentvolume_claim_ref gauge
+					kube_persistentvolume_claim_ref{claim_namespace="default",name="pv-claim",persistentvolume="test-claimed-pv"} 1
+				`,
+			MetricNames: []string{"kube_persistentvolume_claim_ref"},
+		},
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-unclaimed-pv",
+				},
+				Status: v1.PersistentVolumeStatus{
+					Phase: v1.VolumeAvailable,
+				},
+			},
+			Want: `
+					# HELP kube_persistentvolume_claim_ref Information about the Persitant Volume Claim Reference.
+					# TYPE kube_persistentvolume_claim_ref gauge
+				`,
+			MetricNames: []string{"kube_persistentvolume_claim_ref"},
+		},
+		{
+			Obj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-pv",
 				},
 				Spec: v1.PersistentVolumeSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: 
https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adds a new metrics to provide claimRef information to Prometheus. In
tracking down lingering PVs, it would be of interest to know where the
PV came from. With the claimRef information, it is easier to track down
the resource owners and inform that they have unclaimed PVs lingering
around.

Main motivation is that PVs cost money at cloud providers, if PVs stick
around for long, the costs might increase significantly.