### PR TITLE
tests/e2e.sh: Test with kind 0.11.0 & k8s 1.21.1

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -24,13 +24,13 @@ case $(uname -m) in
 esac
 
 NODE_IMAGE_NAME="docker.io/kindest/node"
-KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.20.0"}
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.21.1"}
 KUBE_STATE_METRICS_LOG_DIR=./log
 KUBE_STATE_METRICS_CURRENT_IMAGE_NAME="k8s.gcr.io/kube-state-metrics/kube-state-metrics"
 KUBE_STATE_METRICS_IMAGE_NAME="k8s.gcr.io/kube-state-metrics/kube-state-metrics-${ARCH}"
 E2E_SETUP_KIND=${E2E_SETUP_KIND:-}
 E2E_SETUP_KUBECTL=${E2E_SETUP_KUBECTL:-}
-KIND_VERSION=v0.10.0
+KIND_VERSION=v0.11.0
 SUDO=${SUDO:-}
 
 OS=$(uname -s | awk '{print tolower($0)}')


### PR DESCRIPTION
**What this PR does / why we need it**:
This now includes testing against k8s 1.21.1 node images as well as an update to the latest release of kind.
