### PR TITLE
internal/store: fix potential panic in pod store

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -130,15 +130,18 @@ func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 			labelKeys := []string{"container", "image_spec", "image", "image_id", "container_id"}
 
-			for i, cs := range p.Status.ContainerStatuses {
-				specImage := p.Spec.Containers[i].Image
-				ms[i] = &metric.Metric{
-					LabelKeys:   labelKeys,
-					LabelValues: []string{cs.Name, specImage, cs.Image, cs.ImageID, cs.ContainerID},
-					Value:       1,
+			for i, c := range p.Spec.Containers {
+				for _, cs := range p.Status.ContainerStatuses {
+					if cs.Name != c.Name {
+						continue
+					}
+					ms[i] = &metric.Metric{
+						LabelKeys:   labelKeys,
+						LabelValues: []string{cs.Name, c.Image, cs.Image, cs.ImageID, cs.ContainerID},
+						Value:       1,
+					}
 				}
 			}
-
 			return &metric.Family{
 				Metrics: ms,
 			}
@@ -587,12 +590,16 @@ func createPodInitContainerInfoFamilyGenerator() generator.FamilyGenerator {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 			labelKeys := []string{"container", "image_spec", "image", "image_id", "container_id"}
 
-			for i, cs := range p.Status.InitContainerStatuses {
-				specImage := p.Spec.InitContainers[i].Image
-				ms[i] = &metric.Metric{
-					LabelKeys:   labelKeys,
-					LabelValues: []string{cs.Name, specImage, cs.Image, cs.ImageID, cs.ContainerID},
-					Value:       1,
+			for i, c := range p.Spec.InitContainers {
+				for _, cs := range p.Status.InitContainerStatuses {
+					if cs.Name != c.Name {
+						continue
+					}
+					ms[i] = &metric.Metric{
+						LabelKeys:   labelKeys,
+						LabelValues: []string{cs.Name, c.Image, cs.Image, cs.ImageID, cs.ContainerID},
+						Value:       1,
+					}
 				}
 			}
 

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -45,6 +45,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container1",
 							Image: "k8s.gcr.io/hyperkube1_spec",
 						},
 					},
@@ -76,14 +77,17 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container2",
 							Image: "k8s.gcr.io/hyperkube2_spec",
 						},
 						{
+							Name:  "container3",
 							Image: "k8s.gcr.io/hyperkube3_spec",
 						},
 					},
 					InitContainers: []v1.Container{
 						{
+							Name:  "initContainer",
 							Image: "k8s.gcr.io/initfoo_spec",
 						},
 					},
@@ -133,6 +137,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container1",
 							Image: "k8s.gcr.io/hyperkube1_spec",
 						},
 					},
@@ -162,9 +167,11 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container2",
 							Image: "k8s.gcr.io/hyperkube2_spec",
 						},
 						{
+							Name:  "container3",
 							Image: "k8s.gcr.io/hyperkube3_spec",
 						},
 					},
@@ -200,17 +207,21 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container2",
 							Image: "k8s.gcr.io/hyperkube2_spec",
 						},
 						{
+							Name:  "container3",
 							Image: "k8s.gcr.io/hyperkube3_spec",
 						},
 					},
 					InitContainers: []v1.Container{
 						{
+							Name:  "initcontainer1",
 							Image: "k8s.gcr.io/initfoo_spec",
 						},
 						{
+							Name:  "initcontainer2",
 							Image: "k8s.gcr.io/initfoo_spec",
 						},
 					},
@@ -256,6 +267,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container1",
 							Image: "k8s.gcr.io/hyperkube1_spec",
 						},
 					},
@@ -286,6 +298,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					InitContainers: []v1.Container{
 						{
+							Name:  "initcontainer1",
 							Image: "k8s.gcr.io/initfoo_spec",
 						},
 					},
@@ -316,9 +329,11 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container2",
 							Image: "k8s.gcr.io/hyperkube2_spec",
 						},
 						{
+							Name:  "container3",
 							Image: "k8s.gcr.io/hyperkube3_spec",
 						},
 					},
@@ -354,9 +369,11 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					InitContainers: []v1.Container{
 						{
+							Name:  "initcontainer2",
 							Image: "k8s.gcr.io/initfoo_spec",
 						},
 						{
+							Name:  "initcontainer3",
 							Image: "k8s.gcr.io/initfoo_spec",
 						},
 					},
