### PR TITLE
internal/store: fix high cyclo complexity

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,9 +18,6 @@ linters:
 linters-settings:
   goimports:
     local-prefixes: k8s.io/kube-state-metrics
-  gocyclo:
-    # temporary until we refactor the pod function 
-    min-complexity: 128
 
 issues:
   exclude-use-default: false

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -40,205 +40,223 @@ var (
 
 func nodeMetricFamilies(allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
-			"kube_node_info",
-			"Information about a cluster node.",
-			metric.Gauge,
-			"",
-			wrapNodeFunc(func(n *v1.Node) *metric.Family {
-				labelKeys := []string{
-					"kernel_version",
-					"os_image",
-					"container_runtime_version",
-					"kubelet_version",
-					"kubeproxy_version",
-					"provider_id",
-					"pod_cidr",
-				}
-				labelValues := []string{
-					n.Status.NodeInfo.KernelVersion,
-					n.Status.NodeInfo.OSImage,
-					n.Status.NodeInfo.ContainerRuntimeVersion,
-					n.Status.NodeInfo.KubeletVersion,
-					n.Status.NodeInfo.KubeProxyVersion,
-					n.Spec.ProviderID,
-					n.Spec.PodCIDR,
-				}
+		createNodeCreatedFamilyGenerator(),
+		createNodeInfoFamilyGenerator(),
+		createNodeLabelsGenerator(allowLabelsList),
+		createNodeRoleFamilyGenerator(),
+		createNodeSpecTaintFamilyGenerator(),
+		createNodeSpecUnschedulableFamilyGenerator(),
+		createNodeStatusAllocatableFamilyGenerator(),
+		createNodeStatusCapacityFamilyGenerator(),
+		createNodeStatusConditionFamilyGenerator(),
+	}
+}
 
-				internalIP := ""
-				for _, address := range n.Status.Addresses {
-					if address.Type == "InternalIP" {
-						internalIP = address.Address
-					}
-				}
-				labelKeys = append(labelKeys, "internal_ip")
-				labelValues = append(labelValues, internalIP)
+func createNodeCreatedFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_node_created",
+		"Unix creation timestamp",
+		metric.Gauge,
+		"",
+		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			ms := []*metric.Metric{}
 
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+			if !n.CreationTimestamp.IsZero() {
+				ms = append(ms, &metric.Metric{
+
+					Value: float64(n.CreationTimestamp.Unix()),
+				})
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createNodeInfoFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_node_info",
+		"Information about a cluster node.",
+		metric.Gauge,
+		"",
+		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			labelKeys := []string{
+				"kernel_version",
+				"os_image",
+				"container_runtime_version",
+				"kubelet_version",
+				"kubeproxy_version",
+				"provider_id",
+				"pod_cidr",
+			}
+			labelValues := []string{
+				n.Status.NodeInfo.KernelVersion,
+				n.Status.NodeInfo.OSImage,
+				n.Status.NodeInfo.ContainerRuntimeVersion,
+				n.Status.NodeInfo.KubeletVersion,
+				n.Status.NodeInfo.KubeProxyVersion,
+				n.Spec.ProviderID,
+				n.Spec.PodCIDR,
+			}
+
+			internalIP := ""
+			for _, address := range n.Status.Addresses {
+				if address.Type == "InternalIP" {
+					internalIP = address.Address
+				}
+			}
+			labelKeys = append(labelKeys, "internal_ip")
+			labelValues = append(labelValues, internalIP)
+
+			return &metric.Family{
+				Metrics: []*metric.Metric{
+					{
+						LabelKeys:   labelKeys,
+						LabelValues: labelValues,
+						Value:       1,
 					},
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_node_created",
-			"Unix creation timestamp",
-			metric.Gauge,
-			"",
-			wrapNodeFunc(func(n *v1.Node) *metric.Family {
-				ms := []*metric.Metric{}
+				},
+			}
+		}),
+	)
+}
 
-				if !n.CreationTimestamp.IsZero() {
+func createNodeLabelsGenerator(allowLabelsList []string) generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		descNodeLabelsName,
+		descNodeLabelsHelp,
+		metric.Gauge,
+		"",
+		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			labelKeys, labelValues := createLabelKeysValues(n.Labels, allowLabelsList)
+			return &metric.Family{
+				Metrics: []*metric.Metric{
+					{
+						LabelKeys:   labelKeys,
+						LabelValues: labelValues,
+						Value:       1,
+					},
+				},
+			}
+		}),
+	)
+}
+
+func createNodeRoleFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_node_role",
+		"The role of a cluster node.",
+		metric.Gauge,
+		"",
+		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			const prefix = "node-role.kubernetes.io/"
+			ms := []*metric.Metric{}
+			for lbl := range n.Labels {
+				if strings.HasPrefix(lbl, prefix) {
 					ms = append(ms, &metric.Metric{
-
-						Value: float64(n.CreationTimestamp.Unix()),
+						LabelKeys:   []string{"role"},
+						LabelValues: []string{strings.TrimPrefix(lbl, prefix)},
+						Value:       float64(1),
 					})
 				}
+			}
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
 
