### PR TITLE
Revert "cloudbuild.yaml: Drop _ prefix for vars"

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930'
     entrypoint: make
     env:
-    - TAG=$PULL_BASE_REF
-    - GIT_COMMIT=$PULL_BASE_SHA
+    - TAG=$_PULL_BASE_REF
+    - GIT_COMMIT=$_PULL_BASE_SHA
     args:
     - push


### PR DESCRIPTION
This reverts commit fdad0b5f621136a5fbf1093988e278744878e920.

Fixes the Prow build job.