### PR TITLE
Add status metrics to HPA

### DIFF
--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -7,6 +7,7 @@
 | kube_horizontalpodautoscaler_spec_max_replicas        | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_spec_min_replicas        | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_spec_target_metric       | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
+| kube_horizontalpodautoscaler_status_current_metric    | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
 | kube_horizontalpodautoscaler_status_condition         | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_horizontalpodautoscaler_status_current_replicas  | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_status_desired_replicas  | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -41,6 +41,7 @@ func TestHPAStore(t *testing.T) {
 		# HELP kube_horizontalpodautoscaler_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
 		# HELP kube_horizontalpodautoscaler_spec_target_metric The metric specifications used by this autoscaler when calculating the desired replica count.
 		# HELP kube_horizontalpodautoscaler_status_condition The condition of this autoscaler.
+		# HELP kube_horizontalpodautoscaler_status_current_metric The metric current status used by this autoscaler when calculating the desired replica count.
 		# HELP kube_horizontalpodautoscaler_status_current_replicas Current number of replicas of pods managed by this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
 		# TYPE kube_horizontalpodautoscaler_labels gauge
@@ -49,6 +50,7 @@ func TestHPAStore(t *testing.T) {
 		# TYPE kube_horizontalpodautoscaler_spec_min_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_spec_target_metric gauge
 		# TYPE kube_horizontalpodautoscaler_status_condition gauge
+		# TYPE kube_horizontalpodautoscaler_status_current_metric gauge
 		# TYPE kube_horizontalpodautoscaler_status_current_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_status_desired_replicas gauge
 	`
@@ -172,6 +174,8 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="false"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="true"} 1
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="unknown"} 0
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 0
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 0
 				kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
 				kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
 			`,
@@ -180,6 +184,7 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_spec_max_replicas",
 				"kube_horizontalpodautoscaler_spec_min_replicas",
 				"kube_horizontalpodautoscaler_spec_target_metric",
+				"kube_horizontalpodautoscaler_status_current_metric",
 				"kube_horizontalpodautoscaler_status_current_replicas",
 				"kube_horizontalpodautoscaler_status_desired_replicas",
 				"kube_horizontalpodautoscaler_status_condition",
@@ -293,6 +298,11 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="false"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="true"} 1
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="unknown"} 0
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 6
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="average",namespace="ns1"} 8.47775744e+08
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 28
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 0
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 0
 				kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
 				kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
 			`,
@@ -301,6 +311,7 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_spec_max_replicas",
 				"kube_horizontalpodautoscaler_spec_min_replicas",
 				"kube_horizontalpodautoscaler_spec_target_metric",
+				"kube_horizontalpodautoscaler_status_current_metric",
 				"kube_horizontalpodautoscaler_status_current_replicas",
 				"kube_horizontalpodautoscaler_status_desired_replicas",
 				"kube_horizontalpodautoscaler_status_condition",


### PR DESCRIPTION
**What this PR does / why we need it**:

Add metric with HPA Status 



```
kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 6
kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="average",namespace="ns1"} 8.47775744e+08
kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 28
```

