### PR TITLE
jsonnet: Drop all Linux capabilities

### DIFF
--- a/examples/autosharding/statefulset.yaml
+++ b/examples/autosharding/statefulset.yaml
@@ -55,6 +55,9 @@ spec:
           timeoutSeconds: 5
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
           runAsUser: 65534
       nodeSelector:

--- a/examples/standard/deployment.yaml
+++ b/examples/standard/deployment.yaml
@@ -42,6 +42,9 @@ spec:
           timeoutSeconds: 5
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
           runAsUser: 65534
       nodeSelector:

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -167,6 +167,7 @@
         runAsUser: 65534, 
         allowPrivilegeEscalation: false,        
         readOnlyRootFilesystem: true,
+        capabilities: { drop: ['ALL'] },
       },
       livenessProbe: { timeoutSeconds: 5, initialDelaySeconds: 5, httpGet: {
         port: 8080,


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This is part of the initiative to tighten security in kube-prometheus

We're reducing the attack surface by dropping all Linux capabilities since kube-state-metrics doesn't need any to run smoothly

Following remediation docs from https://hub.armo.cloud/docs/c-0055

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
It doesn't

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None
