### PR TITLE
capture start time for containers in terminated state

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -292,6 +292,12 @@ func createPodContainerStateStartedFamilyGenerator() generator.FamilyGenerator {
 						LabelValues: []string{cs.Name},
 						Value:       float64((cs.State.Running.StartedAt).Unix()),
 					})
+				} else if cs.State.Terminated != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{"container"},
+						LabelValues: []string{cs.Name},
+						Value:       float64((cs.State.Terminated.StartedAt).Unix()),
+					})
 				}
 			}
 

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -368,6 +368,56 @@ func TestPodStore(t *testing.T) {
 		{
 			Obj: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "ns1",
+					UID:       "uid1",
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "container1",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									StartedAt: metav1.Time{
+										Time: time.Unix(1501777018, 0),
+									},
+									Reason: "Completed",
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: `
+				# HELP kube_pod_container_status_running Describes whether the container is currently in running state.
+				# HELP kube_pod_container_state_started Start time in unix timestamp for a pod container.
+				# HELP kube_pod_container_status_terminated Describes whether the container is currently in terminated state.
+				# HELP kube_pod_container_status_terminated_reason Describes the reason the container is currently in terminated state.
+				# HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
+				# HELP kube_pod_container_status_waiting_reason Describes the reason the container is currently in waiting state.
+				# TYPE kube_pod_container_status_running gauge
+				# TYPE kube_pod_container_state_started gauge
+				# TYPE kube_pod_container_status_terminated gauge
+				# TYPE kube_pod_container_status_terminated_reason gauge
+				# TYPE kube_pod_container_status_waiting gauge
+				# TYPE kube_pod_container_status_waiting_reason gauge
+				kube_pod_container_state_started{container="container1",namespace="ns1",pod="pod1",uid="uid1"} 1.501777018e+09
+				kube_pod_container_status_running{container="container1",namespace="ns1",pod="pod1",uid="uid1"} 0
+				kube_pod_container_status_terminated_reason{container="container1",namespace="ns1",pod="pod1",reason="Completed",uid="uid1"} 1
+				kube_pod_container_status_terminated{container="container1",namespace="ns1",pod="pod1",uid="uid1"} 1
+				kube_pod_container_status_waiting{container="container1",namespace="ns1",pod="pod1",uid="uid1"} 0
+			`,
+			MetricNames: []string{
+				"kube_pod_container_status_running",
+				"kube_pod_container_state_started",
+				"kube_pod_container_status_waiting",
+				"kube_pod_container_status_terminated",
+				"kube_pod_container_status_terminated_reason",
+			},
+		},
+		{
+			Obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod2",
 					Namespace: "ns2",
 					UID:       "uid2",
@@ -378,6 +428,9 @@ func TestPodStore(t *testing.T) {
 							Name: "container2",
 							State: v1.ContainerState{
 								Terminated: &v1.ContainerStateTerminated{
+									StartedAt: metav1.Time{
+										Time: time.Unix(1501777018, 0),
+									},
 									Reason: "OOMKilled",
 								},
 							},
@@ -395,17 +448,20 @@ func TestPodStore(t *testing.T) {
 			},
 			Want: `
 				# HELP kube_pod_container_status_running Describes whether the container is currently in running state.
+				# HELP kube_pod_container_state_started Start time in unix timestamp for a pod container.
 				# HELP kube_pod_container_status_terminated Describes whether the container is currently in terminated state.
 				# HELP kube_pod_container_status_terminated_reason Describes the reason the container is currently in terminated state.
 				# HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
 				# HELP kube_pod_container_status_waiting_reason Describes the reason the container is currently in waiting state.
 				# TYPE kube_pod_container_status_running gauge
+				# TYPE kube_pod_container_state_started gauge
 				# TYPE kube_pod_container_status_terminated gauge
 				# TYPE kube_pod_container_status_terminated_reason gauge
 				# TYPE kube_pod_container_status_waiting gauge
 				# TYPE kube_pod_container_status_waiting_reason gauge
 				kube_pod_container_status_running{container="container2",namespace="ns2",pod="pod2",uid="uid2"} 0
 				kube_pod_container_status_running{container="container3",namespace="ns2",pod="pod2",uid="uid2"} 0
+				kube_pod_container_state_started{container="container2",namespace="ns2",pod="pod2",uid="uid2"} 1.501777018e+09
 				kube_pod_container_status_terminated_reason{container="container2",namespace="ns2",pod="pod2",reason="OOMKilled",uid="uid2"} 1
 				kube_pod_container_status_terminated{container="container2",namespace="ns2",pod="pod2",uid="uid2"} 1
 				kube_pod_container_status_terminated{container="container3",namespace="ns2",pod="pod2",uid="uid2"} 0
@@ -415,6 +471,7 @@ func TestPodStore(t *testing.T) {
 `,
 			MetricNames: []string{
 				"kube_pod_container_status_running",
+				"kube_pod_container_state_started",
 				"kube_pod_container_status_waiting",
 				"kube_pod_container_status_terminated",
 				"kube_pod_container_status_terminated_reason",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In reference to the metric:
```
kube_pod_container_state_started
Start time in unix timestamp for a pod container
```
The metric is collected only for the containers which are in "Running" state and not when the state of the container is "Terminated". The metric can be collected for the "Terminated" containers as well, this PR adds the logic for the same. 
This will fix the issue where this metric is missing for pods which run for a short time and the containers are terminated after completion of the job/task

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1467 

