### PR TITLE
Fix docs README link to a nonexistent section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,6 @@ Any contribution to improving this documentation or adding sample usages will be
 ## Table of Contents
 
 - [Metrics Stages](#metrics-stages)
-- [Metrics Deprecation](#metrics-deprecation)
 - [Exposed Metrics](#exposed-metrics)
 - [Join Metrics](#join-metrics)
 - [CLI arguments](#cli-arguments)


### PR DESCRIPTION
I assume deprecation information is supposed to be contained in the metric tables in the relevant sub-documents for metric categories.

**What this PR does / why we need it**:
Cleans up a dead link in the docs/ README.md

