### PR TITLE
added: support for providing extraArgs via helm to ksm

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.10.1
+version: 2.11.0
 appVersion: 1.9.7
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -62,6 +62,11 @@ spec:
               fieldPath: metadata.namespace
 {{- end }}
         args:
+{{  if .Values.extraArgs  }}
+        {{- range .Values.extraArgs  }}
+        - {{ . }}
+        {{- end  }}
+{{  end  }}
 {{  if .Values.collectors.certificatesigningrequests  }}
         - --collectors=certificatesigningrequests
 {{  end  }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -17,6 +17,11 @@ autosharding:
 
 replicas: 1
 
+# List of additional cli arguments to configure kube-state-metrics
+# for example: --enable-gzip-encoding, --log-file, etc.
+# all the possible args can be found here: https://github.com/kubernetes/kube-state-metrics/blob/master/docs/cli-arguments.md
+extraArgs: []
+
 service:
   port: 8080
   # Default to clusterIP for backward compatibility


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR allows the user to provide extra args, like `--enable-gzip-encoding`, `--log-file`, etc. (or any of [them](https://github.com/kubernetes/kube-state-metrics/blob/master/docs/cli-arguments.md)) while deploying kube-state-metrics via helm. 
The required args would have to be provided as a list under `extraArgs` in `values.yaml`

**Which issue(s) this PR fixes**:
Fixes #1357 

