### PR TITLE
Add "kube_horizontalpodautoscaler_info" metric

### DIFF
--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -2,6 +2,7 @@
 
 | Metric name                       | Metric type | Labels/tags                                                   | Status |
 | --------------------------------  | ----------- | ------------------------------------------------------------- | ------ |
+| kube_horizontalpodautoscaler_info                     | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `scaletargetref_api_version`=&lt;hpa-target-api-version&gt; <br> `scaletargetref_kind`=&lt;hpa-target-kind&gt; <br> `scaletargetref_name`=&lt;hpa-target-name&gt; | EXPERIMENTAL |
 | kube_horizontalpodautoscaler_annotations              | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | EXPERIMENTAL |
 | kube_horizontalpodautoscaler_labels                   | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_metadata_generation      | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -57,6 +57,29 @@ var (
 func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_info",
+			"Information about this autoscaler.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				labelKeys := []string{"scaletargetref_kind", "scaletargetref_name"}
+				labelValues := []string{a.Spec.ScaleTargetRef.Kind, a.Spec.ScaleTargetRef.Name}
+				if a.Spec.ScaleTargetRef.APIVersion != "" {
+					labelKeys = append([]string{"scaletargetref_api_version"}, labelKeys...)
+					labelValues = append([]string{a.Spec.ScaleTargetRef.APIVersion}, labelValues...)
+				}
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
 			"kube_horizontalpodautoscaler_metadata_generation",
 			"The generation observed by the HorizontalPodAutoscaler controller.",
 			metric.Gauge,

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -35,6 +35,7 @@ func TestHPAStore(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
+		# HELP kube_horizontalpodautoscaler_info Information about this autoscaler.
 		# HELP kube_horizontalpodautoscaler_annotations Kubernetes annotations converted to Prometheus labels.
 		# HELP kube_horizontalpodautoscaler_labels Kubernetes labels converted to Prometheus labels.
 		# HELP kube_horizontalpodautoscaler_metadata_generation The generation observed by the HorizontalPodAutoscaler controller.
@@ -44,6 +45,7 @@ func TestHPAStore(t *testing.T) {
 		# HELP kube_horizontalpodautoscaler_status_condition The condition of this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_current_replicas Current number of replicas of pods managed by this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
+		# TYPE kube_horizontalpodautoscaler_info gauge
 		# TYPE kube_horizontalpodautoscaler_annotations gauge
 		# TYPE kube_horizontalpodautoscaler_labels gauge
 		# TYPE kube_horizontalpodautoscaler_metadata_generation gauge
@@ -183,6 +185,7 @@ func TestHPAStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
+				kube_horizontalpodautoscaler_info{horizontalpodautoscaler="hpa1",namespace="ns1",scaletargetref_api_version="apps/v1",scaletargetref_kind="Deployment",scaletargetref_name="deployment1"} 1
 				kube_horizontalpodautoscaler_annotations{horizontalpodautoscaler="hpa1",namespace="ns1"} 1
 				kube_horizontalpodautoscaler_labels{horizontalpodautoscaler="hpa1",namespace="ns1"} 1
 				kube_horizontalpodautoscaler_metadata_generation{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
@@ -203,6 +206,7 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
 			`,
 			MetricNames: []string{
+				"kube_horizontalpodautoscaler_info",
 				"kube_horizontalpodautoscaler_metadata_generation",
 				"kube_horizontalpodautoscaler_spec_max_replicas",
 				"kube_horizontalpodautoscaler_spec_min_replicas",
@@ -278,9 +282,8 @@ func TestHPAStore(t *testing.T) {
 						},
 					},
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{
-						APIVersion: "apps/v1",
-						Kind:       "Deployment",
-						Name:       "deployment1",
+						Kind: "Deployment",
+						Name: "deployment1",
 					},
 				},
 				Status: autoscaling.HorizontalPodAutoscalerStatus{
@@ -341,6 +344,7 @@ func TestHPAStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
+				kube_horizontalpodautoscaler_info{horizontalpodautoscaler="hpa2",namespace="ns1",scaletargetref_kind="Deployment",scaletargetref_name="deployment1"} 1
 				kube_horizontalpodautoscaler_annotations{annotation_app_k8s_io_owner="@foo",horizontalpodautoscaler="hpa2",namespace="ns1"} 1
 				kube_horizontalpodautoscaler_labels{horizontalpodautoscaler="hpa2",namespace="ns1"} 1
 				kube_horizontalpodautoscaler_metadata_generation{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
@@ -357,6 +361,7 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
 			`,
 			MetricNames: []string{
+				"kube_horizontalpodautoscaler_info",
 				"kube_horizontalpodautoscaler_metadata_generation",
 				"kube_horizontalpodautoscaler_spec_max_replicas",
 				"kube_horizontalpodautoscaler_spec_min_replicas",


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a metric which exposes the `scaleTargetRef.apiVersion`, `scaleTargetRef.kind` and `scaleTargetRef.name` of the `HorizontalPodAutoscaler` resource objects in the cluster.

**How does this change affect the cardinality of KSM**:
>Adding a new metric for the HPA target will have a slight impact on cardinality, but most clusters have at most a double or triple digit amount of HPAs. So we are talking about at most 1000 newly added time series, which is really not that significant compared to the number of time series we export for pods and nodes.

**Which issue(s) this PR fixes**:
Fixes #1635
