### PR TITLE
.github/ci.yml: Update golangci-lint to 1.39.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Lint
       run: |
-        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
+        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.39.0
         make lint
 
   ci-validate-manifests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrading golangci-lint to a more recent version. https://github.com/golangci/golangci-lint/releases/tag/v1.39.0

