### PR TITLE
Remove ksonnet and move to absolute import paths

### DIFF
--- a/examples/autosharding/statefulset.yaml
+++ b/examples/autosharding/statefulset.yaml
@@ -24,12 +24,10 @@ spec:
         - --pod-namespace=$(POD_NAMESPACE)
         env:
         - name: POD_NAME
-          value: ""
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
         - name: POD_NAMESPACE
-          value: ""
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -57,4 +55,3 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: kube-state-metrics
-  volumeClaimTemplates: []

--- a/jsonnet/kube-state-metrics/jsonnetfile.json
+++ b/jsonnet/kube-state-metrics/jsonnetfile.json
@@ -1,14 +1,3 @@
 {
-    "dependencies": [
-        {
-            "name": "ksonnet",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/ksonnet/ksonnet-lib",
-                    "subdir": ""
-                }
-            },
-            "version": "master"
-        }
-    ]
+    "dependencies": []
 }

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -1,5 +1,3 @@
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
-
 {
   local ksm = self,
   name:: error 'must set namespace',
@@ -19,247 +17,301 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
   },
 
   clusterRoleBinding:
-    local clusterRoleBinding = k.rbac.v1.clusterRoleBinding;
-
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata.withName(ksm.name) +
-    clusterRoleBinding.mixin.metadata.withLabels(ksm.commonLabels) +
-    clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
-    clusterRoleBinding.mixin.roleRef.withName(ksm.name) +
-    clusterRoleBinding.mixin.roleRef.mixinInstance({ kind: 'ClusterRole' }) +
-    clusterRoleBinding.withSubjects([{ kind: 'ServiceAccount', name: ksm.name, namespace: ksm.namespace }]),
+    {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: ksm.name,
+        labels: ksm.commonLabels,
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: ksm.name,
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: ksm.name,
+        namespace: ksm.namespace,
+      }],
+    },
 
   clusterRole:
