### PR TITLE
internal: Migrate HPA API version to autoscaling/v2beta2

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -27,7 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	certv1 "k8s.io/api/certificates/v1"

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -19,7 +19,7 @@ package store
 import (
 	"context"
 
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -116,35 +116,34 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 
 					switch m.Type {
 					case autoscaling.ObjectMetricSourceType:
-						metricName = m.Object.MetricName
+						metricName = m.Object.Metric.Name
 
-						v[value], ok[value] = m.Object.TargetValue.AsInt64()
-						if m.Object.AverageValue != nil {
-							v[average], ok[average] = m.Object.AverageValue.AsInt64()
+						v[value], ok[value] = m.Object.Target.Value.AsInt64()
+						if m.Object.Target.AverageValue != nil {
+							v[average], ok[average] = m.Object.Target.AverageValue.AsInt64()
 						}
 					case autoscaling.PodsMetricSourceType:
-						metricName = m.Pods.MetricName
+						metricName = m.Pods.Metric.Name
 
-						v[average], ok[average] = m.Pods.TargetAverageValue.AsInt64()
+						v[average], ok[average] = m.Pods.Target.AverageValue.AsInt64()
 					case autoscaling.ResourceMetricSourceType:
 						metricName = string(m.Resource.Name)
 
-						if ok[utilization] = (m.Resource.TargetAverageUtilization != nil); ok[utilization] {
-							v[utilization] = int64(*m.Resource.TargetAverageUtilization)
+						if ok[utilization] = (m.Resource.Target.AverageUtilization != nil); ok[utilization] {
+							v[utilization] = int64(*m.Resource.Target.AverageUtilization)
 						}
 
-						if m.Resource.TargetAverageValue != nil {
-							v[average], ok[average] = m.Resource.TargetAverageValue.AsInt64()
+						if m.Resource.Target.AverageValue != nil {
+							v[average], ok[average] = m.Resource.Target.AverageValue.AsInt64()
 						}
 					case autoscaling.ExternalMetricSourceType:
-						metricName = m.External.MetricName
+						metricName = m.External.Metric.Name
 
-						// The TargetValue and TargetAverageValue are mutually exclusive
-						if m.External.TargetValue != nil {
-							v[value], ok[value] = m.External.TargetValue.AsInt64()
+						if m.External.Target.Value != nil {
+							v[value], ok[value] = m.External.Target.Value.AsInt64()
 						}
-						if m.External.TargetAverageValue != nil {
-							v[average], ok[average] = m.External.TargetAverageValue.AsInt64()
+						if m.External.Target.AverageValue != nil {
+							v[average], ok[average] = m.External.Target.AverageValue.AsInt64()
 						}
 					default:
 						// Skip unsupported metric type
@@ -275,10 +274,10 @@ func wrapHPAFunc(f func(*autoscaling.HorizontalPodAutoscaler) *metric.Family) fu
 func createHPAListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(ns).List(context.TODO(), opts)
+			return kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(ns).List(context.TODO(), opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(ns).Watch(context.TODO(), opts)
+			return kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(ns).Watch(context.TODO(), opts)
 		},
 	}
 }

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -19,7 +19,7 @@ package store
 import (
 	"testing"
 
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,31 +71,43 @@ func TestHPAStore(t *testing.T) {
 						{
 							Type: autoscaling.ObjectMetricSourceType,
 							Object: &autoscaling.ObjectMetricSource{
-								MetricName:   "hits",
-								TargetValue:  resource.MustParse("10"),
-								AverageValue: resourcePtr(resource.MustParse("12")),
+								Metric: autoscaling.MetricIdentifier{
+									Name: "hits",
+								},
+								Target: autoscaling.MetricTarget{
+									Value:        resourcePtr(resource.MustParse("10")),
+									AverageValue: resourcePtr(resource.MustParse("12")),
+								},
 							},
 						},
 						{
 							Type: autoscaling.PodsMetricSourceType,
 							Pods: &autoscaling.PodsMetricSource{
-								MetricName:         "transactions_processed",
-								TargetAverageValue: resource.MustParse("33"),
+								Metric: autoscaling.MetricIdentifier{
+									Name: "transactions_processed",
+								},
+								Target: autoscaling.MetricTarget{
+									AverageValue: resourcePtr(resource.MustParse("33")),
+								},
 							},
 						},
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
-								Name:                     "cpu",
-								TargetAverageUtilization: int32ptr(80),
+								Name: "cpu",
+								Target: autoscaling.MetricTarget{
+									AverageUtilization: int32ptr(80),
+								},
 							},
 						},
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
-								Name:                     "memory",
-								TargetAverageUtilization: int32ptr(80),
-								TargetAverageValue:       resourcePtr(resource.MustParse("800Ki")),
+								Name: "memory",
+								Target: autoscaling.MetricTarget{
+									AverageValue:       resourcePtr(resource.MustParse("800Ki")),
+									AverageUtilization: int32ptr(80),
+								},
 							},
 						},
 						// No targets, this metric should be ignored
@@ -108,15 +120,23 @@ func TestHPAStore(t *testing.T) {
 						{
 							Type: autoscaling.ExternalMetricSourceType,
 							External: &autoscaling.ExternalMetricSource{
-								MetricName:  "sqs_jobs",
-								TargetValue: resourcePtr(resource.MustParse("30")),
+								Metric: autoscaling.MetricIdentifier{
+									Name: "sqs_jobs",
+								},
+								Target: autoscaling.MetricTarget{
+									Value: resourcePtr(resource.MustParse("30")),
+								},
 							},
 						},
 						{
 							Type: autoscaling.ExternalMetricSourceType,
 							External: &autoscaling.ExternalMetricSource{
-								MetricName:         "events",
-								TargetAverageValue: resourcePtr(resource.MustParse("30")),
+								Metric: autoscaling.MetricIdentifier{
+									Name: "events",
+								},
+								Target: autoscaling.MetricTarget{
+									AverageValue: resourcePtr(resource.MustParse("30")),
+								},
 							},
 						},
 					},
@@ -140,17 +160,21 @@ func TestHPAStore(t *testing.T) {
 						{
 							Type: "Resource",
 							Resource: &autoscaling.ResourceMetricStatus{
-								Name:                      "cpu",
-								CurrentAverageUtilization: new(int32),
-								CurrentAverageValue:       resource.MustParse("7m"),
+								Name: "cpu",
+								Current: autoscaling.MetricValueStatus{
+									AverageValue:       resourcePtr(resource.MustParse("7m")),
+									AverageUtilization: new(int32),
+								},
 							},
 						},
 						{
 							Type: "Resource",
 							Resource: &autoscaling.ResourceMetricStatus{
-								Name:                      "memory",
-								CurrentAverageUtilization: new(int32),
-								CurrentAverageValue:       resource.MustParse("26335914666m"),
+								Name: "memory",
+								Current: autoscaling.MetricValueStatus{
+									AverageValue:       resourcePtr(resource.MustParse("26335914666m")),
+									AverageUtilization: new(int32),
+								},
 							},
 						},
 					},
@@ -204,29 +228,41 @@ func TestHPAStore(t *testing.T) {
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
-								Name:                     "memory",
-								TargetAverageUtilization: int32ptr(75),
+								Name: "memory",
+								Target: autoscaling.MetricTarget{
+									AverageUtilization: int32ptr(75),
+								},
 							},
 						},
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
-								Name:                     "cpu",
-								TargetAverageUtilization: int32ptr(80),
+								Name: "cpu",
+								Target: autoscaling.MetricTarget{
+									AverageUtilization: int32ptr(80),
+								},
 							},
 						},
 						{
 							Type: autoscaling.ExternalMetricSourceType,
 							External: &autoscaling.ExternalMetricSource{
-								MetricName:  "traefik_backend_requests_per_second",
-								TargetValue: resourcePtr(resource.MustParse("100")),
+								Metric: autoscaling.MetricIdentifier{
+									Name: "traefik_backend_requests_per_second",
+								},
+								Target: autoscaling.MetricTarget{
+									Value: resourcePtr(resource.MustParse("100")),
+								},
 							},
 						},
 						{
 							Type: autoscaling.ExternalMetricSourceType,
 							External: &autoscaling.ExternalMetricSource{
-								MetricName:  "traefik_backend_errors_per_second",
-								TargetValue: resourcePtr(resource.MustParse("100")),
+								Metric: autoscaling.MetricIdentifier{
+									Name: "traefik_backend_errors_per_second",
+								},
+								Target: autoscaling.MetricTarget{
+									Value: resourcePtr(resource.MustParse("100")),
+								},
 							},
 						},
 					},
