### PR TITLE
pod: add gauge for runtimeclass handler

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -24,6 +24,7 @@
 | kube_pod_container_resource_limits | Gauge | `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt; <br> `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
 | kube_pod_overhead_cpu_cores | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
 | kube_pod_overhead_memory_bytes | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
+| kube_pod_runtimeclass_name_info | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
 | kube_pod_created | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_deletion_timestamp | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
 | kube_pod_restart_policy | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `type`=&lt;Always|Never|OnFailure&gt; | STABLE |

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -1317,6 +1317,27 @@ var (
 				}
 			}),
 		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_runtimeclass_name_info",
+			"The runtimeclass associated with the pod.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if p.Spec.RuntimeClassName != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{"runtimeclass_name"},
+						LabelValues: []string{*p.Spec.RuntimeClassName},
+						Value:       1,
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
 	}
 )
 

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestPodStore(t *testing.T) {
 	var test = true
+	runtimeclass := "foo"
 	startTime := 1501569018
 	metav1StartTime := metav1.Unix(int64(startTime), 0)
 
@@ -1575,6 +1576,28 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				"kube_pod_spec_volumes_persistentvolumeclaims_readonly",
 			},
 		},
+		{
+			Obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "ns1",
+					Labels: map[string]string{
+						"app": "example",
+					},
+				},
+				Spec: v1.PodSpec{
+					RuntimeClassName: &runtimeclass,
+				},
+			},
+			Want: `
+				# HELP kube_pod_runtimeclass_name_info The runtimeclass associated with the pod.
+				# TYPE kube_pod_runtimeclass_name_info gauge
+				kube_pod_runtimeclass_name_info{namespace="ns1",pod="pod1",runtimeclass_name="foo"} 1
+			`,
+			MetricNames: []string{
+				"kube_pod_runtimeclass_name_info",
+			},
+		},
 	}
 
 	for i, c := range cases {
@@ -1650,7 +1673,7 @@ func BenchmarkPodStore(b *testing.B) {
 		},
 	}
 
-	expectedFamilies := 49
+	expectedFamilies := 50
 	for n := 0; n < b.N; n++ {
 		families := f(pod)
 		if len(families) != expectedFamilies {

--- a/main_test.go
+++ b/main_test.go
@@ -202,6 +202,7 @@ func TestFullScrapeCycle(t *testing.T) {
 # HELP kube_pod_labels Kubernetes labels converted to Prometheus labels.
 # HELP kube_pod_overhead_cpu_cores The pod overhead in regards to cpu cores associated with running a pod.
 # HELP kube_pod_overhead_memory_bytes The pod overhead in regards to memory associated with running a pod.
+# HELP kube_pod_runtimeclass_name_info The runtimeclass associated with the pod.
 # HELP kube_pod_owner Information about the Pod's owner.
 # HELP kube_pod_restart_policy Describes the restart policy in use by this pod.
 # HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
@@ -251,6 +252,7 @@ func TestFullScrapeCycle(t *testing.T) {
 # TYPE kube_pod_labels gauge
 # TYPE kube_pod_overhead_cpu_cores gauge
 # TYPE kube_pod_overhead_memory_bytes gauge
+# TYPE kube_pod_runtimeclass_name_info gauge
 # TYPE kube_pod_owner gauge
 # TYPE kube_pod_restart_policy gauge
 # TYPE kube_pod_spec_volumes_persistentvolumeclaims_info gauge


### PR DESCRIPTION

**What this PR does / why we need it**:

This adds a metric for observability of the RuntimeClass feature:
kube_pod_runtimeclass_handler

Using this metrics allows end-users to quickly verify that the RuntimeClass feature is being utilized and is healthy.

When combined with the kube_pod_status_phase, end-users can use tools like grafana to quickly assess how pods running with a particular runtimeclass are behaving compared to other runtimeclasses and the default runtime. 

**Which issue(s) this PR fixes**

Fixes: https://github.com/kubernetes/kube-state-metrics/issues/1274
