### PR TITLE
jsonnet: Forbid write access to root filesystem

### DIFF
--- a/examples/autosharding/statefulset.yaml
+++ b/examples/autosharding/statefulset.yaml
@@ -55,6 +55,7 @@ spec:
           timeoutSeconds: 5
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsUser: 65534
       nodeSelector:
         kubernetes.io/os: linux

--- a/examples/standard/deployment.yaml
+++ b/examples/standard/deployment.yaml
@@ -42,6 +42,7 @@ spec:
           timeoutSeconds: 5
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsUser: 65534
       nodeSelector:
         kubernetes.io/os: linux

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -163,7 +163,11 @@
         { name: 'http-metrics', containerPort: 8080 },
         { name: 'telemetry', containerPort: 8081 },
       ],
-      securityContext: { runAsUser: 65534, allowPrivilegeEscalation: false },
+      securityContext: { 
+        runAsUser: 65534, 
+        allowPrivilegeEscalation: false,        
+        readOnlyRootFilesystem: true,
+      },
       livenessProbe: { timeoutSeconds: 5, initialDelaySeconds: 5, httpGet: {
         port: 8080,
         path: '/healthz',


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This is part of the initiative to tighten security in kube-prometheus - prometheus-operator/kube-prometheus#1595.

An attacker who has access to a container, can create files and download scripts as he wishes, and modify the underlying application running on the container. If a container, e.g. kube-state-metrics, needs to write to the filesystem, a strict volume mount should be used.

Following remediation docs from https://hub.armo.cloud/docs/c-0017

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
It doesn't


