### PR TITLE
jsonnet: explicitly forbid privilege escalation

### DIFF
--- a/examples/autosharding/statefulset.yaml
+++ b/examples/autosharding/statefulset.yaml
@@ -54,6 +54,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:
+          allowPrivilegeEscalation: false
           runAsUser: 65534
       nodeSelector:
         kubernetes.io/os: linux

--- a/examples/standard/deployment.yaml
+++ b/examples/standard/deployment.yaml
@@ -41,6 +41,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:
+          allowPrivilegeEscalation: false
           runAsUser: 65534
       nodeSelector:
         kubernetes.io/os: linux

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -163,7 +163,7 @@
         { name: 'http-metrics', containerPort: 8080 },
         { name: 'telemetry', containerPort: 8081 },
       ],
-      securityContext: { runAsUser: 65534 },
+      securityContext: { runAsUser: 65534, allowPrivilegeEscalation: false },
       livenessProbe: { timeoutSeconds: 5, initialDelaySeconds: 5, httpGet: {
         port: 8080,
         path: '/healthz',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We just [introduced Kubernetes manifests scanning](https://github.com/prometheus-operator/kube-prometheus/pull/1584) with [Kubescape](https://github.com/armosec/kubescape) in kube-prometheus. Kubescape is a security scanning tool used to help us maintain a good risk analysis and be aligned with security compliances. 

One of the failures found with Kubescape is that we [don't explicitly forbid container privilege escalation](https://github.com/prometheus-operator/kube-prometheus/issues/1588) for several components, including kube-state-metrics. 

Looking at [kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/): 
```
AllowPrivilegeEscalation: Controls whether a process can gain more privileges than its parent process. This bool directly controls whether the no_new_privs flag gets set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged OR 2) has CAP_SYS_ADMIN.
```

Which means that kube-state-metrics's container is already deployed with `AllowPrivilegeEscalation` set to false because there's no need to run it as a privileged container, but kubescape asks to explicitly set this to false.

We can override this ourselves downstream, but we're wondering if it would be ok to include this in kube-state-metrics repository.

Cheers 👋 

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Does not change

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None
