### PR TITLE
Optimize Slice Allocations ( ~ -19% byte/op, -14% ns/op, ~ -11% allocs )

### DIFF
--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -133,8 +133,14 @@ func wrapCSRFunc(f func(*certv1.CertificateSigningRequest) *metric.Family) func(
 		metricFamily := f(csr)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descCSRLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{csr.Name, csr.Spec.SignerName}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descCSRLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descCSRLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descCSRLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, csr.Name, csr.Spec.SignerName)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -142,8 +142,14 @@ func wrapConfigMapFunc(f func(*v1.ConfigMap) *metric.Family) func(interface{}) *
 		metricFamily := f(configMap)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descConfigMapLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{configMap.Namespace, configMap.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descConfigMapLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descConfigMapLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descConfigMapLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, configMap.Namespace, configMap.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -285,8 +285,14 @@ func wrapCronJobFunc(f func(*batchv1.CronJob) *metric.Family) func(interface{}) 
 		metricFamily := f(cronJob)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descCronJobLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{cronJob.Namespace, cronJob.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descCronJobLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descCronJobLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descCronJobLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, cronJob.Namespace, cronJob.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -258,8 +258,14 @@ func wrapDaemonSetFunc(f func(*v1.DaemonSet) *metric.Family) func(interface{}) *
 		metricFamily := f(daemonSet)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descDaemonSetLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{daemonSet.Namespace, daemonSet.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descDaemonSetLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descDaemonSetLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descDaemonSetLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, daemonSet.Namespace, daemonSet.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -314,8 +314,14 @@ func wrapDeploymentFunc(f func(*v1.Deployment) *metric.Family) func(interface{})
 		metricFamily := f(deployment)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descDeploymentLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{deployment.Namespace, deployment.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descDeploymentLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descDeploymentLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descDeploymentLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, deployment.Namespace, deployment.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -182,8 +182,14 @@ func wrapEndpointFunc(f func(*v1.Endpoints) *metric.Family) func(interface{}) *m
 		metricFamily := f(endpoint)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descEndpointLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{endpoint.Namespace, endpoint.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descEndpointLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descEndpointLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descEndpointLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, endpoint.Namespace, endpoint.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -286,8 +286,14 @@ func wrapHPAFunc(f func(*autoscaling.HorizontalPodAutoscaler) *metric.Family) fu
 		metricFamily := f(hpa)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descHorizontalPodAutoscalerLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{hpa.Namespace, hpa.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descHorizontalPodAutoscalerLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descHorizontalPodAutoscalerLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descHorizontalPodAutoscalerLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, hpa.Namespace, hpa.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -185,8 +185,14 @@ func wrapIngressFunc(f func(*networkingv1.Ingress) *metric.Family) func(interfac
 		metricFamily := f(ingress)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descIngressLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{ingress.Namespace, ingress.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descIngressLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descIngressLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descIngressLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, ingress.Namespace, ingress.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -387,8 +387,14 @@ func wrapJobFunc(f func(*v1batch.Job) *metric.Family) func(interface{}) *metric.
 		metricFamily := f(job)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descJobLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{job.Namespace, job.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descJobLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descJobLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descJobLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, job.Namespace, job.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -97,8 +97,14 @@ func wrapLeaseFunc(f func(*coordinationv1.Lease) *metric.Family) func(interface{
 		metricFamily := f(lease)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descLeaseLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{lease.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descLeaseLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descLeaseLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descLeaseLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, lease.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/limitrange.go
+++ b/internal/store/limitrange.go
@@ -119,8 +119,14 @@ func wrapLimitRangeFunc(f func(*v1.LimitRange) *metric.Family) func(interface{})
 		metricFamily := f(limitRange)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descLimitRangeLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{limitRange.Namespace, limitRange.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descLimitRangeLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descLimitRangeLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descLimitRangeLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, limitRange.Namespace, limitRange.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -99,8 +99,14 @@ func wrapMutatingWebhookConfigurationFunc(f func(*admissionregistrationv1.Mutati
 		metricFamily := f(mutatingWebhookConfiguration)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descMutatingWebhookConfigurationDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{mutatingWebhookConfiguration.Namespace, mutatingWebhookConfiguration.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descMutatingWebhookConfigurationDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descMutatingWebhookConfigurationDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descMutatingWebhookConfigurationDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, mutatingWebhookConfiguration.Namespace, mutatingWebhookConfiguration.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -155,8 +155,14 @@ func wrapNamespaceFunc(f func(*v1.Namespace) *metric.Family) func(interface{}) *
 		metricFamily := f(namespace)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descNamespaceLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{namespace.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descNamespaceLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descNamespaceLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descNamespaceLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, namespace.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/networkpolicy.go
+++ b/internal/store/networkpolicy.go
@@ -137,8 +137,14 @@ func wrapNetworkPolicyFunc(f func(*networkingv1.NetworkPolicy) *metric.Family) f
 		metricFamily := f(networkPolicy)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descNetworkPolicyLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{networkPolicy.Namespace, networkPolicy.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descNetworkPolicyLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descNetworkPolicyLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descNetworkPolicyLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, networkPolicy.Namespace, networkPolicy.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -446,8 +446,14 @@ func wrapNodeFunc(f func(*v1.Node) *metric.Family) func(interface{}) *metric.Fam
 		metricFamily := f(node)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descNodeLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{node.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descNodeLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descNodeLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descNodeLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, node.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -266,8 +266,14 @@ func wrapPersistentVolumeFunc(f func(*v1.PersistentVolume) *metric.Family) func(
 		metricFamily := f(persistentVolume)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descPersistentVolumeLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{persistentVolume.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descPersistentVolumeLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descPersistentVolumeLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descPersistentVolumeLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, persistentVolume.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -210,8 +210,14 @@ func wrapPersistentVolumeClaimFunc(f func(*v1.PersistentVolumeClaim) *metric.Fam
 		metricFamily := f(persistentVolumeClaim)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descPersistentVolumeClaimLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{persistentVolumeClaim.Namespace, persistentVolumeClaim.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descPersistentVolumeClaimLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descPersistentVolumeClaimLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descPersistentVolumeClaimLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, persistentVolumeClaim.Namespace, persistentVolumeClaim.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -1365,8 +1365,14 @@ func wrapPodFunc(f func(*v1.Pod) *metric.Family) func(interface{}) *metric.Famil
 		metricFamily := f(pod)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descPodLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{pod.Namespace, pod.Name, string(pod.UID)}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descPodLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descPodLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descPodLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, pod.Namespace, pod.Name, string(pod.UID))
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -180,8 +180,14 @@ func wrapPodDisruptionBudgetFunc(f func(*policyv1.PodDisruptionBudget) *metric.F
 		metricFamily := f(podDisruptionBudget)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descPodDisruptionBudgetLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{podDisruptionBudget.Namespace, podDisruptionBudget.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descPodDisruptionBudgetLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descPodDisruptionBudgetLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descPodDisruptionBudgetLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, podDisruptionBudget.Namespace, podDisruptionBudget.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -245,8 +245,14 @@ func wrapReplicaSetFunc(f func(*v1.ReplicaSet) *metric.Family) func(interface{})
 		metricFamily := f(replicaSet)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descReplicaSetLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{replicaSet.Namespace, replicaSet.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descReplicaSetLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descReplicaSetLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descReplicaSetLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, replicaSet.Namespace, replicaSet.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -209,8 +209,14 @@ func wrapReplicationControllerFunc(f func(*v1.ReplicationController) *metric.Fam
 		metricFamily := f(replicationController)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descReplicationControllerLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{replicationController.Namespace, replicationController.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descReplicationControllerLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descReplicationControllerLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descReplicationControllerLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, replicationController.Namespace, replicationController.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/resourcequota.go
+++ b/internal/store/resourcequota.go
@@ -94,8 +94,14 @@ func wrapResourceQuotaFunc(f func(*v1.ResourceQuota) *metric.Family) func(interf
 		metricFamily := f(resourceQuota)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descResourceQuotaLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{resourceQuota.Namespace, resourceQuota.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descResourceQuotaLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descResourceQuotaLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descResourceQuotaLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, resourceQuota.Namespace, resourceQuota.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -151,8 +151,14 @@ func wrapSecretFunc(f func(*v1.Secret) *metric.Family) func(interface{}) *metric
 		metricFamily := f(secret)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descSecretLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{secret.Namespace, secret.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descSecretLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descSecretLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descSecretLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, secret.Namespace, secret.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -180,8 +180,14 @@ func wrapSvcFunc(f func(*v1.Service) *metric.Family) func(interface{}) *metric.F
 		metricFamily := f(svc)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descServiceLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{svc.Namespace, svc.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descServiceLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descServiceLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descServiceLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, svc.Namespace, svc.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -262,8 +262,14 @@ func wrapStatefulSetFunc(f func(*v1.StatefulSet) *metric.Family) func(interface{
 		metricFamily := f(statefulSet)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descStatefulSetLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{statefulSet.Namespace, statefulSet.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descStatefulSetLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descStatefulSetLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descStatefulSetLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, statefulSet.Namespace, statefulSet.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -127,8 +127,14 @@ func wrapStorageClassFunc(f func(*storagev1.StorageClass) *metric.Family) func(i
 		metricFamily := f(storageClass)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descStorageClassLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{storageClass.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descStorageClassLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descStorageClassLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descStorageClassLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, storageClass.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -99,8 +99,14 @@ func wrapValidatingWebhookConfigurationFunc(f func(*admissionregistrationv1.Vali
 		metricFamily := f(mutatingWebhookConfiguration)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descValidatingWebhookConfigurationDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{mutatingWebhookConfiguration.Namespace, mutatingWebhookConfiguration.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descValidatingWebhookConfigurationDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descValidatingWebhookConfigurationDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descValidatingWebhookConfigurationDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, mutatingWebhookConfiguration.Namespace, mutatingWebhookConfiguration.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/verticalpodautoscaler.go
+++ b/internal/store/verticalpodautoscaler.go
@@ -288,8 +288,14 @@ func wrapVPAFunc(f func(*autoscaling.VerticalPodAutoscaler) *metric.Family) func
 		}
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descVerticalPodAutoscalerLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{vpa.Namespace, vpa.Name, targetRef.APIVersion, targetRef.Kind, targetRef.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descVerticalPodAutoscalerLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descVerticalPodAutoscalerLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descVerticalPodAutoscalerLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, vpa.Namespace, vpa.Name, targetRef.APIVersion, targetRef.Kind, targetRef.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily

--- a/internal/store/volumeattachment.go
+++ b/internal/store/volumeattachment.go
@@ -153,8 +153,14 @@ func wrapVolumeAttachmentFunc(f func(*storagev1.VolumeAttachment) *metric.Family
 		metricFamily := f(va)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys = append(descVolumeAttachmentLabelsDefaultLabels, m.LabelKeys...)
-			m.LabelValues = append([]string{va.Name}, m.LabelValues...)
+			commonLabelKeys := make([]string, 0, len(descVolumeAttachmentLabelsDefaultLabels)+len(m.LabelKeys))
+			commonLabelValues := make([]string, 0, len(descVolumeAttachmentLabelsDefaultLabels)+len(m.LabelValues))
+
+			commonLabelKeys = append(commonLabelKeys, descVolumeAttachmentLabelsDefaultLabels...)
+			commonLabelValues = append(commonLabelValues, va.Name)
+
+			m.LabelKeys = append(commonLabelKeys, m.LabelKeys...)
+			m.LabelValues = append(commonLabelValues, m.LabelValues...)
 		}
 
 		return metricFamily


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

# **What this PR does / why we need it**:

- This PR Optimizes Slices Allocations in the `wrap<resource>Func()` by pre-allocate the required capacity and avoiding re-allocations.
- The slices are small, however, **two new slices** are allocated, and expanded, **for each metric family, of each resource**. 
- Pre-allocating slices capacity is possible because we know how many element we'll need for each slice. 

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
- Does not affect cardinality.

#  Benchmarks:

Using ` make test-benchmark-compare`

### Compared to Master
<details>
<summary> Logs </summary>

```
./tests/compare_benchmarks.sh master

### Testing alloc-optimize
?   	k8s.io/kube-state-metrics/v2	[no test files]
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/internal/store
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkPodStore-16    	  106828	     11251 ns/op	   12816 B/op	     232 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/internal/store	2.354s
?   	k8s.io/kube-state-metrics/v2/pkg/allow	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/allowdenylist	0.411s
I0205 18:59:19.881358   94914 builder.go:232] Active resources: certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/pkg/app
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkKubeStateMetrics/GenerateMetrics-16         	       1	1004373526 ns/op	63972984 B/op	  602716 allocs/op
BenchmarkKubeStateMetrics/MakeRequests-16            	       1	3626366009 ns/op	1712.31 MB/s	14257183408 B/op	  509450 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/app	8.037s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/builder	0.450s
?   	k8s.io/kube-state-metrics/v2/pkg/builder/types	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/constant	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/customresource	[no test files]
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/pkg/metric
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkMetricWrite/value-1-16         	 2916366	       407.8 ns/op	     536 B/op	       7 allocs/op
BenchmarkMetricWrite/value-35.7-16      	 2276084	       528.0 ns/op	     536 B/op	       7 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/metric	3.655s
?   	k8s.io/kube-state-metrics/v2/pkg/metric_generator	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/metrics_store	0.477s
?   	k8s.io/kube-state-metrics/v2/pkg/metricshandler	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/optin	0.494s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/options	0.478s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/sharding	0.449s
?   	k8s.io/kube-state-metrics/v2/pkg/util/proc	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/version	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/watch	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/tests/e2e	0.388s
?   	k8s.io/kube-state-metrics/v2/tests/e2e/framework	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/tests/lib	0.507s

### Done testing alloc-optimize

### Testing master
Switched to branch 'master'
Your branch is ahead of 'origin/master' by 2 commits.
  (use "git push" to publish your local commits)
?   	k8s.io/kube-state-metrics/v2	[no test files]
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/internal/store
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkPodStore-16    	   90944	     13116 ns/op	   15888 B/op	     262 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/internal/store	1.852s
?   	k8s.io/kube-state-metrics/v2/pkg/allow	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/allowdenylist	0.340s
I0205 18:59:38.861400   95006 builder.go:240] Active resources: certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/pkg/app
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkKubeStateMetrics/GenerateMetrics-16         	       1	1001920205 ns/op	66873336 B/op	  636615 allocs/op
BenchmarkKubeStateMetrics/MakeRequests-16            	       1	3657135938 ns/op	1697.90 MB/s	14257066328 B/op	  509427 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/app	8.074s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/builder	0.553s
?   	k8s.io/kube-state-metrics/v2/pkg/builder/types	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/constant	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/customresource	[no test files]
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/pkg/metric
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkMetricWrite/value-1-16         	 2950290	       406.6 ns/op	     536 B/op	       7 allocs/op
BenchmarkMetricWrite/value-35.7-16      	 2294436	       527.8 ns/op	     536 B/op	       7 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/metric	3.631s
?   	k8s.io/kube-state-metrics/v2/pkg/metric_generator	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/metrics_store	0.309s
?   	k8s.io/kube-state-metrics/v2/pkg/metricshandler	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/optin	0.242s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/options	0.410s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/sharding	0.353s
?   	k8s.io/kube-state-metrics/v2/pkg/util/proc	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/version	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/watch	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/tests/e2e	0.334s
?   	k8s.io/kube-state-metrics/v2/tests/e2e/framework	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/tests/lib	0.461s

### Done testing master
Switched to branch 'alloc-optimize'
Your branch is up to date with 'fork/alloc-optimize'.

### Result
old=master new=alloc-optimize
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                        old ns/op      new ns/op      delta
BenchmarkPodStore-16                             13116          11251          -14.22%
BenchmarkKubeStateMetrics/GenerateMetrics-16     1001920205     1004373526     +0.24%
BenchmarkKubeStateMetrics/MakeRequests-16        3657135938     3626366009     -0.84%
BenchmarkMetricWrite/value-1-16                  407            408            +0.30%
BenchmarkMetricWrite/value-35.7-16               528            528            +0.04%

benchmark                                     old MB/s     new MB/s     speedup
BenchmarkKubeStateMetrics/MakeRequests-16     1697.90      1712.31      1.01x

benchmark                                        old allocs     new allocs     delta
BenchmarkPodStore-16                             262            232            -11.45%
BenchmarkKubeStateMetrics/GenerateMetrics-16     636615         602716         -5.32%
BenchmarkKubeStateMetrics/MakeRequests-16        509427         509450         +0.00%
BenchmarkMetricWrite/value-1-16                  7              7              +0.00%
BenchmarkMetricWrite/value-35.7-16               7              7              +0.00%

benchmark                                        old bytes       new bytes       delta
BenchmarkPodStore-16                             15888           12816           -19.34%
BenchmarkKubeStateMetrics/GenerateMetrics-16     66873336        63972984        -4.34%
BenchmarkKubeStateMetrics/MakeRequests-16        14257066328     14257183408     +0.00%
BenchmarkMetricWrite/value-1-16                  536             536             +0.00%
BenchmarkMetricWrite/value-35.7-16               536             536             +0.00%
```
</details>

#### results
```
### Result
old=master new=alloc-optimize
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                        old ns/op      new ns/op      delta
BenchmarkPodStore-16                             13116          11251          -14.22%
BenchmarkKubeStateMetrics/GenerateMetrics-16     1001920205     1004373526     +0.24%
BenchmarkKubeStateMetrics/MakeRequests-16        3657135938     3626366009     -0.84%
BenchmarkMetricWrite/value-1-16                  407            408            +0.30%
BenchmarkMetricWrite/value-35.7-16               528            528            +0.04%

benchmark                                     old MB/s     new MB/s     speedup
BenchmarkKubeStateMetrics/MakeRequests-16     1697.90      1712.31      1.01x

benchmark                                        old allocs     new allocs     delta
BenchmarkPodStore-16                             262            232            -11.45%
BenchmarkKubeStateMetrics/GenerateMetrics-16     636615         602716         -5.32%
BenchmarkKubeStateMetrics/MakeRequests-16        509427         509450         +0.00%
BenchmarkMetricWrite/value-1-16                  7              7              +0.00%
BenchmarkMetricWrite/value-35.7-16               7              7              +0.00%

benchmark                                        old bytes       new bytes       delta
BenchmarkPodStore-16                             15888           12816           -19.34%
BenchmarkKubeStateMetrics/GenerateMetrics-16     66873336        63972984        -4.34%
BenchmarkKubeStateMetrics/MakeRequests-16        14257066328     14257183408     +0.00%
BenchmarkMetricWrite/value-1-16                  536             536             +0.00%
BenchmarkMetricWrite/value-35.7-16               536             536             +0.00%
```



### Compared to Latest Release
<details>
<summary> Logs </summary>

```
### Testing alloc-optimize
?   	k8s.io/kube-state-metrics/v2	[no test files]
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/internal/store
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkPodStore-16    	  106470	     11287 ns/op	   12816 B/op	     232 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/internal/store	1.735s
?   	k8s.io/kube-state-metrics/v2/pkg/allow	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/allowdenylist	0.259s
I0205 18:59:57.085779   95106 builder.go:232] Active resources: certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/pkg/app
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkKubeStateMetrics/GenerateMetrics-16         	       1	1003332439 ns/op	63895760 B/op	  602677 allocs/op
BenchmarkKubeStateMetrics/MakeRequests-16            	       1	3730689662 ns/op	1664.43 MB/s	14256884576 B/op	  509375 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/app	8.054s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/builder	0.424s
?   	k8s.io/kube-state-metrics/v2/pkg/builder/types	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/constant	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/customresource	[no test files]
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/pkg/metric
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkMetricWrite/value-1-16         	 2967225	       404.1 ns/op	     536 B/op	       7 allocs/op
BenchmarkMetricWrite/value-35.7-16      	 2307228	       522.2 ns/op	     536 B/op	       7 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/metric	3.652s
?   	k8s.io/kube-state-metrics/v2/pkg/metric_generator	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/metrics_store	0.268s
?   	k8s.io/kube-state-metrics/v2/pkg/metricshandler	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/optin	0.202s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/options	0.259s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/sharding	0.337s
?   	k8s.io/kube-state-metrics/v2/pkg/util/proc	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/version	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/watch	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/tests/e2e	0.320s
?   	k8s.io/kube-state-metrics/v2/tests/e2e/framework	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/tests/lib	0.443s

### Done testing alloc-optimize

### Testing release-2.3
Switched to branch 'release-2.3'
Your branch is up to date with 'origin/release-2.3'.
I0205 19:00:13.391361   95193 builder.go:192] Active resources: certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkKubeStateMetrics/GenerateMetrics-16         	       1	1004029168 ns/op	66918864 B/op	  636653 allocs/op
BenchmarkKubeStateMetrics/MakeRequests-16            	       1	3674074324 ns/op	1690.08 MB/s	14257290016 B/op	  509309 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2	8.504s
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/internal/store
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkPodStore-16    	   91106	     13081 ns/op	   15888 B/op	     262 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/internal/store	1.860s
?   	k8s.io/kube-state-metrics/v2/pkg/allow	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/allowdenylist	0.324s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/builder	0.532s
?   	k8s.io/kube-state-metrics/v2/pkg/builder/types	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/constant	[no test files]
goos: darwin
goarch: amd64
pkg: k8s.io/kube-state-metrics/v2/pkg/metric
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkMetricWrite/value-1-16         	 2925446	       408.5 ns/op	     536 B/op	       7 allocs/op
BenchmarkMetricWrite/value-35.7-16      	 2271388	       526.8 ns/op	     536 B/op	       7 allocs/op
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/metric	3.620s
?   	k8s.io/kube-state-metrics/v2/pkg/metric_generator	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/metrics_store	0.305s
?   	k8s.io/kube-state-metrics/v2/pkg/metricshandler	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/optin	0.294s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/options	0.356s
PASS
ok  	k8s.io/kube-state-metrics/v2/pkg/sharding	0.376s
?   	k8s.io/kube-state-metrics/v2/pkg/util/proc	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/version	[no test files]
?   	k8s.io/kube-state-metrics/v2/pkg/watch	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/tests/e2e	0.301s
?   	k8s.io/kube-state-metrics/v2/tests/e2e/framework	[no test files]
PASS
ok  	k8s.io/kube-state-metrics/v2/tests/lib	0.374s

### Done testing release-2.3
```
</details>

#### results
```
### Result
old=release-2.3 new=alloc-optimize
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                        old ns/op      new ns/op      delta
BenchmarkKubeStateMetrics/GenerateMetrics-16     1004029168     1003332439     -0.07%
BenchmarkKubeStateMetrics/MakeRequests-16        3674074324     3730689662     +1.54%
BenchmarkPodStore-16                             13081          11287          -13.71%
BenchmarkMetricWrite/value-1-16                  408            404            -1.08%
BenchmarkMetricWrite/value-35.7-16               527            522            -0.87%

benchmark                                     old MB/s     new MB/s     speedup
BenchmarkKubeStateMetrics/MakeRequests-16     1690.08      1664.43      0.98x

benchmark                                        old allocs     new allocs     delta
BenchmarkKubeStateMetrics/GenerateMetrics-16     636653         602677         -5.34%
BenchmarkKubeStateMetrics/MakeRequests-16        509309         509375         +0.01%
BenchmarkPodStore-16                             262            232            -11.45%
BenchmarkMetricWrite/value-1-16                  7              7              +0.00%
BenchmarkMetricWrite/value-35.7-16               7              7              +0.00%

benchmark                                        old bytes       new bytes       delta
BenchmarkKubeStateMetrics/GenerateMetrics-16     66918864        63895760        -4.52%
BenchmarkKubeStateMetrics/MakeRequests-16        14257290016     14256884576     -0.00%
BenchmarkPodStore-16                             15888           12816           -19.34%
BenchmarkMetricWrite/value-1-16                  536             536             +0.00%
BenchmarkMetricWrite/value-35.7-16               536             536             +0.00%
```



## Notes
- Benchmarks only test Pods, however the PR changes all `wrap(.*)Func`(s).
