### PR TITLE
Add metric for node selectors on deployment

### DIFF
--- a/docs/deployment-metrics.md
+++ b/docs/deployment-metrics.md
@@ -15,3 +15,4 @@
 | kube_deployment_metadata_generation | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_labels | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; <br> `label_DEPLOYMENT_LABEL`=&lt;DEPLOYMENT_LABEL&gt; | STABLE |
 | kube_deployment_created | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
+| kube_deployment_spec_nodeselector | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; <br> `label_SELECTOR_LABEL`=&lt;NODE_SELECTOR_LABEL&gt;| STABLE |

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -269,6 +269,29 @@ func deploymentMetricFamilies(allowLabelsList []string) []generator.FamilyGenera
 				}
 			}),
 		),
+		*generator.NewFamilyGenerator(
+			"kube_deployment_spec_nodeselector",
+			"The node Selector for the deployment",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				if d.Spec.Template.Spec.NodeSelector == nil {
+					return &metric.Family{}
+				}
+
+				selectorlabelKeys, selectorlabelValues := kubeLabelsToPrometheusLabels(d.Spec.Template.Spec.NodeSelector)
+
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   selectorlabelKeys,
+							LabelValues: selectorlabelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
 	}
 }
 

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -69,6 +69,8 @@ func TestDeploymentStore(t *testing.T) {
 		# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
 		# HELP kube_deployment_labels Kubernetes labels converted to Prometheus labels.
 		# TYPE kube_deployment_labels gauge
+		# HELP kube_deployment_spec_nodeselector The node Selector lables for the deployment converted to prometheus labels.
+		# TYPE kube_deployment_spec_nodeselector gauge
 	`
 	cases := []generateMetricsTestCase{
 		{
@@ -104,7 +106,8 @@ func TestDeploymentStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-        kube_deployment_created{deployment="depl1",namespace="ns1"} 1.5e+09
+		kube_deployment_created{deployment="depl1",namespace="ns1"} 1.5e+09
+		kube_deployment_spec_nodeselector{namespace="ns1",deployment="d1"} 1
         kube_deployment_labels{deployment="depl1",namespace="ns1"} 1
         kube_deployment_metadata_generation{deployment="depl1",namespace="ns1"} 21
         kube_deployment_spec_paused{deployment="depl1",namespace="ns1"} 0
@@ -159,7 +162,8 @@ func TestDeploymentStore(t *testing.T) {
 			},
 			Want: metadata + `
        	kube_deployment_labels{deployment="depl2",namespace="ns2"} 1
-        kube_deployment_metadata_generation{deployment="depl2",namespace="ns2"} 14
+		kube_deployment_metadata_generation{deployment="depl2",namespace="ns2"} 14
+		kube_deployment_spec_nodeselector{namespace="ns1",deployment="d1"} 1
         kube_deployment_spec_paused{deployment="depl2",namespace="ns2"} 1
         kube_deployment_spec_replicas{deployment="depl2",namespace="ns2"} 5
         kube_deployment_spec_strategy_rollingupdate_max_surge{deployment="depl2",namespace="ns2"} 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add a metric for adding the node selectors as prometheus labels for the deployments. This will help in plotting all the deployments for a given nodeSelector. 


