### PR TITLE
build as non root and keep working dir clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ help.txt
 
 # jsonnet dependency management
 /scripts/vendor
+
+/output*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
 ARG GOVERSION=1.17
 ARG GOARCH
 FROM golang:${GOVERSION} as builder
+USER 65534
 ARG GOARCH
 ENV GOARCH=${GOARCH}
+ENV GOCACHE=/tmp/.cache
 WORKDIR /go/src/k8s.io/kube-state-metrics/
-COPY . /go/src/k8s.io/kube-state-metrics/
+COPY --chown=65534:65534 . /go/src/k8s.io/kube-state-metrics/
 
 RUN make build-local
 
 FROM gcr.io/distroless/static:latest-${GOARCH}
-COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
+USER 65534
 
-USER nobody
+COPY --from=builder --chown=65534:65534 /go/src/k8s.io/kube-state-metrics/output/kube-state-metrics /
 
 ENTRYPOINT ["/kube-state-metrics", "--port=8080", "--telemetry-port=8081"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,18 @@ ARG GOVERSION=1.17
 ARG GOARCH
 FROM golang:${GOVERSION} as builder
 USER 65534
-ARG GOARCH
 ENV GOARCH=${GOARCH}
 ENV GOCACHE=/tmp/.cache
 WORKDIR /go/src/k8s.io/kube-state-metrics/
 COPY --chown=65534:65534 . /go/src/k8s.io/kube-state-metrics/
+
 
 RUN make build-local
 
 FROM gcr.io/distroless/static:latest-${GOARCH}
 USER 65534
 
-COPY --from=builder --chown=65534:65534 /go/src/k8s.io/kube-state-metrics/output/kube-state-metrics /
+COPY --from=builder /go/src/k8s.io/kube-state-metrics/output/kube-state-metrics /
 
 ENTRYPOINT ["/kube-state-metrics", "--port=8080", "--telemetry-port=8081"]
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ build-local:
 build: kube-state-metrics
 
 kube-state-metrics:
-	${DOCKER_CLI} run -u $(USERID):$(USERGROUP) --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics -e GOOS=$(OS) -e GOARCH=$(ARCH) golang:${GO_VERSION} make build-local
+	${DOCKER_CLI} run -u $(USERID):$(USERGROUP) --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics -e GOOS=$(OS) -e GOARCH=$(ARCH) -e GOCACHE="/tmp/.cache" golang:${GO_VERSION} make build-local
 
 test-unit:
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(TESTENVVAR) go test --race $(FLAGS) $(PKGS)

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -24,7 +24,7 @@ spec:
 [embedmd]:# (../help.txt)
 ```txt
 $ kube-state-metrics -h
-Usage of ./kube-state-metrics:
+Usage of ./output/kube-state-metrics:
       --add_dir_header                        If true, adds the file directory to the header of the log messages
       --alsologtostderr                       log to standard error as well as files
       --apiserver string                      The URL of the apiserver to use as a master

--- a/scripts/generate-help-text.sh
+++ b/scripts/generate-help-text.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 echo "$ kube-state-metrics -h" > help.txt
-./kube-state-metrics -h 2>> help.txt
+./output/kube-state-metrics -h 2>> help.txt
 exit 0


### PR DESCRIPTION
**What this PR does / why we need it**:

* build the kube-state-metrics binary into the new output directory
* build the kube-state-metrics binary as current logged in user
* build the kube-state-metrics binary via Dockerfile (docker build .) as
65543 (nobody)
* download and extract the promtool binary into the output directory
* make clean remove all files under output/*

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Signed-off-by: Constanti, Mario <mario.constanti@daimler.com>
