### PR TITLE
Revert "Rework resource metrics"

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -20,16 +20,8 @@
 | kube_pod_container_status_last_terminated_reason | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `reason`=&lt;OOMKilled\|Error\|Completed\|ContainerCannotRun\|DeadlineExceeded&gt; | STABLE |
 | kube_pod_container_status_ready | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |
 | kube_pod_container_status_restarts_total | Counter | `container`=&lt;container-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `pod`=&lt;pod-name&gt; | STABLE |
-| kube_pod_container_resource_requests | Gauge | `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt; <br> `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
-| kube_pod_container_resource_requests_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
-| kube_pod_container_resource_requests_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
-| kube_pod_container_resource_requests_storage_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
-| kube_pod_container_resource_requests_ephemeral_storage_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
+| kube_pod_container_resource_requests | Gauge | `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt; <br> `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `node`=&lt; node-name&gt; | EXPERIMENTAL |
 | kube_pod_container_resource_limits | Gauge | `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt; <br> `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
-| kube_pod_container_resource_limits_cpu_cores | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
-| kube_pod_container_resource_limits_memory_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
-| kube_pod_container_resource_limits_storage_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
-| kube_pod_container_resource_limits_ephemeral_storage_bytes | Gauge | `container`=&lt;container-name&gt; <br> `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
 | kube_pod_overhead_cpu_cores | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
 | kube_pod_overhead_memory_bytes | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | EXPERIMENTAL |
 | kube_pod_created | Gauge | `pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; | STABLE |

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -825,114 +825,6 @@ var (
 			}),
 		),
 		*generator.NewFamilyGenerator(
-			"kube_pod_container_resource_requests_cpu_cores",
-			"The number of CPU cores requested by a container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.Containers {
-					req := c.Resources.Requests
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceCPU {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.MilliValue()) / 1000,
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_resource_requests_memory_bytes",
-			"Bytes of memory requested by a container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.Containers {
-					req := c.Resources.Requests
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceMemory {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_resource_requests_storage_bytes",
-			"Bytes of storage requested by a container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.Containers {
-					req := c.Resources.Requests
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceStorage {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_resource_requests_ephemeral_storage_bytes",
-			"Bytes of ephemeral-storage requested by a container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.Containers {
-					req := c.Resources.Requests
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceEphemeralStorage {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
 			"kube_pod_container_resource_requests",
 			"The number of requested request resource by a container.",
 			metric.Gauge,
@@ -944,137 +836,46 @@ var (
 					req := c.Resources.Requests
 
 					for resourceName, val := range req {
-						if isHugePageResourceName(resourceName) {
+						switch resourceName {
+						case v1.ResourceCPU:
 							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+								Value:       float64(val.MilliValue()) / 1000,
+							})
+						case v1.ResourceStorage:
+							fallthrough
+						case v1.ResourceEphemeralStorage:
+							fallthrough
+						case v1.ResourceMemory:
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
 								Value:       float64(val.Value()),
 							})
-						}
-						if isAttachableVolumeResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-								Value:       float64(val.Value()),
-							})
-						}
-						if isExtendedResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
-								Value:       float64(val.Value()),
-							})
+						default:
+							if isHugePageResourceName(resourceName) {
+								ms = append(ms, &metric.Metric{
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									Value:       float64(val.Value()),
+								})
+							}
+							if isAttachableVolumeResourceName(resourceName) {
+								ms = append(ms, &metric.Metric{
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+									Value:       float64(val.Value()),
+								})
+							}
+							if isExtendedResourceName(resourceName) {
+								ms = append(ms, &metric.Metric{
+									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+									Value:       float64(val.Value()),
+								})
+							}
 						}
 					}
 				}
 
 				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "resource", "unit"}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_resource_limits_cpu_cores",
