### PR TITLE
jsonnet: increase security by specifying automountServiceAccountToken on pod level and not on serviceAccount

### DIFF
--- a/examples/autosharding/service-account.yaml
+++ b/examples/autosharding/service-account.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:

--- a/examples/autosharding/statefulset.yaml
+++ b/examples/autosharding/statefulset.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/version: 2.3.0
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --pod=$(POD_NAME)

--- a/examples/standard/deployment.yaml
+++ b/examples/standard/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/version: 2.3.0
     spec:
+      automountServiceAccountToken: true
       containers:
       - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         livenessProbe:

--- a/examples/standard/service-account.yaml
+++ b/examples/standard/service-account.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -192,6 +192,7 @@
           spec: {
             containers: [c],
             serviceAccountName: ksm.serviceAccount.metadata.name,
+            automountServiceAccountToken: true,
             nodeSelector: { 'kubernetes.io/os': 'linux' },
           },
         },
@@ -207,6 +208,7 @@
         namespace: ksm.namespace,
         labels: ksm.commonLabels + ksm.extraRecommendedLabels,
       },
+      automountServiceAccountToken: false,
     },
 
   service:
@@ -302,6 +304,7 @@
             spec: {
               containers: [c],
               serviceAccountName: ksm.serviceAccount.metadata.name,
+              automountServiceAccountToken: true,
               nodeSelector: { 'kubernetes.io/os': 'linux' },
             },
           },


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This increases security by moving SA token automounting from SA to pod. This approach is recommended by https://hub.armo.cloud/docs/c-0034

This is a part of the initiative specified in https://github.com/prometheus-operator/kube-prometheus/issues/1589. More details in that issue.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

it doesn't change cardinality

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

