### PR TITLE
Add pod preparation period metrics

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -90,6 +90,7 @@ func podMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 		createPodStatusScheduledFamilyGenerator(),
 		createPodStatusScheduledTimeFamilyGenerator(),
 		createPodStatusUnschedulableFamilyGenerator(),
+                createPodPreparationPeriodFamilyGenerator(), 
 	}
 }
 
@@ -1559,6 +1560,43 @@ func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
 						Value:       1,
 					})
 				}
+			}
+
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodPreparationPeriodFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_status_preparation_period",
+		"Describes the preparation period for the pod",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+
+			var PodScheduledTime float64
+			var PodReadyTime float64
+			for _, c := range p.Status.Conditions {
+				if c.Type == v1.PodScheduled && c.Status == v1.ConditionTrue {
+					PodScheduledTime = float64(c.LastTransitionTime.Unix())
+				}
+				if c.Type == v1.PodReady && c.Status == v1.ConditionTrue {
+					PodReadyTime = float64(c.LastTransitionTime.Unix())
+
+				}
+
+			}
+
+			if PodReadyTime > PodScheduledTime {
+				ms = append(ms, &metric.Metric{
+					LabelKeys:   []string{},
+					LabelValues: []string{},
+					Value:       PodReadyTime - PodScheduledTime,
+				})
 			}
 
 			return &metric.Family{


### PR DESCRIPTION
What this PR does / why we need it:
add pod preparation period metrics 
kube_pod_status_preparation_period{namespace="default",pod="nginx-5dbf784b68-ljz9k",uid="070793df-db03-48ae-bb72-dfcbc5059c3a"} 9

i



How does this change affect the cardinality of KSM: (increases, decreases or does not change cardinality)
none
Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #