### PR TITLE
Add gh-pages Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# kube-state-metrics Helm Charts
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Release Charts](https://github.com/kubernetes/kube-state-metrics/workflows/Release%20Charts/badge.svg?branch=master)
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```console
+helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics
+```
+
+You can then run `helm search repo kube-state-metrics` to see the charts.
+
+## Contributing
+
+The source code of the `kube-state-metrics` [Helm](https://helm.sh) chart can be found on Github: <https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics>
+
+<!-- Keep full URL links to repo files because this README syncs from main to gh-pages.  -->
+We'd love to have you contribute! Please refer to our [contribution guidelines](https://github.com/kubernetes/kube-state-metrics/blob/master/CONTRIBUTING.md) for details.
+
+## License
+
+<!-- Keep full URL links to repo files because this README syncs from main to gh-pages.  -->
+[Apache 2.0 License](https://github.com/kubernetes/kube-state-metrics/blob/master/LICENSE).
+
+## Helm charts build status
+
+![Release Charts](https://github.com/kubernetes/kube-state-metrics/workflows/Release%20Charts/badge.svg?branch=master)


### PR DESCRIPTION
**What this PR does / why we need it**:

Friendly landing page for end users who may browse to https://kubernetes.github.io/kube-state-metrics.

Once merged, it would look similar to https://prometheus-community.github.io/helm-charts/