### PR TITLE
Expose sharding configuration via telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,14 +135,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: prom/prometheus:v2.24.1
-      volumes:
-        - .:/mnt
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
       - name: Rule tests
         run: |
-          pwd
-          ls -lA
-          promtool test rules /mnt/tests/rules/alerts-test.yaml
+          promtool test rules "$GITHUB_WORKSPACE/tests/rules/alerts-test.yaml"
 
   ci-benchmark-tests:
     name: ci-benchmark-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,12 +135,14 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: prom/prometheus:v2.24.1
+      volumes:
+        - .:/mnt
     steps:
       - name: Rule tests
         run: |
           pwd
           ls -lA
-          promtool test rules tests/rules/alerts-test.yaml
+          promtool test rules /mnt/tests/rules/alerts-test.yaml
 
   ci-benchmark-tests:
     name: ci-benchmark-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,18 @@ jobs:
       run: |
         make test-unit
 
+  ci-rule-tests:
+    name: ci-rule-tests
+    runs-on: ubuntu-latest
+    container:
+      image: prom/prometheus:v2.24.1
+    steps:
+      - name: Rule tests
+        run: |
+          pwd
+          ls -lA
+          promtool test rules tests/rules/alerts-test.yaml
+
   ci-benchmark-tests:
     name: ci-benchmark-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,15 +133,17 @@ jobs:
   ci-rule-tests:
     name: ci-rule-tests
     runs-on: ubuntu-latest
-    container:
-      image: prom/prometheus:v2.24.1
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - name: Setup promtool
+        run: |
+          make install-promtool
+
       - name: Rule tests
         run: |
-          promtool test rules "$GITHUB_WORKSPACE/tests/rules/alerts-test.yaml"
+          PROMTOOL_CLI=./promtool make test-rules
 
   ci-benchmark-tests:
     name: ci-benchmark-tests

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ kube-state-metrics:
 test-unit:
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(TESTENVVAR) go test --race $(FLAGS) $(PKGS)
 
+test-rules:
+	promtool test rules tests/rules/alerts-test.yaml
+
 shellcheck:
 	${DOCKER_CLI} run -v "${PWD}:/mnt" koalaman/shellcheck:stable $(shell find . -type f -name "*.sh" -not -path "*vendor*")
 
@@ -152,4 +155,4 @@ install-tools:
 	@echo Installing tools from tools.go
 	@cat tools/tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
 
-.PHONY: all build build-local all-push all-container container container-* do-push-* sub-push-* push push-multi-arch quay-push test-unit test-benchmark-compare clean e2e validate-modules shellcheck licensecheck lint generate embedmd
+.PHONY: all build build-local all-push all-container container container-* do-push-* sub-push-* push push-multi-arch quay-push test-unit test-rules test-benchmark-compare clean e2e validate-modules shellcheck licensecheck lint generate embedmd

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ TAG ?= $(TAG_PREFIX)$(VERSION)
 LATEST_RELEASE_BRANCH := release-$(shell grep -ohE "[0-9]+.[0-9]+" VERSION)
 BRANCH = $(strip $(shell git rev-parse --abbrev-ref HEAD))
 DOCKER_CLI ?= docker
+PROMTOOL_CLI ?= promtool
 PKGS = $(shell go list ./... | grep -v /vendor/ | grep -v /tests/e2e)
 ARCH ?= $(shell go env GOARCH)
 BUILD_DATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
@@ -66,7 +67,7 @@ test-unit:
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(TESTENVVAR) go test --race $(FLAGS) $(PKGS)
 
 test-rules:
-	promtool test rules tests/rules/alerts-test.yaml
+	${PROMTOOL_CLI} test rules tests/rules/alerts-test.yaml
 
 shellcheck:
 	${DOCKER_CLI} run -v "${PWD}:/mnt" koalaman/shellcheck:stable $(shell find . -type f -name "*.sh" -not -path "*vendor*")
@@ -154,5 +155,9 @@ scripts/vendor: scripts/jsonnetfile.json scripts/jsonnetfile.lock.json
 install-tools:
 	@echo Installing tools from tools.go
 	@cat tools/tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
