### PR TITLE
fixed four resources with copy/paste issues

### DIFF
--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -49,7 +49,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			metric.Gauge,
 			"",
 			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
-				annotationKeys, annotationValues := createPrometheusLabelKeysValues("label", j.Annotations, allowLabelsList)
+				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -218,7 +218,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			metric.Gauge,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowLabelsList)
+				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -199,7 +199,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			metric.Gauge,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", a.Annotations, allowLabelsList)
+				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", a.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -35,6 +35,7 @@ func TestHPAStore(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_horizontalpodautoscaler_annotations Kubernetes annotations converted to Prometheus labels.
 		# HELP kube_horizontalpodautoscaler_labels Kubernetes labels converted to Prometheus labels.
 		# HELP kube_horizontalpodautoscaler_metadata_generation The generation observed by the HorizontalPodAutoscaler controller.
 		# HELP kube_horizontalpodautoscaler_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
@@ -43,6 +44,7 @@ func TestHPAStore(t *testing.T) {
 		# HELP kube_horizontalpodautoscaler_status_condition The condition of this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_current_replicas Current number of replicas of pods managed by this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
+		# TYPE kube_horizontalpodautoscaler_annotations gauge
 		# TYPE kube_horizontalpodautoscaler_labels gauge
 		# TYPE kube_horizontalpodautoscaler_metadata_generation gauge
 		# TYPE kube_horizontalpodautoscaler_spec_max_replicas gauge
@@ -181,6 +183,7 @@ func TestHPAStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
+				kube_horizontalpodautoscaler_annotations{horizontalpodautoscaler="hpa1",namespace="ns1"} 1
 				kube_horizontalpodautoscaler_labels{horizontalpodautoscaler="hpa1",namespace="ns1"} 1
 				kube_horizontalpodautoscaler_metadata_generation{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
 				kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 4
@@ -207,11 +210,15 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_status_current_replicas",
 				"kube_horizontalpodautoscaler_status_desired_replicas",
 				"kube_horizontalpodautoscaler_status_condition",
+				"kube_horizontalpodautoscaler_annotations",
 				"kube_horizontalpodautoscaler_labels",
 			},
 		},
 		{
 			// Verify populating base metric.
+			AllowAnnotationsList: []string{
+				"app.k8s.io/owner",
+			},
 			Obj: &autoscaling.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Generation: 2,
@@ -219,6 +226,10 @@ func TestHPAStore(t *testing.T) {
 					Namespace:  "ns1",
 					Labels: map[string]string{
 						"app": "foobar",
+					},
+					Annotations: map[string]string{
+						"app":              "mysql-server",
+						"app.k8s.io/owner": "@foo",
 					},
 				},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
@@ -330,6 +341,7 @@ func TestHPAStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
+				kube_horizontalpodautoscaler_annotations{annotation_app_k8s_io_owner="@foo",horizontalpodautoscaler="hpa2",namespace="ns1"} 1
 				kube_horizontalpodautoscaler_labels{horizontalpodautoscaler="hpa2",namespace="ns1"} 1
 				kube_horizontalpodautoscaler_metadata_generation{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
 				kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 4
@@ -352,13 +364,14 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_status_current_replicas",
 				"kube_horizontalpodautoscaler_status_desired_replicas",
 				"kube_horizontalpodautoscaler_status_condition",
+				"kube_horizontalpodautoscaler_annotation",
 				"kube_horizontalpodautoscaler_labels",
 			},
 		},
 	}
 	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(hpaMetricFamilies(nil, nil))
-		c.Headers = generator.ExtractMetricFamilyHeaders(hpaMetricFamilies(nil, nil))
+		c.Func = generator.ComposeMetricGenFuncs(hpaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.Headers = generator.ExtractMetricFamilyHeaders(hpaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -61,7 +61,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			metric.Gauge,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
-				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", i.Annotations, allowLabelsList)
+				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", i.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes what seems like a copy/paste issue in the annotation implementation, where `allowLabelsList` was used instead of `allowAnnotationsList`.
Added tests for this as well.

**How does this change affect the cardinality of KSM**:
Decreases, annotations are can be suppressed in four more resources.

**Which issue(s) this PR fixes**:
Fixes #1576
