### PR TITLE
chart: Upgrade to multi-arch v1.9.8 image

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.12.2
-appVersion: 1.9.7
+version: 2.13.0
+appVersion: 1.9.8
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -1,8 +1,8 @@
 # Default values for kube-state-metrics.
 prometheusScrape: true
 image:
-  repository: quay.io/coreos/kube-state-metrics
-  tag: v1.9.7
+  repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
+  tag: v1.9.8
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Switches the Helm chart to use the latest 1.9 release using the new multi-arch image on gcr.io.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No open issues for this at the moment.