+
+install-promtool:
+	@echo Installing promtool
+	@wget -qO- "https://github.com/prometheus/prometheus/releases/download/v2.24.1/prometheus-2.24.1.linux-amd64.tar.gz" | tar xvz --strip-components=1
 
 .PHONY: all build build-local all-push all-container container container-* do-push-* sub-push-* push push-multi-arch quay-push test-unit test-rules test-benchmark-compare clean e2e validate-modules shellcheck licensecheck lint generate embedmd

--- a/README.md
+++ b/README.md
@@ -150,14 +150,15 @@ http_request_duration_seconds_sum{handler="metrics",method="get"} 0.021113919999
 http_request_duration_seconds_count{handler="metrics",method="get"} 30
 ```
 
-kube-state-metrics exposes the build info metric:
+kube-state-metrics also exposes build and configuration metrics:
 ```
 kube_state_metrics_build_info{branch="master",goversion="go1.15.3",revision="6c9d775d",version="v2.0.0-beta"} 1
+kube_state_metrics_shard_ordinal 0
+kube_state_metrics_total_shards 1
 ```
 
 `kube_state_metrics_build_info` is used to expose version and other build information. For more usage about the info pattern,
 please check the blog post [here](https://www.robustperception.io/exposing-the-software-version-to-prometheus).
-
 
 ### Scaling kube-state-metrics
 

--- a/README.md
+++ b/README.md
@@ -153,12 +153,14 @@ http_request_duration_seconds_count{handler="metrics",method="get"} 30
 kube-state-metrics also exposes build and configuration metrics:
 ```
 kube_state_metrics_build_info{branch="master",goversion="go1.15.3",revision="6c9d775d",version="v2.0.0-beta"} 1
