### PR TITLE
Properly initialize KSM server test

### DIFF
--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/kube-state-metrics/v2/pkg/optin"
+
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -151,7 +153,17 @@ func TestFullScrapeCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	builder.WithFamilyGeneratorFilter(l)
+
+	optInMetrics := make(map[string]struct{})
+	optInMetricFamilyFilter, err := optin.NewMetricFamilyFilter(optInMetrics)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	builder.WithFamilyGeneratorFilter(generator.NewCompositeFamilyGeneratorFilter(
+		l,
+		optInMetricFamilyFilter,
+	))
 	builder.WithAllowLabels(map[string][]string{
 		"kube_pod_labels": {
 			"namespace",
@@ -207,7 +219,6 @@ func TestFullScrapeCycle(t *testing.T) {
 # HELP kube_pod_init_container_status_waiting Describes whether the init container is currently in waiting state.
 # HELP kube_pod_init_container_status_waiting_reason Describes the reason the init container is currently in waiting state.
 # HELP kube_pod_labels Kubernetes labels converted to Prometheus labels.
-# HELP kube_pod_nodeselectors Describes the Pod nodeSelectors.
 # HELP kube_pod_overhead_cpu_cores The pod overhead in regards to cpu cores associated with running a pod.
 # HELP kube_pod_overhead_memory_bytes The pod overhead in regards to memory associated with running a pod.
 # HELP kube_pod_runtimeclass_name_info The runtimeclass associated with the pod.
@@ -251,7 +262,6 @@ func TestFullScrapeCycle(t *testing.T) {
 # TYPE kube_pod_init_container_status_waiting gauge
 # TYPE kube_pod_init_container_status_waiting_reason gauge
 # TYPE kube_pod_labels gauge
-# TYPE kube_pod_nodeselectors gauge
 # TYPE kube_pod_overhead_cpu_cores gauge
 # TYPE kube_pod_overhead_memory_bytes gauge
 # TYPE kube_pod_runtimeclass_name_info gauge
@@ -298,7 +308,6 @@ kube_pod_container_status_waiting{namespace="default",pod="pod0",uid="abc-0",con
 kube_pod_created{namespace="default",pod="pod0",uid="abc-0"} 1.5e+09
 kube_pod_info{namespace="default",pod="pod0",uid="abc-0",host_ip="1.1.1.1",pod_ip="1.2.3.4",node="node1",created_by_kind="<none>",created_by_name="<none>",priority_class="",host_network="false"} 1
 kube_pod_labels{namespace="default",pod="pod0",uid="abc-0"} 1
-kube_pod_nodeselectors{namespace="default",pod="pod0",uid="abc-0"} 1
 kube_pod_owner{namespace="default",pod="pod0",uid="abc-0",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
 kube_pod_restart_policy{namespace="default",pod="pod0",uid="abc-0",type="Always"} 1
 kube_pod_status_phase{namespace="default",pod="pod0",uid="abc-0",phase="Failed"} 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The pkg/app/server test does not properly initialize KSM with an empty
metrics opt-in list. This results in opt-in metrics showing up in the
expected test results.

This commit changes the test to be in line with how KSM is initialized
in production code by passing in an empty opt-in list.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
No effect

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
