### PR TITLE
add pod ready time metrics

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -53,7 +53,7 @@
 | kube_pod_status_reason | Gauge | The pod status reasons | |`pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `reason`=&lt;NodeLost\|Evicted\|UnexpectedAdmissionError&gt; <br> `uid`=&lt;pod-uid&gt; | EXPERIMENTAL |
 | kube_pod_status_scheduled_time | Gauge | Unix timestamp when pod moved into scheduled status | seconds |`pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `uid`=&lt;pod-uid&gt; | STABLE |
 | kube_pod_status_unschedulable | Gauge | Describes the unschedulable status for the pod | |`pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `uid`=&lt;pod-uid&gt; | STABLE |
-
+| kube_pod_status_ready_time | Gauge | Describes the ready time for the pod |seconds |`pod`=&lt;pod-name&gt; <br> `namespace`=&lt;pod-namespace&gt; <br> `uid`=&lt;pod-uid&gt; | EXPERIMENTAL |
 ## Useful metrics queries
 
 ### How to retrieve non-standard Pod state

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -90,6 +90,7 @@ func podMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 		createPodStatusScheduledFamilyGenerator(),
 		createPodStatusScheduledTimeFamilyGenerator(),
 		createPodStatusUnschedulableFamilyGenerator(),
+		createPodReadyTimeFamilyGeneratorFamilyGenerator(),
 	}
 }
 
@@ -1561,6 +1562,31 @@ func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
 				}
 			}
 
+			return &metric.Family{
+				Metrics: ms,
+			}
+		}),
+	)
+}
+
+func createPodReadyTimeFamilyGeneratorFamilyGenerator() generator.FamilyGenerator {
+	return *generator.NewFamilyGenerator(
+		"kube_pod_status_ready_time",
+		"Describes the ready time for the pod.",
+		metric.Gauge,
+		"",
+		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			ms := []*metric.Metric{}
+			for _, c := range p.Status.Conditions {
+				if c.Type == v1.PodReady && c.Status == v1.ConditionTrue {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(c.LastTransitionTime.Unix()),
+					})
+				}
+
+			}
 			return &metric.Family{
 				Metrics: ms,
 			}

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1132,18 +1132,25 @@ func TestPodStore(t *testing.T) {
 						{
 							Type:   v1.PodReady,
 							Status: v1.ConditionTrue,
+							LastTransitionTime: metav1.Time{
+								Time: time.Unix(1501666018, 0),
+							},
+
 						},
 					},
 				},
 			},
 			Want: `
 				# HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
-				# TYPE kube_pod_status_ready gauge
-				kube_pod_status_ready{condition="false",namespace="ns1",pod="pod1",uid="uid1"} 0
-				kube_pod_status_ready{condition="true",namespace="ns1",pod="pod1",uid="uid1"} 1
-				kube_pod_status_ready{condition="unknown",namespace="ns1",pod="pod1",uid="uid1"} 0
+                # HELP kube_pod_status_ready_time Describes the ready time for the pod.
+                # TYPE kube_pod_status_ready gauge
+                # TYPE kube_pod_status_ready_time gauge
+                kube_pod_status_ready_time{namespace="ns1",pod="pod1",uid="uid1"} 1.501666018e+09
+                kube_pod_status_ready{condition="false",namespace="ns1",pod="pod1",uid="uid1"} 0
+                kube_pod_status_ready{condition="true",namespace="ns1",pod="pod1",uid="uid1"} 1
+                kube_pod_status_ready{condition="unknown",namespace="ns1",pod="pod1",uid="uid1"} 0
 			`,
-			MetricNames: []string{"kube_pod_status_ready"},
+			MetricNames: []string{"kube_pod_status_ready","kube_pod_status_ready_time"},
 		},
 		{
 			Obj: &v1.Pod{
@@ -1163,10 +1170,12 @@ func TestPodStore(t *testing.T) {
 			},
 			Want: `
 				# HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
-				# TYPE kube_pod_status_ready gauge
-				kube_pod_status_ready{condition="false",namespace="ns2",pod="pod2",uid="uid2"} 1
-				kube_pod_status_ready{condition="true",namespace="ns2",pod="pod2",uid="uid2"} 0
-				kube_pod_status_ready{condition="unknown",namespace="ns2",pod="pod2",uid="uid2"} 0
+                # HELP kube_pod_status_ready_time Describes the ready time for the pod.
+                # TYPE kube_pod_status_ready gauge
+                # TYPE kube_pod_status_ready_time gauge
+                kube_pod_status_ready{condition="false",namespace="ns2",pod="pod2",uid="uid2"} 1
+                kube_pod_status_ready{condition="true",namespace="ns2",pod="pod2",uid="uid2"} 0
+                kube_pod_status_ready{condition="unknown",namespace="ns2",pod="pod2",uid="uid2"} 0
 			`,
 			MetricNames: []string{"kube_pod_status_ready"},
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -213,6 +213,7 @@ func TestFullScrapeCycle(t *testing.T) {
 # HELP kube_pod_start_time Start time in unix timestamp for a pod.
 # HELP kube_pod_status_phase The pods current phase.
 # HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
+# HELP kube_pod_status_ready_time Describes the ready time for the pod.
 # HELP kube_pod_status_reason The pod status reasons
 # HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
 # HELP kube_pod_status_scheduled_time Unix timestamp when pod moved into scheduled status
@@ -264,6 +265,7 @@ func TestFullScrapeCycle(t *testing.T) {
 # TYPE kube_pod_start_time gauge
 # TYPE kube_pod_status_phase gauge
 # TYPE kube_pod_status_ready gauge
+# TYPE kube_pod_status_ready_time gauge
 # TYPE kube_pod_status_reason gauge
 # TYPE kube_pod_status_scheduled gauge
 # TYPE kube_pod_status_scheduled_time gauge


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
add pod ready time metrics with test case 
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
