### PR TITLE
Propagate resource version when sharded

### DIFF
--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -67,7 +67,7 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 	}
 	
 	metaObj, err := meta.ListAccessor(list)
-        res.ListMeta.ResourceVersion = metaObj.GetResourceVersion()
+	res.ListMeta.ResourceVersion = metaObj.GetResourceVersion()
 
 	return res, nil
 }

--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -66,7 +66,7 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 		}
 	}
 	
-	metaObj, err := meta.ListAccessor(list)
+	metaObj := meta.ListAccessor(list)
 	res.ListMeta.ResourceVersion = metaObj.GetResourceVersion()
 
 	return res, nil

--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -53,6 +53,10 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 	if err != nil {
 		return nil, err
 	}
+	metaObj, err := meta.ListAccessor(list)
+	if err != nil {
+		return nil, err
+	}
 	res := &metav1.List{
 		Items: []runtime.RawExtension{},
 	}
@@ -66,7 +70,6 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 		}
 	}
 	
-	metaObj, err := meta.ListAccessor(list)
 	res.ListMeta.ResourceVersion = metaObj.GetResourceVersion()
 
 	return res, nil

--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -65,6 +65,9 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 			res.Items = append(res.Items, runtime.RawExtension{Object: item})
 		}
 	}
+	
+	metaObj, err := meta.ListAccessor(list)
+        res.ListMeta.ResourceVersion = metaObj.GetResourceVersion()
 
 	return res, nil
 }

--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -69,7 +69,6 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 			res.Items = append(res.Items, runtime.RawExtension{Object: item})
 		}
 	}
-	
 	res.ListMeta.ResourceVersion = metaObj.GetResourceVersion()
 
 	return res, nil

--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -66,7 +66,7 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 		}
 	}
 	
-	metaObj := meta.ListAccessor(list)
+	metaObj, err := meta.ListAccessor(list)
 	res.ListMeta.ResourceVersion = metaObj.GetResourceVersion()
 
 	return res, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses a bug that causes a gap between `list` and `watch` when kube-state-metrics is sharded 

**Which issue(s) this PR fixes**:

Partially fix for:#694 (https://github.com/kubernetes/kube-state-metrics/issues/694)
    
Kube-state-metrics does a `list` and then enters a `watch` loop. The intention is to `watch` **all** events after the initial list. The k8s API takes an optional `resource version` parameter which is returned as part of the `list` call and can be forwarded to the `watch` call, in order to fetch all events after the initial `list`.

In its sharded version, kube-state-metrics intercepts the returned `list` in order to filter out the events for other shards. It reconstructs the response, but it does not propagate the `resource version` to the modified response. The subsequent `watch` call does not refer to a resource version.

When `watch` is called without a `resource version`, it will provide a view consistent with the **most recent** resource version of the `watch` call, missing the events between the `resource version` at `list` call and the most recent one. The k8s documentation captures this as follows: _Get State and Start at Most Recent: Start a watch at the most recent resource version, which must be consistent (i.e. served from etcd via a quorum read). To establish initial state, the watch begins with synthetic "Added" events of all resources instances that exist at the starting resource version. All following watch events are for all changes that occurred after the resource version the watch started at._

Testing: Reproduced the original bug report deterministically by introducing an artificial delay (120s) in list, prior to returning the response, and terminating some pods. Unless the bug is fixed, the terminated pods continue to be reported as running for an indefinite amount of time by kube-state-metrics