### PR TITLE
Add promlinter to lint metric naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Lint
       run: |
-        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.39.0
+        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.0
         make lint
 
   ci-validate-manifests:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - gocritic
     - govet
     - unconvert
+    - promlinter
 
 linters-settings:
   goimports:
@@ -21,3 +22,8 @@ linters-settings:
 
 issues:
   exclude-use-default: false
+  exclude-rules:
+    # We don't check metrics naming in the tests.
+    - path: _test\.go
+      linters:
+        - promlinter

--- a/main_test.go
+++ b/main_test.go
@@ -534,12 +534,12 @@ func TestShardingEquivalenceScrapeCycle(t *testing.T) {
 		t.Fatal("shard 2 has 0 metrics when it shouldn't")
 	}
 
-	gotFiltered := append(got1Filtered, got2Filtered...)
-	sort.Strings(gotFiltered)
+	got1Filtered = append(got1Filtered, got2Filtered...)
+	sort.Strings(got1Filtered)
 
 	for i := 0; i < len(expectedFiltered); i++ {
 		expected := strings.TrimSpace(expectedFiltered[i])
-		got := strings.TrimSpace(gotFiltered[i])
+		got := strings.TrimSpace(got1Filtered[i])
 		if expected != got {
 			t.Fatalf("\n\nexpected:\n\n%q\n\nbut got:\n\n%q\n\n", expected, got)
 		}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This pr updates `golangci-lint` and enables `promlinter`, which is a metrics naming static linter. It also supports metrics created by kube-state-metrics generators.

Example of using `promlinter` to list all metrics created by kube-state-metrics:

```
➜  kube-state-metrics git:(add-promlinter) promlinter list . --add-help | head -n 10 
TYPE                NAME                                                                                       HELP
GAUGE               kube_certificatesigningrequest_labels                                                      Kubernetes labels converted to Prometheus labels.
GAUGE               kube_certificatesigningrequest_created                                                     Unix creation timestamp
GAUGE               kube_certificatesigningrequest_condition                                                   The number of each certificatesigningrequest condition
GAUGE               kube_certificatesigningrequest_cert_length                                                 Length of the issued cert
GAUGE               kube_configmap_info                                                                        Information about configmap.
GAUGE               kube_configmap_created                                                                     Unix creation timestamp
GAUGE               kube_configmap_metadata_resource_version                                                   Resource version representing a specific version of the configmap.
GAUGE               kube_cronjob_status_active                                                                 Active holds pointers to currently running jobs.
GAUGE               kube_cronjob_status_last_schedule_time                                                     LastScheduleTime keeps information of when was the last time the job was successfully scheduled.

```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

