### PR TITLE
Add ReadyReplicas metric to deployment metric family

### DIFF
--- a/docs/deployment-metrics.md
+++ b/docs/deployment-metrics.md
@@ -3,7 +3,7 @@
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
 | kube_deployment_status_replicas | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
-| kube_deployment_status_replicas_ready | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
+| kube_deployment_status_replicas_ready | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | EXPERIMENTAL |
 | kube_deployment_status_replicas_available | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_status_replicas_unavailable | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_status_replicas_updated | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |

--- a/docs/deployment-metrics.md
+++ b/docs/deployment-metrics.md
@@ -3,6 +3,7 @@
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
 | kube_deployment_status_replicas | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
+| kube_deployment_status_replicas_ready | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_status_replicas_available | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_status_replicas_unavailable | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_status_replicas_updated | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -74,6 +74,21 @@ func deploymentMetricFamilies(allowLabelsList []string) []generator.FamilyGenera
 			}),
 		),
 		*generator.NewFamilyGenerator(
+			"kube_deployment_status_ready_replicas",
+			"The number of ready replicas per deployment.",
+			metric.Gauge,
+			"",
+			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							Value: float64(d.Status.ReadyReplicas),
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
 			"kube_deployment_status_replicas_available",
 			"The number of available replicas per deployment.",
 			metric.Gauge,

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -74,7 +74,7 @@ func deploymentMetricFamilies(allowLabelsList []string) []generator.FamilyGenera
 			}),
 		),
 		*generator.NewFamilyGenerator(
-			"kube_deployment_status_ready_replicas",
+			"kube_deployment_status_replicas_ready",
 			"The number of ready replicas per deployment.",
 			metric.Gauge,
 			"",

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -53,8 +53,8 @@ func TestDeploymentStore(t *testing.T) {
 		# TYPE kube_deployment_spec_replicas gauge
 		# HELP kube_deployment_status_replicas The number of replicas per deployment.
 		# TYPE kube_deployment_status_replicas gauge
-		# HELP kube_deployment_status_ready_replicas The number of ready replicas per deployment.
-		# TYPE kube_deployment_status_ready_replicas gauge
+		# HELP kube_deployment_status_replicas_ready The number of ready replicas per deployment.
+		# TYPE kube_deployment_status_replicas_ready gauge
 		# HELP kube_deployment_status_replicas_available The number of available replicas per deployment.
 		# TYPE kube_deployment_status_replicas_available gauge
 		# HELP kube_deployment_status_replicas_unavailable The number of unavailable replicas per deployment.
@@ -119,7 +119,7 @@ func TestDeploymentStore(t *testing.T) {
         kube_deployment_status_replicas_unavailable{deployment="depl1",namespace="ns1"} 5
         kube_deployment_status_replicas_updated{deployment="depl1",namespace="ns1"} 2
         kube_deployment_status_replicas{deployment="depl1",namespace="ns1"} 15
-        kube_deployment_status_ready_replicas{deployment="depl1",namespace="ns1"} 10
+        kube_deployment_status_replicas_ready{deployment="depl1",namespace="ns1"} 10
         kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="true"} 1
         kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="true"} 1
         kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="false"} 0
@@ -174,7 +174,7 @@ func TestDeploymentStore(t *testing.T) {
         kube_deployment_status_replicas_unavailable{deployment="depl2",namespace="ns2"} 0
         kube_deployment_status_replicas_updated{deployment="depl2",namespace="ns2"} 1
         kube_deployment_status_replicas{deployment="depl2",namespace="ns2"} 10
-        kube_deployment_status_ready_replicas{deployment="depl2",namespace="ns2"} 5
+        kube_deployment_status_replicas_ready{deployment="depl2",namespace="ns2"} 5
         kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="true"} 0
         kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="true"} 0
         kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="true"} 1

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -53,6 +53,8 @@ func TestDeploymentStore(t *testing.T) {
 		# TYPE kube_deployment_spec_replicas gauge
 		# HELP kube_deployment_status_replicas The number of replicas per deployment.
 		# TYPE kube_deployment_status_replicas gauge
+		# HELP kube_deployment_status_ready_replicas The number of ready replicas per deployment.
+		# TYPE kube_deployment_status_ready_replicas gauge
 		# HELP kube_deployment_status_replicas_available The number of available replicas per deployment.
 		# TYPE kube_deployment_status_replicas_available gauge
 		# HELP kube_deployment_status_replicas_unavailable The number of unavailable replicas per deployment.
@@ -84,6 +86,7 @@ func TestDeploymentStore(t *testing.T) {
 				},
 				Status: v1.DeploymentStatus{
 					Replicas:            15,
+					ReadyReplicas:       10,
 					AvailableReplicas:   10,
 					UnavailableReplicas: 5,
 					UpdatedReplicas:     2,
@@ -116,6 +119,7 @@ func TestDeploymentStore(t *testing.T) {
         kube_deployment_status_replicas_unavailable{deployment="depl1",namespace="ns1"} 5
         kube_deployment_status_replicas_updated{deployment="depl1",namespace="ns1"} 2
         kube_deployment_status_replicas{deployment="depl1",namespace="ns1"} 15
+        kube_deployment_status_ready_replicas{deployment="depl1",namespace="ns1"} 10
         kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="true"} 1
         kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="true"} 1
         kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="false"} 0
@@ -136,6 +140,7 @@ func TestDeploymentStore(t *testing.T) {
 				},
 				Status: v1.DeploymentStatus{
 					Replicas:            10,
+					ReadyReplicas:       5,
 					AvailableReplicas:   5,
 					UnavailableReplicas: 0,
 					UpdatedReplicas:     1,
@@ -169,6 +174,7 @@ func TestDeploymentStore(t *testing.T) {
         kube_deployment_status_replicas_unavailable{deployment="depl2",namespace="ns2"} 0
         kube_deployment_status_replicas_updated{deployment="depl2",namespace="ns2"} 1
         kube_deployment_status_replicas{deployment="depl2",namespace="ns2"} 10
+        kube_deployment_status_ready_replicas{deployment="depl2",namespace="ns2"} 5
         kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="true"} 0
         kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="true"} 0
         kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="true"} 1


### PR DESCRIPTION
* Add ReadyReplicas field in Deployment status to deployment metrics
* Depicts number of readyReplicas across all replicas sets owned by the deployment

Signed-off-by: Akshit Grover <akshit.grover@appdynamics.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds ReadyReplicas field in Deployment status to deployment metrics

Ready Replicas count is an insightful metric as it depicts the number of traffic serving pods for a particular deployment, This can be used in number of ways to compare across the board for troubleshooting

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Increases cardinality as it add another metric in the deployment metrics family

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1522 