-				return &metric.Family{
-					Metrics: ms,
+func createNodeSpecTaintFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_node_spec_taint",
+		"The taint of a cluster node.",
+		metric.Gauge,
+		"",
+		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			ms := make([]*metric.Metric, len(n.Spec.Taints))
+
+			for i, taint := range n.Spec.Taints {
+				// Taints are applied to repel pods from nodes that do not have a corresponding
+				// toleration.  Many node conditions are optionally reflected as taints
+				// by the node controller in order to simplify scheduling constraints.
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"key", "value", "effect"},
+					LabelValues: []string{taint.Key, taint.Value, string(taint.Effect)},
+					Value:       1,
 				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			descNodeLabelsName,
-			descNodeLabelsHelp,
-			metric.Gauge,
-			"",
-			wrapNodeFunc(func(n *v1.Node) *metric.Family {
-				labelKeys, labelValues := createLabelKeysValues(n.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createNodeSpecUnschedulableFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_node_spec_unschedulable",
+		"Whether a node can schedule new pods.",
+		metric.Gauge,
+		"",
+		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			return &metric.Family{
+				Metrics: []*metric.Metric{
+					{
+						Value: boolFloat64(n.Spec.Unschedulable),
 					},
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_node_role",
-			"The role of a cluster node.",
-			metric.Gauge,
-			"",
-			wrapNodeFunc(func(n *v1.Node) *metric.Family {
-				const prefix = "node-role.kubernetes.io/"
-				ms := []*metric.Metric{}
-				for lbl := range n.Labels {
-					if strings.HasPrefix(lbl, prefix) {
-						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"role"},
-							LabelValues: []string{strings.TrimPrefix(lbl, prefix)},
-							Value:       float64(1),
-						})
-					}
-				}
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_node_spec_unschedulable",
-			"Whether a node can schedule new pods.",
-			metric.Gauge,
-			"",
-			wrapNodeFunc(func(n *v1.Node) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: boolFloat64(n.Spec.Unschedulable),
+				},
+			}
+		}),
+	)
+}
+
+func createNodeStatusAllocatableFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_node_status_allocatable",
+		"The allocatable for different resources of a node that are available for scheduling.",
+		metric.Gauge,
+		"",
+		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			ms := []*metric.Metric{}
+
+			allocatable := n.Status.Allocatable
+
+			for resourceName, val := range allocatable {
+				switch resourceName {
+				case v1.ResourceCPU:
+					ms = append(ms, &metric.Metric{
+						LabelValues: []string{
+							sanitizeLabelName(string(resourceName)),
+							string(constant.UnitCore),
 						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_node_spec_taint",
-			"The taint of a cluster node.",
-			metric.Gauge,
-			"",
-			wrapNodeFunc(func(n *v1.Node) *metric.Family {
-				ms := make([]*metric.Metric, len(n.Spec.Taints))
-
-				for i, taint := range n.Spec.Taints {
-					// Taints are applied to repel pods from nodes that do not have a corresponding
-					// toleration.  Many node conditions are optionally reflected as taints
-					// by the node controller in order to simplify scheduling constraints.
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"key", "value", "effect"},
-						LabelValues: []string{taint.Key, taint.Value, string(taint.Effect)},
-						Value:       1,
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		// This all-in-one metric family contains all conditions for extensibility.
-		// Third party plugin may report customized condition for cluster node
-		// (e.g. node-problem-detector), and Kubernetes may add new core
-		// conditions in future.
-		*generator.NewFamilyGenerator(
-			"kube_node_status_condition",
-			"The condition of a cluster node.",
-			metric.Gauge,
-			"",
-			wrapNodeFunc(func(n *v1.Node) *metric.Family {
-				ms := make([]*metric.Metric, len(n.Status.Conditions)*len(conditionStatuses))
-
-				// Collect node conditions and while default to false.
-				for i, c := range n.Status.Conditions {
-					conditionMetrics := addConditionMetrics(c.Status)
-
-					for j, m := range conditionMetrics {
-						metric := m
-
-						metric.LabelKeys = []string{"condition", "status"}
-						metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
-
-						ms[i*len(conditionStatuses)+j] = metric
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_node_status_capacity",
-			"The capacity for different resources of a node.",
-			metric.Gauge,
-			"",
-			wrapNodeFunc(func(n *v1.Node) *metric.Family {
-				ms := []*metric.Metric{}
-
-				capacity := n.Status.Capacity
-				for resourceName, val := range capacity {
-					switch resourceName {
-					case v1.ResourceCPU:
-						ms = append(ms, &metric.Metric{
-							LabelValues: []string{
-								sanitizeLabelName(string(resourceName)),
-								string(constant.UnitCore),
-							},
-							Value: float64(val.MilliValue()) / 1000,
-						})
-					case v1.ResourceStorage:
-						fallthrough
-					case v1.ResourceEphemeralStorage:
-						fallthrough
-					case v1.ResourceMemory:
+						Value: float64(val.MilliValue()) / 1000,
+					})
+				case v1.ResourceStorage:
+					fallthrough
+				case v1.ResourceEphemeralStorage:
+					fallthrough
+				case v1.ResourceMemory:
+					ms = append(ms, &metric.Metric{
+						LabelValues: []string{
+							sanitizeLabelName(string(resourceName)),
+							string(constant.UnitByte),
+						},
+						Value: float64(val.MilliValue()) / 1000,
+					})
+				case v1.ResourcePods:
+					ms = append(ms, &metric.Metric{
+						LabelValues: []string{
+							sanitizeLabelName(string(resourceName)),
+							string(constant.UnitInteger),
+						},
+						Value: float64(val.MilliValue()) / 1000,
+					})
+				default:
+					if isHugePageResourceName(resourceName) {
 						ms = append(ms, &metric.Metric{
 							LabelValues: []string{
 								sanitizeLabelName(string(resourceName)),
@@ -246,79 +264,8 @@ func nodeMetricFamilies(allowLabelsList []string) []generator.FamilyGenerator {
 							},
 							Value: float64(val.MilliValue()) / 1000,
 						})
-					case v1.ResourcePods:
-						ms = append(ms, &metric.Metric{
-							LabelValues: []string{
-								sanitizeLabelName(string(resourceName)),
-								string(constant.UnitInteger),
-							},
-							Value: float64(val.MilliValue()) / 1000,
-						})
-					default:
-						if isHugePageResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{
-									sanitizeLabelName(string(resourceName)),
-									string(constant.UnitByte),
-								},
-								Value: float64(val.MilliValue()) / 1000,
-							})
-						}
-						if isAttachableVolumeResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{
-									sanitizeLabelName(string(resourceName)),
-									string(constant.UnitByte),
-								},
-								Value: float64(val.MilliValue()) / 1000,
-							})
-						}
-						if isExtendedResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{
-									sanitizeLabelName(string(resourceName)),
-									string(constant.UnitInteger),
-								},
-								Value: float64(val.MilliValue()) / 1000,
-							})
-						}
 					}
-				}
-
-				for _, metric := range ms {
-					metric.LabelKeys = []string{"resource", "unit"}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_node_status_allocatable",
-			"The allocatable for different resources of a node that are available for scheduling.",
-			metric.Gauge,
-			"",
-			wrapNodeFunc(func(n *v1.Node) *metric.Family {
-				ms := []*metric.Metric{}
-
-				allocatable := n.Status.Allocatable
-
-				for resourceName, val := range allocatable {
-					switch resourceName {
-					case v1.ResourceCPU:
-						ms = append(ms, &metric.Metric{
-							LabelValues: []string{
-								sanitizeLabelName(string(resourceName)),
-								string(constant.UnitCore),
-							},
-							Value: float64(val.MilliValue()) / 1000,
-						})
-					case v1.ResourceStorage:
-						fallthrough
-					case v1.ResourceEphemeralStorage:
-						fallthrough
-					case v1.ResourceMemory:
+					if isAttachableVolumeResourceName(resourceName) {
 						ms = append(ms, &metric.Metric{
 							LabelValues: []string{
 								sanitizeLabelName(string(resourceName)),
@@ -326,7 +273,8 @@ func nodeMetricFamilies(allowLabelsList []string) []generator.FamilyGenerator {
 							},
 							Value: float64(val.MilliValue()) / 1000,
 						})
-					case v1.ResourcePods:
+					}
+					if isExtendedResourceName(resourceName) {
 						ms = append(ms, &metric.Metric{
 							LabelValues: []string{
 								sanitizeLabelName(string(resourceName)),
@@ -334,47 +282,135 @@ func nodeMetricFamilies(allowLabelsList []string) []generator.FamilyGenerator {
 							},
 							Value: float64(val.MilliValue()) / 1000,
 						})
-					default:
-						if isHugePageResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{
-									sanitizeLabelName(string(resourceName)),
-									string(constant.UnitByte),
-								},
-								Value: float64(val.MilliValue()) / 1000,
-							})
-						}
-						if isAttachableVolumeResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{
-									sanitizeLabelName(string(resourceName)),
-									string(constant.UnitByte),
-								},
-								Value: float64(val.MilliValue()) / 1000,
-							})
-						}
-						if isExtendedResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{
-									sanitizeLabelName(string(resourceName)),
-									string(constant.UnitInteger),
-								},
-								Value: float64(val.MilliValue()) / 1000,
-							})
-						}
 					}
 				}
+			}
 
-				for _, m := range ms {
-					m.LabelKeys = []string{"resource", "unit"}
-				}
+			for _, m := range ms {
+				m.LabelKeys = []string{"resource", "unit"}
+			}
 
-				return &metric.Family{
-					Metrics: ms,
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createNodeStatusCapacityFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_node_status_capacity",
+		"The capacity for different resources of a node.",
+		metric.Gauge,
+		"",
+		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			ms := []*metric.Metric{}
+
+			capacity := n.Status.Capacity
+			for resourceName, val := range capacity {
+				switch resourceName {
+				case v1.ResourceCPU:
+					ms = append(ms, &metric.Metric{
+						LabelValues: []string{
+							sanitizeLabelName(string(resourceName)),
+							string(constant.UnitCore),
+						},
+						Value: float64(val.MilliValue()) / 1000,
+					})
+				case v1.ResourceStorage:
+					fallthrough
+				case v1.ResourceEphemeralStorage:
+					fallthrough
+				case v1.ResourceMemory:
+					ms = append(ms, &metric.Metric{
+						LabelValues: []string{
+							sanitizeLabelName(string(resourceName)),
+							string(constant.UnitByte),
+						},
+						Value: float64(val.MilliValue()) / 1000,
+					})
+				case v1.ResourcePods:
+					ms = append(ms, &metric.Metric{
+						LabelValues: []string{
+							sanitizeLabelName(string(resourceName)),
+							string(constant.UnitInteger),
+						},
+						Value: float64(val.MilliValue()) / 1000,
+					})
+				default:
+					if isHugePageResourceName(resourceName) {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{
+								sanitizeLabelName(string(resourceName)),
+								string(constant.UnitByte),
+							},
+							Value: float64(val.MilliValue()) / 1000,
+						})
+					}
+					if isAttachableVolumeResourceName(resourceName) {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{
+								sanitizeLabelName(string(resourceName)),
+								string(constant.UnitByte),
+							},
+							Value: float64(val.MilliValue()) / 1000,
+						})
+					}
+					if isExtendedResourceName(resourceName) {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{
+								sanitizeLabelName(string(resourceName)),
+								string(constant.UnitInteger),
+							},
+							Value: float64(val.MilliValue()) / 1000,
+						})
+					}
 				}
