### PR TITLE
persistentvolumeclaim: Implement annotation and fix label metrics generation

### DIFF
--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -46,6 +46,24 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			metric.Gauge,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			descPersistentVolumeClaimAnnotationsName,
+			descPersistentVolumeClaimAnnotationsHelp,
+			metric.Gauge,
+			"",
+			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/persistentvolumeclaim_test.go
+++ b/internal/store/persistentvolumeclaim_test.go
@@ -31,6 +31,78 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 	cases := []generateMetricsTestCase{
 		// Verify phase enumerations.
 		{
+			AllowAnnotationsList: []string{
+				"app.k8s.io/owner",
+			},
+			Obj: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mysql-data",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"app":              "mysql-server",
+						"app.k8s.io/owner": "@foo",
+					},
+				},
+				Spec: v1.PersistentVolumeClaimSpec{
+					AccessModes: []v1.PersistentVolumeAccessMode{
+						v1.ReadWriteOnce,
+					},
+					StorageClassName: &storageClassName,
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+					VolumeName: "pvc-mysql-data",
+				},
+				Status: v1.PersistentVolumeClaimStatus{
+					Phase: v1.ClaimBound,
+					Conditions: []v1.PersistentVolumeClaimCondition{
+						{Type: v1.PersistentVolumeClaimResizing, Status: v1.ConditionTrue},
+						{Type: v1.PersistentVolumeClaimFileSystemResizePending, Status: v1.ConditionFalse},
+						{Type: v1.PersistentVolumeClaimConditionType("CustomizedType"), Status: v1.ConditionTrue},
+					},
+				},
+			},
+			Want: `
+				# HELP kube_persistentvolumeclaim_access_mode The access mode(s) specified by the persistent volume claim.
+				# HELP kube_persistentvolumeclaim_annotations Kubernetes annotations converted to Prometheus labels.
+				# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
+				# HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
+				# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
+				# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
+				# HELP kube_persistentvolumeclaim_status_condition Information about status of different conditions of persistent volume claim.
+				# TYPE kube_persistentvolumeclaim_access_mode gauge
+				# TYPE kube_persistentvolumeclaim_annotations gauge
+				# TYPE kube_persistentvolumeclaim_info gauge
+				# TYPE kube_persistentvolumeclaim_labels gauge
+				# TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
+				# TYPE kube_persistentvolumeclaim_status_phase gauge
+				# TYPE kube_persistentvolumeclaim_status_condition gauge
+				kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",volumename="pvc-mysql-data"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Bound"} 1
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Lost"} 0
+				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
+				kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
+				kube_persistentvolumeclaim_annotations{annotation_app_k8s_io_owner="@foo",namespace="default",persistentvolumeclaim="mysql-data"} 1
+				kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="mysql-data"} 1
+				kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="mysql-data",access_mode="ReadWriteOnce"} 1
+				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="false",condition="CustomizedType"} 0
+				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="false",condition="FileSystemResizePending"} 1
+				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="false",condition="Resizing"} 0
+				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="true",condition="CustomizedType"} 1
+				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="true",condition="FileSystemResizePending"} 0
+				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="true",condition="Resizing"} 1
+				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="unknown",condition="CustomizedType"} 0
+				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="unknown",condition="FileSystemResizePending"} 0
+				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="unknown",condition="Resizing"} 0
+`,
+			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_annotations", "kube_persistentvolumeclaim_labels", "kube_persistentvolumeclaim_access_mode", "kube_persistentvolumeclaim_status_condition"},
+		},
+		{
+			AllowLabelsList: []string{
+				"app",
+			},
 			Obj: &v1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mysql-data",
@@ -62,12 +134,14 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 			},
 			Want: `
 				# HELP kube_persistentvolumeclaim_access_mode The access mode(s) specified by the persistent volume claim.
+				# HELP kube_persistentvolumeclaim_annotations Kubernetes annotations converted to Prometheus labels.
 				# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
 				# HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
 				# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
 				# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
 				# HELP kube_persistentvolumeclaim_status_condition Information about status of different conditions of persistent volume claim.
 				# TYPE kube_persistentvolumeclaim_access_mode gauge
+				# TYPE kube_persistentvolumeclaim_annotations gauge
 				# TYPE kube_persistentvolumeclaim_info gauge
 				# TYPE kube_persistentvolumeclaim_labels gauge
 				# TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
@@ -78,7 +152,8 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Lost"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
 				kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
-				kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="mysql-data"} 1
+				kube_persistentvolumeclaim_annotations{namespace="default",persistentvolumeclaim="mysql-data"} 1
+				kube_persistentvolumeclaim_labels{label_app="mysql-server",namespace="default",persistentvolumeclaim="mysql-data"} 1
 				kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="mysql-data",access_mode="ReadWriteOnce"} 1
 				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="false",condition="CustomizedType"} 0
 				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="false",condition="FileSystemResizePending"} 1
@@ -90,7 +165,7 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="unknown",condition="FileSystemResizePending"} 0
 				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="unknown",condition="Resizing"} 0
 `,
