### PR TITLE
endpoints: export number of ports as new metric

### DIFF
--- a/docs/endpoint-metrics.md
+++ b/docs/endpoint-metrics.md
@@ -8,3 +8,4 @@
 | kube_endpoint_info | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt;  | STABLE |
 | kube_endpoint_labels | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `label_ENDPOINT_LABEL`=&lt;ENDPOINT_LABEL&gt;  | STABLE |
 | kube_endpoint_created | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; | STABLE |
+| kube_endpoint_ports | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `port_name`=&lt;endpoint-port-name&gt; <br> `port_protocol`=&lt;endpoint-port-protocol&gt; <br> `port_number`=&lt;endpoint-port-number&gt; | EXPERIMENTAL |

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"context"
+	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -147,6 +148,27 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 							Value: float64(notReady),
 						},
 					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_endpoint_ports",
+			"Information about the Endpoint ports.",
+			metric.Gauge,
+			"",
+			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+				ms := []*metric.Metric{}
+				for _, s := range e.Subsets {
+					for _, port := range s.Ports {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{port.Name, string(port.Protocol), strconv.FormatInt(int64(port.Port), 10)},
+							LabelKeys:   []string{"port_name", "port_protocol", "port_number"},
+							Value:       1,
+						})
+					}
+				}
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Export the number of ports per endpoint.

The number of Ports per service can change during their lifetime. When changing a service with type `LoadBalancer`, the cloud-specific controller mostly change corresponding Loadbalancer-Objects on the cloud-provider side.

If a customer add a new Port to an existing Service-Object, the Endpoint will be updated and the cloud-controller will update the Loadbalancer object on cloud-provider side and a new Listener will be added.
In this special case, the metric can be read as "number of Listeners on a Cloud-Provider Loadbalancer side".


**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Signed-off-by: Constanti, Mario <mario.constanti@daimler.com>