-			"The number of CPU cores requested limit by a container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.Containers {
-					req := c.Resources.Limits
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceCPU {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.MilliValue()) / 1000,
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_resource_limits_memory_bytes",
-			"Bytes of memory requested limit by a container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.Containers {
-					req := c.Resources.Limits
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceMemory {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_resource_limits_storage_bytes",
-			"Bytes of storage requested limit by a container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.Containers {
-					req := c.Resources.Limits
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceStorage {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_resource_limits_ephemeral_storage_bytes",
-			"Bytes of ephemeral-storage requested limit by a container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.Containers {
-					req := c.Resources.Limits
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceEphemeralStorage {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
+					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
 				}
 
 				return &metric.Family{

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1376,78 +1376,53 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				},
 			},
 			Want: `
-				# HELP kube_pod_container_resource_limits The number of requested limit resource by a container.
-				# HELP kube_pod_container_resource_limits_cpu_cores The number of CPU cores requested limit by a container.
-				# HELP kube_pod_container_resource_limits_ephemeral_storage_bytes Bytes of ephemeral-storage requested limit by a container.
-				# HELP kube_pod_container_resource_limits_memory_bytes Bytes of memory requested limit by a container.
-				# HELP kube_pod_container_resource_limits_storage_bytes Bytes of storage requested limit by a container.
-				# HELP kube_pod_container_resource_requests The number of requested request resource by a container.
-				# HELP kube_pod_container_resource_requests_cpu_cores The number of CPU cores requested by a container.
-				# HELP kube_pod_container_resource_requests_ephemeral_storage_bytes Bytes of ephemeral-storage requested by a container.
-				# HELP kube_pod_container_resource_requests_memory_bytes Bytes of memory requested by a container.
-				# HELP kube_pod_container_resource_requests_storage_bytes Bytes of storage requested by a container.
-				# HELP kube_pod_init_container_resource_limits The number of requested limit resource by an init container.
-				# HELP kube_pod_init_container_resource_limits_cpu_cores The number of CPU cores requested limit by an init container.
-				# HELP kube_pod_init_container_resource_limits_ephemeral_storage_bytes Bytes of ephemeral-storage requested limit by an init container.
-				# HELP kube_pod_init_container_resource_limits_memory_bytes Bytes of memory requested limit by an init container.
-				# HELP kube_pod_init_container_resource_limits_storage_bytes Bytes of storage requested limit by an init container.
-				# HELP kube_pod_init_container_resource_requests The number of requested request resource by an init container.
-				# HELP kube_pod_init_container_resource_requests_cpu_cores The number of CPU cores requested by an init container.
-				# HELP kube_pod_init_container_resource_requests_ephemeral_storage_bytes Bytes of ephemeral-storage requested by an init container.
-				# HELP kube_pod_init_container_resource_requests_memory_bytes Bytes of memory requested by an init container.
-				# HELP kube_pod_init_container_resource_requests_storage_bytes Bytes of storage requested by an init container.
-				# HELP kube_pod_init_container_status_last_terminated_reason Describes the last reason the init container was in terminated state.
-				# TYPE kube_pod_container_resource_limits gauge
-				# TYPE kube_pod_container_resource_limits_cpu_cores gauge
-				# TYPE kube_pod_container_resource_limits_ephemeral_storage_bytes gauge
-				# TYPE kube_pod_container_resource_limits_memory_bytes gauge
-				# TYPE kube_pod_container_resource_limits_storage_bytes gauge
-				# TYPE kube_pod_container_resource_requests gauge
-				# TYPE kube_pod_container_resource_requests_cpu_cores gauge
-				# TYPE kube_pod_container_resource_requests_ephemeral_storage_bytes gauge
-				# TYPE kube_pod_container_resource_requests_memory_bytes gauge
-				# TYPE kube_pod_container_resource_requests_storage_bytes gauge
-				# TYPE kube_pod_init_container_resource_limits gauge
-				# TYPE kube_pod_init_container_resource_limits_cpu_cores gauge
-				# TYPE kube_pod_init_container_resource_limits_ephemeral_storage_bytes gauge
-				# TYPE kube_pod_init_container_resource_limits_memory_bytes gauge
-				# TYPE kube_pod_init_container_resource_limits_storage_bytes gauge
-				# TYPE kube_pod_init_container_resource_requests gauge
-				# TYPE kube_pod_init_container_resource_requests_cpu_cores gauge
-				# TYPE kube_pod_init_container_resource_requests_ephemeral_storage_bytes gauge
-				# TYPE kube_pod_init_container_resource_requests_memory_bytes gauge
-				# TYPE kube_pod_init_container_resource_requests_storage_bytes gauge
-				# TYPE kube_pod_init_container_status_last_terminated_reason gauge
-				kube_pod_container_resource_limits_cpu_cores{container="pod1_con1",namespace="ns1",pod="pod1"} 0.2
-				kube_pod_container_resource_limits_cpu_cores{container="pod1_con2",namespace="ns1",pod="pod1"} 0.3
-				kube_pod_container_resource_limits_ephemeral_storage_bytes{container="pod1_con1",namespace="ns1",pod="pod1"} 3e+08
-				kube_pod_container_resource_limits_memory_bytes{container="pod1_con1",namespace="ns1",pod="pod1"} 1e+08
-				kube_pod_container_resource_limits_memory_bytes{container="pod1_con2",namespace="ns1",pod="pod1"} 2e+08
-				kube_pod_container_resource_limits_storage_bytes{container="pod1_con1",namespace="ns1",pod="pod1"} 4e+08
-				kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
-				kube_pod_container_resource_requests_cpu_cores{container="pod1_con1",namespace="ns1",pod="pod1"} 0.2
-				kube_pod_container_resource_requests_cpu_cores{container="pod1_con2",namespace="ns1",pod="pod1"} 0.3
-				kube_pod_container_resource_requests_ephemeral_storage_bytes{container="pod1_con1",namespace="ns1",pod="pod1"} 3e+08
-				kube_pod_container_resource_requests_memory_bytes{container="pod1_con1",namespace="ns1",pod="pod1"} 1e+08
-				kube_pod_container_resource_requests_memory_bytes{container="pod1_con2",namespace="ns1",pod="pod1"} 2e+08
-				kube_pod_container_resource_requests_storage_bytes{container="pod1_con1",namespace="ns1",pod="pod1"} 4e+08
-				kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
-				kube_pod_init_container_resource_limits_cpu_cores{container="pod1_initcon1",namespace="ns1",pod="pod1"} 0.2
-				kube_pod_init_container_resource_limits_ephemeral_storage_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 3e+08
-				kube_pod_init_container_resource_limits_memory_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 1e+08
-				kube_pod_init_container_resource_limits_storage_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 4e+08
-				kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
-				kube_pod_init_container_resource_requests_cpu_cores{container="pod1_initcon1",namespace="ns1",pod="pod1"} 0.2
-				kube_pod_init_container_resource_requests_ephemeral_storage_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 3e+08
-				kube_pod_init_container_resource_requests_memory_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 1e+08
-				kube_pod_init_container_resource_requests_storage_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 4e+08
-				kube_pod_init_container_resource_requests{container="pod1_initcon1",namespace="ns1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
+		# HELP kube_pod_container_resource_limits The number of requested limit resource by a container.
+        # HELP kube_pod_container_resource_requests The number of requested request resource by a container.
+        # HELP kube_pod_init_container_resource_limits The number of requested limit resource by an init container.
+        # HELP kube_pod_init_container_resource_limits_cpu_cores The number of CPU cores requested limit by an init container.
+        # HELP kube_pod_init_container_resource_limits_ephemeral_storage_bytes Bytes of ephemeral-storage requested limit by an init container.
+        # HELP kube_pod_init_container_resource_limits_memory_bytes Bytes of memory requested limit by an init container.
+        # HELP kube_pod_init_container_resource_limits_storage_bytes Bytes of storage requested limit by an init container.
+        # HELP kube_pod_init_container_resource_requests The number of requested request resource by an init container.
+        # HELP kube_pod_init_container_resource_requests_cpu_cores The number of CPU cores requested by an init container.
+        # HELP kube_pod_init_container_resource_requests_ephemeral_storage_bytes Bytes of ephemeral-storage requested by an init container.
+        # HELP kube_pod_init_container_resource_requests_memory_bytes Bytes of memory requested by an init container.
+        # HELP kube_pod_init_container_resource_requests_storage_bytes Bytes of storage requested by an init container.
+        # HELP kube_pod_init_container_status_last_terminated_reason Describes the last reason the init container was in terminated state.
+        # TYPE kube_pod_container_resource_limits gauge
+        # TYPE kube_pod_container_resource_requests gauge
+        # TYPE kube_pod_init_container_resource_limits gauge
+        # TYPE kube_pod_init_container_resource_limits_cpu_cores gauge
+        # TYPE kube_pod_init_container_resource_limits_ephemeral_storage_bytes gauge
+        # TYPE kube_pod_init_container_resource_limits_memory_bytes gauge
+        # TYPE kube_pod_init_container_resource_limits_storage_bytes gauge
+        # TYPE kube_pod_init_container_resource_requests gauge
+        # TYPE kube_pod_init_container_resource_requests_cpu_cores gauge
+        # TYPE kube_pod_init_container_resource_requests_ephemeral_storage_bytes gauge
+        # TYPE kube_pod_init_container_resource_requests_memory_bytes gauge
+        # TYPE kube_pod_init_container_resource_requests_storage_bytes gauge
+        # TYPE kube_pod_init_container_status_last_terminated_reason gauge
+        kube_pod_container_resource_limits{container="pod1_con1",namespace="ns1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
+        kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="",pod="pod1",resource="cpu",unit="core"} 0.2
+        kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="",pod="pod1",resource="ephemeral_storage",unit="byte"} 3e+08
+        kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="",pod="pod1",resource="memory",unit="byte"} 1e+08
+        kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
+        kube_pod_container_resource_requests{container="pod1_con1",namespace="ns1",node="",pod="pod1",resource="storage",unit="byte"} 4e+08
+        kube_pod_container_resource_requests{container="pod1_con2",namespace="ns1",node="",pod="pod1",resource="cpu",unit="core"} 0.3
+        kube_pod_container_resource_requests{container="pod1_con2",namespace="ns1",node="",pod="pod1",resource="memory",unit="byte"} 2e+08
+        kube_pod_init_container_resource_limits_cpu_cores{container="pod1_initcon1",namespace="ns1",pod="pod1"} 0.2
+        kube_pod_init_container_resource_limits_ephemeral_storage_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 3e+08
+        kube_pod_init_container_resource_limits_memory_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 1e+08
+        kube_pod_init_container_resource_limits_storage_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 4e+08
+        kube_pod_init_container_resource_limits{container="pod1_initcon1",namespace="ns1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
+        kube_pod_init_container_resource_requests_cpu_cores{container="pod1_initcon1",namespace="ns1",pod="pod1"} 0.2
+        kube_pod_init_container_resource_requests_ephemeral_storage_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 3e+08
+        kube_pod_init_container_resource_requests_memory_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 1e+08
+        kube_pod_init_container_resource_requests_storage_bytes{container="pod1_initcon1",namespace="ns1",pod="pod1"} 4e+08
+        kube_pod_init_container_resource_requests{container="pod1_initcon1",namespace="ns1",pod="pod1",resource="nvidia_com_gpu",unit="integer"} 1
 		`,
 			MetricNames: []string{
 				"kube_pod_container_resource_requests",
-				"kube_pod_container_resource_requests_memory_bytes",
-				"kube_pod_container_resource_requests_storage_bytes",
-				"kube_pod_container_resource_requests_ephemeral_storage_bytes",
 				"kube_pod_container_resource_limits",
 				"kube_pod_init_container_resource_limits",
 				"kube_pod_init_container_resource_requests",
@@ -1512,34 +1487,14 @@ kube_pod_container_status_last_terminated_reason{container="container7",namespac
 				},
 			},
 			Want: `
-				# HELP kube_pod_container_resource_limits_cpu_cores The number of CPU cores requested limit by a container.
-				# HELP kube_pod_container_resource_limits_memory_bytes Bytes of memory requested limit by a container.
-				# HELP kube_pod_container_resource_requests_cpu_cores The number of CPU cores requested by a container.
-				# HELP kube_pod_container_resource_requests_memory_bytes Bytes of memory requested by a container.
-				# HELP kube_pod_init_container_resource_limits_cpu_cores The number of CPU cores requested limit by an init container.
-				# HELP kube_pod_init_container_resource_limits_memory_bytes Bytes of memory requested limit by an init container.
-				# TYPE kube_pod_container_resource_limits_cpu_cores gauge
-				# TYPE kube_pod_container_resource_limits_memory_bytes gauge
-				# TYPE kube_pod_container_resource_requests_cpu_cores gauge
-				# TYPE kube_pod_container_resource_requests_memory_bytes gauge
-				# TYPE kube_pod_init_container_resource_limits_cpu_cores gauge
-				# TYPE kube_pod_init_container_resource_limits_memory_bytes gauge
-				kube_pod_container_resource_requests_cpu_cores{container="pod2_con1",namespace="ns2",pod="pod2"} 0.4
-				kube_pod_container_resource_requests_cpu_cores{container="pod2_con2",namespace="ns2",pod="pod2"} 0.5
-				kube_pod_container_resource_requests_memory_bytes{container="pod2_con1",namespace="ns2",pod="pod2"} 3e+08
-				kube_pod_container_resource_requests_memory_bytes{container="pod2_con2",namespace="ns2",pod="pod2"} 4e+08
-				kube_pod_container_resource_limits_cpu_cores{container="pod2_con1",namespace="ns2",pod="pod2"} 0.4
-				kube_pod_container_resource_limits_cpu_cores{container="pod2_con2",namespace="ns2",pod="pod2"} 0.5
-				kube_pod_container_resource_limits_memory_bytes{container="pod2_con1",namespace="ns2",pod="pod2"} 3e+08
-				kube_pod_container_resource_limits_memory_bytes{container="pod2_con2",namespace="ns2",pod="pod2"} 4e+08
-				kube_pod_init_container_resource_limits_cpu_cores{container="pod2_initcon1",namespace="ns2",pod="pod2"} 0.4
-				kube_pod_init_container_resource_limits_memory_bytes{container="pod2_initcon1",namespace="ns2",pod="pod2"} 3e+08
+		# HELP kube_pod_init_container_resource_limits_cpu_cores The number of CPU cores requested limit by an init container.
+        # HELP kube_pod_init_container_resource_limits_memory_bytes Bytes of memory requested limit by an init container.
+        # TYPE kube_pod_init_container_resource_limits_cpu_cores gauge
+        # TYPE kube_pod_init_container_resource_limits_memory_bytes gauge
+        kube_pod_init_container_resource_limits_cpu_cores{container="pod2_initcon1",namespace="ns2",pod="pod2"} 0.4
+        kube_pod_init_container_resource_limits_memory_bytes{container="pod2_initcon1",namespace="ns2",pod="pod2"} 3e+08
 		`,
 			MetricNames: []string{
-				"kube_pod_container_resource_requests_cpu_cores",
-				"kube_pod_container_resource_requests_memory_bytes",
-				"kube_pod_container_resource_limits_cpu_cores",
-				"kube_pod_container_resource_limits_memory_bytes",
 				"kube_pod_init_container_resource_limits_cpu_cores",
 				"kube_pod_init_container_resource_limits_memory_bytes",
 			},
@@ -1695,7 +1650,7 @@ func BenchmarkPodStore(b *testing.B) {
 		},
 	}
 
