### PR TITLE
Replace deprecated io/ioutil

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"sort"
 	"strconv"
@@ -163,7 +163,7 @@ func TestFullScrapeCycle(t *testing.T) {
 		t.Fatalf("expected 200 status code but got %v", resp.StatusCode)
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	expected := `# HELP kube_pod_completion_time Completion time in unix timestamp for a pod.
 # HELP kube_pod_container_info Information about a container in a pod.
@@ -346,7 +346,7 @@ kube_pod_status_reason{namespace="default",pod="pod0",uid="abc-0",reason="Unexpe
 		t.Fatalf("expected 200 status code but got %v", resp.StatusCode)
 	}
 
-	body2, _ := ioutil.ReadAll(resp2.Body)
+	body2, _ := io.ReadAll(resp2.Body)
 
 	expected2 := `# HELP kube_state_metrics_shard_ordinal Current sharding ordinal/index of this instance
 # HELP kube_state_metrics_total_shards Number of total shards this instance is aware of
@@ -457,7 +457,7 @@ func TestShardingEquivalenceScrapeCycle(t *testing.T) {
 		t.Fatalf("expected 200 status code but got %v", resp.StatusCode)
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	expected := string(body)
 
 	// sharded requests
@@ -473,7 +473,7 @@ func TestShardingEquivalenceScrapeCycle(t *testing.T) {
 		t.Fatalf("expected 200 status code but got %v", resp.StatusCode)
 	}
 
-	body, _ = ioutil.ReadAll(resp.Body)
+	body, _ = io.ReadAll(resp.Body)
 	got1 := string(body)
 
 	// request second shard
@@ -487,7 +487,7 @@ func TestShardingEquivalenceScrapeCycle(t *testing.T) {
 		t.Fatalf("expected 200 status code but got %v", resp.StatusCode)
 	}
 
-	body, _ = ioutil.ReadAll(resp.Body)
+	body, _ = io.ReadAll(resp.Body)
 	got2 := string(body)
 
 	// normalize results:

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -106,7 +105,7 @@ func (k *KSMClient) IsHealthz() (bool, error) {
 		return false, err
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}()
 
@@ -135,7 +134,7 @@ func (k *KSMClient) writeMetrics(endpoint *url.URL, w io.Writer) error {
 		return err
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}()
 

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -146,7 +145,7 @@ func getLabelsDocumentation() (map[string][]string, error) {
 	documentedMetrics := map[string][]string{}
 
 	docPath := "../../docs/"
-	docFiles, err := ioutil.ReadDir(docPath)
+	docFiles, err := os.ReadDir(docPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read documentation directory")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
io/ioutil was deprecated in golang 1.16: https://golang.org/doc/go1.16#ioutil

Thinking a bit about it:
Not a super urgent change and likely will break builds with <go-1.16. Let's wait till go 1.17 is out.