### PR TITLE
fix labels-metric-allow-list documentation

### DIFF
--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -32,7 +32,7 @@ Usage of ./kube-state-metrics:
   -h, --help                              Print Help text
       --host string                       Host to expose metrics on. (default "0.0.0.0")
       --kubeconfig string                 Absolute path to the kubeconfig file
-      --labels-metric-allow-list string   Allows to pass a list of additional Kubernetes label keys that will be used in the resource' labels metric. By default the metric contains only name and namespace labels. To include additional labels provide a list of resource names in their plural form and Kubernetes label keys you would like to allow for them (Example: '=namespaces=["k8s-label-1","k8s-label-n",...],pods=["app"],...)'
+      --labels-metric-allow-list string   Allows to pass a list of additional Kubernetes label keys that will be used in the resource' labels metric. By default the metric contains only name and namespace labels. To include additional labels provide a list of resource names in their plural form and Kubernetes label keys you would like to allow for them (Example: '=namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...)'
       --log_backtrace_at traceLocation    when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                    If non-empty, write log files in this directory
       --log_file string                   If non-empty, use this log file

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -97,7 +97,7 @@ func (o *Options) AddFlags() {
 	o.flags.StringVar(&o.Namespace, "pod-namespace", "", "Name of the namespace of the pod specified by --pod. "+autoshardingNotice)
 	o.flags.BoolVarP(&o.Version, "version", "", false, "kube-state-metrics build version information")
 	o.flags.BoolVar(&o.EnableGZIPEncoding, "enable-gzip-encoding", false, "Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.")
-	o.flags.Var(&o.LabelsAllowList, "labels-metric-allow-list", "Allows to pass a list of additional Kubernetes label keys that will be used in the resource' labels metric. By default the metric contains only name and namespace labels. To include additional labels provide a list of resource names in their plural form and Kubernetes label keys you would like to allow for them (Example: '=namespaces=[\"k8s-label-1\",\"k8s-label-n\",...],pods=[\"app\"],...)'")
+	o.flags.Var(&o.LabelsAllowList, "labels-metric-allow-list", "Allows to pass a list of additional Kubernetes label keys that will be used in the resource' labels metric. By default the metric contains only name and namespace labels. To include additional labels provide a list of resource names in their plural form and Kubernetes label keys you would like to allow for them (Example: '=namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...)'")
 }
 
 // Parse parses the flag definitions from the argument list.


### PR DESCRIPTION
The parser defined in types.go does not expect quotes
https://github.com/kubernetes/kube-state-metrics/blob/release-2.0/pkg/options/types.go#L136-L140
https://github.com/kubernetes/kube-state-metrics/blob/release-2.0/pkg/options/types_test.go#L168

This issue is unfortunate because ksm does parse the quoted syntax fine but the labels never match (eg label is `foo` but ksm matches against `"foo"`). As such this is pretty important patch for the 2.0 release. Further improvements could be made but this documentation fix is the bare minimum.

Targeting release-2.0 (or should this be based on master and backported afterwards?)