### PR TITLE
Implement kube_*_labels and kube_*_annotations metrics for pdb

### DIFF
--- a/docs/poddisruptionbudget-metrics.md
+++ b/docs/poddisruptionbudget-metrics.md
@@ -2,6 +2,8 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
+| kube_poddisruptionbudget_annotations | Gauge | `poddisruptionbudget`=&lt;poddisruptionbudget-name&gt; <br> `namespace`=&lt;poddisruptionbudget-namespace&gt; <br> `annotation_PODDISRUPTIONBUDGET_ANNOTATION`=&lt;PODDISRUPTIONBUDGET_ANNOATION&gt;  | EXPERIMENTAL |
+| kube_poddisruptionbudget_labels | Gauge | `poddisruptionbudget`=&lt;poddisruptionbudget-name&gt; <br> `namespace`=&lt;poddisruptionbudget-namespace&gt; <br> `label_PODDISRUPTIONBUDGET_LABEL`=&lt;PODDISRUPTIONBUDGET_ANNOATION&gt;  | EXPERIMENTAL |
 | kube_poddisruptionbudget_created | Gauge | `poddisruptionbudget`=&lt;pdb-name&gt; <br> `namespace`=&lt;pdb-namespace&gt;  | STABLE
 | kube_poddisruptionbudget_status_current_healthy | Gauge | `poddisruptionbudget`=&lt;pdb-name&gt; <br> `namespace`=&lt;pdb-namespace&gt;  | STABLE
 | kube_poddisruptionbudget_status_desired_healthy | Gauge | `poddisruptionbudget`=&lt;pdb-name&gt; <br> `namespace`=&lt;pdb-namespace&gt;  | STABLE

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -325,7 +325,7 @@ func (b *Builder) buildPersistentVolumeStores() []cache.Store {
 }
 
 func (b *Builder) buildPodDisruptionBudgetStores() []cache.Store {
-	return b.buildStoresFunc(podDisruptionBudgetMetricFamilies, &policy.PodDisruptionBudget{}, createPodDisruptionBudgetListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(podDisruptionBudgetMetricFamilies(b.allowAnnotationsList["poddisruptionbudget"], b.allowLabelsList["poddisruptionbudget"]), &policy.PodDisruptionBudget{}, createPodDisruptionBudgetListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildReplicaSetStores() []cache.Store {

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -32,8 +32,50 @@ import (
 
 var (
 	descPodDisruptionBudgetLabelsDefaultLabels = []string{"namespace", "poddisruptionbudget"}
+	descPodDisruptionBudgetAnnotationsName     = "kube_poddisruptionbudget_annotations"
+	descPodDisruptionBudgetAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
+	descPodDisruptionBudgetLabelsName          = "kube_poddisruptionbudget_labels"
+	descPodDisruptionBudgetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+)
 
-	podDisruptionBudgetMetricFamilies = []generator.FamilyGenerator{
+func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
+		*generator.NewFamilyGenerator(
+			descPodDisruptionBudgetAnnotationsName,
+			descPodDisruptionBudgetAnnotationsHelp,
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   annotationKeys,
+							LabelValues: annotationValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			descPodDisruptionBudgetLabelsName,
+			descPodDisruptionBudgetLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
 		*generator.NewFamilyGenerator(
 			"kube_poddisruptionbudget_created",
 			"Unix creation timestamp",
@@ -129,7 +171,7 @@ var (
 			}),
 		),
 	}
-)
+}
 
 func wrapPodDisruptionBudgetFunc(f func(*v1beta1.PodDisruptionBudget) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This commit introduces kube_*_labels and kube_*_annotations metrics to
poddisruptionbudget to keep in consistency with other k8s objects.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
This change adds 2 new metrics PodDisruptionBudget(PDB) object to get information about labels and annotations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
