### PR TITLE
Add `disable-label-rewriting` option

### DIFF
--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -28,6 +28,7 @@ Usage of ./kube-state-metrics:
       --add_dir_header                        If true, adds the file directory to the header of the log messages
       --alsologtostderr                       log to standard error as well as files
       --apiserver string                      The URL of the apiserver to use as a master
+      --disable-label-rewriting               If true, disable transforming label keys to snake case.
       --enable-gzip-encoding                  Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.
   -h, --help                                  Print Help text
       --host string                           Host to expose metrics on. (default "::")

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -123,6 +123,9 @@ func mapToPrometheusLabels(labels map[string]string, prefix string) ([]string, [
 }
 
 func labelName(prefix, labelName string) string {
+	if options.GetDisableLabelRewriting() {
+		return prefix + "_" + sanitizeLabelName(labelName)
+	}
 	return prefix + "_" + lintLabelName(sanitizeLabelName(labelName))
 }
 

--- a/internal/store/utils_test.go
+++ b/internal/store/utils_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+
 	"k8s.io/kube-state-metrics/v2/pkg/options"
 )
 

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -71,6 +71,7 @@ func (pl promLogger) Log(v ...interface{}) error {
 // Any out-of-tree custom resource metrics could be registered by newing a registry factory
 // which implements customresource.RegistryFactory and pass all factories into this function.
 func RunKubeStateMetrics(ctx context.Context, opts *options.Options, factories ...customresource.RegistryFactory) error {
+	options.SetDisableLabelRewriting(opts.DisableLabelRewriting)
 	promLogger := promLogger{}
 
 	storeBuilder := store.NewBuilder()

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -28,27 +28,28 @@ import (
 
 // Options are the configurable parameters for kube-state-metrics.
 type Options struct {
-	Apiserver            string
-	Kubeconfig           string
-	Help                 bool
-	Port                 int
-	Host                 string
-	TelemetryPort        int
-	TelemetryHost        string
-	TLSConfig            string
-	Resources            ResourceSet
-	Namespaces           NamespaceList
-	NamespacesDenylist   NamespaceList
-	Shard                int32
-	TotalShards          int
-	Pod                  string
-	Namespace            string
-	MetricDenylist       MetricSet
-	MetricAllowlist      MetricSet
-	MetricOptInList      MetricSet
-	Version              bool
-	AnnotationsAllowList LabelsAllowList
-	LabelsAllowList      LabelsAllowList
+	Apiserver             string
+	Kubeconfig            string
+	Help                  bool
+	Port                  int
+	Host                  string
+	TelemetryPort         int
+	TelemetryHost         string
+	TLSConfig             string
+	Resources             ResourceSet
+	Namespaces            NamespaceList
+	NamespacesDenylist    NamespaceList
+	Shard                 int32
+	TotalShards           int
+	Pod                   string
+	Namespace             string
+	MetricDenylist        MetricSet
+	MetricAllowlist       MetricSet
+	MetricOptInList       MetricSet
+	Version               bool
+	AnnotationsAllowList  LabelsAllowList
+	LabelsAllowList       LabelsAllowList
+	DisableLabelRewriting bool
 
 	EnableGZIPEncoding bool
 
@@ -104,6 +105,7 @@ func (o *Options) AddFlags() {
 	o.flags.Var(&o.LabelsAllowList, "metric-labels-allowlist", "Comma-separated list of additional Kubernetes label keys that will be used in the resource' labels metric. By default the metric contains only name and namespace labels. To include additional labels provide a list of resource names in their plural form and Kubernetes label keys you would like to allow for them (Example: '=namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...)'. A single '*' can be provided per resource instead to allow any labels, but that has severe performance implications (Example: '=pods=[*]').")
 	o.flags.Int32Var(&o.Shard, "shard", int32(0), "The instances shard nominal (zero indexed) within the total number of shards. (default 0)")
 	o.flags.IntVar(&o.TotalShards, "total-shards", 1, "The total number of shards. Sharding is disabled when total shards is set to 1.")
+	o.flags.BoolVarP(&o.DisableLabelRewriting, "disable-label-rewriting", "", false, "If true, disable transforming label keys to snake case.")
 
 	autoshardingNotice := "When set, it is expected that --pod and --pod-namespace are both set. Most likely this should be passed via the downward API. This is used for auto-detecting sharding. If set, this has preference over statically configured sharding. This is experimental, it may be removed without notice."
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -105,7 +105,7 @@ func (o *Options) AddFlags() {
 	o.flags.Var(&o.LabelsAllowList, "metric-labels-allowlist", "Comma-separated list of additional Kubernetes label keys that will be used in the resource' labels metric. By default the metric contains only name and namespace labels. To include additional labels provide a list of resource names in their plural form and Kubernetes label keys you would like to allow for them (Example: '=namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...)'. A single '*' can be provided per resource instead to allow any labels, but that has severe performance implications (Example: '=pods=[*]').")
 	o.flags.Int32Var(&o.Shard, "shard", int32(0), "The instances shard nominal (zero indexed) within the total number of shards. (default 0)")
 	o.flags.IntVar(&o.TotalShards, "total-shards", 1, "The total number of shards. Sharding is disabled when total shards is set to 1.")
-	o.flags.BoolVarP(&o.DisableLabelRewriting, "disable-label-rewriting", "", false, "If true, disable transforming label keys to snake case.")
+	o.flags.BoolVar(&o.DisableLabelRewriting, "disable-label-rewriting", false, "If true, disable transforming label keys to snake case.")
 
 	autoshardingNotice := "When set, it is expected that --pod and --pod-namespace are both set. Most likely this should be passed via the downward API. This is used for auto-detecting sharding. If set, this has preference over statically configured sharding. This is experimental, it may be removed without notice."
 

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -256,3 +256,16 @@ func (l *LabelsAllowList) String() string {
 func (l *LabelsAllowList) Type() string {
 	return "string"
 }
+
+// disableLabelRewriting is used in the branch to transform label keys to snake case.
+var disableLabelRewriting = false
+
+// SetDisableLabelRewriting sets the boolean to disableLabelRewriting
+func SetDisableLabelRewriting(s bool) {
+	disableLabelRewriting = s
+}
+
+// GetDisableLabelRewriting gets values from disableLabelRewriting
+func GetDisableLabelRewriting() bool {
+	return disableLabelRewriting
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Added a `disable-label-rewriting` option to kube-state-metrics for disabling transformation of labels from camel case to snake case.

Quality Assurance)

<details>

<summary>sample yaml</summary>

```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/component: exporter
    app.kubernetes.io/name: kube-state-metrics
    app.kubernetes.io/version: 2.3.0
  name: kube-state-metrics
  namespace: kube-system
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: kube-state-metrics
  template:
    metadata:
      labels:
        app.kubernetes.io/component: exporter
        app.kubernetes.io/name: kube-state-metrics
        app.kubernetes.io/version: 2.3.0
    spec:
      automountServiceAccountToken: true
      containers:
      - image: shotnaka/kube-state-metrics-amd64:latest
        args:
        - --metric-labels-allowlist=pods=[com.acme/fooBar]
        # - --disable-label-rewriting=true
        livenessProbe:
          httpGet:
            path: /healthz
            port: 8080
          initialDelaySeconds: 5
          timeoutSeconds: 5
        name: kube-state-metrics
        ports:
        - containerPort: 8080
          name: http-metrics
        - containerPort: 8081
          name: telemetry
        readinessProbe:
          httpGet:
            path: /
            port: 8081
          initialDelaySeconds: 5
          timeoutSeconds: 5
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          readOnlyRootFilesystem: true
          runAsUser: 65534
      nodeSelector:
        kubernetes.io/os: linux
      serviceAccountName: kube-state-metrics
---
apiVersion: v1
kind: Pod
metadata:
  name: nginx
  labels:
    com.acme/fooBar: "yes"
spec:
  containers:
  - image: nginx
    name: nginx
```

</details>

After applying above yaml, I checked metrics of nginx pod in kube-state-metrics

```
$ kubectl --context kind-kind apply -f svc-monitor.yaml -n kube-system
deployment.apps/kube-state-metrics unchanged
pod/nginx created

$ kubectl port-forward --context kind-kind -n kube-system  svc/kube-state-metrics 8080:8080
Forwarding from 127.0.0.1:8080 -> 8080
Forwarding from [::1]:8080 -> 8080
Handling connection for 8080
```

in case of,

without `--disable-label-rewriting=true`
```
[~]$ curl -sS localhost:8080/metrics | grep foo
kube_pod_labels{namespace="kube-system",pod="nginx",uid="3ff54e5e-0d49-4851-8631-7d1d3cb82975",label_com_acme_foo_bar="yes"} 1
```

with `--disable-label-rewriting=true`
- It doesn't convert to snake case

```
[~]$ curl -sS localhost:8080/metrics | grep foo
kube_pod_labels{namespace="kube-system",pod="nginx",uid="6cd0198a-560f-4018-9673-fe01104cadf2",label_com_acme_fooBar="yes"} 1
```


**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

Nothing. I added & run test to check that this change doesn't affect others.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1662