### PR TITLE
Backport #1455: Fix builder.Builder WithMetrics signature

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -44,7 +44,7 @@ func NewBuilder() *Builder {
 }
 
 // WithMetrics sets the metrics property of a Builder.
-func (b *Builder) WithMetrics(r *prometheus.Registry) {
+func (b *Builder) WithMetrics(r prometheus.Registerer) {
 	b.internal.WithMetrics(r)
 }
 


### PR DESCRIPTION
## Backport of #1455 on `release-2.0`

**What this PR does / why we need it**:

The `WithMetrics` method signature changed from

```
func (b *Builder) WithMetrics(r *prometheus.Registry) {
```

to

```
func (b *Builder) WithMetrics(r prometheus.Registerer) {
```

in #1223 but one occurrence was forgotten.

**Which issue(s) this PR fixes**

Fixes the following compilation error when `kube-state-metrics` is used as a GO dependency of an external project:
```pkg/kubestatemetrics/builder/builder.go:48:3: cannot use builder.NewBuilder() (type *builder.Builder) as type "k8s.io/kube-state-metrics/v2/pkg/builder/types".BuilderInterface in field value:
	*builder.Builder does not implement "k8s.io/kube-state-metrics/v2/pkg/builder/types".BuilderInterface (wrong type for WithMetrics method)
		have WithMetrics(*prometheus.Registry)
		want WithMetrics(prometheus.Registerer)
```