### PR TITLE
fix: avoid panic because of VPA objects without target ref

### DIFF
--- a/internal/store/verticalpodautoscaler.go
+++ b/internal/store/verticalpodautoscaler.go
@@ -19,7 +19,7 @@ package store
 import (
 	"context"
 
-	k8sautoscaling "k8s.io/api/autoscaling/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -284,7 +284,7 @@ func wrapVPAFunc(f func(*autoscaling.VerticalPodAutoscaler) *metric.Family) func
 		// * to alert about VPA objects without target refs
 		// * to count the right amount of VPA objects in a cluster
 		if targetRef == nil {
-			targetRef = &k8sautoscaling.CrossVersionObjectReference{}
+			targetRef = &autoscalingv1.CrossVersionObjectReference{}
 		}
 
 		for _, m := range metricFamily.Metrics {

--- a/internal/store/verticalpodautoscaler.go
+++ b/internal/store/verticalpodautoscaler.go
@@ -274,9 +274,15 @@ func vpaResourcesToMetrics(containerName string, resources v1.ResourceList) []*m
 func wrapVPAFunc(f func(*autoscaling.VerticalPodAutoscaler) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {
 		vpa := obj.(*autoscaling.VerticalPodAutoscaler)
+		targetRef := vpa.Spec.TargetRef
+
+		// targetRef was not a mandatory field, which can lead to a nil pointer exception here.
+		// Since it is pointless to have a VPA object without target ref, skip exporting metrics.
+		if targetRef == nil {
+			return &metric.Family{}
+		}
 
 		metricFamily := f(vpa)
-		targetRef := vpa.Spec.TargetRef
 
 		for _, m := range metricFamily.Metrics {
 			m.LabelKeys = append(descVerticalPodAutoscalerLabelsDefaultLabels, m.LabelKeys...)

--- a/internal/store/verticalpodautoscaler_test.go
+++ b/internal/store/verticalpodautoscaler_test.go
@@ -169,7 +169,35 @@ func TestVPAStore(t *testing.T) {
 					},
 				},
 			},
-			Want: metadata,
+			Want: metadata + `
+				kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed{container="*",namespace="ns2",resource="cpu",target_api_version="",target_kind="",target_name="",unit="core",verticalpodautoscaler="vpa-without-target-ref"} 4
+				kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed{container="*",namespace="ns2",resource="memory",target_api_version="",target_kind="",target_name="",unit="byte",verticalpodautoscaler="vpa-without-target-ref"} 8.589934592e+09
+				kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed{container="*",namespace="ns2",resource="cpu",target_api_version="",target_kind="",target_name="",unit="core",verticalpodautoscaler="vpa-without-target-ref"} 1
+				kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed{container="*",namespace="ns2",resource="memory",target_api_version="",target_kind="",target_name="",unit="byte",verticalpodautoscaler="vpa-without-target-ref"} 4.294967296e+09
+				kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{container="container1",namespace="ns2",resource="cpu",target_api_version="",target_kind="",target_name="",unit="core",verticalpodautoscaler="vpa-without-target-ref"} 1
+				kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{container="container1",namespace="ns2",resource="memory",target_api_version="",target_kind="",target_name="",unit="byte",verticalpodautoscaler="vpa-without-target-ref"} 4.294967296e+09
+				kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target{container="container1",namespace="ns2",resource="cpu",target_api_version="",target_kind="",target_name="",unit="core",verticalpodautoscaler="vpa-without-target-ref"} 3
+				kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target{container="container1",namespace="ns2",resource="memory",target_api_version="",target_kind="",target_name="",unit="byte",verticalpodautoscaler="vpa-without-target-ref"} 7.516192768e+09
+				kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget{container="container1",namespace="ns2",resource="cpu",target_api_version="",target_kind="",target_name="",unit="core",verticalpodautoscaler="vpa-without-target-ref"} 6
+				kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget{container="container1",namespace="ns2",resource="memory",target_api_version="",target_kind="",target_name="",unit="byte",verticalpodautoscaler="vpa-without-target-ref"} 1.073741824e+10
+				kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{container="container1",namespace="ns2",resource="cpu",target_api_version="",target_kind="",target_name="",unit="core",verticalpodautoscaler="vpa-without-target-ref"} 4
+				kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{container="container1",namespace="ns2",resource="memory",target_api_version="",target_kind="",target_name="",unit="byte",verticalpodautoscaler="vpa-without-target-ref"} 8.589934592e+09				
+				kube_verticalpodautoscaler_labels{namespace="ns2",target_api_version="",target_kind="",target_name="",verticalpodautoscaler="vpa-without-target-ref"} 1
+				kube_verticalpodautoscaler_spec_updatepolicy_updatemode{namespace="ns2",target_api_version="",target_kind="",target_name="",update_mode="Auto",verticalpodautoscaler="vpa-without-target-ref"} 0
+				kube_verticalpodautoscaler_spec_updatepolicy_updatemode{namespace="ns2",target_api_version="",target_kind="",target_name="",update_mode="Initial",verticalpodautoscaler="vpa-without-target-ref"} 0
+				kube_verticalpodautoscaler_spec_updatepolicy_updatemode{namespace="ns2",target_api_version="",target_kind="",target_name="",update_mode="Off",verticalpodautoscaler="vpa-without-target-ref"} 0
+				kube_verticalpodautoscaler_spec_updatepolicy_updatemode{namespace="ns2",target_api_version="",target_kind="",target_name="",update_mode="Recreate",verticalpodautoscaler="vpa-without-target-ref"} 1
+			`,
+			MetricNames: []string{
+				"kube_verticalpodautoscaler_labels",
+				"kube_verticalpodautoscaler_spec_updatepolicy_updatemode",
+				"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed",
+				"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed",
+				"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound",
+				"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound",
+				"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target",
+				"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget",
+			},
 		},
 	}
 	for i, c := range cases {

--- a/internal/store/verticalpodautoscaler_test.go
+++ b/internal/store/verticalpodautoscaler_test.go
@@ -19,7 +19,7 @@ package store
 import (
 	"testing"
 
-	k8sautoscaling "k8s.io/api/autoscaling/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,7 +69,7 @@ func TestVPAStore(t *testing.T) {
 					},
 				},
 				Spec: autoscaling.VerticalPodAutoscalerSpec{
-					TargetRef: &k8sautoscaling.CrossVersionObjectReference{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       "deployment1",

--- a/internal/store/verticalpodautoscaler_test.go
+++ b/internal/store/verticalpodautoscaler_test.go
@@ -131,6 +131,46 @@ func TestVPAStore(t *testing.T) {
 				"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget",
 			},
 		},
+		{
+			Obj: &autoscaling.VerticalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 2,
+					Name:       "vpa-without-target-ref",
+					Namespace:  "ns2",
+					Labels: map[string]string{
+						"app": "foobar",
+					},
+				},
+				Spec: autoscaling.VerticalPodAutoscalerSpec{
+					UpdatePolicy: &autoscaling.PodUpdatePolicy{
+						UpdateMode: &updateMode,
+					},
+					ResourcePolicy: &autoscaling.PodResourcePolicy{
+						ContainerPolicies: []autoscaling.ContainerResourcePolicy{
+							{
+								ContainerName: "*",
+								MinAllowed:    v1Resource("1", "4Gi"),
+								MaxAllowed:    v1Resource("4", "8Gi"),
+							},
+						},
+					},
+				},
+				Status: autoscaling.VerticalPodAutoscalerStatus{
+					Recommendation: &autoscaling.RecommendedPodResources{
+						ContainerRecommendations: []autoscaling.RecommendedContainerResources{
+							{
+								ContainerName:  "container1",
+								LowerBound:     v1Resource("1", "4Gi"),
+								UpperBound:     v1Resource("4", "8Gi"),
+								Target:         v1Resource("3", "7Gi"),
+								UncappedTarget: v1Resource("6", "10Gi"),
+							},
+						},
+					},
+				},
+			},
+			Want: metadata,
+		},
 	}
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(vpaMetricFamilies(nil, nil))


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

