### PR TITLE
allow metric labels by default

### DIFF
--- a/internal/store/metriclabels.go
+++ b/internal/store/metriclabels.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import "k8s.io/kube-state-metrics/v2/pkg/allow"
+
+func init() {
+	var labels []string
+	for _, lbls := range [][]string{
+		descCSRLabelsDefaultLabels,
+		descConfigMapLabelsDefaultLabels,
+		descCronJobLabelsDefaultLabels,
+		descDaemonSetLabelsDefaultLabels,
+		descDeploymentLabelsDefaultLabels,
+		descEndpointLabelsDefaultLabels,
+		descHorizontalPodAutoscalerLabelsDefaultLabels,
+		descIngressLabelsDefaultLabels,
+		descJobLabelsDefaultLabels,
+		descLeaseLabelsDefaultLabels,
+		descLimitRangeLabelsDefaultLabels,
+		descMutatingWebhookConfigurationDefaultLabels,
+		descNamespaceLabelsDefaultLabels,
+		descNetworkPolicyLabelsDefaultLabels,
+		descNodeLabelsDefaultLabels,
+		descPersistentVolumeLabelsDefaultLabels,
+		descPersistentVolumeClaimLabelsDefaultLabels,
+		descPodLabelsDefaultLabels,
+		descPodDisruptionBudgetLabelsDefaultLabels,
+		descReplicaSetLabelsDefaultLabels,
+		descReplicationControllerLabelsDefaultLabels,
+		descResourceQuotaLabelsDefaultLabels,
+		descSecretLabelsDefaultLabels,
+		descServiceLabelsDefaultLabels,
+		descStatefulSetLabelsDefaultLabels,
+		descStorageClassLabelsDefaultLabels,
+		descValidatingWebhookConfigurationDefaultLabels,
+		descVerticalPodAutoscalerLabelsDefaultLabels,
+		descVolumeAttachmentLabelsDefaultLabels,
+	} {
+		labels = append(labels, lbls...)
+	}
+
+	for defaultMetric, defaultLabels := range allow.DefaultMetricLabels {
+		allow.DefaultMetricLabels[defaultMetric] = append(defaultLabels, labels...)
+	}
+}

--- a/pkg/allow/allow_labels.go
+++ b/pkg/allow/allow_labels.go
@@ -20,7 +20,8 @@ import (
 	"regexp"
 )
 
-var defaultMetricLabels = map[*regexp.Regexp][]string{
+// DefaultMetricLabels is a list of all available resources default prometheus labels
+var DefaultMetricLabels = map[*regexp.Regexp][]string{
 	regexp.MustCompile(".*_labels$"):      {},
 	regexp.MustCompile(".*_annotations$"): {},
 }
@@ -35,7 +36,7 @@ func (a Labels) Allowed(metric string, labels, values []string) ([]string, []str
 	allowedLabels, ok := a[metric]
 	if !ok {
 		var defaultsPresent bool
-		for metricReg, lbls := range defaultMetricLabels {
+		for metricReg, lbls := range DefaultMetricLabels {
 			if metricReg.MatchString(metric) {
 				allowedLabels = append(allowedLabels, lbls...)
 				defaultsPresent = true

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -163,7 +163,7 @@ mkdir -p ${KUBE_STATE_METRICS_LOG_DIR}
 echo "access kube-state-metrics metrics endpoint"
 curl -s "http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy/metrics" >${KUBE_STATE_METRICS_LOG_DIR}/metrics
 
-resources=$(find internal/store/ -maxdepth 1 -name "*.go" -not -name "*_test.go" -not -name "builder.go" -not -name "testutils.go" -not -name "utils.go" -print0 | xargs -0 -n1 basename | awk -F. '{print $1}'| grep -v "$EXCLUDED_RESOURCE_REGEX")
+resources=$(find internal/store/ -maxdepth 1 -name "*.go" -not -name "*_test.go" -not -name "builder.go" -not -name "testutils.go" -not -name "utils.go" -not -name "metriclabels.go" -print0 | xargs -0 -n1 basename | awk -F. '{print $1}'| grep -v "$EXCLUDED_RESOURCE_REGEX")
 echo "available resources: $resources"
 for resource in ${resources}; do
     echo "checking that kube_${resource}* metrics exists"


### PR DESCRIPTION
Signed-off-by: Joel Whittaker-Smith <jdws.dev@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
It adds each metric's default labels to be allowed for label/annotation related metrics
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1270 

