### PR TITLE
feat: add `signer_name` to CSR metrics

### DIFF
--- a/docs/certificatessigningrequest-metrics.md
+++ b/docs/certificatessigningrequest-metrics.md
@@ -2,7 +2,7 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
-| kube_certificatesigningrequest_created| Gauge | `certificatesigningrequest`=&lt;certificatesigningrequest-name&gt;| STABLE |
-| kube_certificatesigningrequest_condition | Gauge | `certificatesigningrequest`=&lt;certificatesigningrequest-name&gt; <br> `condition`=&lt;approved\|denied&gt; | STABLE |
-| kube_certificatesigningrequest_labels | Gauge | `certificatesigningrequest`=&lt;certificatesigningrequest-name&gt;| STABLE |
-| kube_certificatesigningrequest_cert_length | Gauge | `certificatesigningrequest`=&lt;certificatesigningrequest-name&gt;| STABLE |
+| kube_certificatesigningrequest_created| Gauge | `certificatesigningrequest`=&lt;certificatesigningrequest-name&gt; <br> `signer_name`=&lt;certificatesigningrequest-signer-name&gt;| STABLE |
+| kube_certificatesigningrequest_condition | Gauge | `certificatesigningrequest`=&lt;certificatesigningrequest-name&gt; <br> `signer_name`=&lt;certificatesigningrequest-signer-name&gt; <br> `condition`=&lt;approved\|denied&gt; | STABLE |
+| kube_certificatesigningrequest_labels | Gauge | `certificatesigningrequest`=&lt;certificatesigningrequest-name&gt; <br> `signer_name`=&lt;certificatesigningrequest-signer-name&gt;| STABLE |
+| kube_certificatesigningrequest_cert_length | Gauge | `certificatesigningrequest`=&lt;certificatesigningrequest-name&gt; <br> `signer_name`=&lt;certificatesigningrequest-signer-name&gt;| STABLE |

--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -33,7 +33,7 @@ import (
 var (
 	descCSRLabelsName          = "kube_certificatesigningrequest_labels"
 	descCSRLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descCSRLabelsDefaultLabels = []string{"certificatesigningrequest"}
+	descCSRLabelsDefaultLabels = []string{"certificatesigningrequest", "signer_name"}
 )
 
 func csrMetricFamilies(allowLabelsList []string) []generator.FamilyGenerator {
@@ -114,7 +114,7 @@ func wrapCSRFunc(f func(*certv1.CertificateSigningRequest) *metric.Family) func(
 
 		for _, m := range metricFamily.Metrics {
 			m.LabelKeys = append(descCSRLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{csr.Name}, m.LabelValues...)
+			m.LabelValues = append([]string{csr.Name, csr.Spec.SignerName}, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/certificatesigningrequest_test.go
+++ b/internal/store/certificatesigningrequest_test.go
@@ -49,14 +49,16 @@ func TestCsrStore(t *testing.T) {
 					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 				},
 				Status: certv1.CertificateSigningRequestStatus{},
-				Spec:   certv1.CertificateSigningRequestSpec{},
+				Spec: certv1.CertificateSigningRequestSpec{
+					SignerName: "signer",
+				},
 			},
 			Want: metadata + `
-				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test"} 1.5e+09
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="approved"} 0
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="denied"} 0
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test"} 1
-				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test"} 0
+				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 0
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 0
+				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
+				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 0
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
 		},
@@ -77,14 +79,16 @@ func TestCsrStore(t *testing.T) {
 						},
 					},
 				},
-				Spec: certv1.CertificateSigningRequestSpec{},
+				Spec: certv1.CertificateSigningRequestSpec{
+					SignerName: "signer",
+				},
 			},
 			Want: metadata + `
-				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test"} 1.5e+09
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="approved"} 0
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="denied"} 1
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test"} 1
-				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test"} 0
+				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 0
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 1
+				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
+				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 0
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
 		},
@@ -105,14 +109,16 @@ func TestCsrStore(t *testing.T) {
 						},
 					},
 				},
-				Spec: certv1.CertificateSigningRequestSpec{},
+				Spec: certv1.CertificateSigningRequestSpec{
+					SignerName: "signer",
+				},
 			},
 			Want: metadata + `
-				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test"} 1.5e+09
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="approved"} 1
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="denied"} 0
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test"} 1
-				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test"} 0
+				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 1
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 0
+				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
+				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 0
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
 		},
@@ -125,6 +131,9 @@ func TestCsrStore(t *testing.T) {
 						"cert": "test",
 					},
 					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+				},
+				Spec: certv1.CertificateSigningRequestSpec{
+					SignerName: "signer",
 				},
 				Status: certv1.CertificateSigningRequestStatus{
 					Certificate: []byte("just for test"),
@@ -136,11 +145,11 @@ func TestCsrStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test"} 1.5e+09
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="approved"} 1
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="denied"} 0
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test"} 1
-				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test"} 13
+				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 1
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 0
+				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
+				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 13
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
 		},
@@ -154,6 +163,9 @@ func TestCsrStore(t *testing.T) {
 					},
 					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 				},
+				Spec: certv1.CertificateSigningRequestSpec{
+					SignerName: "signer",
+				},
 				Status: certv1.CertificateSigningRequestStatus{
 					Conditions: []certv1.CertificateSigningRequestCondition{
 						{
@@ -166,11 +178,11 @@ func TestCsrStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test"} 1.5e+09
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="approved"} 1
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="denied"} 1
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test"} 1
-				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test"} 0
+				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 1
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 1
+				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
+				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 0
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
 		},
@@ -184,6 +196,9 @@ func TestCsrStore(t *testing.T) {
 					},
 					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 				},
+				Spec: certv1.CertificateSigningRequestSpec{
+					SignerName: "signer",
+				},
 				Status: certv1.CertificateSigningRequestStatus{
 					Conditions: []certv1.CertificateSigningRequestCondition{
 						{
@@ -202,11 +217,11 @@ func TestCsrStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test"} 1.5e+09
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="approved"} 2
-				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",condition="denied"} 2
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test"} 1
-				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test"} 0
+				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 2
+				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 2
+				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
+				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 0
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This pull request added new label `signer_name` to CSR metrics, to help metrics user distinct the CSR by “signer type”. According to Kubernetes’ doc, in CSR v1 API, the `CertificateSigningRequest.spec.signerName` is required, so we can assume this value is never empty.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1513