VPA is a custom resource. CRDs for this resource can be found [there](https://github.com/kubernetes/autoscaler/tree/vertical-pod-autoscaler/v0.9.2/vertical-pod-autoscaler/deploy). 

The problem is that the `targetRef` field was not required by the spec, so there is a possibility to deploy VPA to the cluster without it, which makes kube-state-metrics panic.
```
I0921 13:39:41.487672       1 main.go:191] Communication with server successful
I0921 13:39:41.487934       1 main.go:225] Starting metrics server: 127.0.0.1:8081
I0921 13:39:41.488119       1 main.go:200] Starting kube-state-metrics self metrics server: 127.0.0.1:8082
I0921 13:39:41.488125       1 metrics_handler.go:96] Autosharding disabled
I0921 13:39:41.489736       1 builder.go:144] Active collectors: certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,namespaces,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,verticalpodautoscalers
E0921 13:39:41.547405       1 runtime.go:73] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 91 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x12c5a60, 0x1d35e80)
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/runtime/runtime.go:69 +0x7b
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190612205821-1799e75a0719/pkg/util/runtime/runtime.go:51 +0x89
panic(0x12c5a60, 0x1d35e80)
	/usr/local/go/src/runtime/panic.go:969 +0x1b9
k8s.io/kube-state-metrics/internal/store.wrapVPAFunc.func1(0x1403040, 0xc000164738, 0x8)
	/src/kube-state-metrics/internal/store/verticalpodautoscaler.go:250 +0x1f0
k8s.io/kube-state-metrics/pkg/metric.(*FamilyGenerator).Generate(...)
	/src/kube-state-metrics/pkg/metric/generator.go:39
```
Without target ref, VPA objects receive no recommendation update. It is pointless trying to expose metrics for them.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

It does not change cardinality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Did not manage to find one.
