### PR TITLE
Expose configmap labels and annotations

### DIFF
--- a/docs/configmap-metrics.md
+++ b/docs/configmap-metrics.md
@@ -2,6 +2,8 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
+| kube_configmap_annotations | Gauge | `configmap`=&lt;configmap-name&gt; <br> `namespace`=&lt;configmap-namespace&gt; <br> `annotation_CONFIGMAP_ANNOTATION`=&lt;CONFIGMAP_ANNOTATION&gt; | EXPERIMENTAL
+| kube_configmap_labels | Gauge | `configmap`=&lt;configmap-name&gt; <br> `namespace`=&lt;configmap-namespace&gt; <br> `label_CONFIGMAP_LABEL`=&lt;CONFIGMAP_LABEL&gt; | STABLE
 | kube_configmap_info | Gauge | `configmap`=&lt;configmap-name&gt; <br> `namespace`=&lt;configmap-namespace&gt; | STABLE |
 | kube_configmap_created  | Gauge | `configmap`=&lt;configmap-name&gt; <br> `namespace`=&lt;configmap-namespace&gt; | STABLE |
 | kube_configmap_metadata_resource_version | Gauge | `configmap`=&lt;configmap-name&gt; <br> `namespace`=&lt;configmap-namespace&gt; | EXPERIMENTAL |

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -238,119 +238,264 @@ func availableResources() []string {
 }
 
 func (b *Builder) buildConfigMapStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(configMapMetricFamilies, &v1.ConfigMap{}, createConfigMapListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		configMapMetricFamilies(b.allowAnnotationsList["configmaps"], b.allowLabelsList["configmaps"]),
+		&v1.ConfigMap{},
+		createConfigMapListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildCronJobStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(cronJobMetricFamilies(b.allowAnnotationsList["cronjobs"], b.allowLabelsList["cronjobs"]), &batchv1beta1.CronJob{}, createCronJobListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		cronJobMetricFamilies(b.allowAnnotationsList["cronjobs"], b.allowLabelsList["cronjobs"]),
+		&batchv1beta1.CronJob{},
+		createCronJobListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildDaemonSetStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(daemonSetMetricFamilies(b.allowAnnotationsList["daemonsets"], b.allowLabelsList["daemonsets"]), &appsv1.DaemonSet{}, createDaemonSetListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		daemonSetMetricFamilies(b.allowAnnotationsList["daemonsets"], b.allowLabelsList["daemonsets"]),
+		&appsv1.DaemonSet{},
+		createDaemonSetListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildDeploymentStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(deploymentMetricFamilies(b.allowAnnotationsList["deployments"], b.allowLabelsList["deployments"]), &appsv1.Deployment{}, createDeploymentListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		deploymentMetricFamilies(b.allowAnnotationsList["deployments"], b.allowLabelsList["deployments"]),
+		&appsv1.Deployment{},
+		createDeploymentListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildEndpointsStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(endpointMetricFamilies(b.allowAnnotationsList["endpoints"], b.allowLabelsList["endpoints"]), &v1.Endpoints{}, createEndpointsListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		endpointMetricFamilies(b.allowAnnotationsList["endpoints"], b.allowLabelsList["endpoints"]),
+		&v1.Endpoints{},
+		createEndpointsListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildHPAStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(hpaMetricFamilies(b.allowAnnotationsList["horizontalpodautoscalers"], b.allowLabelsList["horizontalpodautoscalers"]), &autoscaling.HorizontalPodAutoscaler{}, createHPAListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		hpaMetricFamilies(b.allowAnnotationsList["horizontalpodautoscalers"], b.allowLabelsList["horizontalpodautoscalers"]),
+		&autoscaling.HorizontalPodAutoscaler{},
+		createHPAListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildIngressStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(ingressMetricFamilies(b.allowAnnotationsList["ingresses"], b.allowLabelsList["ingresses"]), &networkingv1.Ingress{}, createIngressListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		ingressMetricFamilies(b.allowAnnotationsList["ingresses"], b.allowLabelsList["ingresses"]),
+		&networkingv1.Ingress{},
+		createIngressListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildJobStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(jobMetricFamilies(b.allowAnnotationsList["jobs"], b.allowLabelsList["jobs"]), &batchv1.Job{}, createJobListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		jobMetricFamilies(b.allowAnnotationsList["jobs"], b.allowLabelsList["jobs"]),
+		&batchv1.Job{},
+		createJobListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildLimitRangeStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(limitRangeMetricFamilies, &v1.LimitRange{}, createLimitRangeListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		limitRangeMetricFamilies,
+		&v1.LimitRange{},
+		createLimitRangeListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildMutatingWebhookConfigurationStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(mutatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.MutatingWebhookConfiguration{}, createMutatingWebhookConfigurationListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		mutatingWebhookConfigurationMetricFamilies,
+		&admissionregistrationv1.MutatingWebhookConfiguration{},
+		createMutatingWebhookConfigurationListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildNamespaceStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(namespaceMetricFamilies(b.allowAnnotationsList["namespaces"], b.allowLabelsList["namespaces"]), &v1.Namespace{}, createNamespaceListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		namespaceMetricFamilies(b.allowAnnotationsList["namespaces"], b.allowLabelsList["namespaces"]),
+		&v1.Namespace{},
+		createNamespaceListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildNetworkPolicyStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(networkPolicyMetricFamilies(b.allowAnnotationsList["networkpolicies"], b.allowLabelsList["networkpolicies"]), &networkingv1.NetworkPolicy{}, createNetworkPolicyListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		networkPolicyMetricFamilies(b.allowAnnotationsList["networkpolicies"], b.allowLabelsList["networkpolicies"]),
+		&networkingv1.NetworkPolicy{},
+		createNetworkPolicyListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildNodeStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(nodeMetricFamilies(b.allowAnnotationsList["nodes"], b.allowLabelsList["nodes"]), &v1.Node{}, createNodeListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		nodeMetricFamilies(b.allowAnnotationsList["nodes"], b.allowLabelsList["nodes"]),
+		&v1.Node{},
+		createNodeListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildPersistentVolumeClaimStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(persistentVolumeClaimMetricFamilies(b.allowAnnotationsList["persistentvolumeclaims"], b.allowLabelsList["persistentvolumeclaims"]), &v1.PersistentVolumeClaim{}, createPersistentVolumeClaimListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		persistentVolumeClaimMetricFamilies(b.allowAnnotationsList["persistentvolumeclaims"], b.allowLabelsList["persistentvolumeclaims"]),
+		&v1.PersistentVolumeClaim{},
+		createPersistentVolumeClaimListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildPersistentVolumeStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(persistentVolumeMetricFamilies(b.allowAnnotationsList["persistentvolumes"], b.allowLabelsList["persistentvolumes"]), &v1.PersistentVolume{}, createPersistentVolumeListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		persistentVolumeMetricFamilies(b.allowAnnotationsList["persistentvolumes"], b.allowLabelsList["persistentvolumes"]),
+		&v1.PersistentVolume{},
+		createPersistentVolumeListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildPodDisruptionBudgetStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(podDisruptionBudgetMetricFamilies, &policy.PodDisruptionBudget{}, createPodDisruptionBudgetListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		podDisruptionBudgetMetricFamilies,
+		&policy.PodDisruptionBudget{},
+		createPodDisruptionBudgetListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildReplicaSetStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(replicaSetMetricFamilies(b.allowAnnotationsList["replicasets"], b.allowLabelsList["replicasets"]), &appsv1.ReplicaSet{}, createReplicaSetListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		replicaSetMetricFamilies(b.allowAnnotationsList["replicasets"], b.allowLabelsList["replicasets"]),
+		&appsv1.ReplicaSet{},
+		createReplicaSetListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildReplicationControllerStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(replicationControllerMetricFamilies, &v1.ReplicationController{}, createReplicationControllerListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		replicationControllerMetricFamilies,
+		&v1.ReplicationController{},
+		createReplicationControllerListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildResourceQuotaStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(resourceQuotaMetricFamilies, &v1.ResourceQuota{}, createResourceQuotaListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		resourceQuotaMetricFamilies,
+		&v1.ResourceQuota{},
+		createResourceQuotaListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildSecretStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(secretMetricFamilies(b.allowAnnotationsList["secrets"], b.allowLabelsList["secrets"]), &v1.Secret{}, createSecretListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		secretMetricFamilies(b.allowAnnotationsList["secrets"], b.allowLabelsList["secrets"]),
+		&v1.Secret{},
+		createSecretListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildServiceStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(serviceMetricFamilies(b.allowAnnotationsList["services"], b.allowLabelsList["services"]), &v1.Service{}, createServiceListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		serviceMetricFamilies(b.allowAnnotationsList["services"], b.allowLabelsList["services"]),
+		&v1.Service{},
+		createServiceListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildStatefulSetStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(statefulSetMetricFamilies(b.allowAnnotationsList["statefulsets"], b.allowLabelsList["statefulsets"]), &appsv1.StatefulSet{}, createStatefulSetListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		statefulSetMetricFamilies(b.allowAnnotationsList["statefulsets"], b.allowLabelsList["statefulsets"]),
+		&appsv1.StatefulSet{},
+		createStatefulSetListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildStorageClassStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(storageClassMetricFamilies(b.allowAnnotationsList["storageclasses"], b.allowLabelsList["storageclasses"]), &storagev1.StorageClass{}, createStorageClassListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		storageClassMetricFamilies(b.allowAnnotationsList["storageclasses"], b.allowLabelsList["storageclasses"]),
+		&storagev1.StorageClass{},
+		createStorageClassListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildPodStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(podMetricFamilies(b.allowAnnotationsList["pods"], b.allowLabelsList["pods"]), &v1.Pod{}, createPodListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		podMetricFamilies(b.allowAnnotationsList["pods"], b.allowLabelsList["pods"]),
+		&v1.Pod{},
+		createPodListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildCsrStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(csrMetricFamilies(b.allowAnnotationsList["certificatesigningrequests"], b.allowLabelsList["certificatesigningrequests"]), &certv1.CertificateSigningRequest{}, createCSRListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		csrMetricFamilies(b.allowAnnotationsList["certificatesigningrequests"], b.allowLabelsList["certificatesigningrequests"]),
+		&certv1.CertificateSigningRequest{},
+		createCSRListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildValidatingWebhookConfigurationStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(validatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.ValidatingWebhookConfiguration{}, createValidatingWebhookConfigurationListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		validatingWebhookConfigurationMetricFamilies,
+		&admissionregistrationv1.ValidatingWebhookConfiguration{},
+		createValidatingWebhookConfigurationListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildVolumeAttachmentStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(volumeAttachmentMetricFamilies, &storagev1.VolumeAttachment{}, createVolumeAttachmentListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		volumeAttachmentMetricFamilies,
+		&storagev1.VolumeAttachment{},
+		createVolumeAttachmentListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildVPAStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(vpaMetricFamilies(b.allowAnnotationsList["verticalpodautoscalers"], b.allowLabelsList["verticalpodautoscalers"]), &vpaautoscaling.VerticalPodAutoscaler{}, createVPAListWatchFunc(b.vpaClient), b.useAPIServerCache)
+	return b.buildStoresFunc(
+		vpaMetricFamilies(b.allowAnnotationsList["verticalpodautoscalers"], b.allowLabelsList["verticalpodautoscalers"]),
+		&vpaautoscaling.VerticalPodAutoscaler{},
+		createVPAListWatchFunc(b.vpaClient),
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildLeasesStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(leaseMetricFamilies, &coordinationv1.Lease{}, createLeaseListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(
+		leaseMetricFamilies,
+		&coordinationv1.Lease{},
+		createLeaseListWatch,
+		b.useAPIServerCache,
+	)
 }
 
 func (b *Builder) buildStores(

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -238,264 +238,119 @@ func availableResources() []string {
 }
 
 func (b *Builder) buildConfigMapStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		configMapMetricFamilies(b.allowAnnotationsList["configmaps"], b.allowLabelsList["configmaps"]),
-		&v1.ConfigMap{},
-		createConfigMapListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(configMapMetricFamilies(b.allowAnnotationsList["configmaps"], b.allowLabelsList["configmaps"]), &v1.ConfigMap{}, createConfigMapListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildCronJobStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		cronJobMetricFamilies(b.allowAnnotationsList["cronjobs"], b.allowLabelsList["cronjobs"]),
-		&batchv1beta1.CronJob{},
-		createCronJobListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(cronJobMetricFamilies(b.allowAnnotationsList["cronjobs"], b.allowLabelsList["cronjobs"]), &batchv1beta1.CronJob{}, createCronJobListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildDaemonSetStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		daemonSetMetricFamilies(b.allowAnnotationsList["daemonsets"], b.allowLabelsList["daemonsets"]),
-		&appsv1.DaemonSet{},
-		createDaemonSetListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(daemonSetMetricFamilies(b.allowAnnotationsList["daemonsets"], b.allowLabelsList["daemonsets"]), &appsv1.DaemonSet{}, createDaemonSetListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildDeploymentStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		deploymentMetricFamilies(b.allowAnnotationsList["deployments"], b.allowLabelsList["deployments"]),
-		&appsv1.Deployment{},
-		createDeploymentListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(deploymentMetricFamilies(b.allowAnnotationsList["deployments"], b.allowLabelsList["deployments"]), &appsv1.Deployment{}, createDeploymentListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildEndpointsStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		endpointMetricFamilies(b.allowAnnotationsList["endpoints"], b.allowLabelsList["endpoints"]),
-		&v1.Endpoints{},
-		createEndpointsListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(endpointMetricFamilies(b.allowAnnotationsList["endpoints"], b.allowLabelsList["endpoints"]), &v1.Endpoints{}, createEndpointsListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildHPAStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		hpaMetricFamilies(b.allowAnnotationsList["horizontalpodautoscalers"], b.allowLabelsList["horizontalpodautoscalers"]),
-		&autoscaling.HorizontalPodAutoscaler{},
-		createHPAListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(hpaMetricFamilies(b.allowAnnotationsList["horizontalpodautoscalers"], b.allowLabelsList["horizontalpodautoscalers"]), &autoscaling.HorizontalPodAutoscaler{}, createHPAListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildIngressStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		ingressMetricFamilies(b.allowAnnotationsList["ingresses"], b.allowLabelsList["ingresses"]),
-		&networkingv1.Ingress{},
-		createIngressListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(ingressMetricFamilies(b.allowAnnotationsList["ingresses"], b.allowLabelsList["ingresses"]), &networkingv1.Ingress{}, createIngressListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildJobStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		jobMetricFamilies(b.allowAnnotationsList["jobs"], b.allowLabelsList["jobs"]),
-		&batchv1.Job{},
-		createJobListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(jobMetricFamilies(b.allowAnnotationsList["jobs"], b.allowLabelsList["jobs"]), &batchv1.Job{}, createJobListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildLimitRangeStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		limitRangeMetricFamilies,
-		&v1.LimitRange{},
-		createLimitRangeListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(limitRangeMetricFamilies, &v1.LimitRange{}, createLimitRangeListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildMutatingWebhookConfigurationStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		mutatingWebhookConfigurationMetricFamilies,
-		&admissionregistrationv1.MutatingWebhookConfiguration{},
-		createMutatingWebhookConfigurationListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(mutatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.MutatingWebhookConfiguration{}, createMutatingWebhookConfigurationListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildNamespaceStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		namespaceMetricFamilies(b.allowAnnotationsList["namespaces"], b.allowLabelsList["namespaces"]),
-		&v1.Namespace{},
-		createNamespaceListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(namespaceMetricFamilies(b.allowAnnotationsList["namespaces"], b.allowLabelsList["namespaces"]), &v1.Namespace{}, createNamespaceListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildNetworkPolicyStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		networkPolicyMetricFamilies(b.allowAnnotationsList["networkpolicies"], b.allowLabelsList["networkpolicies"]),
-		&networkingv1.NetworkPolicy{},
-		createNetworkPolicyListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(networkPolicyMetricFamilies(b.allowAnnotationsList["networkpolicies"], b.allowLabelsList["networkpolicies"]), &networkingv1.NetworkPolicy{}, createNetworkPolicyListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildNodeStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		nodeMetricFamilies(b.allowAnnotationsList["nodes"], b.allowLabelsList["nodes"]),
-		&v1.Node{},
-		createNodeListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(nodeMetricFamilies(b.allowAnnotationsList["nodes"], b.allowLabelsList["nodes"]), &v1.Node{}, createNodeListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildPersistentVolumeClaimStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		persistentVolumeClaimMetricFamilies(b.allowAnnotationsList["persistentvolumeclaims"], b.allowLabelsList["persistentvolumeclaims"]),
-		&v1.PersistentVolumeClaim{},
-		createPersistentVolumeClaimListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(persistentVolumeClaimMetricFamilies(b.allowAnnotationsList["persistentvolumeclaims"], b.allowLabelsList["persistentvolumeclaims"]), &v1.PersistentVolumeClaim{}, createPersistentVolumeClaimListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildPersistentVolumeStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		persistentVolumeMetricFamilies(b.allowAnnotationsList["persistentvolumes"], b.allowLabelsList["persistentvolumes"]),
-		&v1.PersistentVolume{},
-		createPersistentVolumeListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(persistentVolumeMetricFamilies(b.allowAnnotationsList["persistentvolumes"], b.allowLabelsList["persistentvolumes"]), &v1.PersistentVolume{}, createPersistentVolumeListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildPodDisruptionBudgetStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		podDisruptionBudgetMetricFamilies,
-		&policy.PodDisruptionBudget{},
-		createPodDisruptionBudgetListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(podDisruptionBudgetMetricFamilies, &policy.PodDisruptionBudget{}, createPodDisruptionBudgetListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildReplicaSetStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		replicaSetMetricFamilies(b.allowAnnotationsList["replicasets"], b.allowLabelsList["replicasets"]),
-		&appsv1.ReplicaSet{},
-		createReplicaSetListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(replicaSetMetricFamilies(b.allowAnnotationsList["replicasets"], b.allowLabelsList["replicasets"]), &appsv1.ReplicaSet{}, createReplicaSetListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildReplicationControllerStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		replicationControllerMetricFamilies,
-		&v1.ReplicationController{},
-		createReplicationControllerListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(replicationControllerMetricFamilies, &v1.ReplicationController{}, createReplicationControllerListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildResourceQuotaStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		resourceQuotaMetricFamilies,
-		&v1.ResourceQuota{},
-		createResourceQuotaListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(resourceQuotaMetricFamilies, &v1.ResourceQuota{}, createResourceQuotaListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildSecretStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		secretMetricFamilies(b.allowAnnotationsList["secrets"], b.allowLabelsList["secrets"]),
-		&v1.Secret{},
-		createSecretListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(secretMetricFamilies(b.allowAnnotationsList["secrets"], b.allowLabelsList["secrets"]), &v1.Secret{}, createSecretListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildServiceStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		serviceMetricFamilies(b.allowAnnotationsList["services"], b.allowLabelsList["services"]),
-		&v1.Service{},
-		createServiceListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(serviceMetricFamilies(b.allowAnnotationsList["services"], b.allowLabelsList["services"]), &v1.Service{}, createServiceListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildStatefulSetStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		statefulSetMetricFamilies(b.allowAnnotationsList["statefulsets"], b.allowLabelsList["statefulsets"]),
-		&appsv1.StatefulSet{},
-		createStatefulSetListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(statefulSetMetricFamilies(b.allowAnnotationsList["statefulsets"], b.allowLabelsList["statefulsets"]), &appsv1.StatefulSet{}, createStatefulSetListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildStorageClassStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		storageClassMetricFamilies(b.allowAnnotationsList["storageclasses"], b.allowLabelsList["storageclasses"]),
-		&storagev1.StorageClass{},
-		createStorageClassListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(storageClassMetricFamilies(b.allowAnnotationsList["storageclasses"], b.allowLabelsList["storageclasses"]), &storagev1.StorageClass{}, createStorageClassListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildPodStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		podMetricFamilies(b.allowAnnotationsList["pods"], b.allowLabelsList["pods"]),
-		&v1.Pod{},
-		createPodListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(podMetricFamilies(b.allowAnnotationsList["pods"], b.allowLabelsList["pods"]), &v1.Pod{}, createPodListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildCsrStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		csrMetricFamilies(b.allowAnnotationsList["certificatesigningrequests"], b.allowLabelsList["certificatesigningrequests"]),
-		&certv1.CertificateSigningRequest{},
-		createCSRListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(csrMetricFamilies(b.allowAnnotationsList["certificatesigningrequests"], b.allowLabelsList["certificatesigningrequests"]), &certv1.CertificateSigningRequest{}, createCSRListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildValidatingWebhookConfigurationStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		validatingWebhookConfigurationMetricFamilies,
-		&admissionregistrationv1.ValidatingWebhookConfiguration{},
-		createValidatingWebhookConfigurationListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(validatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.ValidatingWebhookConfiguration{}, createValidatingWebhookConfigurationListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildVolumeAttachmentStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		volumeAttachmentMetricFamilies,
-		&storagev1.VolumeAttachment{},
-		createVolumeAttachmentListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(volumeAttachmentMetricFamilies, &storagev1.VolumeAttachment{}, createVolumeAttachmentListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildVPAStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		vpaMetricFamilies(b.allowAnnotationsList["verticalpodautoscalers"], b.allowLabelsList["verticalpodautoscalers"]),
-		&vpaautoscaling.VerticalPodAutoscaler{},
-		createVPAListWatchFunc(b.vpaClient),
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(vpaMetricFamilies(b.allowAnnotationsList["verticalpodautoscalers"], b.allowLabelsList["verticalpodautoscalers"]), &vpaautoscaling.VerticalPodAutoscaler{}, createVPAListWatchFunc(b.vpaClient), b.useAPIServerCache)
 }
 
 func (b *Builder) buildLeasesStores() []*metricsstore.MetricsStore {
-	return b.buildStoresFunc(
-		leaseMetricFamilies,
-		&coordinationv1.Lease{},
-		createLeaseListWatch,
-		b.useAPIServerCache,
-	)
+	return b.buildStoresFunc(leaseMetricFamilies, &coordinationv1.Lease{}, createLeaseListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildStores(

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"context"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -18,7 +18,6 @@ package store
 
 import (
 	"context"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,8 +31,46 @@ import (
 
 var (
 	descConfigMapLabelsDefaultLabels = []string{"namespace", "configmap"}
+)
 
-	configMapMetricFamilies = []generator.FamilyGenerator{
+func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
+		*generator.NewFamilyGenerator(
+			"kube_configmap_annotations",
+			"Kubernetes annotations converted to Prometheus labels.",
+			metric.Gauge,
+			"",
+			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", c.Annotations, allowAnnotationsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   annotationKeys,
+							LabelValues: annotationValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_configmap_labels",
+			"Kubernetes labels converted to Prometheus labels.",
+			metric.Gauge,
+			"",
+			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+				labelKeys, labelValues := createPrometheusLabelKeysValues("label", c.Labels, allowLabelsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
 		*generator.NewFamilyGenerator(
 			"kube_configmap_info",
 			"Information about configmap.",
@@ -82,7 +119,7 @@ var (
 			}),
 		),
 	}
-)
+}
 
 func createConfigMapListWatch(kubeClient clientset.Interface, ns string) cache.ListerWatcher {
 	return &cache.ListWatch{


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds labels and annotations metrics to configmaps. Allowlist and tests are included.

**How does this change affect the cardinality of KSM**: 
Not by default, Two new stable metrics added - with the same cardinally impact as other such metrics,

**Which issue(s) this PR fixes**:
Fixes #1503
