### PR TITLE
Allow quotes in LabelsAllowList

### DIFF
--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -169,7 +169,8 @@ func (l *LabelsAllowList) Set(value string) error {
 			if previous == ',' || next != '[' {
 				return errLabelsAllowListFormat
 			}
-			name = strings.TrimSpace(string(([]rune(value)[firstWordPos:i])))
+			token := string([]rune(value)[firstWordPos:i])
+			name = strings.Trim(token, `"' `)
 			m[name] = []string{}
 			firstWordPos = i + 1
 		case '[':
@@ -179,11 +180,12 @@ func (l *LabelsAllowList) Set(value string) error {
 			firstWordPos = i + 1
 		case ']':
 			// if after metric group, has char not comma or end.
-			if next != EOF && next != ',' {
+			if next != EOF && next != ',' && next != '"' {
 				return errLabelsAllowListFormat
 			}
 			if previous != '[' {
-				m[name] = append(m[name], strings.TrimSpace(string(([]rune(value)[firstWordPos:i]))))
+				token := string([]rune(value)[firstWordPos:i])
+				m[name] = append(m[name], strings.Trim(token, `"' `))
 			}
 			firstWordPos = i + 1
 		case ',':
@@ -192,7 +194,8 @@ func (l *LabelsAllowList) Set(value string) error {
 				return errLabelsAllowListFormat
 			}
 			if previous != ']' {
-				m[name] = append(m[name], strings.TrimSpace(string(([]rune(value)[firstWordPos:i]))))
+				token := string([]rune(value)[firstWordPos:i])
+				m[name] = append(m[name], strings.Trim(token, `"' `))
 			}
 			firstWordPos = i + 1
 		}

--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -202,13 +202,48 @@ func TestLabelsAllowListSet(t *testing.T) {
 					"bar",
 					"*"}}),
 		},
+		{
+			Desc:  "with quoted tokens",
+			Value: `"nodes=["kubernetes.io/arch","gpu.infra/intel","network.infra/fast"]"`,
+			Wanted: LabelsAllowList(map[string][]string{
+				"nodes": {
+					"kubernetes.io/arch",
+					"gpu.infra/intel",
+					"network.infra/fast",
+				}}),
+		},
+		{
+			Desc:  "with quoted labels",
+			Value: `nodes=["kubernetes.io/arch","gpu.infra/intel","network.infra/fast"]`,
+			Wanted: LabelsAllowList(map[string][]string{
+				"nodes": {
+					"kubernetes.io/arch",
+					"gpu.infra/intel",
+					"network.infra/fast",
+				}}),
+		},
+		{
+			Desc:  "with quoted array",
+			Value: `"nodes=[kubernetes.io/arch,gpu.infra/intel,network.infra/fast]"`,
+			Wanted: LabelsAllowList(map[string][]string{
+				"nodes": {
+					"kubernetes.io/arch",
+					"gpu.infra/intel",
+					"network.infra/fast",
+				}}),
+		},
 	}
 
 	for _, test := range tests {
-		lal := &LabelsAllowList{}
-		gotError := lal.Set(test.Value)
-		if gotError != nil && !test.err || !reflect.DeepEqual(*lal, test.Wanted) {
-			t.Errorf("Test error for Desc: %s\n Want: \n%+v\n Got: \n%#+v\n Got Error: %#v", test.Desc, test.Wanted, *lal, gotError)
-		}
+		t.Run(test.Desc, func(t *testing.T) {
+			test := test
+
+			lal := &LabelsAllowList{}
+			gotError := lal.Set(test.Value)
+			if gotError != nil && !test.err || !reflect.DeepEqual(*lal, test.Wanted) {
+				t.Errorf("Test error for Desc: %s\n Want: \n%+v\n Got: \n%#+v\n Got Error: %#v", test.Desc, test.Wanted, *lal, gotError)
+			}
+		})
+
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Allows using quotes when setting the `--metric-labels-allowlist` option

**Which issue(s) this PR fixes**
Fixes https://github.com/kubernetes/kube-state-metrics/issues/1313

