### PR TITLE
Add `WithAllowLabels` to public `BuilderInterface`

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -51,6 +51,10 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/watch"
 )
 
+// Make sure the internal Builder implements the public BuilderInterface.
+// New Builder methods should be added to the public BuilderInterface.
+var _ ksmtypes.BuilderInterface = &Builder{}
+
 // Builder helps to build store. It follows the builder pattern
 // (https://en.wikipedia.org/wiki/Builder_pattern).
 type Builder struct {

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -84,6 +84,11 @@ func (b *Builder) WithAllowDenyList(l ksmtypes.AllowDenyLister) {
 	b.internal.WithAllowDenyList(l)
 }
 
+// WithAllowLabels configures which labels can be returned for metrics
+func (b *Builder) WithAllowLabels(l map[string][]string) {
+	b.internal.WithAllowLabels(l)
+}
+
 // WithGenerateStoreFunc configures a custom generate store function
 func (b *Builder) WithGenerateStoreFunc(f ksmtypes.BuildStoreFunc) {
 	b.internal.WithGenerateStoreFunc(f)

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -39,6 +39,7 @@ type BuilderInterface interface {
 	WithVPAClient(c vpaclientset.Interface)
 	WithAllowDenyList(l AllowDenyLister)
 	WithGenerateStoreFunc(f BuildStoreFunc)
+	WithAllowLabels(l map[string][]string)
 	DefaultGenerateStoreFunc() BuildStoreFunc
 	Build() []cache.Store
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

fixes: https://github.com/kubernetes/kube-state-metrics/issues/1515

Add the method `WithAllowLabels` to public `BuilderInterface`.

It provides an option to configure `--metric-labels-allowlist` when `kube-state-metrics` is used as a Go dependency of another project.