@@ -250,32 +286,44 @@ func TestHPAStore(t *testing.T) {
 						{
 							Type: "Resource",
 							Resource: &autoscaling.ResourceMetricStatus{
-								Name:                      "memory",
-								CurrentAverageUtilization: int32ptr(28),
-								CurrentAverageValue:       resource.MustParse("847775744"),
+								Name: "memory",
+								Current: autoscaling.MetricValueStatus{
+									AverageValue:       resourcePtr(resource.MustParse("847775744")),
+									AverageUtilization: int32ptr(28),
+								},
 							},
 						},
 						{
 							Type: "Resource",
 							Resource: &autoscaling.ResourceMetricStatus{
-								Name:                      "cpu",
-								CurrentAverageUtilization: int32ptr(6),
-								CurrentAverageValue:       resource.MustParse("62m"),
+								Name: "cpu",
+								Current: autoscaling.MetricValueStatus{
+									AverageValue:       resourcePtr(resource.MustParse("62m")),
+									AverageUtilization: int32ptr(6),
+								},
 							},
 						},
 						{
 							Type: "External",
 							External: &autoscaling.ExternalMetricStatus{
-								MetricName:          "traefik_backend_requests_per_second",
-								CurrentValue:        resource.MustParse("0"),
-								CurrentAverageValue: resourcePtr(resource.MustParse("2900m")),
+								Metric: autoscaling.MetricIdentifier{
+									Name: "traefik_backend_requests_per_second",
+								},
+								Current: autoscaling.MetricValueStatus{
+									Value:        resourcePtr(resource.MustParse("0")),
+									AverageValue: resourcePtr(resource.MustParse("2900m")),
+								},
 							},
 						},
 						{
 							Type: "External",
 							External: &autoscaling.ExternalMetricStatus{
-								MetricName:   "traefik_backend_errors_per_second",
-								CurrentValue: resource.MustParse("0"),
+								Metric: autoscaling.MetricIdentifier{
+									Name: "traefik_backend_errors_per_second",
+								},
+								Current: autoscaling.MetricValueStatus{
+									Value: resourcePtr(resource.MustParse("0")),
+								},
 							},
 						},
 					},


### PR DESCRIPTION
autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22+ and becomes
unavailable in v1.25+

This change updates the client to use autoscaling/v2beta2

Signed-off-by: Philip Gough <philip.p.gough@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