@@ -392,11 +409,13 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container1",
 							Image: "k8s.gcr.io/hyperkube2_spec",
 						},
 					},
 					InitContainers: []v1.Container{
 						{
+							Name:  "initcontainer1",
 							Image: "k8s.gcr.io/initfoo_spec",
 						},
 					},
@@ -478,6 +497,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container1",
 							Image: "k8s.gcr.io/hyperkube1_spec",
 						},
 					},
@@ -535,9 +555,11 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container2",
 							Image: "k8s.gcr.io/hyperkube2_spec",
 						},
 						{
+							Name:  "container3",
 							Image: "k8s.gcr.io/hyperkube3_spec",
 						},
 					},
@@ -607,6 +629,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container4",
 							Image: "k8s.gcr.io/hyperkube4_spec",
 						},
 					},
@@ -668,6 +691,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container7",
 							Image: "k8s.gcr.io/hyperkube7_spec",
 						},
 					},
@@ -732,6 +756,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container7",
 							Image: "k8s.gcr.io/hyperkube7_spec",
 						},
 					},
@@ -796,6 +821,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container5",
 							Image: "k8s.gcr.io/hyperkube5_spec",
 						},
 					},
@@ -847,6 +873,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container6",
 							Image: "k8s.gcr.io/hyperkube1_spec",
 						},
 					},
@@ -898,6 +925,7 @@ func TestPodStore(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
+							Name:  "container8",
 							Image: "k8s.gcr.io/hyperkube1_spec",
 						},
 					},
@@ -1063,12 +1091,15 @@ func TestPodStore(t *testing.T) {
 					NodeName: "node2",
 					Containers: []v1.Container{
 						{
+							Name:  "container2_1",
 							Image: "k8s.gcr.io/hyperkube2_spec",
 						},
 						{
+							Name:  "container2_2",
 							Image: "k8s.gcr.io/hyperkube2_spec",
 						},
 						{
+							Name:  "container2_3",
 							Image: "k8s.gcr.io/hyperkube2_spec",
 						},
 					},
@@ -1908,12 +1939,15 @@ func BenchmarkPodStore(b *testing.B) {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
+					Name:  "container1",
 					Image: "k8s.gcr.io/hyperkube1_spec",
 				},
 				{
+					Name:  "container2",
 					Image: "k8s.gcr.io/hyperkube1_spec",
 				},
 				{
+					Name:  "container3",
 					Image: "k8s.gcr.io/hyperkube1_spec",
 				},
 			},
@@ -1937,7 +1971,7 @@ func BenchmarkPodStore(b *testing.B) {
 					},
 				},
 				{
-					Name:         "container1",
+					Name:         "container2",
 					Image:        "k8s.gcr.io/hyperkube1",
 					ImageID:      "docker://sha256:aaa",
 					ContainerID:  "docker://ab123",
@@ -1953,7 +1987,7 @@ func BenchmarkPodStore(b *testing.B) {
 					},
 				},
 				{
-					Name:         "container1",
+					Name:         "container3",
 					Image:        "k8s.gcr.io/hyperkube1",
 					ImageID:      "docker://sha256:aaa",
 					ContainerID:  "docker://ab123",

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -277,8 +277,8 @@ func TestFullScrapeCycle(t *testing.T) {
 # TYPE kube_pod_status_scheduled_time gauge
 # TYPE kube_pod_status_unschedulable gauge
 kube_pod_annotations{namespace="default",pod="pod0",uid="abc-0"} 1
-kube_pod_container_info{namespace="default",pod="pod0",uid="abc-0",container="container2",image_spec="k8s.gcr.io/hyperkube2_spec",image="k8s.gcr.io/hyperkube2",image_id="docker://sha256:bbb",container_id="docker://cd456"} 1
-kube_pod_container_info{namespace="default",pod="pod0",uid="abc-0",container="container3",image_spec="k8s.gcr.io/hyperkube3_spec",image="k8s.gcr.io/hyperkube3",image_id="docker://sha256:ccc",container_id="docker://ef789"} 1
+kube_pod_container_info{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1",image_spec="k8s.gcr.io/hyperkube2_spec",image="k8s.gcr.io/hyperkube2",image_id="docker://sha256:bbb",container_id="docker://cd456"} 1
+kube_pod_container_info{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2",image_spec="k8s.gcr.io/hyperkube3_spec",image="k8s.gcr.io/hyperkube3",image_id="docker://sha256:ccc",container_id="docker://ef789"} 1
 kube_pod_container_resource_limits{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1",node="node1",resource="cpu",unit="core"} 0.2
 kube_pod_container_resource_limits{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1",node="node1",resource="ephemeral_storage",unit="byte"} 3e+08
 kube_pod_container_resource_limits{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1",node="node1",resource="memory",unit="byte"} 1e+08
@@ -293,18 +293,18 @@ kube_pod_container_resource_requests{namespace="default",pod="pod0",uid="abc-0",
 kube_pod_container_resource_requests{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1",node="node1",resource="storage",unit="byte"} 4e+08
 kube_pod_container_resource_requests{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2",node="node1",resource="cpu",unit="core"} 0.3
 kube_pod_container_resource_requests{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2",node="node1",resource="memory",unit="byte"} 2e+08
-kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",uid="abc-0",container="container2",reason="OOMKilled"} 1
-kube_pod_container_status_ready{namespace="default",pod="pod0",uid="abc-0",container="container2"} 0
-kube_pod_container_status_ready{namespace="default",pod="pod0",uid="abc-0",container="container3"} 0
-kube_pod_container_status_restarts_total{namespace="default",pod="pod0",uid="abc-0",container="container2"} 0
-kube_pod_container_status_restarts_total{namespace="default",pod="pod0",uid="abc-0",container="container3"} 0
-kube_pod_container_status_running{namespace="default",pod="pod0",uid="abc-0",container="container2"} 0
-kube_pod_container_status_running{namespace="default",pod="pod0",uid="abc-0",container="container3"} 0
-kube_pod_container_status_terminated{namespace="default",pod="pod0",uid="abc-0",container="container2"} 0
-kube_pod_container_status_terminated{namespace="default",pod="pod0",uid="abc-0",container="container3"} 0
-kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",uid="abc-0",container="container2",reason="CrashLoopBackOff"} 1
-kube_pod_container_status_waiting{namespace="default",pod="pod0",uid="abc-0",container="container2"} 1
-kube_pod_container_status_waiting{namespace="default",pod="pod0",uid="abc-0",container="container3"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1",reason="OOMKilled"} 1
+kube_pod_container_status_ready{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1"} 0
+kube_pod_container_status_ready{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2"} 0
+kube_pod_container_status_running{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1"} 0
+kube_pod_container_status_running{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2"} 0
+kube_pod_container_status_terminated{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1"} 0
+kube_pod_container_status_terminated{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1",reason="CrashLoopBackOff"} 1
+kube_pod_container_status_waiting{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1"} 1
+kube_pod_container_status_waiting{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2"} 0
 kube_pod_created{namespace="default",pod="pod0",uid="abc-0"} 1.5e+09
 kube_pod_info{namespace="default",pod="pod0",uid="abc-0",host_ip="1.1.1.1",pod_ip="1.2.3.4",node="node1",created_by_kind="<none>",created_by_name="<none>",priority_class="",host_network="false"} 1
 kube_pod_labels{namespace="default",pod="pod0",uid="abc-0"} 1
@@ -779,7 +779,7 @@ func pod(client *fake.Clientset, index int) error {
 			Phase:  v1.PodRunning,
 			ContainerStatuses: []v1.ContainerStatus{
 				{
-					Name:        "container2",
+					Name:        "pod1_con1",
 					Image:       "k8s.gcr.io/hyperkube2",
 					ImageID:     "docker://sha256:bbb",
 					ContainerID: "docker://cd456",
@@ -795,7 +795,7 @@ func pod(client *fake.Clientset, index int) error {
 					},
 				},
 				{
-					Name:        "container3",
+					Name:        "pod1_con2",
 					Image:       "k8s.gcr.io/hyperkube3",
 					ImageID:     "docker://sha256:ccc",
 					ContainerID: "docker://ef789",


### PR DESCRIPTION
**What this PR does / why we need it**:

Based on [this](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-disruptive-4.11/1518364808469024768/artifacts/e2e-aws-disruptive/pods/openshift-monitoring_kube-state-metrics-6f497695d7-qbfkd_kube-state-metrics_previous.log) OpenShift CI run, kube-state-metrics might panic if the pod status container statuses do not match the containers in spec. The reason how/why this can happen is still being investigated, but this PR should mitigate the chance by iterating the spec containers which is an immutable field.