-			}),
-		),
-	}
+			}
+
+			for _, metric := range ms {
+				metric.LabelKeys = []string{"resource", "unit"}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+// createNodeStatusConditionFamilyGenerator returns an all-in-one metric family
+// containing all conditions for extensibility. Third party plugin may report
+// customized condition for cluster node (e.g. node-problem-detector), and
+// Kubernetes may add new core conditions in future.
+func createNodeStatusConditionFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_node_status_condition",
+		"The condition of a cluster node.",
+		metric.Gauge,
+		"",
+		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			ms := make([]*metric.Metric, len(n.Status.Conditions)*len(conditionStatuses))
+
+			// Collect node conditions and while default to false.
+			for i, c := range n.Status.Conditions {
+				conditionMetrics := addConditionMetrics(c.Status)
+
+				for j, m := range conditionMetrics {
+					metric := m
+
+					metric.LabelKeys = []string{"condition", "status"}
+					metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
+
+					ms[i*len(conditionStatuses)+j] = metric
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
 }
 
 func wrapNodeFunc(f func(*v1.Node) *metric.Family) func(interface{}) *metric.Family {

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -41,1316 +41,1515 @@ var (
 
 func podMetricFamilies(allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
-			"kube_pod_info",
-			"Information about pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				createdBy := metav1.GetControllerOf(p)
-				createdByKind := "<none>"
-				createdByName := "<none>"
-				if createdBy != nil {
-					if createdBy.Kind != "" {
-						createdByKind = createdBy.Kind
-					}
-					if createdBy.Name != "" {
-						createdByName = createdBy.Name
+		createPodCompletionTimeFamilyGenerator(),
+		createPodContainerInfoFamilyGenerator(),
+		createPodContainerResourceLimitsFamilyGenerator(),
+		createPodContainerResourceRequestsFamilyGenerator(),
+		createPodContainerStateStartedFamilyGenerator(),
+		createPodContainerStatusLastTerminatedReasonFamilyGenerator(),
+		createPodContainerStatusReadyFamilyGenerator(),
+		createPodContainerStatusRestartsTotalFamilyGenerator(),
+		createPodContainerStatusRunningFamilyGenerator(),
+		createPodContainerStatusTerminatedFamilyGenerator(),
+		createPodContainerStatusTerminatedReasonFamilyGenerator(),
+		createPodContainerStatusWaitingFamilyGenerator(),
+		createPodContainerStatusWaitingReasonFamilyGenerator(),
+		createPodCreatedFamilyGenerator(),
+		createPodDeletionTimestampFamilyGenerator(),
+		createPodInfoFamilyGenerator(),
+		createPodInitContainerInfoFamilyGenerator(),
+		createPodInitContainerResourceLimitsCPUCoresFamilyGenerator(),
+		createPodInitContainerResourceLimitsEphemeralStorageBytesFamilyGenerator(),
+		createPodInitContainerResourceLimitsFamilyGenerator(),
+		createPodInitContainerResourceLimitsMemoryBytesFamilyGenerator(),
+		createPodInitContainerResourceLimitsStorageBytesFamilyGenerator(),
+		createPodInitContainerResourceRequestsCPUCoresFamilyGenerator(),
+		createPodInitContainerResourceRequestsEphemeralStorageBytesFamilyGenerator(),
+		createPodInitContainerResourceRequestsFamilyGenerator(),
+		createPodInitContainerResourceRequestsMemoryBytesFamilyGenerator(),
+		createPodInitContainerResourceRequestsStorageBytesFamilyGenerator(),
+		createPodInitContainerStatusLastTerminatedReasonFamilyGenerator(),
+		createPodInitContainerStatusReadyFamilyGenerator(),
+		createPodInitContainerStatusRestartsTotalFamilyGenerator(),
+		createPodInitContainerStatusRunningFamilyGenerator(),
+		createPodInitContainerStatusTerminatedFamilyGenerator(),
+		createPodInitContainerStatusTerminatedReasonFamilyGenerator(),
+		createPodInitContainerStatusWaitingFamilyGenerator(),
+		createPodInitContainerStatusWaitingReasonFamilyGenerator(),
+		createPodLabelsGenerator(allowLabelsList),
+		createPodOverheadCPUCoresFamilyGenerator(),
+		createPodOverheadMemoryBytesFamilyGenerator(),
+		createPodOwnerFamilyGenerator(),
+		createPodRestartPolicyFamilyGenerator(),
+		createPodRuntimeClassNameInfoFamilyGenerator(),
+		createPodSpecVolumesPersistentVolumeClaimsInfoFamilyGenerator(),
+		createPodSpecVolumesPersistentVolumeClaimsReadonlyFamilyGenerator(),
+		createPodStartTimeFamilyGenerator(),
+		createPodStatusPhaseFamilyGenerator(),
+		createPodStatusReadyFamilyGenerator(),
+		createPodStatusReasonFamilyGenerator(),
+		createPodStatusScheduledFamilyGenerator(),
+		createPodStatusScheduledTimeFamilyGenerator(),
+		createPodStatusUnschedulableFamilyGenerator(),
+	}
+}
+
+func createPodCompletionTimeFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_completion_time",
+		"Completion time in unix timestamp for a pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			var lastFinishTime float64
+			for _, cs := range p.Status.ContainerStatuses {
+				if cs.State.Terminated != nil {
+					if lastFinishTime == 0 || lastFinishTime < float64(cs.State.Terminated.FinishedAt.Unix()) {
+						lastFinishTime = float64(cs.State.Terminated.FinishedAt.Unix())
 					}
 				}
+			}
 
-				m := metric.Metric{
+			if lastFinishTime > 0 {
+				ms = append(ms, &metric.Metric{
 
-					LabelKeys:   []string{"host_ip", "pod_ip", "node", "created_by_kind", "created_by_name", "priority_class", "host_network"},
-					LabelValues: []string{p.Status.HostIP, p.Status.PodIP, p.Spec.NodeName, createdByKind, createdByName, p.Spec.PriorityClassName, strconv.FormatBool(p.Spec.HostNetwork)},
+					LabelKeys:   []string{},
+					LabelValues: []string{},
+					Value:       lastFinishTime,
+				})
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_info",
+		"Information about a container in a pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+			labelKeys := []string{"container", "image", "image_id", "container_id"}
+
+			for i, cs := range p.Status.ContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   labelKeys,
+					LabelValues: []string{cs.Name, cs.Image, cs.ImageID, cs.ContainerID},
 					Value:       1,
 				}
+			}
 
-				return &metric.Family{
-					Metrics: []*metric.Metric{&m},
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_resource_limits",
+		"The number of requested limit resource by a container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Spec.Containers {
+				lim := c.Resources.Limits
+
+				for resourceName, val := range lim {
+					switch resourceName {
+					case v1.ResourceCPU:
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+							Value:       float64(val.MilliValue()) / 1000,
+						})
+					case v1.ResourceStorage:
+						fallthrough
+					case v1.ResourceEphemeralStorage:
+						fallthrough
+					case v1.ResourceMemory:
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+							Value:       float64(val.Value()),
+						})
+					default:
+						if isHugePageResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								Value:       float64(val.Value()),
+							})
+						}
+						if isAttachableVolumeResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								Value:       float64(val.Value()),
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+							})
+						}
+						if isExtendedResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								Value:       float64(val.Value()),
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+							})
+
+						}
+					}
 				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_start_time",