-kube_state_metrics_shard_ordinal 0
+kube_state_metrics_shard_ordinal{shard_ordinal="0"} 0
 kube_state_metrics_total_shards 1
 ```
 
 `kube_state_metrics_build_info` is used to expose version and other build information. For more usage about the info pattern,
 please check the blog post [here](https://www.robustperception.io/exposing-the-software-version-to-prometheus).
+Sharding metrics expose `--shard` and `--total-shards` flags and can be used to validate
+run-time configuration, see [`/examples/prometheus-alerting-rules`](./examples/prometheus-alerting-rules).
 
 ### Scaling kube-state-metrics
 

--- a/examples/prometheus-alerting-rules/alerts.yaml
+++ b/examples/prometheus-alerting-rules/alerts.yaml
@@ -25,3 +25,24 @@ groups:
     for: 15m
     labels:
       severity: critical
+  - alert: KubeStateMetricsShardingMismatch
+    annotations:
+      description: kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all.
+      summary: kube-state-metrics sharding is misconfigured.
+    expr: |
+      stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) != 0
+    for: 15m
+    labels:
+      severity: critical
+  - alert: KubeStateMetricsShardsMissing
+    annotations:
+      description: kube-state-metrics shards are missing, some Kubernetes objects are not being exposed.
+      summary: kube-state-metrics shards are missing.
+    expr: |
+      2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) - 1
+        -
+      sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"}) )
+      != 0
+    for: 15m
+    labels:
+      severity: critical

--- a/examples/prometheus-alerting-rules/alerts.yaml
+++ b/examples/prometheus-alerting-rules/alerts.yaml
@@ -27,7 +27,9 @@ groups:
       severity: critical
   - alert: KubeStateMetricsShardingMismatch
     annotations:
-      description: kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all.
+      description: kube-state-metrics pods are running with different --total-shards
+        configuration, some Kubernetes objects may be exposed multiple times or not
+        exposed at all.
       summary: kube-state-metrics sharding is misconfigured.
     expr: |
       stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) != 0
@@ -36,7 +38,8 @@ groups:
       severity: critical
   - alert: KubeStateMetricsShardsMissing
     annotations:
-      description: kube-state-metrics shards are missing, some Kubernetes objects are not being exposed.
+      description: kube-state-metrics shards are missing, some Kubernetes objects
+        are not being exposed.
       summary: kube-state-metrics shards are missing.
     expr: |
       2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) - 1

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -104,7 +105,9 @@ func (b *Builder) WithNamespaces(n options.NamespaceList) {
 // WithSharding sets the shard and totalShards property of a Builder.
 func (b *Builder) WithSharding(shard int32, totalShards int) {
 	b.shard = shard
-	b.shardingMetrics.Ordinal.Set(float64(shard))
+	labels := map[string]string{sharding.LabelOrdinal: strconv.Itoa(int(shard))}
+	b.shardingMetrics.Ordinal.Reset()
+	b.shardingMetrics.Ordinal.With(labels).Set(float64(shard))
 	b.totalShards = totalShards
 	b.shardingMetrics.Total.Set(float64(totalShards))
 }

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -59,7 +59,8 @@ type Builder struct {
 	ctx              context.Context
 	enabledResources []string
 	allowDenyList    ksmtypes.AllowDenyLister
-	metrics          *watch.ListWatchMetrics
+	listWatchMetrics *watch.ListWatchMetrics
+	shardingMetrics  *sharding.Metrics
 	shard            int32
 	totalShards      int
 	buildStoreFunc   ksmtypes.BuildStoreFunc
@@ -74,7 +75,8 @@ func NewBuilder() *Builder {
 
 // WithMetrics sets the metrics property of a Builder.
 func (b *Builder) WithMetrics(r prometheus.Registerer) {
-	b.metrics = watch.NewListWatchMetrics(r)
+	b.listWatchMetrics = watch.NewListWatchMetrics(r)
+	b.shardingMetrics = sharding.NewShardingMetrics(r)
 }
 
 // WithEnabledResources sets the enabledResources property of a Builder.
@@ -102,7 +104,9 @@ func (b *Builder) WithNamespaces(n options.NamespaceList) {
 // WithSharding sets the shard and totalShards property of a Builder.
 func (b *Builder) WithSharding(shard int32, totalShards int) {
 	b.shard = shard
+	b.shardingMetrics.Ordinal.Set(float64(shard))
 	b.totalShards = totalShards
+	b.shardingMetrics.Total.Set(float64(totalShards))
 }
 
 // WithContext sets the ctx property of a Builder.
@@ -354,7 +358,7 @@ func (b *Builder) reflectorPerNamespace(
 ) {
 	lwf := func(ns string) cache.ListerWatcher { return listWatchFunc(b.kubeClient, ns) }
 	lw := listwatch.MultiNamespaceListerWatcher(b.namespaces, nil, lwf)
-	instrumentedListWatch := watch.NewInstrumentedListerWatcher(lw, b.metrics, reflect.TypeOf(expectedType).String())
+	instrumentedListWatch := watch.NewInstrumentedListerWatcher(lw, b.listWatchMetrics, reflect.TypeOf(expectedType).String())
 	reflector := cache.NewReflector(sharding.NewShardedListWatch(b.shard, b.totalShards, instrumentedListWatch), expectedType, store, 0)
 	go reflector.Run(b.ctx.Done())
 }

--- a/jsonnet/kube-state-metrics-mixin/alerts.libsonnet
+++ b/jsonnet/kube-state-metrics-mixin/alerts.libsonnet
@@ -38,6 +38,43 @@
               description: 'kube-state-metrics is experiencing errors at an elevated rate in watch operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.',
             },
           },
+          {
+            alert: 'KubeStateMetricsShardingMismatch',
+            //
+            expr: |||
+              stdvar (kube_state_metrics_total_shards{%(kubeStateMetricsSelector)s}) != 0
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'kube-state-metrics sharding is misconfigured.',
+              description: 'kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all.',
+            },
+          },
+          {
+            alert: 'KubeStateMetricsShardsMissing',
+            // Each shard ordinal is assigned a binary position (2^ordinal) and we compute a sum of those.
+            // This sum is compared to the expected number (2^total_shards - 1).
+            // Result of zero all shards are being scraped, anything else indicates an issue.
+            // A handy side effect of this computation is the result indicates what ordinals are missing.
+            // Eg. a result of "5" decimal, which translates to binary "101", means shards #0 and #2 are not available.
+            expr: |||
+              2^max(kube_state_metrics_total_shards{%(kubeStateMetricsSelector)s}) - 1
+                -
+              sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{%(kubeStateMetricsSelector)s}) )
+              != 0
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'kube-state-metrics shards are missing.',
+              description: 'kube-state-metrics shards are missing, some Kubernetes objects are not being exposed.',
+            },
+          },
         ],
       },
     ],

--- a/main_test.go
+++ b/main_test.go
@@ -388,7 +388,7 @@ kube_pod_status_reason{namespace="default",pod="pod0",uid="abc-0",reason="Unexpe
 # HELP kube_state_metrics_total_shards Number of total shards this instance is aware of
 # TYPE kube_state_metrics_shard_ordinal gauge
 # TYPE kube_state_metrics_total_shards gauge
-kube_state_metrics_shard_ordinal 0
+kube_state_metrics_shard_ordinal{shard_ordinal="0"} 0
 kube_state_metrics_total_shards 1
 `
 

