### PR TITLE
cloudbuild.yaml: Update cloudbuild image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930'
     entrypoint: make
     env:
     - TAG=$_PULL_BASE_REF


### PR DESCRIPTION
**What this PR does / why we need it**:
I don't have a great way to test this, but I believe in spirit of best practices we should not rely on an almost 2y old image here.

Best option to test it locally was something like: `docker run -it --rm -w /tmp/ksm -v $(pwd):/tmp/ksm -v /var/run:/var/run "gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930"` and then call make push inside it.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
