### PR TITLE
charts: point out that the repo isn't set up yet

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.9.5
+version: 2.9.6
 appVersion: 1.9.7
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/README.md
+++ b/charts/kube-state-metrics/README.md
@@ -2,6 +2,13 @@
 
 Installs the [kube-state-metrics agent](https://github.com/kubernetes/kube-state-metrics).
 
+## Warning
+
+**The integration is still work in progress. As of now, the mentioned repositories below are not fully set up yet.
+You can still use the deprecated [helm/stable](https://charts.helm.sh/stable/) repository and migrate at a later point to the new location.
+At this point in time, no significant changes to the chart were made in this repository.
+For more information, please see: https://github.com/kubernetes/kube-state-metrics/pull/1325#issuecomment-749732052**
+
 ## Get Repo Info
 
 ```console

--- a/charts/kube-state-metrics/README.md
+++ b/charts/kube-state-metrics/README.md
@@ -2,12 +2,13 @@
 
 Installs the [kube-state-metrics agent](https://github.com/kubernetes/kube-state-metrics).
 
-## Warning
+## ⚠️ Warning
 
-**The integration is still work in progress. As of now, the mentioned repositories below are not fully set up yet.
-You can still use the deprecated [helm/stable](https://charts.helm.sh/stable/) repository and migrate at a later point to the new location.
+**Chart Releasing workflow is currently broken due to an upstream issue with this repo and `kubernetes/test-infra`, which is actively being worked on.**
+Until then, the mentioned repositories below are not fully set up yet.
+You can still use the deprecated [helm/stable](https://charts.helm.sh/stable/) repository and migrate to the new location in the near future.
 At this point in time, no significant changes to the chart were made in this repository.
-For more information, please see: https://github.com/kubernetes/kube-state-metrics/pull/1325#issuecomment-749732052**
+For more information or to follow progress, see: https://github.com/kubernetes/kube-state-metrics/pull/1325#issuecomment-749732052
 
 ## Get Repo Info
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Users wonder why the chart repo is not available yet.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See also: https://github.com/kubernetes/kube-state-metrics/issues/1342

