### PR TITLE
Change the processing type from int to float in kube_horizontalpodautoscaler_spec_target_metric

### DIFF
--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -134,53 +134,52 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				for _, m := range a.Spec.Metrics {
 					var metricName string
 
-					var v [metricTargetTypeCount]int64
-					var ok [metricTargetTypeCount]bool
+					var v [metricTargetTypeCount]float64
 
 					switch m.Type {
 					case autoscaling.ObjectMetricSourceType:
 						metricName = m.Object.Metric.Name
 
-						v[value], ok[value] = m.Object.Target.Value.AsInt64()
+						if m.Object.Target.Value != nil {
+							v[value] = float64(m.Object.Target.Value.MilliValue()) / 1000
+						}
 						if m.Object.Target.AverageValue != nil {
-							v[average], ok[average] = m.Object.Target.AverageValue.AsInt64()
+							v[average] = float64(m.Object.Target.AverageValue.MilliValue()) / 1000
 						}
 					case autoscaling.PodsMetricSourceType:
 						metricName = m.Pods.Metric.Name
 
-						v[average], ok[average] = m.Pods.Target.AverageValue.AsInt64()
+						v[average] = float64(m.Pods.Target.AverageValue.MilliValue()) / 1000
 					case autoscaling.ResourceMetricSourceType:
 						metricName = string(m.Resource.Name)
 
-						if ok[utilization] = (m.Resource.Target.AverageUtilization != nil); ok[utilization] {
-							v[utilization] = int64(*m.Resource.Target.AverageUtilization)
+						if m.Resource.Target.AverageUtilization != nil {
+							v[utilization] = float64(*m.Resource.Target.AverageUtilization)
 						}
 
 						if m.Resource.Target.AverageValue != nil {
-							v[average], ok[average] = m.Resource.Target.AverageValue.AsInt64()
+							v[average] = float64(m.Resource.Target.AverageValue.MilliValue()) / 1000
 						}
 					case autoscaling.ExternalMetricSourceType:
 						metricName = m.External.Metric.Name
 
 						if m.External.Target.Value != nil {
-							v[value], ok[value] = m.External.Target.Value.AsInt64()
+							v[value] = float64(m.External.Target.Value.MilliValue()) / 1000
 						}
 						if m.External.Target.AverageValue != nil {
-							v[average], ok[average] = m.External.Target.AverageValue.AsInt64()
+							v[average] = float64(m.External.Target.AverageValue.MilliValue()) / 1000
 						}
 					default:
 						// Skip unsupported metric type
 						continue
 					}
 
-					for i := range ok {
-						if ok[i] {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   targetMetricLabels,
-								LabelValues: []string{metricName, metricTargetType(i).String()},
-								Value:       float64(v[i]),
-							})
-						}
+					for i := range v {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   targetMetricLabels,
+							LabelValues: []string{metricName, metricTargetType(i).String()},
+							Value:       v[i],
+						})
 					}
 				}
 				return &metric.Family{Metrics: ms}

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -80,7 +80,7 @@ func TestHPAStore(t *testing.T) {
 								},
 								Target: autoscaling.MetricTarget{
 									Value:        resourcePtr(resource.MustParse("10")),
-									AverageValue: resourcePtr(resource.MustParse("12")),
+									AverageValue: resourcePtr(resource.MustParse("0.5")),
 								},
 							},
 						},
@@ -193,7 +193,7 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="events",metric_target_type="average",namespace="ns1"} 30
-				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="hits",metric_target_type="average",namespace="ns1"} 12
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="hits",metric_target_type="average",namespace="ns1"} 0.5
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="hits",metric_target_type="value",namespace="ns1"} 10
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 819200
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80


### PR DESCRIPTION

**What this PR does / why we need it**:
Since the kube_horizontalpodautoscaler_spec_target_metric metric currently uses the AsInt64() function when processing data, if there is a float type metric between 0 and 1, it will be filtered and will not be displayed.
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1594 
