### PR TITLE
charts: Mark chart as deprecated

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -6,13 +6,10 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.13.2
+version: 2.13.3
 appVersion: 1.9.8
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/
-maintainers:
-- name: tariq1890
-  email: tariq.ibrahim@mulesoft.com
-- name: mrueg
-  email: manuel@rueg.eu
+# This chart is deprecated in favor of https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
+deprecated: true

--- a/charts/kube-state-metrics/README.md
+++ b/charts/kube-state-metrics/README.md
@@ -1,5 +1,8 @@
 # kube-state-metrics Helm Chart
 
+> **UPDATE**: This chart is deprecated in favor of https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
+We decided to migrate the chart into this repository as maintaining it with the source code caused issues for non-helm users.
+
 Installs the [kube-state-metrics agent](https://github.com/kubernetes/kube-state-metrics).
 
 ## Get Repo Info


### PR DESCRIPTION
**What this PR does / why we need it**:
We will migrate this chart to https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics

@tariq1890 @lilic @scottrigby 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1392
