### PR TITLE
Add ingressclass to kube_ingress_info metric

### DIFF
--- a/docs/ingress-metrics.md
+++ b/docs/ingress-metrics.md
@@ -3,7 +3,7 @@
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
 | kube_ingress_annotations | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `annotation_INGRESS_ANNOTATION`=&lt;ANNOTATION_LABEL&gt; | EXPERIMENTAL |
-| kube_ingress_info | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; | STABLE |
+| kube_ingress_info | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `ingressclass`=&lt;ingress-class&gt; or `_default` if not set | STABLE |
 | kube_ingress_labels | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; <br> `label_INGRESS_LABEL`=&lt;INGRESS_LABEL&gt; | STABLE |
 | kube_ingress_created  | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; | STABLE |
 | kube_ingress_metadata_resource_version  | Gauge | `ingress`=&lt;ingress-name&gt; <br> `namespace`=&lt;ingress-namespace&gt; | EXPERIMENTAL |

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -46,11 +46,21 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"Information about ingress.",
 			metric.Gauge,
 			"",
-			wrapIngressFunc(func(s *networkingv1.Ingress) *metric.Family {
+			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
+				ingressClassName := "_default"
+				if i.Spec.IngressClassName != nil {
+					ingressClassName = *i.Spec.IngressClassName
+				}
+				if className, ok := i.Annotations["kubernetes.io/ingress.class"]; ok {
+					ingressClassName = className
+				}
+
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							Value: 1,
+							LabelKeys:   []string{"ingressclass"},
+							LabelValues: []string{ingressClassName},
+							Value:       1,
 						},
 					}}
 			}),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add ingressclass to kube_ingress_info metric

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Should be same cardinality since it adds a tag to an existing metric that is already one per resource.

