### PR TITLE
Makefile: remove test-unit dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build: kube-state-metrics
 kube-state-metrics:
 	${DOCKER_CLI} run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics golang:${GO_VERSION} make build-local
 
-test-unit: clean build
+test-unit:
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(TESTENVVAR) go test --race $(FLAGS) $(PKGS)
 
 shellcheck:


### PR DESCRIPTION
The test-unit Makefile rule had a dependency on the clean and build
rules. However, these rules aren't needed to run kube-state-metrics unit
tests.
The original setup can be problematic when running the unit tests in an
environment without docker installed.

