### PR TITLE
Use the architecture specified in the Makefile for the Docker image and binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG GOVERSION=1.17
+ARG GOARCH
 FROM golang:${GOVERSION} as builder
 ARG GOARCH
 ENV GOARCH=${GOARCH}
@@ -7,7 +8,7 @@ COPY . /go/src/k8s.io/kube-state-metrics/
 
 RUN make build-local
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:latest-${GOARCH}
 COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 USER nobody

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ build-local:
 build: kube-state-metrics
 
 kube-state-metrics:
-	${DOCKER_CLI} run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics golang:${GO_VERSION} make build-local
+	${DOCKER_CLI} run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics -e GOOS=$(OS) -e GOARCH=$(ARCH) golang:${GO_VERSION} make build-local
 
 test-unit:
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(TESTENVVAR) go test --race $(FLAGS) $(PKGS)


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the distroless image according to the specified architecture from the Makefile and pass the architecture as environment variable to the container which runs `make build-local` so that the binary is built with the correct architecture as well.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Does not change the cardinality of KSM

**Which issue(s) this PR fixes**:
Fixes #1615
