### PR TITLE
add useExistingRole option - to support running in specific namespace…

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.9.8
+version: 2.10.0
 appVersion: 1.9.7
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/charts/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.rbac.useClusterRole -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -11,7 +11,11 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+{{- if .Values.rbac.useExistingRole }}
+  name: {{ .Values.rbac.useExistingRole }}
+{{- else }}
   name: {{ template "kube-state-metrics.fullname" . }}
+{{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "kube-state-metrics.fullname" . }}

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -1,180 +1,192 @@
-{{- if .Values.rbac.create -}}
+{{- if and (eq $.Values.rbac.create true) (not .Values.rbac.useExistingRole)  -}}
+{{- if eq .Values.rbac.useClusterRole false }}
+{{-   range (split "," $.Values.namespace) }}
+{{- end }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if eq .Values.rbac.useClusterRole false }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 metadata:
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-  name: {{ template "kube-state-metrics.fullname" . }}
+    app.kubernetes.io/name: {{ template "kube-state-metrics.name" $ }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  name: {{ template "kube-state-metrics.fullname" $ }}
+{{- if eq .Values.rbac.useClusterRole false }}
+  namespace: {{ . }}
+{{- end }}
 rules:
-{{ if .Values.collectors.certificatesigningrequests }}
+{{ if $.Values.collectors.certificatesigningrequests }}
 - apiGroups: ["certificates.k8s.io"]
   resources:
   - certificatesigningrequests
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.configmaps }}
+{{ if $.Values.collectors.configmaps }}
 - apiGroups: [""]
   resources:
   - configmaps
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.cronjobs }}
+{{ if $.Values.collectors.cronjobs }}
 - apiGroups: ["batch"]
   resources:
   - cronjobs
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.daemonsets }}
+{{ if $.Values.collectors.daemonsets }}
 - apiGroups: ["extensions", "apps"]
   resources:
   - daemonsets
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.deployments }}
+{{ if $.Values.collectors.deployments }}
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.endpoints }}
+{{ if $.Values.collectors.endpoints }}
 - apiGroups: [""]
   resources:
   - endpoints
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.horizontalpodautoscalers }}
+{{ if $.Values.collectors.horizontalpodautoscalers }}
 - apiGroups: ["autoscaling"]
   resources:
   - horizontalpodautoscalers
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.ingresses }}
+{{ if $.Values.collectors.ingresses }}
 - apiGroups: ["extensions", "networking.k8s.io"]
   resources:
   - ingresses
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.jobs }}
+{{ if $.Values.collectors.jobs }}
 - apiGroups: ["batch"]
   resources:
   - jobs
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.limitranges }}
+{{ if $.Values.collectors.limitranges }}
 - apiGroups: [""]
   resources:
   - limitranges
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.mutatingwebhookconfigurations }}
+{{ if $.Values.collectors.mutatingwebhookconfigurations }}
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:
     - mutatingwebhookconfigurations
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.namespaces }}
+{{ if $.Values.collectors.namespaces }}
 - apiGroups: [""]
   resources:
   - namespaces
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.networkpolicies }}
+{{ if $.Values.collectors.networkpolicies }}
 - apiGroups: ["networking.k8s.io"]
   resources:
   - networkpolicies
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.nodes }}
+{{ if $.Values.collectors.nodes }}
 - apiGroups: [""]
   resources:
   - nodes
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.persistentvolumeclaims }}
+{{ if $.Values.collectors.persistentvolumeclaims }}
 - apiGroups: [""]
   resources:
   - persistentvolumeclaims
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.persistentvolumes }}
+{{ if $.Values.collectors.persistentvolumes }}
 - apiGroups: [""]
   resources:
   - persistentvolumes
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.poddisruptionbudgets }}
+{{ if $.Values.collectors.poddisruptionbudgets }}
 - apiGroups: ["policy"]
   resources:
     - poddisruptionbudgets
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.pods }}
+{{ if $.Values.collectors.pods }}
 - apiGroups: [""]
   resources:
   - pods
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.replicasets }}
+{{ if $.Values.collectors.replicasets }}
 - apiGroups: ["extensions", "apps"]
   resources:
   - replicasets
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.replicationcontrollers }}
+{{ if $.Values.collectors.replicationcontrollers }}
 - apiGroups: [""]
   resources:
   - replicationcontrollers
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.resourcequotas }}
+{{ if $.Values.collectors.resourcequotas }}
 - apiGroups: [""]
   resources:
   - resourcequotas
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.secrets }}
+{{ if $.Values.collectors.secrets }}
 - apiGroups: [""]
   resources:
   - secrets
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.services }}
+{{ if $.Values.collectors.services }}
 - apiGroups: [""]
   resources:
   - services
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.statefulsets }}
+{{ if $.Values.collectors.statefulsets }}
 - apiGroups: ["apps"]
   resources:
   - statefulsets
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.storageclasses }}
+{{ if $.Values.collectors.storageclasses }}
 - apiGroups: ["storage.k8s.io"]
   resources:
     - storageclasses
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.validatingwebhookconfigurations }}
+{{ if $.Values.collectors.validatingwebhookconfigurations }}
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:
     - validatingwebhookconfigurations
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.volumeattachments }}
+{{ if $.Values.collectors.volumeattachments }}
 - apiGroups: ["storage.k8s.io"]
   resources:
     - volumeattachments
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.verticalpodautoscalers }}
+{{ if $.Values.collectors.verticalpodautoscalers }}
 - apiGroups: ["autoscaling.k8s.io"]
   resources:
     - verticalpodautoscalers
   verbs: ["list", "watch"]
 {{ end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/kube-state-metrics/templates/rolebinding.yaml
+++ b/charts/kube-state-metrics/templates/rolebinding.yaml
@@ -1,0 +1,27 @@
+{{- if and (eq  .Values.rbac.create true) (eq .Values.rbac.useClusterRole false) -}}
+{{- range (split "," $.Values.namespace) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "kube-state-metrics.name" $ }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  name: {{ template "kube-state-metrics.fullname" $ }}
+  namespace: {{ . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+{{- if (not $.Values.rbac.useExistingRole) }}
+  name: {{ template "kube-state-metrics.fullname" $ }}
+{{- else }}
+  name: {{ $.Values.rbac.useExistingRole }}
+{{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kube-state-metrics.fullname" $ }}
+  namespace: {{ template "kube-state-metrics.namespace" $ }}
+{{- end -}}
+{{- end -}}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -33,6 +33,12 @@ rbac:
   # If true, create & use RBAC resources
   create: true
 
+  # Set to a rolename to use existing role - skipping role creating - but still doing serviceaccount and rolebinding to it, rolename set here.
+  # useExistingRole: your-existing-role
+
+  # If set to false - Run without Cluteradmin privs needed - ONLY works if namespace is also set (if useExistingRole is set this name is used as ClusterRole or Role to bind to)
+  useClusterRole: true
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created, require rbac true
   create: true


### PR DESCRIPTION
…s without needing clusteradmin privs

This is a repost of https://github.com/helm/charts/pull/23953

This adds support for running on kubernetes setups (such as is typical in openshift) where you only have access to your own namespaces.

I've gotten this support merged in both Prometheus and Grafana charts and
I'd really like to get it in this last chart I use for our Prometheus setup ;)