-	expectedFamilies := 57
+	expectedFamilies := 49
 	for n := 0; n < b.N; n++ {
 		families := f(pod)
 		if len(families) != expectedFamilies {

--- a/main_test.go
+++ b/main_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http/httptest"
 	"sort"
@@ -163,197 +164,175 @@ func TestFullScrapeCycle(t *testing.T) {
 
 	body, _ := ioutil.ReadAll(resp.Body)
 
-	expected := `# HELP kube_pod_info Information about pod.
-# TYPE kube_pod_info gauge
-kube_pod_info{namespace="default",pod="pod0",host_ip="1.1.1.1",pod_ip="1.2.3.4",uid="abc-0",node="node1",created_by_kind="<none>",created_by_name="<none>",priority_class="",host_network="false"} 1
-# HELP kube_pod_start_time Start time in unix timestamp for a pod.
-# TYPE kube_pod_start_time gauge
-# HELP kube_pod_container_state_started Start time in unix timestamp for a pod container.
-# TYPE kube_pod_container_state_started gauge
-# HELP kube_pod_completion_time Completion time in unix timestamp for a pod.
-# TYPE kube_pod_completion_time gauge
-# HELP kube_pod_owner Information about the Pod's owner.
-# TYPE kube_pod_owner gauge
-kube_pod_owner{namespace="default",pod="pod0",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
-# HELP kube_pod_labels Kubernetes labels converted to Prometheus labels.
-# TYPE kube_pod_labels gauge
-kube_pod_labels{namespace="default",pod="pod0"} 1
-# HELP kube_pod_created Unix creation timestamp
-# TYPE kube_pod_created gauge
-kube_pod_created{namespace="default",pod="pod0"} 1.5e+09
-# HELP kube_pod_deletion_timestamp Unix deletion timestamp
-# TYPE kube_pod_deletion_timestamp gauge
-# HELP kube_pod_restart_policy Describes the restart policy in use by this pod.
-# TYPE kube_pod_restart_policy gauge
-kube_pod_restart_policy{namespace="default",pod="pod0",type="Always"} 1
-# HELP kube_pod_status_scheduled_time Unix timestamp when pod moved into scheduled status
-# TYPE kube_pod_status_scheduled_time gauge
-# HELP kube_pod_status_unschedulable Describes the unschedulable status for the pod.
-# TYPE kube_pod_status_unschedulable gauge
-# HELP kube_pod_status_phase The pods current phase.
-# TYPE kube_pod_status_phase gauge
-kube_pod_status_phase{namespace="default",pod="pod0",phase="Pending"} 0
-kube_pod_status_phase{namespace="default",pod="pod0",phase="Succeeded"} 0
-kube_pod_status_phase{namespace="default",pod="pod0",phase="Failed"} 0
-kube_pod_status_phase{namespace="default",pod="pod0",phase="Unknown"} 0
-kube_pod_status_phase{namespace="default",pod="pod0",phase="Running"} 1
-# HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
-# TYPE kube_pod_status_ready gauge
-# HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
-# TYPE kube_pod_status_scheduled gauge
-# HELP kube_pod_status_reason The pod status reasons
-# TYPE kube_pod_status_reason gauge
-kube_pod_status_reason{namespace="default",pod="pod0",reason="NodeLost"} 0
-kube_pod_status_reason{namespace="default",pod="pod0",reason="Evicted"} 0
-kube_pod_status_reason{namespace="default",pod="pod0",reason="UnexpectedAdmissionError"} 0
+	expected := `# HELP kube_pod_completion_time Completion time in unix timestamp for a pod.
 # HELP kube_pod_container_info Information about a container in a pod.
+# HELP kube_pod_container_resource_limits The number of requested limit resource by a container.
+# HELP kube_pod_container_resource_requests The number of requested request resource by a container.
+# HELP kube_pod_container_state_started Start time in unix timestamp for a pod container.
+# HELP kube_pod_container_status_last_terminated_reason Describes the last reason the container was in terminated state.
+# HELP kube_pod_container_status_ready Describes whether the containers readiness check succeeded.
+# HELP kube_pod_container_status_restarts_total The number of container restarts per container.
+# HELP kube_pod_container_status_running Describes whether the container is currently in running state.
+# HELP kube_pod_container_status_terminated Describes whether the container is currently in terminated state.
+# HELP kube_pod_container_status_terminated_reason Describes the reason the container is currently in terminated state.
+# HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
+# HELP kube_pod_container_status_waiting_reason Describes the reason the container is currently in waiting state.
+# HELP kube_pod_created Unix creation timestamp
+# HELP kube_pod_deletion_timestamp Unix deletion timestamp
+# HELP kube_pod_info Information about pod.
+# HELP kube_pod_init_container_info Information about an init container in a pod.
+# HELP kube_pod_init_container_resource_limits The number of requested limit resource by an init container.
+# HELP kube_pod_init_container_resource_limits_cpu_cores The number of CPU cores requested limit by an init container.
+# HELP kube_pod_init_container_resource_limits_ephemeral_storage_bytes Bytes of ephemeral-storage requested limit by an init container.
+# HELP kube_pod_init_container_resource_limits_memory_bytes Bytes of memory requested limit by an init container.
+# HELP kube_pod_init_container_resource_limits_storage_bytes Bytes of storage requested limit by an init container.
+# HELP kube_pod_init_container_resource_requests The number of requested request resource by an init container.
+# HELP kube_pod_init_container_resource_requests_cpu_cores The number of CPU cores requested by an init container.
+# HELP kube_pod_init_container_resource_requests_ephemeral_storage_bytes Bytes of ephemeral-storage requested by an init container.
+# HELP kube_pod_init_container_resource_requests_memory_bytes Bytes of memory requested by an init container.
+# HELP kube_pod_init_container_resource_requests_storage_bytes Bytes of storage requested by an init container.
+# HELP kube_pod_init_container_status_last_terminated_reason Describes the last reason the init container was in terminated state.
+# HELP kube_pod_init_container_status_ready Describes whether the init containers readiness check succeeded.
+# HELP kube_pod_init_container_status_restarts_total The number of restarts for the init container.
+# HELP kube_pod_init_container_status_running Describes whether the init container is currently in running state.
+# HELP kube_pod_init_container_status_terminated Describes whether the init container is currently in terminated state.
+# HELP kube_pod_init_container_status_terminated_reason Describes the reason the init container is currently in terminated state.
+# HELP kube_pod_init_container_status_waiting Describes whether the init container is currently in waiting state.
+# HELP kube_pod_init_container_status_waiting_reason Describes the reason the init container is currently in waiting state.
+# HELP kube_pod_labels Kubernetes labels converted to Prometheus labels.
+# HELP kube_pod_overhead_cpu_cores The pod overhead in regards to cpu cores associated with running a pod.
+# HELP kube_pod_overhead_memory_bytes The pod overhead in regards to memory associated with running a pod.
+# HELP kube_pod_owner Information about the Pod's owner.
+# HELP kube_pod_restart_policy Describes the restart policy in use by this pod.
+# HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
+# HELP kube_pod_spec_volumes_persistentvolumeclaims_readonly Describes whether a persistentvolumeclaim is mounted read only.
+# HELP kube_pod_start_time Start time in unix timestamp for a pod.
+# HELP kube_pod_status_phase The pods current phase.
+# HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
+# HELP kube_pod_status_reason The pod status reasons
+# HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
+# HELP kube_pod_status_scheduled_time Unix timestamp when pod moved into scheduled status
+# HELP kube_pod_status_unschedulable Describes the unschedulable status for the pod.
+# TYPE kube_pod_completion_time gauge
 # TYPE kube_pod_container_info gauge
+# TYPE kube_pod_container_resource_limits gauge
+# TYPE kube_pod_container_resource_requests gauge
+# TYPE kube_pod_container_state_started gauge
+# TYPE kube_pod_container_status_last_terminated_reason gauge
+# TYPE kube_pod_container_status_ready gauge
+# TYPE kube_pod_container_status_restarts_total counter
+# TYPE kube_pod_container_status_running gauge
+# TYPE kube_pod_container_status_terminated gauge
+# TYPE kube_pod_container_status_terminated_reason gauge
+# TYPE kube_pod_container_status_waiting gauge
+# TYPE kube_pod_container_status_waiting_reason gauge
+# TYPE kube_pod_created gauge
+# TYPE kube_pod_deletion_timestamp gauge
+# TYPE kube_pod_info gauge
+# TYPE kube_pod_init_container_info gauge
+# TYPE kube_pod_init_container_resource_limits gauge
+# TYPE kube_pod_init_container_resource_limits_cpu_cores gauge
+# TYPE kube_pod_init_container_resource_limits_ephemeral_storage_bytes gauge
+# TYPE kube_pod_init_container_resource_limits_memory_bytes gauge
+# TYPE kube_pod_init_container_resource_limits_storage_bytes gauge
+# TYPE kube_pod_init_container_resource_requests gauge
+# TYPE kube_pod_init_container_resource_requests_cpu_cores gauge
+# TYPE kube_pod_init_container_resource_requests_ephemeral_storage_bytes gauge
+# TYPE kube_pod_init_container_resource_requests_memory_bytes gauge
+# TYPE kube_pod_init_container_resource_requests_storage_bytes gauge
+# TYPE kube_pod_init_container_status_last_terminated_reason gauge
+# TYPE kube_pod_init_container_status_ready gauge
+# TYPE kube_pod_init_container_status_restarts_total counter
+# TYPE kube_pod_init_container_status_running gauge
+# TYPE kube_pod_init_container_status_terminated gauge
+# TYPE kube_pod_init_container_status_terminated_reason gauge
+# TYPE kube_pod_init_container_status_waiting gauge
+# TYPE kube_pod_init_container_status_waiting_reason gauge
+# TYPE kube_pod_labels gauge
+# TYPE kube_pod_overhead_cpu_cores gauge
+# TYPE kube_pod_overhead_memory_bytes gauge
+# TYPE kube_pod_owner gauge
+# TYPE kube_pod_restart_policy gauge
+# TYPE kube_pod_spec_volumes_persistentvolumeclaims_info gauge
+# TYPE kube_pod_spec_volumes_persistentvolumeclaims_readonly gauge
+# TYPE kube_pod_start_time gauge
+# TYPE kube_pod_status_phase gauge
+# TYPE kube_pod_status_ready gauge
+# TYPE kube_pod_status_reason gauge
+# TYPE kube_pod_status_scheduled gauge
+# TYPE kube_pod_status_scheduled_time gauge
+# TYPE kube_pod_status_unschedulable gauge
 kube_pod_container_info{namespace="default",pod="pod0",container="container2",image="k8s.gcr.io/hyperkube2",image_id="docker://sha256:bbb",container_id="docker://cd456"} 1
 kube_pod_container_info{namespace="default",pod="pod0",container="container3",image="k8s.gcr.io/hyperkube3",image_id="docker://sha256:ccc",container_id="docker://ef789"} 1
-# HELP kube_pod_init_container_info Information about an init container in a pod.
-# TYPE kube_pod_init_container_info gauge
-# HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
-# TYPE kube_pod_container_status_waiting gauge
-kube_pod_container_status_waiting{namespace="default",pod="pod0",container="container2"} 1
-kube_pod_container_status_waiting{namespace="default",pod="pod0",container="container3"} 0
-# HELP kube_pod_init_container_status_waiting Describes whether the init container is currently in waiting state.
-# TYPE kube_pod_init_container_status_waiting gauge
-# HELP kube_pod_container_status_waiting_reason Describes the reason the container is currently in waiting state.
-# TYPE kube_pod_container_status_waiting_reason gauge
+kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",resource="nvidia_com_gpu",unit="integer"} 1
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="cpu",unit="core"} 0.2
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="ephemeral_storage",unit="byte"} 3e+08
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="memory",unit="byte"} 1e+08
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="nvidia_com_gpu",unit="integer"} 1
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",node="node1",resource="storage",unit="byte"} 4e+08
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="cpu",unit="core"} 0.3
+kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con2",node="node1",resource="memory",unit="byte"} 2e+08
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="OOMKilled"} 1
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="OOMKilled"} 0
+kube_pod_container_status_ready{namespace="default",pod="pod0",container="container2"} 0
+kube_pod_container_status_ready{namespace="default",pod="pod0",container="container3"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="pod0",container="container2"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="pod0",container="container3"} 0
+kube_pod_container_status_running{namespace="default",pod="pod0",container="container2"} 0
+kube_pod_container_status_running{namespace="default",pod="pod0",container="container3"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="OOMKilled"} 0
+kube_pod_container_status_terminated{namespace="default",pod="pod0",container="container2"} 0
+kube_pod_container_status_terminated{namespace="default",pod="pod0",container="container3"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="ContainerCreating"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="CrashLoopBackOff"} 1
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="CreateContainerError"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="ErrImagePull"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="ImagePullBackOff"} 0
-kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="CreateContainerError"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container2",reason="InvalidImageName"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="ContainerCreating"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="CrashLoopBackOff"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="CreateContainerError"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="ErrImagePull"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="ImagePullBackOff"} 0
-kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="CreateContainerError"} 0
 kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",container="container3",reason="InvalidImageName"} 0