-    local clusterRole = k.rbac.v1.clusterRole;
-    local rulesType = clusterRole.rulesType;
-
     local rules = [
-      rulesType.new() +
-      rulesType.withApiGroups(['']) +
-      rulesType.withResources([
-        'configmaps',
-        'secrets',
-        'nodes',
-        'pods',
-        'services',
-        'resourcequotas',
-        'replicationcontrollers',
-        'limitranges',
-        'persistentvolumeclaims',
-        'persistentvolumes',
-        'namespaces',
-        'endpoints',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['extensions']) +
-      rulesType.withResources([
-        'daemonsets',
-        'deployments',
-        'replicasets',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['apps']) +
-      rulesType.withResources([
-        'statefulsets',
-        'daemonsets',
-        'deployments',
-        'replicasets',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['batch']) +
-      rulesType.withResources([
-        'cronjobs',
-        'jobs',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['autoscaling']) +
-      rulesType.withResources([
-        'horizontalpodautoscalers',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['authentication.k8s.io']) +
-      rulesType.withResources([
-        'tokenreviews',
-      ]) +
-      rulesType.withVerbs(['create']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['authorization.k8s.io']) +
-      rulesType.withResources([
-        'subjectaccessreviews',
-      ]) +
-      rulesType.withVerbs(['create']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['policy']) +
-      rulesType.withResources([
-        'poddisruptionbudgets',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['certificates.k8s.io']) +
-      rulesType.withResources([
-        'certificatesigningrequests',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['storage.k8s.io']) +
-      rulesType.withResources([
-        'storageclasses',
-        'volumeattachments',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['admissionregistration.k8s.io']) +
-      rulesType.withResources([
-        'mutatingwebhookconfigurations',
-        'validatingwebhookconfigurations',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['networking.k8s.io']) +
-      rulesType.withResources([
-        'networkpolicies',
-        'ingresses',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
-
-      rulesType.new() +
-      rulesType.withApiGroups(['coordination.k8s.io']) +
-      rulesType.withResources([
-        'leases',
-      ]) +
-      rulesType.withVerbs(['list', 'watch']),
+      {
+        apiGroups: [''],
+        resources: [
+          'configmaps',
+          'secrets',
+          'nodes',
+          'pods',
+          'services',
+          'resourcequotas',
+          'replicationcontrollers',
+          'limitranges',
+          'persistentvolumeclaims',
+          'persistentvolumes',
+          'namespaces',
+          'endpoints',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
+        apiGroups: ['extensions'],
+        resources: [
+          'daemonsets',
+          'deployments',
+          'replicasets',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
+        apiGroups: ['apps'],
+        resources: [
+          'statefulsets',
+          'daemonsets',
+          'deployments',
+          'replicasets',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
+        apiGroups: ['batch'],
+        resources: [
+          'cronjobs',
+          'jobs',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
+        apiGroups: ['autoscaling'],
+        resources: [
+          'horizontalpodautoscalers',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
+        apiGroups: ['authentication.k8s.io'],
+        resources: [
+          'tokenreviews',
+        ],
+        verbs: ['create'],
+      },
+      {
+        apiGroups: ['authorization.k8s.io'],
+        resources: [
+          'subjectaccessreviews',
+        ],
+        verbs: ['create'],
+      },
+      {
+        apiGroups: ['policy'],
+        resources: [
+          'poddisruptionbudgets',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
+        apiGroups: ['certificates.k8s.io'],
+        resources: [
+          'certificatesigningrequests',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
+        apiGroups: ['storage.k8s.io'],
+        resources: [
+          'storageclasses',
+          'volumeattachments',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
+        apiGroups: ['admissionregistration.k8s.io'],
+        resources: [
+          'mutatingwebhookconfigurations',
+          'validatingwebhookconfigurations',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
+        apiGroups: ['networking.k8s.io'],
+        resources: [
+          'networkpolicies',
+          'ingresses',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
+        apiGroups: ['coordination.k8s.io'],
+        resources: [
+          'leases',
+        ],
+        verbs: ['list', 'watch'],
+      },
     ];
 
-    clusterRole.new() +
-    clusterRole.mixin.metadata.withName(ksm.name) +
-    clusterRole.mixin.metadata.withLabels(ksm.commonLabels) +
-    clusterRole.withRules(rules),
+    {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: {
+        name: ksm.name,
+        labels: ksm.commonLabels,
+      },
+      rules: rules,
+    },
   deployment:
-    local deployment = k.apps.v1.deployment;
-    local container = deployment.mixin.spec.template.spec.containersType;
-    local volume = deployment.mixin.spec.template.spec.volumesType;
-    local containerPort = container.portsType;
-    local containerVolumeMount = container.volumeMountsType;
-    local podSelector = deployment.mixin.spec.template.spec.selectorType;
+    local c = {
+      name: 'kube-state-metrics',
+      image: ksm.image,
+      ports: [
+        { name: 'http-metrics', containerPort: 8080 },
+        { name: 'telemetry', containerPort: 8081 },
+      ],
+      securityContext: { runAsUser: 65534 },
+      livenessProbe: { timeoutSeconds: 5, initialDelaySeconds: 5, httpGet: {
+        port: 8080,
+        path: '/healthz',
+      } },
+      readinessProbe: { timeoutSeconds: 5, initialDelaySeconds: 5, httpGet: {
+        port: 8081,
+        path: '/',
+      } },
+    };
 
-    local c =
-      container.new('kube-state-metrics', ksm.image) +
-      container.withPorts([
-        containerPort.newNamed(8080, 'http-metrics'),
-        containerPort.newNamed(8081, 'telemetry'),
-      ]) +
-      container.mixin.livenessProbe.httpGet.withPath('/healthz') +
-      container.mixin.livenessProbe.httpGet.withPort(8080) +
-      container.mixin.livenessProbe.withInitialDelaySeconds(5) +
-      container.mixin.livenessProbe.withTimeoutSeconds(5) +
-      container.mixin.readinessProbe.httpGet.withPath('/') +
-      container.mixin.readinessProbe.httpGet.withPort(8081) +
-      container.mixin.readinessProbe.withInitialDelaySeconds(5) +
-      container.mixin.readinessProbe.withTimeoutSeconds(5) +
-      container.mixin.securityContext.withRunAsUser(65534);
-
-    deployment.new(ksm.name, 1, c, ksm.commonLabels) +
-    deployment.mixin.metadata.withNamespace(ksm.namespace) +
-    deployment.mixin.metadata.withLabels(ksm.commonLabels) +
-    deployment.mixin.spec.selector.withMatchLabels(ksm.podLabels) +
-    deployment.mixin.spec.template.spec.withNodeSelector({ 'kubernetes.io/os': 'linux' }) +
-    deployment.mixin.spec.template.spec.withServiceAccountName(ksm.name),
+    {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: ksm.name,
+        namespace: ksm.namespace,
+        labels: ksm.commonLabels,
+      },
+      spec: {
+        replicas: 1,
+        selector: { matchLabels: ksm.podLabels },
+        template: {
+          metadata: {
+            labels: ksm.commonLabels,
+          },
+          spec: {
+            containers: [c],
+            serviceAccountName: ksm.serviceAccount.metadata.name,
+            nodeSelector: { 'kubernetes.io/os': 'linux' },
+          },
+        },
+      },
+    },
 
   serviceAccount:
-    local serviceAccount = k.core.v1.serviceAccount;
-
-    serviceAccount.new(ksm.name) +
-    serviceAccount.mixin.metadata.withNamespace(ksm.namespace) +
-    serviceAccount.mixin.metadata.withLabels(ksm.commonLabels),
+    {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: {
+        name: ksm.name,
+        namespace: ksm.namespace,
+        labels: ksm.commonLabels,
+      },
+    },
 
   service:
-    local service = k.core.v1.service;
-    local servicePort = service.mixin.spec.portsType;
-
-    local ksmServicePortMain = servicePort.newNamed('http-metrics', 8080, 'http-metrics');
-    local ksmServicePortSelf = servicePort.newNamed('telemetry', 8081, 'telemetry');
-
-    service.new(ksm.name, ksm.podLabels, [ksmServicePortMain, ksmServicePortSelf]) +
-    service.mixin.metadata.withNamespace(ksm.namespace) +
-    service.mixin.metadata.withLabels(ksm.commonLabels) +
-    service.mixin.spec.withClusterIp('None'),
+    {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: ksm.name,
+        namespace: ksm.namespace,
+        labels: ksm.commonLabels,
+      },
+      spec: {
+        clusterIP: 'None',
+        selector: ksm.podLabels,
+        ports: [
+          { name: 'http-metrics', port: 8080, targetPort: 'http-metrics' },
+          { name: 'telemetry', port: 8081, targetPort: 'telemetry' },
+        ],
+      },
+    },
 
   autosharding:: {
     role:
-      local role = k.rbac.v1.role;
-      local rulesType = role.rulesType;
-
-      local rules = [
-        rulesType.new() +
-        rulesType.withApiGroups(['']) +
-        rulesType.withResources(['pods']) +
-        rulesType.withVerbs(['get']),
-        rulesType.new() +
-        rulesType.withApiGroups(['apps']) +
-        rulesType.withResources(['statefulsets']) +
-        rulesType.withResourceNames([ksm.name]) +
-        rulesType.withVerbs(['get']),
-      ];
-
-      role.new() +
-      role.mixin.metadata.withName(ksm.name) +
-      role.mixin.metadata.withNamespace(ksm.namespace) +
-      role.mixin.metadata.withLabels(ksm.commonLabels) +
-      role.withRules(rules),
+      {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'Role',
+        metadata: {
+          name: ksm.name,
+          namespace: ksm.namespace,
+          labels: ksm.commonLabels,
+        },
+        rules: [{
+          apiGroups: [''],
+          resources: ['pods'],
+          verbs: ['get'],
+        }, {
+          apiGroups: ['apps'],
+          resourceNames: ['kube-state-metrics'],
+          resources: ['statefulsets'],
+          verbs: ['get'],
+        }],
+      },
 
     roleBinding:
-      local roleBinding = k.rbac.v1.roleBinding;
-
-      roleBinding.new() +
-      roleBinding.mixin.metadata.withName(ksm.name) +
-      roleBinding.mixin.metadata.withNamespace(ksm.namespace) +
-      roleBinding.mixin.metadata.withLabels(ksm.commonLabels) +
-      roleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
-      roleBinding.mixin.roleRef.withName(ksm.name) +
-      roleBinding.mixin.roleRef.mixinInstance({ kind: 'Role' }) +
-      roleBinding.withSubjects([{ kind: 'ServiceAccount', name: ksm.name }]),
+      {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'RoleBinding',
+        metadata: {
+          name: ksm.name,
+          namespace: ksm.namespace,
+          labels: ksm.commonLabels,
+        },
+        roleRef: {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'Role',
+          name: 'kube-state-metrics',
+        },
+        subjects: [{
+          kind: 'ServiceAccount',
+          name: ksm.serviceAccount.metadata.name,
+        }],
+      },
 
     statefulset:
-      local statefulset = k.apps.v1.statefulSet;
-      local container = statefulset.mixin.spec.template.spec.containersType;
-      local containerEnv = container.envType;
+      // extending the default container from above
+      local c = ksm.deployment.spec.template.spec.containers[0] {
+        args: [
+          '--pod=$(POD_NAME)',
+          '--pod-namespace=$(POD_NAMESPACE)',
+        ],
+        env: [
+          { name: 'POD_NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
+          { name: 'POD_NAMESPACE', valueFrom: { fieldRef: { fieldPath: 'metadata.namespace' } } },
+        ],
+      };
 
-      local c = ksm.deployment.spec.template.spec.containers[0] +
-                container.withArgs([
-                  '--pod=$(POD_NAME)',
-                  '--pod-namespace=$(POD_NAMESPACE)',
-                ]) +
-                container.mixin.securityContext.withRunAsUser(65534) +
-                container.withEnv([
-                  containerEnv.new('POD_NAME') +
-                  containerEnv.mixin.valueFrom.fieldRef.withFieldPath('metadata.name'),
-                  containerEnv.new('POD_NAMESPACE') +
-                  containerEnv.mixin.valueFrom.fieldRef.withFieldPath('metadata.namespace'),
-                ]);
-
-      statefulset.new(ksm.name, 2, c, [], ksm.commonLabels) +
-      statefulset.mixin.metadata.withNamespace(ksm.namespace) +
-      statefulset.mixin.metadata.withLabels(ksm.commonLabels) +
-      statefulset.mixin.spec.withServiceName(ksm.service.metadata.name) +
-      statefulset.mixin.spec.selector.withMatchLabels(ksm.podLabels) +
-      statefulset.mixin.spec.template.spec.withNodeSelector({ 'kubernetes.io/os': 'linux' }) +
-      statefulset.mixin.spec.template.spec.withServiceAccountName(ksm.name),
+      {
+        apiVersion: 'apps/v1',
+        kind: 'StatefulSet',
+        metadata: {
+          name: ksm.name,
+          namespace: ksm.namespace,
+          labels: ksm.commonLabels,
+        },
+        spec: {
+          replicas: 2,
+          selector: { matchLabels: ksm.podLabels },
+          serviceName: ksm.service.metadata.name,
+          template: {
+            metadata: {
+              labels: ksm.commonLabels,
+            },
+            spec: {
+              containers: [c],
+              serviceAccountName: ksm.serviceAccount.metadata.name,
+              nodeSelector: { 'kubernetes.io/os': 'linux' },
+            },
+          },
+        },
+      },
   } + {
     service: ksm.service,
     serviceAccount: ksm.serviceAccount,

--- a/scripts/jsonnetfile.json
+++ b/scripts/jsonnetfile.json
@@ -18,5 +18,5 @@
       "version": ""
     }
   ],
-  "legacyImports": true
+  "legacyImports": false
 }

--- a/scripts/jsonnetfile.lock.json
+++ b/scripts/jsonnetfile.lock.json
@@ -3,17 +3,6 @@
   "dependencies": [
     {
       "source": {
-        "git": {
-          "remote": "https://github.com/ksonnet/ksonnet-lib.git",
-          "subdir": ""
-        }
-      },
-      "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
-      "sum": "h28BXZ7+vczxYJ2sCt8JuR9+yznRtU/iA6DCpQUrtEg=",
-      "name": "ksonnet"
-    },
-    {
-      "source": {
         "local": {
           "directory": "../jsonnet/kube-state-metrics"
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

In an effort to move kube-prometheus to use absolute import paths (for better discoverability) I needed to refactor these jsonnet bits.
Next to that, I also refactored the Kubernetes object generation to use plain Jsonnet objects and not ksonnet anymore.

Over the last months/years, we've come to the conclusion that readability is more important than the "type safety" that ksonnet promised.
Instead we're going for external tools that check the generated YAML after it has been generated like [kubeval](https://kubeval.com)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes issues outside this repository.
I've talked to @lilic before making this PR though :innocent: