### PR TITLE
Assert that newlines in coma separated arguments are ignored

### DIFF
--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -106,6 +106,14 @@ func TestMetricSetSet(t *testing.T) {
 				"kube_daemonset_labels": {},
 			}),
 		},
+		{
+			Desc:  "newlines are ignored",
+			Value: "\n^kube_.+_annotations$,\n   ^kube_secret_labels$\n",
+			Wanted: MetricSet{
+				"^kube_secret_labels$":  struct{}{},
+				"^kube_.+_annotations$": struct{}{},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR adds a test to MetricSet type to assert that newlines (`\n`) in a `denylist are ignored, so that this behaviour can be relied upon by users.

```sh
    <ksm> --metric-denylist="
        ^kube_.+_created$,
        ^kube_.+_metadata_resource_version$,
        ^kube_pod_completion_time$,
        ^kube_pod_status_scheduled$
      "
```

**How does this change affect the cardinality of KSM**:  *does not change cardinality*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1705 