-			"Start time in unix timestamp for a pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
+			}
 
-				if p.Status.StartTime != nil {
+			for _, metric := range ms {
+				metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerResourceRequestsFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_resource_requests",
+		"The number of requested request resource by a container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Spec.Containers {
+				req := c.Resources.Requests
+
+				for resourceName, val := range req {
+					switch resourceName {
+					case v1.ResourceCPU:
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
+							Value:       float64(val.MilliValue()) / 1000,
+						})
+					case v1.ResourceStorage:
+						fallthrough
+					case v1.ResourceEphemeralStorage:
+						fallthrough
+					case v1.ResourceMemory:
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+							Value:       float64(val.Value()),
+						})
+					default:
+						if isHugePageResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								Value:       float64(val.Value()),
+							})
+						}
+						if isAttachableVolumeResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+								Value:       float64(val.Value()),
+							})
+						}
+						if isExtendedResourceName(resourceName) {
+							ms = append(ms, &metric.Metric{
+								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+								Value:       float64(val.Value()),
+							})
+						}
+					}
+				}
+			}
+
+			for _, metric := range ms {
+				metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerStateStartedFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_state_started",
+		"Start time in unix timestamp for a pod container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, cs := range p.Status.ContainerStatuses {
+				if cs.State.Running != nil {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{},
-						LabelValues: []string{},
-						Value:       float64((p.Status.StartTime).Unix()),
+						LabelKeys:   []string{"container"},
+						LabelValues: []string{cs.Name},
+						Value:       float64((cs.State.Running.StartedAt).Unix()),
 					})
 				}
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_state_started",
-			"Start time in unix timestamp for a pod container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
+			}
 
-				for _, cs := range p.Status.ContainerStatuses {
-					if cs.State.Running != nil {
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerStatusLastTerminatedReasonFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_status_last_terminated_reason",
+		"Describes the last reason the container was in terminated state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerTerminatedReasons))
+
+			for i, cs := range p.Status.ContainerStatuses {
+				for j, reason := range containerTerminatedReasons {
+					ms[i*len(containerTerminatedReasons)+j] = &metric.Metric{
+						LabelKeys:   []string{"container", "reason"},
+						LabelValues: []string{cs.Name, reason},
+						Value:       boolFloat64(lastTerminationReason(cs, reason)),
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerStatusReadyFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_status_ready",
+		"Describes whether the containers readiness check succeeded.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+
+			for i, cs := range p.Status.ContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"container"},
+					LabelValues: []string{cs.Name},
+					Value:       boolFloat64(cs.Ready),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerStatusRestartsTotalFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_status_restarts_total",
+		"The number of container restarts per container.",
+		metric.Counter,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+
+			for i, cs := range p.Status.ContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"container"},
+					LabelValues: []string{cs.Name},
+					Value:       float64(cs.RestartCount),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerStatusRunningFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_status_running",
+		"Describes whether the container is currently in running state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+
+			for i, cs := range p.Status.ContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"container"},
+					LabelValues: []string{cs.Name},
+					Value:       boolFloat64(cs.State.Running != nil),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerStatusTerminatedFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_status_terminated",
+		"Describes whether the container is currently in terminated state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+
+			for i, cs := range p.Status.ContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"container"},
+					LabelValues: []string{cs.Name},
+					Value:       boolFloat64(cs.State.Terminated != nil),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerStatusTerminatedReasonFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_status_terminated_reason",
+		"Describes the reason the container is currently in terminated state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerTerminatedReasons))
+
+			for i, cs := range p.Status.ContainerStatuses {
+				for j, reason := range containerTerminatedReasons {
+					ms[i*len(containerTerminatedReasons)+j] = &metric.Metric{
+						LabelKeys:   []string{"container", "reason"},
+						LabelValues: []string{cs.Name, reason},
+						Value:       boolFloat64(terminationReason(cs, reason)),
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerStatusWaitingFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_status_waiting",
+		"Describes whether the container is currently in waiting state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+
+			for i, cs := range p.Status.ContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"container"},
+					LabelValues: []string{cs.Name},
+					Value:       boolFloat64(cs.State.Waiting != nil),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodContainerStatusWaitingReasonFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_container_status_waiting_reason",
+		"Describes the reason the container is currently in waiting state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerWaitingReasons))
+
+			for i, cs := range p.Status.ContainerStatuses {
+				for j, reason := range containerWaitingReasons {
+					ms[i*len(containerWaitingReasons)+j] = &metric.Metric{
+						LabelKeys:   []string{"container", "reason"},
+						LabelValues: []string{cs.Name, reason},
+						Value:       boolFloat64(waitingReason(cs, reason)),
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodCreatedFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_created",
+		"Unix creation timestamp",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			if !p.CreationTimestamp.IsZero() {
+				ms = append(ms, &metric.Metric{
+					LabelKeys:   []string{},
+					LabelValues: []string{},
+					Value:       float64(p.CreationTimestamp.Unix()),
+				})
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodDeletionTimestampFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_deletion_timestamp",
+		"Unix deletion timestamp",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			if p.DeletionTimestamp != nil && !p.DeletionTimestamp.IsZero() {
+				ms = append(ms, &metric.Metric{
+					LabelKeys:   []string{},
+					LabelValues: []string{},
+					Value:       float64(p.DeletionTimestamp.Unix()),
+				})
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInfoFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_info",
+		"Information about pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			createdBy := metav1.GetControllerOf(p)
+			createdByKind := "<none>"
+			createdByName := "<none>"
+			if createdBy != nil {
+				if createdBy.Kind != "" {
+					createdByKind = createdBy.Kind
+				}
+				if createdBy.Name != "" {
+					createdByName = createdBy.Name
+				}
+			}
+
+			m := metric.Metric{
+				LabelKeys:   []string{"host_ip", "pod_ip", "node", "created_by_kind", "created_by_name", "priority_class", "host_network"},
+				LabelValues: []string{p.Status.HostIP, p.Status.PodIP, p.Spec.NodeName, createdByKind, createdByName, p.Spec.PriorityClassName, strconv.FormatBool(p.Spec.HostNetwork)},
+				Value:       1,
+			}
+
+			return &metric.Family{
+				Metrics: []*metric.Metric{&m},
+			}
+		}),
+	)
+}
+
+func createPodInitContainerInfoFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_info",
+		"Information about an init container in a pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
+			labelKeys := []string{"container", "image", "image_id", "container_id"}
+
+			for i, cs := range p.Status.InitContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   labelKeys,
+					LabelValues: []string{cs.Name, cs.Image, cs.ImageID, cs.ContainerID},
+					Value:       1,
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerResourceLimitsCPUCoresFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_resource_limits_cpu_cores",
+		"The number of CPU cores requested limit by an init container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Spec.InitContainers {
+				req := c.Resources.Limits
+
+				for resourceName, val := range req {
+					if resourceName == v1.ResourceCPU {
 						ms = append(ms, &metric.Metric{
 							LabelKeys:   []string{"container"},
-							LabelValues: []string{cs.Name},
-							Value:       float64((cs.State.Running.StartedAt).Unix()),
+							LabelValues: []string{c.Name},
+							Value:       float64(val.MilliValue()) / 1000,
 						})
 					}
 				}
+			}
 
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_completion_time",
-			"Completion time in unix timestamp for a pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
 
-				var lastFinishTime float64
-				for _, cs := range p.Status.ContainerStatuses {
-					if cs.State.Terminated != nil {
-						if lastFinishTime == 0 || lastFinishTime < float64(cs.State.Terminated.FinishedAt.Unix()) {
-							lastFinishTime = float64(cs.State.Terminated.FinishedAt.Unix())
-						}
+func createPodInitContainerResourceLimitsEphemeralStorageBytesFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_resource_limits_ephemeral_storage_bytes",
+		"Bytes of ephemeral-storage requested limit by an init container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Spec.InitContainers {
+				req := c.Resources.Limits
+
+				for resourceName, val := range req {
+					if resourceName == v1.ResourceEphemeralStorage {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container"},
+							LabelValues: []string{c.Name},
+							Value:       float64(val.Value()),
+						})
 					}
 				}
+			}
 
-				if lastFinishTime > 0 {
-					ms = append(ms, &metric.Metric{
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
 
-						LabelKeys:   []string{},
-						LabelValues: []string{},
-						Value:       lastFinishTime,
-					})
-				}
+func createPodInitContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_resource_limits",
+		"The number of requested limit resource by an init container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
 
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_owner",
-			"Information about the Pod's owner.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
+			for _, c := range p.Spec.InitContainers {
+				lim := c.Resources.Limits
 
-				owners := p.GetOwnerReferences()
-				if len(owners) == 0 {
-					return &metric.Family{
-						Metrics: []*metric.Metric{
-							{
-								LabelKeys:   labelKeys,
-								LabelValues: []string{"<none>", "<none>", "<none>"},
-								Value:       1,
-							},
-						},
+				for resourceName, val := range lim {
+					if isHugePageResourceName(resourceName) {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+							Value:       float64(val.Value()),
+						})
+					}
+					if isAttachableVolumeResourceName(resourceName) {
+						ms = append(ms, &metric.Metric{
+							Value:       float64(val.Value()),
+							LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+						})
+					}
+					if isExtendedResourceName(resourceName) {
+						ms = append(ms, &metric.Metric{
+							Value:       float64(val.Value()),
+							LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+						})
 					}
 				}
+			}
 
-				ms := make([]*metric.Metric, len(owners))
+			for _, metric := range ms {
+				metric.LabelKeys = []string{"container", "resource", "unit"}
+			}
 
-				for i, owner := range owners {
-					if owner.Controller != nil {
-						ms[i] = &metric.Metric{
-							LabelKeys:   labelKeys,
-							LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
-							Value:       1,
-						}
-					} else {
-						ms[i] = &metric.Metric{
-							LabelKeys:   labelKeys,
-							LabelValues: []string{owner.Kind, owner.Name, "false"},
-							Value:       1,
-						}
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerResourceLimitsMemoryBytesFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_resource_limits_memory_bytes",
+		"Bytes of memory requested limit by an init container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Spec.InitContainers {
+				req := c.Resources.Limits
+
+				for resourceName, val := range req {
+					if resourceName == v1.ResourceMemory {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container"},
+							LabelValues: []string{c.Name},
+							Value:       float64(val.Value()),
+						})
 					}
 				}
+			}
 
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_labels",
-			"Kubernetes labels converted to Prometheus labels.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				labelKeys, labelValues := createLabelKeysValues(p.Labels, allowLabelsList)
-				m := metric.Metric{
-					LabelKeys:   labelKeys,
-					LabelValues: labelValues,
-					Value:       1,
-				}
-				return &metric.Family{
-					Metrics: []*metric.Metric{&m},
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_created",
-			"Unix creation timestamp",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
 
-				if !p.CreationTimestamp.IsZero() {
-					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{},
-						LabelValues: []string{},
-						Value:       float64(p.CreationTimestamp.Unix()),
-					})
-				}
+func createPodInitContainerResourceLimitsStorageBytesFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_resource_limits_storage_bytes",
+		"Bytes of storage requested limit by an init container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
 
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_deletion_timestamp",
-			"Unix deletion timestamp",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
+			for _, c := range p.Spec.InitContainers {
+				req := c.Resources.Limits
 
-				if p.DeletionTimestamp != nil && !p.DeletionTimestamp.IsZero() {
-					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{},
-						LabelValues: []string{},
-						Value:       float64(p.DeletionTimestamp.Unix()),
-					})
+				for resourceName, val := range req {
+					if resourceName == v1.ResourceStorage {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container"},
+							LabelValues: []string{c.Name},
+							Value:       float64(val.Value()),
+						})
+					}
 				}
