### PR TITLE
Fix go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,4 @@ require (
 	k8s.io/klog/v2 v2.2.0
 )
 
-go 1.15
+go 1.14


### PR DESCRIPTION
**What this PR does / why we need it**:
Apologies, I made the change locally but failed to commit this in the go 1.15 update PR #1261 and should have checked twice 

FYI @lilic 

