### PR TITLE
fix multiListWatch resourceVersion mismatch if watch reconnected

### DIFF
--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -167,9 +167,17 @@ func (mlw multiListerWatcher) Watch(options metav1.ListOptions) (watch.Interface
 	resourceVersions := make([]string, len(mlw))
 	// Allow resource versions to be "".
 	if options.ResourceVersion != "" {
-		rvs := strings.Split(options.ResourceVersion, "/")
-		if len(rvs) != len(mlw) {
-			return nil, fmt.Errorf("expected resource version to have %d parts to match the number of ListerWatchers", len(mlw))
+		rvs := make([]string, 0, len(mlw))
+		if strings.Contains(options.ResourceVersion, "/") {
+			rvs = strings.Split(options.ResourceVersion, "/")
+			if len(rvs) != len(mlw) {
+				return nil, fmt.Errorf("expected resource version to have %d parts to match the number of ListerWatchers， actual: %d", len(mlw), len(rvs))
+			}
+		} else {
+			// watch reconnected and resource version is the latest one from event.Object has no "/"
+			for i := 0; i < len(mlw); i++ {
+				rvs = append(rvs, options.ResourceVersion)
+			}
 		}
 		resourceVersions = rvs
 	}


### PR DESCRIPTION
Signed-off-by: KielChan <qingya.chen520@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: bug fix

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # none

I have a problem that report:
``` bash
Failed to watch *v1.Pod: expected resource version to have 2 parts to match the number of ListerWatchers
```

which I wanna collect two namespaces pod metrics with kube-state-metrics. The origin code will split resource version combined by `List` method, but if it is expired or timeout, the client-go will use the latest event.Object resource version to re-watch resources which will lead to the problem.


The same problem occurred  here: [link](https://github.com/prometheus-operator/prometheus-operator/issues/3218). It seemed like using same code.