-# HELP kube_pod_init_container_status_waiting_reason Describes the reason the init container is currently in waiting state.
-# TYPE kube_pod_init_container_status_waiting_reason gauge
-# HELP kube_pod_container_status_running Describes whether the container is currently in running state.
-# TYPE kube_pod_container_status_running gauge
-kube_pod_container_status_running{namespace="default",pod="pod0",container="container2"} 0
-kube_pod_container_status_running{namespace="default",pod="pod0",container="container3"} 0
-# HELP kube_pod_init_container_status_running Describes whether the init container is currently in running state.
-# TYPE kube_pod_init_container_status_running gauge
-# HELP kube_pod_container_status_terminated Describes whether the container is currently in terminated state.
-# TYPE kube_pod_container_status_terminated gauge
-kube_pod_container_status_terminated{namespace="default",pod="pod0",container="container2"} 0
-kube_pod_container_status_terminated{namespace="default",pod="pod0",container="container3"} 0
-# HELP kube_pod_init_container_status_terminated Describes whether the init container is currently in terminated state.
-# TYPE kube_pod_init_container_status_terminated gauge
-# HELP kube_pod_container_status_terminated_reason Describes the reason the container is currently in terminated state.
-# TYPE kube_pod_container_status_terminated_reason gauge
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="OOMKilled"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Completed"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Error"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="ContainerCannotRun"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="DeadlineExceeded"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Evicted"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="OOMKilled"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Completed"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Error"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="ContainerCannotRun"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="DeadlineExceeded"} 0
-kube_pod_container_status_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Evicted"} 0
-# HELP kube_pod_init_container_status_terminated_reason Describes the reason the init container is currently in terminated state.
-# TYPE kube_pod_init_container_status_terminated_reason gauge
-# HELP kube_pod_container_status_last_terminated_reason Describes the last reason the container was in terminated state.
-# TYPE kube_pod_container_status_last_terminated_reason gauge
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="OOMKilled"} 1
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Completed"} 0
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Error"} 0
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="ContainerCannotRun"} 0
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="DeadlineExceeded"} 0
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container2",reason="Evicted"} 0
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="OOMKilled"} 0
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Completed"} 0
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Error"} 0
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="ContainerCannotRun"} 0
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="DeadlineExceeded"} 0
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",container="container3",reason="Evicted"} 0
-# HELP kube_pod_init_container_status_last_terminated_reason Describes the last reason the init container was in terminated state.
-# TYPE kube_pod_init_container_status_last_terminated_reason gauge
-# HELP kube_pod_container_status_ready Describes whether the containers readiness check succeeded.
-# TYPE kube_pod_container_status_ready gauge
-kube_pod_container_status_ready{namespace="default",pod="pod0",container="container2"} 0
-kube_pod_container_status_ready{namespace="default",pod="pod0",container="container3"} 0
-# HELP kube_pod_init_container_status_ready Describes whether the init containers readiness check succeeded.
-# TYPE kube_pod_init_container_status_ready gauge
-# HELP kube_pod_container_status_restarts_total The number of container restarts per container.
-# TYPE kube_pod_container_status_restarts_total counter
-kube_pod_container_status_restarts_total{namespace="default",pod="pod0",container="container2"} 0
-kube_pod_container_status_restarts_total{namespace="default",pod="pod0",container="container3"} 0
-# HELP kube_pod_init_container_status_restarts_total The number of restarts for the init container.
-# TYPE kube_pod_init_container_status_restarts_total counter
-# HELP kube_pod_container_resource_requests_cpu_cores The number of CPU cores requested by a container.
-# TYPE kube_pod_container_resource_requests_cpu_cores gauge
-kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="pod0",container="pod1_con1"} 0.2
-kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="pod0",container="pod1_con2"} 0.3
-# HELP kube_pod_container_resource_requests_memory_bytes Bytes of memory requested by a container.
-# TYPE kube_pod_container_resource_requests_memory_bytes gauge
-kube_pod_container_resource_requests_memory_bytes{namespace="default",pod="pod0",container="pod1_con1"} 1e+08
-kube_pod_container_resource_requests_memory_bytes{namespace="default",pod="pod0",container="pod1_con2"} 2e+08
-# HELP kube_pod_container_resource_requests_storage_bytes Bytes of storage requested by a container.
-# TYPE kube_pod_container_resource_requests_storage_bytes gauge
-kube_pod_container_resource_requests_storage_bytes{namespace="default",pod="pod0",container="pod1_con1"} 4e+08
-# HELP kube_pod_container_resource_requests_ephemeral_storage_bytes Bytes of ephemeral-storage requested by a container.
-# TYPE kube_pod_container_resource_requests_ephemeral_storage_bytes gauge
-kube_pod_container_resource_requests_ephemeral_storage_bytes{namespace="default",pod="pod0",container="pod1_con1"} 3e+08
-# HELP kube_pod_container_resource_requests The number of requested request resource by a container.
-# TYPE kube_pod_container_resource_requests gauge
-kube_pod_container_resource_requests{namespace="default",pod="pod0",container="pod1_con1",resource="nvidia_com_gpu",unit="integer"} 1
-# HELP kube_pod_container_resource_limits_cpu_cores The number of CPU cores requested limit by a container.
-# TYPE kube_pod_container_resource_limits_cpu_cores gauge
-kube_pod_container_resource_limits_cpu_cores{namespace="default",pod="pod0",container="pod1_con1"} 0.2
-kube_pod_container_resource_limits_cpu_cores{namespace="default",pod="pod0",container="pod1_con2"} 0.3
-# HELP kube_pod_container_resource_limits_memory_bytes Bytes of memory requested limit by a container.
-# TYPE kube_pod_container_resource_limits_memory_bytes gauge
-kube_pod_container_resource_limits_memory_bytes{namespace="default",pod="pod0",container="pod1_con1"} 1e+08
-kube_pod_container_resource_limits_memory_bytes{namespace="default",pod="pod0",container="pod1_con2"} 2e+08
-# HELP kube_pod_container_resource_limits_storage_bytes Bytes of storage requested limit by a container.
-# TYPE kube_pod_container_resource_limits_storage_bytes gauge
-kube_pod_container_resource_limits_storage_bytes{namespace="default",pod="pod0",container="pod1_con1"} 4e+08
-# HELP kube_pod_container_resource_limits_ephemeral_storage_bytes Bytes of ephemeral-storage requested limit by a container.
-# TYPE kube_pod_container_resource_limits_ephemeral_storage_bytes gauge
-kube_pod_container_resource_limits_ephemeral_storage_bytes{namespace="default",pod="pod0",container="pod1_con1"} 3e+08
-# HELP kube_pod_container_resource_limits The number of requested limit resource by a container.
-# TYPE kube_pod_container_resource_limits gauge
-kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod1_con1",resource="nvidia_com_gpu",unit="integer"} 1
-# HELP kube_pod_init_container_resource_requests_cpu_cores The number of CPU cores requested by an init container.
-# TYPE kube_pod_init_container_resource_requests_cpu_cores gauge
-# HELP kube_pod_init_container_resource_requests_memory_bytes Bytes of memory requested by an init container.
-# TYPE kube_pod_init_container_resource_requests_memory_bytes gauge
-# HELP kube_pod_init_container_resource_requests_storage_bytes Bytes of storage requested by an init container.
-# TYPE kube_pod_init_container_resource_requests_storage_bytes gauge
-# HELP kube_pod_init_container_resource_requests_ephemeral_storage_bytes Bytes of ephemeral-storage requested by an init container.
-# TYPE kube_pod_init_container_resource_requests_ephemeral_storage_bytes gauge
-# HELP kube_pod_init_container_resource_requests The number of requested request resource by an init container.
-# TYPE kube_pod_init_container_resource_requests gauge
-# HELP kube_pod_init_container_resource_limits_cpu_cores The number of CPU cores requested limit by an init container.
-# TYPE kube_pod_init_container_resource_limits_cpu_cores gauge
-# HELP kube_pod_init_container_resource_limits_memory_bytes Bytes of memory requested limit by an init container.
-# TYPE kube_pod_init_container_resource_limits_memory_bytes gauge
-# HELP kube_pod_init_container_resource_limits_storage_bytes Bytes of storage requested limit by an init container.
-# TYPE kube_pod_init_container_resource_limits_storage_bytes gauge
-# HELP kube_pod_init_container_resource_limits_ephemeral_storage_bytes Bytes of ephemeral-storage requested limit by an init container.
-# TYPE kube_pod_init_container_resource_limits_ephemeral_storage_bytes gauge
-# HELP kube_pod_init_container_resource_limits The number of requested limit resource by an init container.
-# TYPE kube_pod_init_container_resource_limits gauge
-# HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
-# TYPE kube_pod_spec_volumes_persistentvolumeclaims_info gauge
-# HELP kube_pod_spec_volumes_persistentvolumeclaims_readonly Describes whether a persistentvolumeclaim is mounted read only.
-# TYPE kube_pod_spec_volumes_persistentvolumeclaims_readonly gauge
-# HELP kube_pod_overhead_cpu_cores The pod overhead in regards to cpu cores associated with running a pod.
-# TYPE kube_pod_overhead_cpu_cores gauge
-# HELP kube_pod_overhead_memory_bytes The pod overhead in regards to memory associated with running a pod.
-# TYPE kube_pod_overhead_memory_bytes gauge
+kube_pod_container_status_waiting{namespace="default",pod="pod0",container="container2"} 1
+kube_pod_container_status_waiting{namespace="default",pod="pod0",container="container3"} 0
+kube_pod_created{namespace="default",pod="pod0"} 1.5e+09
+kube_pod_info{namespace="default",pod="pod0",host_ip="1.1.1.1",pod_ip="1.2.3.4",uid="abc-0",node="node1",created_by_kind="<none>",created_by_name="<none>",priority_class="",host_network="false"} 1
+kube_pod_labels{namespace="default",pod="pod0"} 1
+kube_pod_owner{namespace="default",pod="pod0",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_restart_policy{namespace="default",pod="pod0",type="Always"} 1
+kube_pod_status_phase{namespace="default",pod="pod0",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="pod0",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="pod0",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="pod0",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="pod0",phase="Unknown"} 0
+kube_pod_status_reason{namespace="default",pod="pod0",reason="Evicted"} 0
+kube_pod_status_reason{namespace="default",pod="pod0",reason="NodeLost"} 0
+kube_pod_status_reason{namespace="default",pod="pod0",reason="UnexpectedAdmissionError"} 0
 `
 
 	expectedSplit := strings.Split(strings.TrimSpace(expected), "\n")
@@ -371,12 +350,14 @@ kube_pod_container_resource_limits{namespace="default",pod="pod0",container="pod
 	sort.Strings(gotFiltered)
 
 	if len(expectedSplit) != len(gotFiltered) {
-		t.Fatalf("expected different output length, expected \n\n%s\n\ngot\n\n%s", expected, string(body))
+		fmt.Println(len(expectedSplit))
+		fmt.Println(len(gotFiltered))
+		t.Fatalf("expected different output length, expected \n\n%s\n\ngot\n\n%s", expected, strings.Join(gotFiltered, "\n"))
 	}
 
 	for i := 0; i < len(expectedSplit); i++ {
 		if expectedSplit[i] != gotFiltered[i] {
-			t.Fatalf("expected:\n\n%v, but got:\n\n%v", expectedSplit[i], gotFiltered[i])
+			t.Fatalf("expected:\n\n%v\n, but got:\n\n%v", expectedSplit[i], gotFiltered[i])
 		}
 	}
 }


### PR DESCRIPTION
After some talk with @brancz who initially did the work for reworking resource metrics we decided to revert the PR, as the KEP that will introduce more detailed resource metrics has been accepted now https://github.com/kubernetes/enhancements/pull/1916 this better aligns the resource metrics to the ones proposed in that KEP, this will prevent users from needing to do triple migration if they want to switch any alerting/recording rules to new metrics and avoid potential confusion. If we were to keep current metrics with the unit suffix the migration work would double, this way potentially only metric name would need to be adjusted.

Closes https://github.com/kubernetes/kube-state-metrics/issues/1263

cc @brancz as agreed before. @tariq1890 PTAL, thanks!