### PR TITLE
[WIP] chart: Update to kube-state-metrics v2.0.0-beta

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: kube-state-metrics
 description: Install kube-state-metrics to generate and expose cluster-level metrics
 keywords:
@@ -6,8 +6,9 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.12.2
-appVersion: 1.9.7
+type: application
+version: 3.0.0
+appVersion: 2.0.0-beta
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/README.md
+++ b/charts/kube-state-metrics/README.md
@@ -14,11 +14,7 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 ## Install Chart
 
 ```console
-# Helm 3
 $ helm install [RELEASE_NAME] kube-state-metrics/kube-state-metrics [flags]
-
-# Helm 2
-$ helm install --name [RELEASE_NAME] kube-state-metrics/kube-state-metrics [flags]
 ```
 
 _See [configuration](#configuration) below._
@@ -28,11 +24,7 @@ _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documen
 ## Uninstall Chart
 
 ```console
-# Helm 3
 $ helm uninstall [RELEASE_NAME]
-
-# Helm 2
-# helm delete --purge [RELEASE_NAME]
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
@@ -42,7 +34,6 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 ## Upgrading Chart
 
 ```console
-# Helm 3 or 2
 $ helm upgrade [RELEASE_NAME] kube-state-metrics/kube-state-metrics [flags]
 ```
 
@@ -63,4 +54,4 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 helm show values kube-state-metrics/kube-state-metrics
 ```
 
-You may also `helm show values` on this chart's [dependencies](#dependencies) for additional options.
+You may also run `helm show values` on this chart's [dependencies](#dependencies) for additional options.

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -69,91 +69,91 @@ spec:
         {{- end  }}
 {{  end  }}
 {{  if .Values.collectors.certificatesigningrequests  }}
-        - --collectors=certificatesigningrequests
+        - --resources=certificatesigningrequests
 {{  end  }}
 {{  if .Values.collectors.configmaps  }}
-        - --collectors=configmaps
+        - --resources=configmaps
 {{  end  }}
 {{  if .Values.collectors.cronjobs  }}
-        - --collectors=cronjobs
+        - --resources=cronjobs
 {{  end  }}
 {{ if .Values.collectors.daemonsets  }}
-        - --collectors=daemonsets
+        - --resources=daemonsets
 {{  end  }}
 {{  if .Values.collectors.deployments  }}
-        - --collectors=deployments
+        - --resources=deployments
 {{  end  }}
 {{  if .Values.collectors.endpoints  }}
-        - --collectors=endpoints
+        - --resources=endpoints
 {{  end  }}
 {{  if .Values.collectors.horizontalpodautoscalers  }}
-        - --collectors=horizontalpodautoscalers
+        - --resources=horizontalpodautoscalers
 {{  end  }}
 {{  if .Values.collectors.ingresses  }}
-        - --collectors=ingresses
+        - --resources=ingresses
 {{  end  }}
 {{  if .Values.collectors.jobs  }}
-        - --collectors=jobs
+        - --resources=jobs
 {{  end  }}
 {{  if .Values.collectors.limitranges  }}
-        - --collectors=limitranges
+        - --resources=limitranges
 {{  end  }}
 {{  if .Values.collectors.mutatingwebhookconfigurations  }}
-        - --collectors=mutatingwebhookconfigurations
+        - --resources=mutatingwebhookconfigurations
 {{  end  }}
 {{  if .Values.collectors.namespaces  }}
-        - --collectors=namespaces
+        - --resources=namespaces
 {{  end  }}
 {{  if .Values.collectors.networkpolicies  }}
-        - --collectors=networkpolicies
+        - --resources=networkpolicies
 {{  end  }}
 {{  if .Values.collectors.nodes  }}
-        - --collectors=nodes
+        - --resources=nodes
 {{  end  }}
 {{  if .Values.collectors.persistentvolumeclaims  }}
-        - --collectors=persistentvolumeclaims
+        - --resources=persistentvolumeclaims
 {{  end  }}
 {{  if .Values.collectors.persistentvolumes  }}
-        - --collectors=persistentvolumes
+        - --resources=persistentvolumes
 {{  end  }}
 {{  if .Values.collectors.poddisruptionbudgets  }}
-        - --collectors=poddisruptionbudgets
+        - --resources=poddisruptionbudgets
 {{  end  }}
 {{  if .Values.collectors.pods  }}
-        - --collectors=pods
+        - --resources=pods
 {{  end  }}
 {{  if .Values.collectors.replicasets  }}
-        - --collectors=replicasets
+        - --resources=replicasets
 {{  end  }}
 {{  if .Values.collectors.replicationcontrollers  }}
-        - --collectors=replicationcontrollers
+        - --resources=replicationcontrollers
 {{  end  }}
 {{  if .Values.collectors.resourcequotas  }}
-        - --collectors=resourcequotas
+        - --resources=resourcequotas
 {{  end  }}
 {{  if .Values.collectors.secrets  }}
-        - --collectors=secrets
+        - --resources=secrets
 {{  end  }}
 {{  if .Values.collectors.services  }}
-        - --collectors=services
+        - --resources=services
 {{  end  }}
 {{  if .Values.collectors.statefulsets  }}
-        - --collectors=statefulsets
+        - --resources=statefulsets
 {{  end  }}
 {{  if .Values.collectors.storageclasses  }}
-        - --collectors=storageclasses
+        - --resources=storageclasses
 {{  end  }}
 {{  if .Values.collectors.validatingwebhookconfigurations  }}
-        - --collectors=validatingwebhookconfigurations
+        - --resources=validatingwebhookconfigurations
 {{  end  }}
 {{  if .Values.collectors.verticalpodautoscalers  }}
-        - --collectors=verticalpodautoscalers
+        - --resources=verticalpodautoscalers
 {{  end  }}
 {{  if .Values.collectors.volumeattachments  }}
-        - --collectors=volumeattachments
+        - --resources=volumeattachments
 {{  end  }}
 {{ if .Values.namespace }}
-        - --namespace={{ .Values.namespace | join "," }}
+        - --namespaces={{ .Values.namespace | join "," }}
 {{ end }}
 {{ if .Values.autosharding.enabled }}
         - --pod=$(POD_NAME)

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -1,8 +1,8 @@
 # Default values for kube-state-metrics.
 prometheusScrape: true
 image:
-  repository: quay.io/coreos/kube-state-metrics
-  tag: v1.9.7
+  repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
+  tag: v2.0.0-beta
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -110,7 +110,7 @@ podAnnotations: {}
 podDisruptionBudget: {}
 
 # Available collectors for kube-state-metrics. By default all available
-# collectors are enabled.
+# resources are enabled.
 collectors:
   certificatesigningrequests: true
   configmaps: true
@@ -147,8 +147,8 @@ kubeconfig:
   # base64 encoded kube-config file
   secret:
 
-# Namespace to be enabled for collecting resources. By default all namespaces are collected.
-# namespace: ""
+# Namespaces to be enabled for collecting resources. By default all namespaces are collected.
+# namespaces: ""
 
 ## Override the deployment namespace
 ##


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates flag naming to kube-state-metrics v2.0.0 as well as drops
support for helm v2.
