### PR TITLE
Use BuilderInterface instead of internal/store.Builder in metricshandler

### DIFF
--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	"k8s.io/kube-state-metrics/v2/internal/store"
+	ksmtypes "k8s.io/kube-state-metrics/v2/pkg/builder/types"
 	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
 	"k8s.io/kube-state-metrics/v2/pkg/options"
 )
@@ -43,7 +43,7 @@ import (
 type MetricsHandler struct {
 	opts               *options.Options
 	kubeClient         kubernetes.Interface
-	storeBuilder       *store.Builder
+	storeBuilder       ksmtypes.BuilderInterface
 	enableGZIPEncoding bool
 
 	cancel func()
@@ -56,7 +56,7 @@ type MetricsHandler struct {
 }
 
 // New creates and returns a new MetricsHandler with the given options.
-func New(opts *options.Options, kubeClient kubernetes.Interface, storeBuilder *store.Builder, enableGZIPEncoding bool) *MetricsHandler {
+func New(opts *options.Options, kubeClient kubernetes.Interface, storeBuilder ksmtypes.BuilderInterface, enableGZIPEncoding bool) *MetricsHandler {
 	return &MetricsHandler{
 		opts:               opts,
 		kubeClient:         kubeClient,


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Use `BuilderInterface` instead of `internal/store.Builder` in metricshandler package.

The MetricsHandler should only care about the interface, not the implementation behind. So that other 3rd party projects can use kube-state-metrics as the basic dependency of their state-metrics subprojects.
