### PR TITLE
Updates ClusterRole with get permissions

### DIFF
--- a/examples/autosharding/cluster-role.yaml
+++ b/examples/autosharding/cluster-role.yaml
@@ -23,6 +23,7 @@ rules:
   - namespaces
   - endpoints
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -33,6 +34,7 @@ rules:
   - deployments
   - replicasets
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -41,6 +43,7 @@ rules:
   - cronjobs
   - jobs
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -48,6 +51,7 @@ rules:
   resources:
   - horizontalpodautoscalers
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -67,6 +71,7 @@ rules:
   resources:
   - poddisruptionbudgets
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -74,6 +79,7 @@ rules:
   resources:
   - certificatesigningrequests
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -82,6 +88,7 @@ rules:
   - storageclasses
   - volumeattachments
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -90,6 +97,7 @@ rules:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -98,6 +106,7 @@ rules:
   - networkpolicies
   - ingresses
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -105,5 +114,6 @@ rules:
   resources:
   - leases
   verbs:
+  - get
   - list
   - watch

--- a/examples/standard/cluster-role.yaml
+++ b/examples/standard/cluster-role.yaml
@@ -23,6 +23,7 @@ rules:
   - namespaces
   - endpoints
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -33,6 +34,7 @@ rules:
   - deployments
   - replicasets
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -41,6 +43,7 @@ rules:
   - cronjobs
   - jobs
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -48,6 +51,7 @@ rules:
   resources:
   - horizontalpodautoscalers
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -67,6 +71,7 @@ rules:
   resources:
   - poddisruptionbudgets
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -74,6 +79,7 @@ rules:
   resources:
   - certificatesigningrequests
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -82,6 +88,7 @@ rules:
   - storageclasses
   - volumeattachments
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -90,6 +97,7 @@ rules:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -98,6 +106,7 @@ rules:
   - networkpolicies
   - ingresses
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -105,5 +114,6 @@ rules:
   resources:
   - leases
   verbs:
+  - get
   - list
   - watch

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -58,7 +58,7 @@
           'namespaces',
           'endpoints',
         ],
-        verbs: ['list', 'watch'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['apps'],
@@ -68,7 +68,7 @@
           'deployments',
           'replicasets',
         ],
-        verbs: ['list', 'watch'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['batch'],
@@ -76,14 +76,14 @@
           'cronjobs',
           'jobs',
         ],
-        verbs: ['list', 'watch'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['autoscaling'],
         resources: [
           'horizontalpodautoscalers',
         ],
-        verbs: ['list', 'watch'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['authentication.k8s.io'],
@@ -104,14 +104,14 @@
         resources: [
           'poddisruptionbudgets',
         ],
-        verbs: ['list', 'watch'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['certificates.k8s.io'],
         resources: [
           'certificatesigningrequests',
         ],
-        verbs: ['list', 'watch'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['storage.k8s.io'],
@@ -119,7 +119,7 @@
           'storageclasses',
           'volumeattachments',
         ],
-        verbs: ['list', 'watch'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['admissionregistration.k8s.io'],
@@ -127,7 +127,7 @@
           'mutatingwebhookconfigurations',
           'validatingwebhookconfigurations',
         ],
-        verbs: ['list', 'watch'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['networking.k8s.io'],
@@ -135,14 +135,14 @@
           'networkpolicies',
           'ingresses',
         ],
-        verbs: ['list', 'watch'],
+        verbs: ['get', 'list', 'watch'],
       },
       {
         apiGroups: ['coordination.k8s.io'],
         resources: [
           'leases',
         ],
-        verbs: ['list', 'watch'],
+        verbs: ['get', 'list', 'watch'],
       },
     ];
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Updates the ClusterRole in the examples so that it works "out of the box". This closes #1613 
Without it (on v2.2.3), I'm running into RBAC errors like 
```
RunGroup Error: detect StatefulSet: retrieve pod kube-state-metrics-e2e-devel-1 for sharding: pods "kube-state-metrics-e2e-devel-1" is forbidden: User "system:serviceaccount:compute:kube-state-metrics" cannot get resource "pods" in API group "" in the namespace "compute"
goroutine 1 [running]:
```

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
This should have no effect...

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1613 
