### PR TITLE
fix namespace parameter in README.md #1267

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ subjects:
     namespace: your-namespace-where-kube-state-metrics-will-deployed
 ```
 
-- then specify a set of namespaces (using the `--namespace` option) and a set of kubernetes objects (using the `--resources`) that your serviceaccount has access to in the `kube-state-metrics` deployment configuration
+- then specify a set of namespaces (using the `--namespaces` option) and a set of kubernetes objects (using the `--resources`) that your serviceaccount has access to in the `kube-state-metrics` deployment configuration
 
 ```yaml
 spec:
@@ -293,7 +293,7 @@ spec:
       - name: kube-state-metrics
         args:
           - '--resources=pods'
-          - '--namespace=project1'
+          - '--namespaces=project1'
 ```
 
 For the full list of arguments available, see the documentation in [docs/cli-arguments.md](./docs/cli-arguments.md)


### PR DESCRIPTION
**What this PR does / why we need it**:

Modify `README.md` document, fix `--namespace` parameter bug, which had deprecated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1267
