### PR TITLE
Add new syntax / notation for selecting namespaces and their labels

### DIFF
--- a/pkg/options/namespace_list/parser.go
+++ b/pkg/options/namespace_list/parser.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespacelist
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Parser parses the syntax for namespace lists
+type Parser struct {
+	source string
+	pos    int
+}
+
+type UnexpectedSyntaxError struct {
+	char string
+	pos  int
+}
+
+// UnexpectedSyntaxError is returned when an invalid syntax is being parsed
+func (err UnexpectedSyntaxError) Error() string {
+	return fmt.Sprintf("syntax error, unexpected %v at col %v", err.char, err.pos)
+}
+
+func (parser *Parser) Parse() (map[string]labels.Selector, error) {
+	reader := bufio.NewReader(strings.NewReader(parser.source))
+	selectors := make(map[string]labels.Selector)
+
+	namespace := strings.Builder{}
+
+	err := readRunes(reader, func(r rune, eof bool, close func()) error {
+		parser.pos++
+
+		if eof {
+			if namespace.Len() > 0 {
+				selectors[namespace.String()] = labels.Everything()
+			}
+			close()
+			return nil
+		}
+
+		if r == '=' {
+			// foo-bar=[...], ...
+			r, _, err := reader.ReadRune()
+			if errors.Is(err, io.EOF) || r != '[' {
+				// foo-bar=...
+				return UnexpectedSyntaxError{char: "EOF", pos: parser.pos}
+			} else if err != nil {
+				return err
+			}
+
+			selector, err := parseSelector(parser, reader)
+			if err != nil {
+				return err
+			}
+
+			selectors[namespace.String()] = selector
+			namespace.Reset()
+			return nil
+		}
+
+		if r == ',' {
+			// foo-bar, ...
+			selectors[namespace.String()] = labels.Everything()
+			namespace.Reset()
+			return nil
+		}
+
+		namespace.WriteRune(r)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return selectors, nil
+}
+
+func parseSelector(parser *Parser, reader *bufio.Reader) (labels.Selector, error) {
+	str := strings.Builder{}
+
+	err := readRunes(reader, func(r rune, eof bool, close func()) error {
+		parser.pos++
+
+		if eof {
+			// a namespace selector should always be closed with a "]"
+			return UnexpectedSyntaxError{char: "EOF", pos: parser.pos}
+		}
+
+		if r == ']' {
+			// indicates the end of a namespace selector
+			close()
+			return nil
+		}
+
+		str.WriteRune(r)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	selector, err := labels.Parse(str.String())
+	if err != nil {
+		return nil, err
+	}
+	return selector, nil
+}
+
+func readRunes(r *bufio.Reader, reader func(r rune, eof bool, close func()) error) error {
+	reading := true
+
+	closer := func() {
+		reading = false
+	}
+
+	for reading {
+		r, _, err := r.ReadRune()
+
+		if errors.Is(err, io.EOF) {
+			err := reader(0, true, closer)
+			if err != nil {
+				return err
+			}
+			reading = false
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		err = reader(r, false, closer)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func NewParser(source string) *Parser {
+	return &Parser{source, 0}
+}

--- a/pkg/options/namespace_list/parser.go
+++ b/pkg/options/namespace_list/parser.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -56,6 +57,11 @@ func (parser *Parser) Parse() (map[string]labels.Selector, error) {
 				selectors[namespace.String()] = labels.Everything()
 			}
 			close()
+			return nil
+		}
+
+		if unicode.IsSpace(r) {
+			// ignore whitespace
 			return nil
 		}
 

--- a/pkg/options/namespace_list/types.go
+++ b/pkg/options/namespace_list/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors All rights reserved.
+Copyright 2021 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,21 +14,43 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package namespace_list
+package namespacelist
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 // NamespaceList represents a list of namespaces by name and labels.
 type NamespaceList map[string]map[string]string
 
+// String returns the map of namespaces and labels as a string
 func (n *NamespaceList) String() string {
-	// TODO: implement the receiver function
-	return ""
+	namespaces := make([]string, 0, len(*n))
+	for namespace, labels := range *n {
+		if len(labels) == 0 {
+			namespaces = append(namespaces, namespace)
+		} else {
+			concatenatedLabelValues := make([]string, 0, len(labels))
+			for label, value := range labels {
+				concatenatedLabelValues = append(concatenatedLabelValues, fmt.Sprintf("%v=%v", label, value))
+			}
+			sort.Strings(concatenatedLabelValues)
+			namespaces = append(namespaces, fmt.Sprintf("%v=[%v]", namespace, strings.Join(concatenatedLabelValues, ",")))
+		}
+	}
+	sort.Strings(namespaces)
+	return strings.Join(namespaces, ",")
 }
 
+// Set converts a comma-separated string of namespaces and labels into a map.
 func (n *NamespaceList) Set(value string) error {
 	// TODO: implement the receiver function
 	return nil
 }
 
+// Type returns a descriptive string about the NamespaceList type.
 func (n *NamespaceList) Type() string {
 	return "string"
 }

--- a/pkg/options/namespace_list/types.go
+++ b/pkg/options/namespace_list/types.go
@@ -20,24 +20,21 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // NamespaceList represents a list of namespaces by name and labels.
-type NamespaceList map[string]map[string]string
+type NamespaceList map[string]labels.Selector
 
 // String returns the map of namespaces and labels as a string
 func (n *NamespaceList) String() string {
 	namespaces := make([]string, 0, len(*n))
-	for namespace, labels := range *n {
-		if len(labels) == 0 {
+	for namespace, selector := range *n {
+		if selector.Empty() {
 			namespaces = append(namespaces, namespace)
 		} else {
-			concatenatedLabelValues := make([]string, 0, len(labels))
-			for label, value := range labels {
-				concatenatedLabelValues = append(concatenatedLabelValues, fmt.Sprintf("%v=%v", label, value))
-			}
-			sort.Strings(concatenatedLabelValues)
-			namespaces = append(namespaces, fmt.Sprintf("%v=[%v]", namespace, strings.Join(concatenatedLabelValues, ",")))
+			namespaces = append(namespaces, fmt.Sprintf("%v=[%v]", namespace, selector))
 		}
 	}
 	sort.Strings(namespaces)

--- a/pkg/options/namespace_list/types.go
+++ b/pkg/options/namespace_list/types.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace_list
+
+// NamespaceList represents a list of namespaces by name and labels.
+type NamespaceList map[string]map[string]string
+
+func (n *NamespaceList) String() string {
+	// TODO: implement the receiver function
+	return ""
+}
+
+func (n *NamespaceList) Set(value string) error {
+	// TODO: implement the receiver function
+	return nil
+}
+
+func (n *NamespaceList) Type() string {
+	return "string"
+}

--- a/pkg/options/namespace_list/types.go
+++ b/pkg/options/namespace_list/types.go
@@ -46,7 +46,12 @@ func (n *NamespaceList) String() string {
 
 // Set converts a comma-separated string of namespaces and labels into a map.
 func (n *NamespaceList) Set(value string) error {
-	// TODO: implement the receiver function
+	parser := NewParser(value)
+	newNamespaceList, err := parser.Parse()
+	if err != nil {
+		return err
+	}
+	*n = newNamespaceList
 	return nil
 }
 

--- a/pkg/options/namespace_list/types_test.go
+++ b/pkg/options/namespace_list/types_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace_list
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	tests := []struct{
+		input    NamespaceList
+		expected string
+	}{
+		{NamespaceList{
+			"project-1": {},
+			"project-2": {},
+			"project-3": {},
+		}, "project-1,project-2,project-3"},
+		{NamespaceList{
+			"*": {
+				"environment": "production",
+				"region": "eu-west-2",
+			},
+		}, "*=[environment=production,region=eu-west-2]"},
+	}
+
+	for _, test := range tests {
+		actual := test.input.String()
+		if actual != test.expected {
+			t.Errorf("expected: %v, got: %v", test.expected, actual)
+		}
+	}
+}
+
+func TestSet(t *testing.T) {
+	tests := []struct{
+		input    string
+		expected NamespaceList
+	}{
+		{"project-1,project-2,project-3", NamespaceList{
+			"project-1": {},
+			"project-2": {},
+			"project-3": {},
+		}},
+		{"*=[environment=production,region=eu-west-2]", NamespaceList{
+			"*": {
+				"environment": "production",
+				"region": "eu-west-2",
+			},
+		}},
+	}
+
+	for _, test := range tests {
+		actual := NamespaceList{}
+		err := actual.Set(test.input)
+		if err != nil {
+			t.Errorf("an unexpected error happened: %v", err)
+		}
+		if !reflect.DeepEqual(actual, test.expected) {
+			t.Errorf("expected: %v, got: %v", test.expected, actual)
+		}
+	}
+}

--- a/pkg/options/namespace_list/types_test.go
+++ b/pkg/options/namespace_list/types_test.go
@@ -105,6 +105,15 @@ func TestSet(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"namespace selector with spaces in between",
+			"project-1, project-2, project-3", NamespaceList{
+				"project-1": labels.Everything(),
+				"project-2": labels.Everything(),
+				"project-3": labels.Everything(),
+			},
+			nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/options/namespace_list/types_test.go
+++ b/pkg/options/namespace_list/types_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors All rights reserved.
+Copyright 2021 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package namespace_list
+package namespacelist
 
 import (
 	"reflect"

--- a/pkg/options/namespace_list/types_test.go
+++ b/pkg/options/namespace_list/types_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/pkg/errors"
 )
 
@@ -29,15 +31,15 @@ func TestString(t *testing.T) {
 		expected string
 	}{
 		{NamespaceList{
-			"project-1": {},
-			"project-2": {},
-			"project-3": {},
+			"project-1": labels.Everything(),
+			"project-2": labels.Everything(),
+			"project-3": labels.Everything(),
 		}, "project-1,project-2,project-3"},
 		{NamespaceList{
-			"*": {
+			"*": labels.SelectorFromSet(labels.Set{
 				"environment": "production",
 				"region":      "eu-west-2",
-			},
+			}),
 		}, "*=[environment=production,region=eu-west-2]"},
 	}
 
@@ -60,19 +62,19 @@ func TestSet(t *testing.T) {
 			"namespace list with 3 namespaces and no labels",
 			"project-1,project-2,project-3",
 			NamespaceList{
-				"project-1": {},
-				"project-2": {},
-				"project-3": {},
+				"project-1": labels.Everything(),
+				"project-2": labels.Everything(),
+				"project-3": labels.Everything(),
 			},
 			nil},
 		{
 			"namespace list with a wildcard namespace and 2 labels",
 			"*=[environment=production,region=eu-west-2]",
 			NamespaceList{
-				"*": {
+				"*": labels.SelectorFromSet(labels.Set{
 					"environment": "production",
 					"region":      "eu-west-2",
-				},
+				}),
 			},
 			nil},
 		{
@@ -96,10 +98,10 @@ func TestSet(t *testing.T) {
 		{
 			"namespace with 2 labels, one with and one without a value",
 			"foo-bar=[foo=,bar=test]", NamespaceList{
-				"foo-bar": {
+				"foo-bar": labels.SelectorFromSet(labels.Set{
 					"foo": "",
 					"bar": "test",
-				},
+				}),
 			},
 			nil,
 		},


### PR DESCRIPTION
**Currently this PR is a draft and meant for receiving feedback on the parsing. Once the parsing is reviewed I will continue refactoring the usages of the "old" namespace list option to the new one.**

**What this PR does / why we need it**:
This PR extends the existing syntax / notation (BC) to allow for selecting namespaces based on their labels. It does not yet implement the filtering upon those aforementioned labels, this will be a separate PR.

**How does this change affect the cardinality of KSM**:
It does not affect cardinality.

**Which issue(s) this PR fixes**: n/a