### PR TITLE
OWNERS: Add dgrisonnet and fpetkovski to reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,7 @@
 reviewers:
   - brancz
+  - dgrisonnet
+  - fpetkovski
   - LiliC
   - mrueg
   - tariq1890


### PR DESCRIPTION
@dgrisonnet and @fpetkovski have been very active on the project and provided useful contributions in various forms.
As discussed within @kubernetes/kube-state-metrics-maintainers we proposed to add them both as reviewers and fortunately they both accepted. :tada: 
Thanks for your contributions to kube-state-metrics! :partying_face: 