### PR TITLE
Retry releasing chart after gh-pages branch protection was removed

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.9.4
+version: 2.9.5
 appVersion: 1.9.7
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:


### PR DESCRIPTION
**What this PR does / why we need it**:

Retrying #1329 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