+			}
 
-				return &metric.Family{
-					Metrics: ms,
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerResourceRequestsCPUCoresFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_resource_requests_cpu_cores",
+		"The number of CPU cores requested by an init container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Spec.InitContainers {
+				req := c.Resources.Requests
+
+				for resourceName, val := range req {
+					if resourceName == v1.ResourceCPU {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container"},
+							LabelValues: []string{c.Name},
+							Value:       float64(val.MilliValue()) / 1000,
+						})
+					}
 				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_restart_policy",
-			"Describes the restart policy in use by this pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerResourceRequestsEphemeralStorageBytesFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_resource_requests_ephemeral_storage_bytes",
+		"Bytes of ephemeral-storage requested by an init container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Spec.InitContainers {
+				req := c.Resources.Requests
+
+				for resourceName, val := range req {
+					if resourceName == v1.ResourceEphemeralStorage {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container"},
+							LabelValues: []string{c.Name},
+							Value:       float64(val.Value()),
+						})
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerResourceRequestsFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_resource_requests",
+		"The number of requested request resource by an init container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Spec.InitContainers {
+				req := c.Resources.Requests
+
+				for resourceName, val := range req {
+					if isHugePageResourceName(resourceName) {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+							Value:       float64(val.Value()),
+						})
+					}
+					if isAttachableVolumeResourceName(resourceName) {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
+							Value:       float64(val.Value()),
+						})
+					}
+					if isExtendedResourceName(resourceName) {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
+							Value:       float64(val.Value()),
+						})
+					}
+				}
+			}
+
+			for _, metric := range ms {
+				metric.LabelKeys = []string{"container", "resource", "unit"}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerResourceRequestsMemoryBytesFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_resource_requests_memory_bytes",
+		"Bytes of memory requested by an init container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Spec.InitContainers {
+				req := c.Resources.Requests
+
+				for resourceName, val := range req {
+					if resourceName == v1.ResourceMemory {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container"},
+							LabelValues: []string{c.Name},
+							Value:       float64(val.Value()),
+						})
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerResourceRequestsStorageBytesFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_resource_requests_storage_bytes",
+		"Bytes of storage requested by an init container.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Spec.InitContainers {
+				req := c.Resources.Requests
+
+				for resourceName, val := range req {
+					if resourceName == v1.ResourceStorage {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   []string{"container"},
+							LabelValues: []string{c.Name},
+							Value:       float64(val.Value()),
+						})
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerStatusLastTerminatedReasonFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_status_last_terminated_reason",
+		"Describes the last reason the init container was in terminated state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses)*len(containerTerminatedReasons))
+
+			for i, cs := range p.Status.InitContainerStatuses {
+				for j, reason := range containerTerminatedReasons {
+					ms[i*len(containerTerminatedReasons)+j] = &metric.Metric{
+						LabelKeys:   []string{"container", "reason"},
+						LabelValues: []string{cs.Name, reason},
+						Value:       boolFloat64(lastTerminationReason(cs, reason)),
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerStatusReadyFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_status_ready",
+		"Describes whether the init containers readiness check succeeded.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
+
+			for i, cs := range p.Status.InitContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"container"},
+					LabelValues: []string{cs.Name},
+					Value:       boolFloat64(cs.Ready),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerStatusRestartsTotalFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_status_restarts_total",
+		"The number of restarts for the init container.",
+		metric.Counter,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
+
+			for i, cs := range p.Status.InitContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"container"},
+					LabelValues: []string{cs.Name},
+					Value:       float64(cs.RestartCount),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerStatusRunningFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_status_running",
+		"Describes whether the init container is currently in running state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
+
+			for i, cs := range p.Status.InitContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"container"},
+					LabelValues: []string{cs.Name},
+					Value:       boolFloat64(cs.State.Running != nil),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerStatusTerminatedFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_status_terminated",
+		"Describes whether the init container is currently in terminated state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
+
+			for i, cs := range p.Status.InitContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"container"},
+					LabelValues: []string{cs.Name},
+					Value:       boolFloat64(cs.State.Terminated != nil),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerStatusTerminatedReasonFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_status_terminated_reason",
+		"Describes the reason the init container is currently in terminated state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses)*len(containerTerminatedReasons))
+
+			for i, cs := range p.Status.InitContainerStatuses {
+				for j, reason := range containerTerminatedReasons {
+					ms[i*len(containerTerminatedReasons)+j] = &metric.Metric{
+						LabelKeys:   []string{"container", "reason"},
+						LabelValues: []string{cs.Name, reason},
+						Value:       boolFloat64(terminationReason(cs, reason)),
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerStatusWaitingFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_status_waiting",
+		"Describes whether the init container is currently in waiting state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
+
+			for i, cs := range p.Status.InitContainerStatuses {
+				ms[i] = &metric.Metric{
+					LabelKeys:   []string{"container"},
+					LabelValues: []string{cs.Name},
+					Value:       boolFloat64(cs.State.Waiting != nil),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodInitContainerStatusWaitingReasonFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_init_container_status_waiting_reason",
+		"Describes the reason the init container is currently in waiting state.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses)*len(containerWaitingReasons))
+
+			for i, cs := range p.Status.InitContainerStatuses {
+				for j, reason := range containerWaitingReasons {
+					ms[i*len(containerWaitingReasons)+j] = &metric.Metric{
+						LabelKeys:   []string{"container", "reason"},
+						LabelValues: []string{cs.Name, reason},
+						Value:       boolFloat64(waitingReason(cs, reason)),
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodLabelsGenerator(allowLabelsList []string) generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_labels",
+		"Kubernetes labels converted to Prometheus labels.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			labelKeys, labelValues := createLabelKeysValues(p.Labels, allowLabelsList)
+			m := metric.Metric{
+				LabelKeys:   labelKeys,
+				LabelValues: labelValues,
+				Value:       1,
+			}
+			return &metric.Family{
+				Metrics: []*metric.Metric{&m},
+			}
+		}),
+	)
+}
+
+func createPodOverheadCPUCoresFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_overhead_cpu_cores",
+		"The pod overhead in regards to cpu cores associated with running a pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			if p.Spec.Overhead != nil {
+				for resourceName, val := range p.Spec.Overhead {
+					if resourceName == v1.ResourceCPU {
+						ms = append(ms, &metric.Metric{
+							Value: float64(val.MilliValue()) / 1000,
+						})
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodOverheadMemoryBytesFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_overhead_memory_bytes",
+		"The pod overhead in regards to memory associated with running a pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			if p.Spec.Overhead != nil {
+				for resourceName, val := range p.Spec.Overhead {
+					if resourceName == v1.ResourceMemory {
+						ms = append(ms, &metric.Metric{
+							Value: float64(val.Value()),
+						})
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodOwnerFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_owner",
+		"Information about the Pod's owner.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
+
+			owners := p.GetOwnerReferences()
+			if len(owners) == 0 {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   []string{"type"},
-							LabelValues: []string{string(p.Spec.RestartPolicy)},
-							Value:       float64(1),
+							LabelKeys:   labelKeys,
+							LabelValues: []string{"<none>", "<none>", "<none>"},
+							Value:       1,
 						},
 					},
 				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_status_scheduled_time",
-			"Unix timestamp when pod moved into scheduled status",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
+			}
 
-				for _, c := range p.Status.Conditions {
-					if c.Type == v1.PodScheduled && c.Status == v1.ConditionTrue {
-						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(c.LastTransitionTime.Unix()),
-						})
-					}
-				}
+			ms := make([]*metric.Metric, len(owners))
 
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_status_unschedulable",
-			"Describes the unschedulable status for the pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Status.Conditions {
-					if c.Type == v1.PodScheduled && c.Status == v1.ConditionFalse {
-						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       1,
-						})
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_status_phase",
-			"The pods current phase.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				phase := p.Status.Phase
-				if phase == "" {
-					return &metric.Family{
-						Metrics: []*metric.Metric{},
-					}
-				}
-
-				phases := []struct {
-					v bool
-					n string
-				}{
-					{phase == v1.PodPending, string(v1.PodPending)},
-					{phase == v1.PodSucceeded, string(v1.PodSucceeded)},
-					{phase == v1.PodFailed, string(v1.PodFailed)},
-					{phase == v1.PodUnknown, string(v1.PodUnknown)},
-					{phase == v1.PodRunning, string(v1.PodRunning)},
-				}
-
-				ms := make([]*metric.Metric, len(phases))
-
-				for i, p := range phases {
-					ms[i] = &metric.Metric{
-
-						LabelKeys:   []string{"phase"},
-						LabelValues: []string{p.n},
-						Value:       boolFloat64(p.v),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_status_ready",
-			"Describes whether the pod is ready to serve requests.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Status.Conditions {
-					if c.Type == v1.PodReady {
-						conditionMetrics := addConditionMetrics(c.Status)
-
-						for _, m := range conditionMetrics {
-							metric := m
-							metric.LabelKeys = []string{"condition"}
-							ms = append(ms, metric)
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_status_scheduled",
-			"Describes the status of the scheduling process for the pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Status.Conditions {
-					if c.Type == v1.PodScheduled {
-						conditionMetrics := addConditionMetrics(c.Status)
-
-						for _, m := range conditionMetrics {
-							metric := m
-							metric.LabelKeys = []string{"condition"}
-							ms = append(ms, metric)
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_status_reason",
-			"The pod status reasons",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, reason := range podStatusReasons {
-					metric := &metric.Metric{}
-					metric.LabelKeys = []string{"reason"}
-					metric.LabelValues = []string{reason}
-					if p.Status.Reason == reason {
-						metric.Value = boolFloat64(true)
-					} else {
-						metric.Value = boolFloat64(false)
-					}
-					ms = append(ms, metric)
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_info",
-			"Information about a container in a pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
-				labelKeys := []string{"container", "image", "image_id", "container_id"}
-
-				for i, cs := range p.Status.ContainerStatuses {
+			for i, owner := range owners {
+				if owner.Controller != nil {
 					ms[i] = &metric.Metric{
 						LabelKeys:   labelKeys,
-						LabelValues: []string{cs.Name, cs.Image, cs.ImageID, cs.ContainerID},
+						LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
+						Value:       1,
+					}
+				} else {
+					ms[i] = &metric.Metric{
+						LabelKeys:   labelKeys,
+						LabelValues: []string{owner.Kind, owner.Name, "false"},
 						Value:       1,
 					}
 				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_info",
-			"Information about an init container in a pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
-				labelKeys := []string{"container", "image", "image_id", "container_id"}
-
-				for i, cs := range p.Status.InitContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   labelKeys,
-						LabelValues: []string{cs.Name, cs.Image, cs.ImageID, cs.ContainerID},
-						Value:       1,
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_status_waiting",
-			"Describes whether the container is currently in waiting state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
-
-				for i, cs := range p.Status.ContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container"},
-						LabelValues: []string{cs.Name},
-						Value:       boolFloat64(cs.State.Waiting != nil),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_status_waiting",
-			"Describes whether the init container is currently in waiting state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
-
-				for i, cs := range p.Status.InitContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container"},
-						LabelValues: []string{cs.Name},
-						Value:       boolFloat64(cs.State.Waiting != nil),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_status_waiting_reason",
-			"Describes the reason the container is currently in waiting state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerWaitingReasons))
-
-				for i, cs := range p.Status.ContainerStatuses {
-					for j, reason := range containerWaitingReasons {
-						ms[i*len(containerWaitingReasons)+j] = &metric.Metric{
-							LabelKeys:   []string{"container", "reason"},
-							LabelValues: []string{cs.Name, reason},
-							Value:       boolFloat64(waitingReason(cs, reason)),
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_status_waiting_reason",
-			"Describes the reason the init container is currently in waiting state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses)*len(containerWaitingReasons))
-
-				for i, cs := range p.Status.InitContainerStatuses {
-					for j, reason := range containerWaitingReasons {
-						ms[i*len(containerWaitingReasons)+j] = &metric.Metric{
-							LabelKeys:   []string{"container", "reason"},
-							LabelValues: []string{cs.Name, reason},
-							Value:       boolFloat64(waitingReason(cs, reason)),
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_status_running",
-			"Describes whether the container is currently in running state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
-
-				for i, cs := range p.Status.ContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container"},
-						LabelValues: []string{cs.Name},
-						Value:       boolFloat64(cs.State.Running != nil),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_status_running",
-			"Describes whether the init container is currently in running state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
-
-				for i, cs := range p.Status.InitContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container"},
-						LabelValues: []string{cs.Name},
-						Value:       boolFloat64(cs.State.Running != nil),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_status_terminated",
-			"Describes whether the container is currently in terminated state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
-
-				for i, cs := range p.Status.ContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container"},
-						LabelValues: []string{cs.Name},
-						Value:       boolFloat64(cs.State.Terminated != nil),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_status_terminated",
-			"Describes whether the init container is currently in terminated state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
-
-				for i, cs := range p.Status.InitContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container"},
-						LabelValues: []string{cs.Name},
-						Value:       boolFloat64(cs.State.Terminated != nil),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_status_terminated_reason",
-			"Describes the reason the container is currently in terminated state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerTerminatedReasons))
-
-				for i, cs := range p.Status.ContainerStatuses {
-					for j, reason := range containerTerminatedReasons {
-						ms[i*len(containerTerminatedReasons)+j] = &metric.Metric{
-							LabelKeys:   []string{"container", "reason"},
-							LabelValues: []string{cs.Name, reason},
-							Value:       boolFloat64(terminationReason(cs, reason)),
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_status_terminated_reason",
-			"Describes the reason the init container is currently in terminated state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses)*len(containerTerminatedReasons))
-
-				for i, cs := range p.Status.InitContainerStatuses {
-					for j, reason := range containerTerminatedReasons {
-						ms[i*len(containerTerminatedReasons)+j] = &metric.Metric{
-							LabelKeys:   []string{"container", "reason"},
-							LabelValues: []string{cs.Name, reason},
-							Value:       boolFloat64(terminationReason(cs, reason)),
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_status_last_terminated_reason",
-			"Describes the last reason the container was in terminated state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses)*len(containerTerminatedReasons))
-
-				for i, cs := range p.Status.ContainerStatuses {
-					for j, reason := range containerTerminatedReasons {
-						ms[i*len(containerTerminatedReasons)+j] = &metric.Metric{
-							LabelKeys:   []string{"container", "reason"},
-							LabelValues: []string{cs.Name, reason},
-							Value:       boolFloat64(lastTerminationReason(cs, reason)),
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_status_last_terminated_reason",
-			"Describes the last reason the init container was in terminated state.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses)*len(containerTerminatedReasons))
-
-				for i, cs := range p.Status.InitContainerStatuses {
-					for j, reason := range containerTerminatedReasons {
-						ms[i*len(containerTerminatedReasons)+j] = &metric.Metric{
-							LabelKeys:   []string{"container", "reason"},
-							LabelValues: []string{cs.Name, reason},
-							Value:       boolFloat64(lastTerminationReason(cs, reason)),
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_status_ready",
-			"Describes whether the containers readiness check succeeded.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
-
-				for i, cs := range p.Status.ContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container"},
-						LabelValues: []string{cs.Name},
-						Value:       boolFloat64(cs.Ready),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_status_ready",
-			"Describes whether the init containers readiness check succeeded.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
-
-				for i, cs := range p.Status.InitContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container"},
-						LabelValues: []string{cs.Name},
-						Value:       boolFloat64(cs.Ready),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_status_restarts_total",
-			"The number of container restarts per container.",
-			metric.Counter,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
-
-				for i, cs := range p.Status.ContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container"},
-						LabelValues: []string{cs.Name},
-						Value:       float64(cs.RestartCount),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_status_restarts_total",
-			"The number of restarts for the init container.",
-			metric.Counter,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
-
-				for i, cs := range p.Status.InitContainerStatuses {
-					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"container"},
-						LabelValues: []string{cs.Name},
-						Value:       float64(cs.RestartCount),
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_resource_requests",
-			"The number of requested request resource by a container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.Containers {
-					req := c.Resources.Requests
-
-					for resourceName, val := range req {
-						switch resourceName {
-						case v1.ResourceCPU:
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
-								Value:       float64(val.MilliValue()) / 1000,
-							})
-						case v1.ResourceStorage:
-							fallthrough
-						case v1.ResourceEphemeralStorage:
-							fallthrough
-						case v1.ResourceMemory:
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-								Value:       float64(val.Value()),
-							})
-						default:
-							if isHugePageResourceName(resourceName) {
-								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-									Value:       float64(val.Value()),
-								})
-							}
-							if isAttachableVolumeResourceName(resourceName) {
-								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-									Value:       float64(val.Value()),
-								})
-							}
-							if isExtendedResourceName(resourceName) {
-								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
-									Value:       float64(val.Value()),
-								})
-							}
-						}
-					}
-				}
-
-				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_container_resource_limits",
-			"The number of requested limit resource by a container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.Containers {
-					lim := c.Resources.Limits
-
-					for resourceName, val := range lim {
-						switch resourceName {
-						case v1.ResourceCPU:
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore)},
-								Value:       float64(val.MilliValue()) / 1000,
-							})
-						case v1.ResourceStorage:
-							fallthrough
-						case v1.ResourceEphemeralStorage:
-							fallthrough
-						case v1.ResourceMemory:
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-								Value:       float64(val.Value()),
-							})
-						default:
-							if isHugePageResourceName(resourceName) {
-								ms = append(ms, &metric.Metric{
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-									Value:       float64(val.Value()),
-								})
-							}
-							if isAttachableVolumeResourceName(resourceName) {
-								ms = append(ms, &metric.Metric{
-									Value:       float64(val.Value()),
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-								})
-							}
-							if isExtendedResourceName(resourceName) {
-								ms = append(ms, &metric.Metric{
-									Value:       float64(val.Value()),
-									LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
-								})
-
-							}
-						}
-					}
-				}
-
-				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "node", "resource", "unit"}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_resource_requests_cpu_cores",
-			"The number of CPU cores requested by an init container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					req := c.Resources.Requests
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceCPU {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.MilliValue()) / 1000,
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_resource_requests_memory_bytes",
-			"Bytes of memory requested by an init container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					req := c.Resources.Requests
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceMemory {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_resource_requests_storage_bytes",
-			"Bytes of storage requested by an init container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					req := c.Resources.Requests
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceStorage {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_resource_requests_ephemeral_storage_bytes",
-			"Bytes of ephemeral-storage requested by an init container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					req := c.Resources.Requests
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceEphemeralStorage {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_resource_requests",
-			"The number of requested request resource by an init container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					req := c.Resources.Requests
-
-					for resourceName, val := range req {
-						if isHugePageResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-								Value:       float64(val.Value()),
-							})
-						}
-						if isAttachableVolumeResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-								Value:       float64(val.Value()),
-							})
-						}
-						if isExtendedResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "resource", "unit"}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_resource_limits_cpu_cores",
-			"The number of CPU cores requested limit by an init container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					req := c.Resources.Limits
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceCPU {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.MilliValue()) / 1000,
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_resource_limits_memory_bytes",
-			"Bytes of memory requested limit by an init container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					req := c.Resources.Limits
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceMemory {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_resource_limits_storage_bytes",
-			"Bytes of storage requested limit by an init container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					req := c.Resources.Limits
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceStorage {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_resource_limits_ephemeral_storage_bytes",
-			"Bytes of ephemeral-storage requested limit by an init container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					req := c.Resources.Limits
-
-					for resourceName, val := range req {
-						if resourceName == v1.ResourceEphemeralStorage {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"container"},
-								LabelValues: []string{c.Name},
-								Value:       float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_init_container_resource_limits",
-			"The number of requested limit resource by an init container.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, c := range p.Spec.InitContainers {
-					lim := c.Resources.Limits
-
-					for resourceName, val := range lim {
-						if isHugePageResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-								Value:       float64(val.Value()),
-							})
-						}
-						if isAttachableVolumeResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								Value:       float64(val.Value()),
-								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitByte)},
-							})
-						}
-						if isExtendedResourceName(resourceName) {
-							ms = append(ms, &metric.Metric{
-								Value:       float64(val.Value()),
-								LabelValues: []string{c.Name, sanitizeLabelName(string(resourceName)), string(constant.UnitInteger)},
-							})
-						}
-					}
-				}
-
-				for _, metric := range ms {
-					metric.LabelKeys = []string{"container", "resource", "unit"}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_spec_volumes_persistentvolumeclaims_info",
-			"Information about persistentvolumeclaim volumes in a pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, v := range p.Spec.Volumes {
-					if v.PersistentVolumeClaim != nil {
-						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"volume", "persistentvolumeclaim"},
-							LabelValues: []string{v.Name, v.PersistentVolumeClaim.ClaimName},
-							Value:       1,
-						})
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_spec_volumes_persistentvolumeclaims_readonly",
-			"Describes whether a persistentvolumeclaim is mounted read only.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				for _, v := range p.Spec.Volumes {
-					if v.PersistentVolumeClaim != nil {
-						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"volume", "persistentvolumeclaim"},
-							LabelValues: []string{v.Name, v.PersistentVolumeClaim.ClaimName},
-							Value:       boolFloat64(v.PersistentVolumeClaim.ReadOnly),
-						})
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_overhead_cpu_cores",
-			"The pod overhead in regards to cpu cores associated with running a pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				if p.Spec.Overhead != nil {
-					for resourceName, val := range p.Spec.Overhead {
-						if resourceName == v1.ResourceCPU {
-							ms = append(ms, &metric.Metric{
-								Value: float64(val.MilliValue()) / 1000,
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_overhead_memory_bytes",
-			"The pod overhead in regards to memory associated with running a pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				if p.Spec.Overhead != nil {
-					for resourceName, val := range p.Spec.Overhead {
-						if resourceName == v1.ResourceMemory {
-							ms = append(ms, &metric.Metric{
-								Value: float64(val.Value()),
-							})
-						}
-					}
-				}
-
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGenerator(
-			"kube_pod_runtimeclass_name_info",
-			"The runtimeclass associated with the pod.",
-			metric.Gauge,
-			"",
-			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				ms := []*metric.Metric{}
-
-				if p.Spec.RuntimeClassName != nil {
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodRestartPolicyFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_restart_policy",
+		"Describes the restart policy in use by this pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			return &metric.Family{
+				Metrics: []*metric.Metric{
+					{
+						LabelKeys:   []string{"type"},
+						LabelValues: []string{string(p.Spec.RestartPolicy)},
+						Value:       float64(1),
+					},
+				},
+			}
+		}),
+	)
+}
+
+func createPodRuntimeClassNameInfoFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_runtimeclass_name_info",
+		"The runtimeclass associated with the pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			if p.Spec.RuntimeClassName != nil {
+				ms = append(ms, &metric.Metric{
+					LabelKeys:   []string{"runtimeclass_name"},
+					LabelValues: []string{*p.Spec.RuntimeClassName},
+					Value:       1,
+				})
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodSpecVolumesPersistentVolumeClaimsInfoFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_spec_volumes_persistentvolumeclaims_info",
+		"Information about persistentvolumeclaim volumes in a pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, v := range p.Spec.Volumes {
+				if v.PersistentVolumeClaim != nil {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"runtimeclass_name"},
-						LabelValues: []string{*p.Spec.RuntimeClassName},
+						LabelKeys:   []string{"volume", "persistentvolumeclaim"},
+						LabelValues: []string{v.Name, v.PersistentVolumeClaim.ClaimName},
 						Value:       1,
 					})
 				}
