### PR TITLE
test: Use go-cmp package to diff test expectation vs actual

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/brancz/gojsontoyaml v0.1.0
 	github.com/campoy/embedmd v1.0.0
 	github.com/dgryski/go-jump v0.0.0-20170409065014-e1f439676b57
+	github.com/google/go-cmp v0.5.5
 	github.com/google/go-jsonnet v0.17.0
 	github.com/jsonnet-bundler/jsonnet-bundler v0.4.1-0.20200708074244-ada055a225fa
 	github.com/oklog/run v1.1.0
@@ -44,7 +45,6 @@ require (
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect

--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
@@ -68,8 +69,8 @@ func compareOutput(expected, actual string) error {
 		}
 	}
 
-	if entities[0] != entities[1] {
-		return errors.Errorf("\nEXPECTED:\n--------------\n%v\nACTUAL:\n--------------\n%v", entities[0], entities[1])
+	if diff := cmp.Diff(entities[0], entities[1]); diff != "" {
+		return errors.Errorf("(-want, +got):\n%s", diff)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Prior to this PR, it is pretty hard and manual to diff the test failure expectation
vs actual. This PR simplifies the comparison `using github.com/google/go-cmp/cmp`
package.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

N/A. It is just a internal test module change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 

N/A

Before this PR:
```
--- FAIL: TestPersistentVolumeClaimStore (0.05s)
    persistentvolumeclaim_test.go:267: unexpected collecting result in 0th run:
        expected wanted output to equal output:
        EXPECTED:
        --------------
        # HELP kube_persistentvolumeclaim_access_mode The access mode(s) specified by the persistent volume claim.
        # HELP kube_persistentvolumeclaim_annotations Kubernetes annotations converted to Prometheus labels.
        # HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
        # HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
        # HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
        # HELP kube_persistentvolumeclaim_status_condition Information about status of different conditions of persistent volume claim.
        # HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
        # TYPE kube_persistentvolumeclaim_access_mode gauge
        # TYPE kube_persistentvolumeclaim_annotations gauge
        # TYPE kube_persistentvolumeclaim_info gauge
        # TYPE kube_persistentvolumeclaim_labels gauge
        # TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
        # TYPE kube_persistentvolumeclaim_status_condition gauge
        # TYPE kube_persistentvolumeclaim_status_phase gauge
        kube_persistentvolumeclaim_access_mode{access_mode="ReadWriteOnce",namespace="default",persistentvolumeclaim="mysql-data"} 1
        kube_persistentvolumeclaim_annotations{annotation_app_k8s_io_owner="@foo",namespace="default",persistentvolumeclaim="mysql-data"} 1
        kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",volumename="pvc-mysql-data1"} 1
        kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="mysql-data"} 1
        kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
        kube_persistentvolumeclaim_status_condition{condition="CustomizedType",namespace="default",persistentvolumeclaim="mysql-data",status="false"} 0
        kube_persistentvolumeclaim_status_condition{condition="CustomizedType",namespace="default",persistentvolumeclaim="mysql-data",status="true"} 1
        kube_persistentvolumeclaim_status_condition{condition="CustomizedType",namespace="default",persistentvolumeclaim="mysql-data",status="unknown"} 0
        kube_persistentvolumeclaim_status_condition{condition="FileSystemResizePending",namespace="default",persistentvolumeclaim="mysql-data",status="false"} 1
        kube_persistentvolumeclaim_status_condition{condition="FileSystemResizePending",namespace="default",persistentvolumeclaim="mysql-data",status="true"} 0
        kube_persistentvolumeclaim_status_condition{condition="FileSystemResizePending",namespace="default",persistentvolumeclaim="mysql-data",status="unknown"} 0
        kube_persistentvolumeclaim_status_condition{condition="Resizing",namespace="default",persistentvolumeclaim="mysql-data",status="false"} 0
        kube_persistentvolumeclaim_status_condition{condition="Resizing",namespace="default",persistentvolumeclaim="mysql-data",status="true"} 1
        kube_persistentvolumeclaim_status_condition{condition="Resizing",namespace="default",persistentvolumeclaim="mysql-data",status="unknown"} 0
        kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Bound"} 1
        kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Lost"} 0
        kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
        ACTUAL:
        --------------
        # HELP kube_persistentvolumeclaim_access_mode The access mode(s) specified by the persistent volume claim.
        # HELP kube_persistentvolumeclaim_annotations Kubernetes annotations converted to Prometheus labels.
        # HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
        # HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
        # HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
        # HELP kube_persistentvolumeclaim_status_condition Information about status of different conditions of persistent volume claim.
        # HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
        # TYPE kube_persistentvolumeclaim_access_mode gauge
        # TYPE kube_persistentvolumeclaim_annotations gauge
        # TYPE kube_persistentvolumeclaim_info gauge
        # TYPE kube_persistentvolumeclaim_labels gauge
        # TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
        # TYPE kube_persistentvolumeclaim_status_condition gauge
        # TYPE kube_persistentvolumeclaim_status_phase gauge
        kube_persistentvolumeclaim_access_mode{access_mode="ReadWriteOnce",namespace="default",persistentvolumeclaim="mysql-data"} 1
        kube_persistentvolumeclaim_annotations{annotation_app_k8s_io_owner="@foo",namespace="default",persistentvolumeclaim="mysql-data"} 1
        kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",volumename="pvc-mysql-data"} 1
        kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="mysql-data"} 1
        kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
        kube_persistentvolumeclaim_status_condition{condition="CustomizedType",namespace="default",persistentvolumeclaim="mysql-data",status="false"} 0
        kube_persistentvolumeclaim_status_condition{condition="CustomizedType",namespace="default",persistentvolumeclaim="mysql-data",status="true"} 1
        kube_persistentvolumeclaim_status_condition{condition="CustomizedType",namespace="default",persistentvolumeclaim="mysql-data",status="unknown"} 0
        kube_persistentvolumeclaim_status_condition{condition="FileSystemResizePending",namespace="default",persistentvolumeclaim="mysql-data",status="false"} 1
        kube_persistentvolumeclaim_status_condition{condition="FileSystemResizePending",namespace="default",persistentvolumeclaim="mysql-data",status="true"} 0
        kube_persistentvolumeclaim_status_condition{condition="FileSystemResizePending",namespace="default",persistentvolumeclaim="mysql-data",status="unknown"} 0
        kube_persistentvolumeclaim_status_condition{condition="Resizing",namespace="default",persistentvolumeclaim="mysql-data",status="false"} 0
        kube_persistentvolumeclaim_status_condition{condition="Resizing",namespace="default",persistentvolumeclaim="mysql-data",status="true"} 1
        kube_persistentvolumeclaim_status_condition{condition="Resizing",namespace="default",persistentvolumeclaim="mysql-data",status="unknown"} 0
        kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Bound"} 1
        kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Lost"} 0
        kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
FAIL
FAIL	k8s.io/kube-state-metrics/v2/internal/store	1.967s
FAIL
```
After this PR:
```
--- FAIL: TestPersistentVolumeClaimStore (0.05s)
    persistentvolumeclaim_test.go:267: unexpected collecting result in 0th run:
        expected wanted output to equal output: (-want, +got):
          (
          	"""
          	... // 14 identical lines
          	kube_persistentvolumeclaim_access_mode{access_mode="ReadWriteOnce",namespace="default",persistentvolumeclaim="mysql-data"} 1
          	kube_persistentvolumeclaim_annotations{annotation_app_k8s_io_owner="@foo",namespace="default",persistentvolumeclaim="mysql-data"} 1
        - 	kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",volumename="pvc-mysql-data1"} 1
        + 	kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="mysql-data",storageclass="rbd",volumename="pvc-mysql-data"} 1
          	kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="mysql-data"} 1
          	kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
          	... // 12 identical lines
          	"""
          )
FAIL
FAIL	k8s.io/kube-state-metrics/v2/internal/store	1.101s
FAIL
```

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>