### PR TITLE
Add statefulset availablereplicas metric

### DIFF
--- a/docs/statefulset-metrics.md
+++ b/docs/statefulset-metrics.md
@@ -5,6 +5,7 @@
 | kube_statefulset_status_replicas | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_status_replicas_current | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_status_replicas_ready | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
+| kube_statefulset_status_replicas_available | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | EXPERIMENTAL |
 | kube_statefulset_status_replicas_updated | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_status_observed_generation | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_replicas | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -73,6 +73,21 @@ func statefulSetMetricFamilies(allowLabelsList []string) []generator.FamilyGener
 			}),
 		),
 		*generator.NewFamilyGenerator(
+			"kube_statefulset_status_replicas_available",
+			"The number of available replicas per StatefulSet.",
+			metric.Gauge,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(s.Status.AvailableReplicas),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
 			"kube_statefulset_status_replicas_current",
 			"The number of current replicas per StatefulSet.",
 			metric.Gauge,

--- a/internal/store/statefulset_test.go
+++ b/internal/store/statefulset_test.go
@@ -67,6 +67,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# HELP kube_statefulset_status_current_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
 				# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
 				# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_available The number of available replicas per StatefulSet.
 				# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
 				# HELP kube_statefulset_status_replicas_ready The number of ready replicas per StatefulSet.
 				# HELP kube_statefulset_status_replicas_updated The number of updated replicas per StatefulSet.
@@ -78,6 +79,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# TYPE kube_statefulset_status_current_revision gauge
 				# TYPE kube_statefulset_status_observed_generation gauge
 				# TYPE kube_statefulset_status_replicas gauge
+				# TYPE kube_statefulset_status_replicas_available gauge
 				# TYPE kube_statefulset_status_replicas_current gauge
 				# TYPE kube_statefulset_status_replicas_ready gauge
 				# TYPE kube_statefulset_status_replicas_updated gauge
@@ -86,6 +88,7 @@ func TestStatefulSetStore(t *testing.T) {
 				kube_statefulset_created{namespace="ns1",statefulset="statefulset1"} 1.5e+09
 				kube_statefulset_status_current_revision{namespace="ns1",revision="cr1",statefulset="statefulset1"} 1
  				kube_statefulset_status_replicas{namespace="ns1",statefulset="statefulset1"} 2
+				kube_statefulset_status_replicas_available{namespace="ns1",statefulset="statefulset1"} 0
 				kube_statefulset_status_replicas_current{namespace="ns1",statefulset="statefulset1"} 0
 				kube_statefulset_status_replicas_ready{namespace="ns1",statefulset="statefulset1"} 0
 				kube_statefulset_status_replicas_updated{namespace="ns1",statefulset="statefulset1"} 0
@@ -101,6 +104,7 @@ func TestStatefulSetStore(t *testing.T) {
 				"kube_statefulset_replicas",
 				"kube_statefulset_status_observed_generation",
 				"kube_statefulset_status_replicas",
+				"kube_statefulset_status_replicas_available",
 				"kube_statefulset_status_replicas_current",
 				"kube_statefulset_status_replicas_ready",
 				"kube_statefulset_status_replicas_updated",
@@ -127,6 +131,7 @@ func TestStatefulSetStore(t *testing.T) {
 					ObservedGeneration: statefulSet2ObservedGeneration,
 					ReadyReplicas:      5,
 					Replicas:           5,
+					AvailableReplicas:  4,
 					UpdatedReplicas:    3,
 					UpdateRevision:     "ur2",
 					CurrentRevision:    "cr2",
@@ -139,6 +144,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# HELP kube_statefulset_status_current_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
 				# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
 				# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_available The number of available replicas per StatefulSet.
 				# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
 				# HELP kube_statefulset_status_replicas_ready The number of ready replicas per StatefulSet.
 				# HELP kube_statefulset_status_replicas_updated The number of updated replicas per StatefulSet.
@@ -149,12 +155,14 @@ func TestStatefulSetStore(t *testing.T) {
 				# TYPE kube_statefulset_status_current_revision gauge
 				# TYPE kube_statefulset_status_observed_generation gauge
 				# TYPE kube_statefulset_status_replicas gauge
+				# TYPE kube_statefulset_status_replicas_available gauge
 				# TYPE kube_statefulset_status_replicas_current gauge
 				# TYPE kube_statefulset_status_replicas_ready gauge
 				# TYPE kube_statefulset_status_replicas_updated gauge
 				# TYPE kube_statefulset_status_update_revision gauge
 				kube_statefulset_status_update_revision{namespace="ns2",revision="ur2",statefulset="statefulset2"} 1
  				kube_statefulset_status_replicas{namespace="ns2",statefulset="statefulset2"} 5
+				kube_statefulset_status_replicas_available{namespace="ns2",statefulset="statefulset2"} 4
 				kube_statefulset_status_replicas_current{namespace="ns2",statefulset="statefulset2"} 2
 				kube_statefulset_status_replicas_ready{namespace="ns2",statefulset="statefulset2"} 5
 				kube_statefulset_status_replicas_updated{namespace="ns2",statefulset="statefulset2"} 3
@@ -170,6 +178,7 @@ func TestStatefulSetStore(t *testing.T) {
 				"kube_statefulset_replicas",
 				"kube_statefulset_status_observed_generation",
 				"kube_statefulset_status_replicas",
+				"kube_statefulset_status_replicas_available",
 				"kube_statefulset_status_replicas_current",
 				"kube_statefulset_status_replicas_ready",
 				"kube_statefulset_status_replicas_updated",
@@ -204,6 +213,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# HELP kube_statefulset_replicas Number of desired pods for a StatefulSet.
 				# HELP kube_statefulset_status_current_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
 				# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_available The number of available replicas per StatefulSet.
 				# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
 				# HELP kube_statefulset_status_replicas_ready The number of ready replicas per StatefulSet.
 				# HELP kube_statefulset_status_replicas_updated The number of updated replicas per StatefulSet.
@@ -213,12 +223,14 @@ func TestStatefulSetStore(t *testing.T) {
 				# TYPE kube_statefulset_replicas gauge
 				# TYPE kube_statefulset_status_current_revision gauge
 				# TYPE kube_statefulset_status_replicas gauge
+				# TYPE kube_statefulset_status_replicas_available gauge
 				# TYPE kube_statefulset_status_replicas_current gauge
 				# TYPE kube_statefulset_status_replicas_ready gauge
 				# TYPE kube_statefulset_status_replicas_updated gauge
 				# TYPE kube_statefulset_status_update_revision gauge
 				kube_statefulset_status_update_revision{namespace="ns3",revision="ur3",statefulset="statefulset3"} 1
  				kube_statefulset_status_replicas{namespace="ns3",statefulset="statefulset3"} 7
+				kube_statefulset_status_replicas_available{namespace="ns3",statefulset="statefulset3"} 0
 				kube_statefulset_status_replicas_current{namespace="ns3",statefulset="statefulset3"} 0
 				kube_statefulset_status_replicas_ready{namespace="ns3",statefulset="statefulset3"} 0
 				kube_statefulset_status_replicas_updated{namespace="ns3",statefulset="statefulset3"} 0
@@ -232,6 +244,7 @@ func TestStatefulSetStore(t *testing.T) {
 				"kube_statefulset_metadata_generation",
 				"kube_statefulset_replicas",
 				"kube_statefulset_status_replicas",
+				"kube_statefulset_status_replicas_available",
 				"kube_statefulset_status_replicas_current",
 				"kube_statefulset_status_replicas_ready",
 				"kube_statefulset_status_replicas_updated",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
StatefulSet minReadySeconds merged upstream and is in alpha stage. This PR bumps api and client-go to v1.22-beta to get AvailableReplicas field of StatefulSet and introduces available replicas metric. I can split bumping into another PR or drop it when 1.22 is released.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
It increases the cardinality as we will start tracking available replicas. However, we have been using the similar metrics for deployment and daemonset.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

cc @simonpasquier 