+			}
 
-				return &metric.Family{
-					Metrics: ms,
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodSpecVolumesPersistentVolumeClaimsReadonlyFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_spec_volumes_persistentvolumeclaims_readonly",
+		"Describes whether a persistentvolumeclaim is mounted read only.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, v := range p.Spec.Volumes {
+				if v.PersistentVolumeClaim != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{"volume", "persistentvolumeclaim"},
+						LabelValues: []string{v.Name, v.PersistentVolumeClaim.ClaimName},
+						Value:       boolFloat64(v.PersistentVolumeClaim.ReadOnly),
+					})
 				}
-			}),
-		),
-	}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodStartTimeFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_start_time",
+		"Start time in unix timestamp for a pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			if p.Status.StartTime != nil {
+				ms = append(ms, &metric.Metric{
+					LabelKeys:   []string{},
+					LabelValues: []string{},
+					Value:       float64((p.Status.StartTime).Unix()),
+				})
+			}
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodStatusPhaseFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_status_phase",
+		"The pods current phase.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			phase := p.Status.Phase
+			if phase == "" {
+				return &metric.Family{
+					Metrics: []*metric.Metric{},
+				}
+			}
+
+			phases := []struct {
+				v bool
+				n string
+			}{
+				{phase == v1.PodPending, string(v1.PodPending)},
+				{phase == v1.PodSucceeded, string(v1.PodSucceeded)},
+				{phase == v1.PodFailed, string(v1.PodFailed)},
+				{phase == v1.PodUnknown, string(v1.PodUnknown)},
+				{phase == v1.PodRunning, string(v1.PodRunning)},
+			}
+
+			ms := make([]*metric.Metric, len(phases))
+
+			for i, p := range phases {
+				ms[i] = &metric.Metric{
+
+					LabelKeys:   []string{"phase"},
+					LabelValues: []string{p.n},
+					Value:       boolFloat64(p.v),
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodStatusReadyFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_status_ready",
+		"Describes whether the pod is ready to serve requests.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Status.Conditions {
+				if c.Type == v1.PodReady {
+					conditionMetrics := addConditionMetrics(c.Status)
+
+					for _, m := range conditionMetrics {
+						metric := m
+						metric.LabelKeys = []string{"condition"}
+						ms = append(ms, metric)
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodStatusReasonFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_status_reason",
+		"The pod status reasons",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, reason := range podStatusReasons {
+				metric := &metric.Metric{}
+				metric.LabelKeys = []string{"reason"}
+				metric.LabelValues = []string{reason}
+				if p.Status.Reason == reason {
+					metric.Value = boolFloat64(true)
+				} else {
+					metric.Value = boolFloat64(false)
+				}
+				ms = append(ms, metric)
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodStatusScheduledFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_status_scheduled",
+		"Describes the status of the scheduling process for the pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Status.Conditions {
+				if c.Type == v1.PodScheduled {
+					conditionMetrics := addConditionMetrics(c.Status)
+
+					for _, m := range conditionMetrics {
+						metric := m
+						metric.LabelKeys = []string{"condition"}
+						ms = append(ms, metric)
+					}
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodStatusScheduledTimeFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_status_scheduled_time",
+		"Unix timestamp when pod moved into scheduled status",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Status.Conditions {
+				if c.Type == v1.PodScheduled && c.Status == v1.ConditionTrue {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(c.LastTransitionTime.Unix()),
+					})
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_status_unschedulable",
+		"Describes the unschedulable status for the pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			for _, c := range p.Status.Conditions {
+				if c.Type == v1.PodScheduled && c.Status == v1.ConditionFalse {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       1,
+					})
+				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
 }
 
 func wrapPodFunc(f func(*v1.Pod) *metric.Family) func(interface{}) *metric.Family {


### PR DESCRIPTION
To reduce the high cyclo complexity of the nodeMetricFamilies and podMetricFamilies, I moved the generators that don't need the labelsAllowList back into a global variable. This approach is the most straightforward that I could find and the one that requires fewer changes to the codebase.

Another option would be to define actual functions to create each metric family generator, but in my opinion, this would make the codebase less readable.

We could also subdivide the metric families based on the subsystem of the metric. For example, with Pods we could separate the families between: `status`, `container`, `init_container`, `spec`, ... However, I also think that this approach would needlessly complexity the codebase compare to the solution I went with here.

Once we come to an agreement, I'll apply this refactor to the other metric families.

Fixes #1306

