### PR TITLE
Change default image registry

### DIFF
--- a/examples/autosharding/statefulset.yaml
+++ b/examples/autosharding/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/coreos/kube-state-metrics:v2.0.0-alpha.3
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-alpha.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/standard/deployment.yaml
+++ b/examples/standard/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app.kubernetes.io/version: 2.0.0-alpha.3
     spec:
       containers:
-      - image: quay.io/coreos/kube-state-metrics:v2.0.0-alpha.3
+      - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-alpha.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/scripts/standard.jsonnet
+++ b/scripts/standard.jsonnet
@@ -5,5 +5,5 @@ ksm {
   name:: 'kube-state-metrics',
   namespace:: 'kube-system',
   version:: version,
-  image:: 'quay.io/coreos/kube-state-metrics:v' + version,
+  image:: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v' + version,
 }


### PR DESCRIPTION
Due to only me having permissions to quay.io/coreos/kube-state-metrics, we want to slowly deprecate pushing to quay registry. Instead, now we have gcr images which all maintainers have access to promoting. This is the first step towards the deprecation, by changing the default in the example manifests.

cc @tariq1890 @brancz PTAL, thanks!