--- a/pkg/sharding/metrics.go
+++ b/pkg/sharding/metrics.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// Name of Prometheus metric label to use in conjunction with kube_state_metrics_shard_ordinal.
+	// LabelOrdinal is name of Prometheus metric label to use in conjunction with kube_state_metrics_shard_ordinal.
 	LabelOrdinal = "shard_ordinal"
 )
 

--- a/pkg/sharding/metrics.go
+++ b/pkg/sharding/metrics.go
@@ -21,10 +21,15 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const (
+	// Name of Prometheus metric label to use in conjunction with kube_state_metrics_shard_ordinal.
+	LabelOrdinal = "shard_ordinal"
+)
+
 // Metrics stores the pointers of kube_state_metrics_shard_ordinal
 // and kube_state_metrics_total_shards metrics.
 type Metrics struct {
-	Ordinal prometheus.Gauge
+	Ordinal *prometheus.GaugeVec
 	Total   prometheus.Gauge
 }
 
@@ -32,11 +37,11 @@ type Metrics struct {
 // and registers sharding configuration metrics. It returns those registered metrics.
 func NewShardingMetrics(r prometheus.Registerer) *Metrics {
 	return &Metrics{
-		Ordinal: promauto.With(r).NewGauge(
+		Ordinal: promauto.With(r).NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "kube_state_metrics_shard_ordinal",
 				Help: "Current sharding ordinal/index of this instance",
-			},
+			}, []string{LabelOrdinal},
 		),
 		Total: promauto.With(r).NewGauge(
 			prometheus.GaugeOpts{

--- a/pkg/sharding/metrics.go
+++ b/pkg/sharding/metrics.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharding
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics stores the pointers of kube_state_metrics_shard_ordinal
+// and kube_state_metrics_total_shards metrics.
+type Metrics struct {
+	Ordinal prometheus.Gauge
+	Total   prometheus.Gauge
+}
+
+// NewShardingMetrics takes in a prometheus registry and initializes
+// and registers sharding configuration metrics. It returns those registered metrics.
+func NewShardingMetrics(r prometheus.Registerer) *Metrics {
+	return &Metrics{
+		Ordinal: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Name: "kube_state_metrics_shard_ordinal",
+				Help: "Current sharding ordinal/index of this instance",
+			},
+		),
+		Total: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Name: "kube_state_metrics_total_shards",
+				Help: "Number of total shards this instance is aware of",
+			},
+		),
+	}
+}

