### PR TITLE
e2e: Test against multiple versions of k8s at the same time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,13 @@ jobs:
   ci-e2e-tests:
     name: ci-e2e-tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cluster_version:
+         - 'v1.18.0'
+         - 'v1.19.0'
+         - 'v1.20.0'
+         - 'v1.21.0'
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -208,5 +215,7 @@ jobs:
         make install-tools
 
     - name: End-to-end tests
+      env:
+        KUBERNETES_VERSION: ${{cluster_version}}
       run: |
         make e2e

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ All additional compatibility is only best effort, or happens to still/already be
 
 At most, 5 kube-state-metrics and 5 [kubernetes releases](https://github.com/kubernetes/kubernetes/releases) will be recorded below.
 
-| kube-state-metrics | **Kubernetes 1.16** |  **Kubernetes 1.17** |  **Kubernetes 1.18** |  **Kubernetes 1.19** |  **Kubernetes 1.20** |
-|--------------------|---------------------|---------------------|----------------------|----------------------|-----------------------|
+| kube-state-metrics | **Kubernetes 1.17** |  **Kubernetes 1.18** |  **Kubernetes 1.19** |  **Kubernetes 1.20** |  **Kubernetes 1.21** |
+|--------------------|---------------------|----------------------|----------------------|----------------------|----------------------|
 | **v1.8.0**         |         -           |          -           |          -           |          -           |          -           |
-| **v1.9.8**         |         ✓           |          -           |          -           |          -           |          -           |
-| **v2.0.0**         |         -           |          -/✓         |         -/✓          |          ✓           |          ✓           |
-| **master**         |         -           |          -/✓         |         -/✓          |          ✓           |          ✓           |
+| **v1.9.8**         |         -           |          -           |          -           |          -           |          -           |
+| **v2.0.0**         |         -/✓         |          -/✓         |          ✓           |          ✓           |          -/✓         |
+| **master**         |         -/✓         |          -/✓         |          ✓           |          ✓           |          ✓           |
 - `✓` Fully supported version range.
 - `-` The Kubernetes cluster has features the client-go library can't use (additional API objects, deprecated APIs, etc).
 

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -24,7 +24,7 @@ case $(uname -m) in
 esac
 
 NODE_IMAGE_NAME="docker.io/kindest/node"
-KUBERNETES_VERSION=v1.20.0
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.20.0"}
 KUBE_STATE_METRICS_LOG_DIR=./log
 KUBE_STATE_METRICS_CURRENT_IMAGE_NAME="k8s.gcr.io/kube-state-metrics/kube-state-metrics"
 KUBE_STATE_METRICS_IMAGE_NAME="k8s.gcr.io/kube-state-metrics/kube-state-metrics-${ARCH}"
@@ -69,7 +69,7 @@ touch "${HOME}"/.kube/config
 
 export KUBECONFIG=$HOME/.kube/config
 
-kind create cluster --image=${NODE_IMAGE_NAME}:${KUBERNETES_VERSION}
+kind create cluster --image="${NODE_IMAGE_NAME}:${KUBERNETES_VERSION}"
 
 kind export kubeconfig
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We support multiple versions of k8s, let's run e2e tests for all as suggested by @lilic 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See #1454

