### PR TITLE
Fix broken link of cip-mm in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,7 +33,7 @@ Maintaining the release branches for older minor releases happens on a best effo
 * Cut the new release tag, e.g. `v1.2.0-rc.0`
 * Create a new **pre-release** on github
 * New images are automatically built and pushed to `gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics`
-* Promote image by sending a PR to [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) repository. Follow the [example PR](https://github.com/kubernetes/k8s.io/pull/1260). Use [cip-mm](https://github.com/kubernetes/release/tree/master/cmd/cip-mm) to update the manifest files in this repository, e.g. `cip-mm --base_dir=k8s.gcr.io --staging_repo=gcr.io/k8s-staging-kube-state-metrics --filter_tag='v2.0.0-rc.1'`
+* Promote image by sending a PR to [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) repository. Follow the [example PR](https://github.com/kubernetes/k8s.io/pull/1260). Use [cip-mm](https://github.com/kubernetes-sigs/promo-tools/tree/main/cmd/cip-mm) to update the manifest files in this repository, e.g. `cip-mm --base_dir=k8s.gcr.io --staging_repo=gcr.io/k8s-staging-kube-state-metrics --filter_tag='v2.0.0-rc.1'`
 * Create a PR to merge the changes of this release back into the master branch.
 * Once the PR to promote the image is merged, mark the pre-release as a regular release.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes broken link cip-mm was redirecting to in RELEASE.md: 
https://github.com/kubernetes/kube-state-metrics/blob/master/RELEASE.md?plain=1#L36. 
 
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