--- a/tests/rules/alerts-test.yaml
+++ b/tests/rules/alerts-test.yaml
@@ -1,0 +1,88 @@
+rule_files:
+  - ../../examples/prometheus-alerting-rules/alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Test long-lasting invalid configuration should trigger alert
+  - interval: 1m
+    input_series:
+      # T=0: 3 shards with correct configuration
+      # T=9m: shard #0 was incorrectly redeployed with --total-shards=1
+      - series: 'kube_state_metrics_total_shards{job="kube-state-metrics",pod="kube-state-metrics-shard-0-0"}'
+        values: '3x9 1x21'
+      - series: 'kube_state_metrics_total_shards{job="kube-state-metrics",pod="kube-state-metrics-shard-1-0"}'
+        values: '3x30'
+      - series: 'kube_state_metrics_total_shards{job="kube-state-metrics",pod="kube-state-metrics-shard-2-0"}'
+        values: '3x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KubeStateMetricsShardingMismatch
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: "kube-state-metrics sharding is misconfigured."
+              description: "kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all."
+
+  # Test deployment from one shard to multiple shards should not trigger alert
+  - interval: 1m
+    input_series:
+      # T=0: 1 shard with correct configuration
+      # T=9m: two more shards were deployed, all shards were correctly configured
+      - series: 'kube_state_metrics_total_shards{job="kube-state-metrics",pod="kube-state-metrics-shard-0-0"}'
+        values: '1x9 3x21'
+      - series: 'kube_state_metrics_total_shards{job="kube-state-metrics",pod="kube-state-metrics-shard-1-0"}'
+        values: '_x9 3x21'
+      - series: 'kube_state_metrics_total_shards{job="kube-state-metrics",pod="kube-state-metrics-shard-2-0"}'
+        values: '_x9 3x21'
+      - series: 'kube_state_metrics_shard_ordinal{job="kube-state-metrics",pod="kube-state-metrics-shard-0-0",shard_ordinal="0"}'
+        values: '0x30'
+      - series: 'kube_state_metrics_shard_ordinal{job="kube-state-metrics",pod="kube-state-metrics-shard-1-0",shard_ordinal="1"}'
+        values: '_x9 1x21'
+      - series: 'kube_state_metrics_shard_ordinal{job="kube-state-metrics",pod="kube-state-metrics-shard-2-0",shard_ordinal="2"}'
+        values: '_x9 2x21'
+    alert_rule_test: []
+
+  # Test misconfigured single shard deployment
+  - interval: 1m
+    input_series:
+      - series: 'kube_state_metrics_total_shards{job="kube-state-metrics",pod="kube-state-metrics-shard-0-0"}'
+        values: '3x30'
+      - series: 'kube_state_metrics_shard_ordinal{job="kube-state-metrics",pod="kube-state-metrics-shard-0-0",shard_ordinal="0"}'
+        values: '0x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KubeStateMetricsShardsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: "kube-state-metrics shards are missing."
+              description: "kube-state-metrics shards are missing, some Kubernetes objects are not being exposed."
+
+  # Test misconfigured single shard deployment
+  - interval: 1m
+    input_series:
+      - series: 'kube_state_metrics_total_shards{job="kube-state-metrics",pod="kube-state-metrics-shard-0-0"}'
+        values: '3x30'
+      - series: 'kube_state_metrics_shard_ordinal{job="kube-state-metrics",pod="kube-state-metrics-shard-0-0",shard_ordinal="0"}'
+        values: '0x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KubeStateMetricsShardsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: "kube-state-metrics shards are missing."
+              description: "kube-state-metrics shards are missing, some Kubernetes objects are not being exposed."
+    promql_expr_test:
+      # Test that missing shards are #2 (0b100) and #1 (0b010)
+      - expr: |
+          2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) - 1
+            -
+          sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"}) )
+        eval_time: 25m
+        exp_samples:
+          - value: 0b110


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Kube-state-metrics component has sharding capabilities, but the sharding configuration is hidden in command arguments and cannot be easily tested after deployment. This may result in multiple forms of misconfiguration, such as:
* part of kubernetes objects may not be processed by any shard (0/3, 1/3, missing 2/3)
* some shards are duplicated, resulting in simple/naive queries yielding incorrect values (0/3, 0/3, 1/3, 2/3)
* variant of the previous state is a residue of old deployment (0/1, 0/3, 1/3, 2/3)

Auto-sharding does not by itself prevent any of those errors, but presumably makes them far less common.


This PR adds two new metrics to kube-state-metrics-self telemetry, namely:
```
# HELP kube_state_metrics_sharding_ordinal Current sharding ordinal/index of this instance
# TYPE kube_state_metrics_sharding_ordinal gauge
kube_state_metrics_sharding_ordinal 0
# HELP kube_state_metrics_sharding_total Number of total shards this instance is aware of
# TYPE kube_state_metrics_sharding_total gauge
kube_state_metrics_sharding_total 1
```

This works with explicit sharding configuration as well as autosharding.

Notes for reviewer:
* I'm not set on `ordinal` being the noun used. The code base uses `shard` which seems less descriptive, but it may be better to keep it consistent?
* Most of the new code is tests. I intentionally did not abstract any of the original tests to keep this separate. It could be eventually refactored, but since this adds new feature it is safer to not also alter the existing tests in the same patch.