-			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels", "kube_persistentvolumeclaim_access_mode", "kube_persistentvolumeclaim_status_condition"},
+			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_annotations", "kube_persistentvolumeclaim_labels", "kube_persistentvolumeclaim_access_mode", "kube_persistentvolumeclaim_status_condition"},
 		},
 		{
 			Obj: &v1.PersistentVolumeClaim{
@@ -152,12 +227,14 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 			},
 			Want: `
 				# HELP kube_persistentvolumeclaim_access_mode The access mode(s) specified by the persistent volume claim.
+				# HELP kube_persistentvolumeclaim_annotations Kubernetes annotations converted to Prometheus labels.
 				# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
 				# HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
 				# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
 				# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
 				# HELP kube_persistentvolumeclaim_status_condition Information about status of different conditions of persistent volume claim.
 				# TYPE kube_persistentvolumeclaim_access_mode gauge
+				# TYPE kube_persistentvolumeclaim_annotations gauge
 				# TYPE kube_persistentvolumeclaim_info gauge
 				# TYPE kube_persistentvolumeclaim_labels gauge
 				# TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
@@ -168,6 +245,7 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Lost"} 1
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Pending"} 0
 				kube_persistentvolumeclaim_labels{namespace="",persistentvolumeclaim="mongo-data"} 1
+				kube_persistentvolumeclaim_annotations{namespace="",persistentvolumeclaim="mongo-data"} 1
 				kube_persistentvolumeclaim_access_mode{namespace="",persistentvolumeclaim="mongo-data",access_mode="ReadWriteOnce"} 1
 				kube_persistentvolumeclaim_status_condition{namespace="",persistentvolumeclaim="mongo-data",status="false",condition="CustomizedType"} 1
 				kube_persistentvolumeclaim_status_condition{namespace="",persistentvolumeclaim="mongo-data",status="false",condition="FileSystemResizePending"} 0
@@ -179,12 +257,12 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 				kube_persistentvolumeclaim_status_condition{namespace="",persistentvolumeclaim="mongo-data",status="unknown",condition="FileSystemResizePending"} 0
 				kube_persistentvolumeclaim_status_condition{namespace="",persistentvolumeclaim="mongo-data",status="unknown",condition="Resizing"} 0
 `,
-			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels", "kube_persistentvolumeclaim_access_mode", "kube_persistentvolumeclaim_status_condition"},
+			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_annotations", "kube_persistentvolumeclaim_labels", "kube_persistentvolumeclaim_access_mode", "kube_persistentvolumeclaim_status_condition"},
 		},
 	}
 	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(persistentVolumeClaimMetricFamilies(nil, nil))
-		c.Headers = generator.ExtractMetricFamilyHeaders(persistentVolumeClaimMetricFamilies(nil, nil))
+		c.Func = generator.ComposeMetricGenFuncs(persistentVolumeClaimMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.Headers = generator.ExtractMetricFamilyHeaders(persistentVolumeClaimMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Implementation of `kube_persistentvolumeclaim_labels` was accidentally removed after https://github.com/kubernetes/kube-state-metrics/pull/1468. This PR add it back with proper unit test.

This PR also implements `kube_persistentvolumeclaim_annotations`.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

N/A

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>