### PR TITLE
feat(hpa): status current metric

### DIFF
--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -9,7 +9,7 @@
 | kube_horizontalpodautoscaler_spec_max_replicas        | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_spec_min_replicas        | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_spec_target_metric       | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
-| kube_horizontalpodautoscaler_status_current_target_metric       | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
+| kube_horizontalpodautoscaler_status_current_metric       | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
 | kube_horizontalpodautoscaler_status_condition         | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_horizontalpodautoscaler_status_current_replicas  | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_status_desired_replicas  | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |

--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -9,7 +9,7 @@
 | kube_horizontalpodautoscaler_spec_max_replicas        | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_spec_min_replicas        | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_spec_target_metric       | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
-| kube_horizontalpodautoscaler_status_current_metric       | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
+| kube_horizontalpodautoscaler_status_target_metric       | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
 | kube_horizontalpodautoscaler_status_condition         | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_horizontalpodautoscaler_status_current_replicas  | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_status_desired_replicas  | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |

--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -9,6 +9,7 @@
 | kube_horizontalpodautoscaler_spec_max_replicas        | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_spec_min_replicas        | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_spec_target_metric       | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
+| kube_horizontalpodautoscaler_status_current_target_metric       | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;value\|utilization\|average&gt; | EXPERIMENTAL |
 | kube_horizontalpodautoscaler_status_condition         | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_horizontalpodautoscaler_status_current_replicas  | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_status_desired_replicas  | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -185,8 +185,8 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			}),
 		),
 		*generator.NewFamilyGenerator(
-			"kube_horizontalpodautoscaler_status_current_metric",
-			"The metric current status used by this autoscaler when calculating the desired replica count.",
+			"kube_horizontalpodautoscaler_status_target_metric",
+			"The current metric status used by this autoscaler when calculating the desired replica count.",
 			metric.Gauge,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -185,7 +185,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			}),
 		),
 		*generator.NewFamilyGenerator(
-			"kube_horizontalpodautoscaler_status_current_target_metric",
+			"kube_horizontalpodautoscaler_status_current_metric",
 			"The metric current status used by this autoscaler when calculating the desired replica count.",
 			metric.Gauge,
 			"",

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -183,6 +183,68 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 				return &metric.Family{Metrics: ms}
 			}),
+		),,
+		*generator.NewFamilyGenerator(
+			"kube_horizontalpodautoscaler_status_current_target_metric",
+			"The metric current status used by this autoscaler when calculating the desired replica count.",
+			metric.Gauge,
+			"",
+			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+				ms := make([]*metric.Metric, 0, len(a.Status.Metrics))
+				for _, m := range a.Status.CurrentMetrics {
+					var metricName string
+
+					// The variable maps the type of metric to the corresponding value
+					metricMap := make(map[metricTargetType]float64)
+
+					switch m.Type {
+					case autoscaling.ObjectMetricSourceType:
+						metricName = m.Object.Metric.Name
+
+						if m.Object.Current.Value != nil {
+							metricMap[value] = float64(m.Object.Current.Value.MilliValue()) / 1000
+						}
+						if m.Object.Current.AverageValue != nil {
+							metricMap[average] = float64(m.Object.Current.AverageValue.MilliValue()) / 1000
+						}
+					case autoscaling.PodsMetricSourceType:
+						metricName = m.Pods.Metric.Name
+
+						metricMap[average] = float64(m.Pods.Current.AverageValue.MilliValue()) / 1000
+					case autoscaling.ResourceMetricSourceType:
+						metricName = string(m.Resource.Name)
+
+						if m.Resource.Current.AverageUtilization != nil {
+							metricMap[utilization] = float64(*m.Resource.Current.AverageUtilization)
+						}
+
+						if m.Resource.Current.AverageValue != nil {
+							metricMap[average] = float64(m.Resource.Current.AverageValue.MilliValue()) / 1000
+						}
+					case autoscaling.ExternalMetricSourceType:
+						metricName = m.External.Metric.Name
+
+						if m.External.Current.Value != nil {
+							metricMap[value] = float64(m.External.Current.Value.MilliValue()) / 1000
+						}
+						if m.External.Current.AverageValue != nil {
+							metricMap[average] = float64(m.External.Current.AverageValue.MilliValue()) / 1000
+						}
+					default:
+						// Skip unsupported metric type
+						continue
+					}
+
+					for metricTypeIndex, metricValue := range metricMap {
+						ms = append(ms, &metric.Metric{
+							LabelKeys:   targetMetricLabels,
+							LabelValues: []string{metricName, metricTypeIndex.String()},
+							Value:       metricValue,
+						})
+					}
+				}
+				return &metric.Family{Metrics: ms}
+			}),
 		),
 		*generator.NewFamilyGenerator(
 			"kube_horizontalpodautoscaler_status_current_replicas",

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -183,14 +183,14 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 				return &metric.Family{Metrics: ms}
 			}),
-		),,
+		),
 		*generator.NewFamilyGenerator(
 			"kube_horizontalpodautoscaler_status_current_target_metric",
 			"The metric current status used by this autoscaler when calculating the desired replica count.",
 			metric.Gauge,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-				ms := make([]*metric.Metric, 0, len(a.Status.Metrics))
+				ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
 				for _, m := range a.Status.CurrentMetrics {
 					var metricName string
 

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -42,7 +42,7 @@ func TestHPAStore(t *testing.T) {
 		# HELP kube_horizontalpodautoscaler_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
 		# HELP kube_horizontalpodautoscaler_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
 		# HELP kube_horizontalpodautoscaler_spec_target_metric The metric specifications used by this autoscaler when calculating the desired replica count.
-		# HELP kube_horizontalpodautoscaler_status_current_metric The metric current status used by this autoscaler when calculating the desired replica count.
+		# HELP kube_horizontalpodautoscaler_status_target_metric The current metric status used by this autoscaler when calculating the desired replica count.
 		# HELP kube_horizontalpodautoscaler_status_condition The condition of this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_current_replicas Current number of replicas of pods managed by this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
@@ -53,7 +53,7 @@ func TestHPAStore(t *testing.T) {
 		# TYPE kube_horizontalpodautoscaler_spec_max_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_spec_min_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_spec_target_metric gauge
-		# TYPE kube_horizontalpodautoscaler_status_current_metric gauge
+		# TYPE kube_horizontalpodautoscaler_status_target_metric gauge
 		# TYPE kube_horizontalpodautoscaler_status_condition gauge
 		# TYPE kube_horizontalpodautoscaler_status_current_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_status_desired_replicas gauge
@@ -215,10 +215,10 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="sqs_jobs",metric_target_type="value",namespace="ns1"} 30
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="transactions_processed",metric_target_type="average",namespace="ns1"} 33
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.007
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 2.6335914666e+07
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.007
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 2.6335914666e+07
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="false"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="true"} 1
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="unknown"} 0
@@ -231,7 +231,7 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_spec_max_replicas",
 				"kube_horizontalpodautoscaler_spec_min_replicas",
 				"kube_horizontalpodautoscaler_spec_target_metric",
-				"kube_horizontalpodautoscaler_status_current_metric",
+				"kube_horizontalpodautoscaler_status_target_metric",
 				"kube_horizontalpodautoscaler_status_current_replicas",
 				"kube_horizontalpodautoscaler_status_desired_replicas",
 				"kube_horizontalpodautoscaler_status_condition",
@@ -375,13 +375,13 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 75
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 100
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 100
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="average",namespace="ns1"} 8.47775744e+08
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 28
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.062
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 6
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 0
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="average",namespace="ns1"} 2.9
-				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 0
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="average",namespace="ns1"} 8.47775744e+08
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 28
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.062
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 6
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 0
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="average",namespace="ns1"} 2.9
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="false"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="true"} 1
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="unknown"} 0
@@ -394,7 +394,7 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_spec_max_replicas",
 				"kube_horizontalpodautoscaler_spec_min_replicas",
 				"kube_horizontalpodautoscaler_spec_target_metric",
-				"kube_horizontalpodautoscaler_status_current_metric",
+				"kube_horizontalpodautoscaler_status_target_metric",
 				"kube_horizontalpodautoscaler_status_current_replicas",
 				"kube_horizontalpodautoscaler_status_desired_replicas",
 				"kube_horizontalpodautoscaler_status_condition",

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -42,6 +42,7 @@ func TestHPAStore(t *testing.T) {
 		# HELP kube_horizontalpodautoscaler_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
 		# HELP kube_horizontalpodautoscaler_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
 		# HELP kube_horizontalpodautoscaler_spec_target_metric The metric specifications used by this autoscaler when calculating the desired replica count.
+		# HELP kube_horizontalpodautoscaler_status_current_target_metric The metric current status used by this autoscaler when calculating the desired replica count.
 		# HELP kube_horizontalpodautoscaler_status_condition The condition of this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_current_replicas Current number of replicas of pods managed by this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
@@ -52,6 +53,7 @@ func TestHPAStore(t *testing.T) {
 		# TYPE kube_horizontalpodautoscaler_spec_max_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_spec_min_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_spec_target_metric gauge
+		# TYPE kube_horizontalpodautoscaler_status_current_target_metric gauge
 		# TYPE kube_horizontalpodautoscaler_status_condition gauge
 		# TYPE kube_horizontalpodautoscaler_status_current_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_status_desired_replicas gauge
@@ -179,7 +181,7 @@ func TestHPAStore(t *testing.T) {
 								Name: "cpu",
 								Current: autoscaling.MetricValueStatus{
 									AverageValue:       resourcePtr(resource.MustParse("7m")),
-									AverageUtilization: new(int32),
+									AverageUtilization: int32ptr(80),
 								},
 							},
 						},
@@ -189,7 +191,7 @@ func TestHPAStore(t *testing.T) {
 								Name: "memory",
 								Current: autoscaling.MetricValueStatus{
 									AverageValue:       resourcePtr(resource.MustParse("26335914666m")),
-									AverageUtilization: new(int32),
+									AverageUtilization: int32ptr(80),
 								},
 							},
 						},
@@ -213,6 +215,10 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="sqs_jobs",metric_target_type="value",namespace="ns1"} 30
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="transactions_processed",metric_target_type="average",namespace="ns1"} 33
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.007
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 26335914.666
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="false"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="true"} 1
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="unknown"} 0
@@ -225,6 +231,7 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_spec_max_replicas",
 				"kube_horizontalpodautoscaler_spec_min_replicas",
 				"kube_horizontalpodautoscaler_spec_target_metric",
+				"kube_horizontalpodautoscaler_status_current_target_metric",
 				"kube_horizontalpodautoscaler_status_current_replicas",
 				"kube_horizontalpodautoscaler_status_desired_replicas",
 				"kube_horizontalpodautoscaler_status_condition",
@@ -368,6 +375,13 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 75
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 100
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 100
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="value",namespace="ns1"} 847775744
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="value",namespace="ns1"} 28
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="value",namespace="ns1"} 0.062
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="value",namespace="ns1"} 6
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 2.9
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 0
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="false"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="true"} 1
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="unknown"} 0
@@ -380,6 +394,7 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_spec_max_replicas",
 				"kube_horizontalpodautoscaler_spec_min_replicas",
 				"kube_horizontalpodautoscaler_spec_target_metric",
+				"kube_horizontalpodautoscaler_status_current_target_metric",
 				"kube_horizontalpodautoscaler_status_current_replicas",
 				"kube_horizontalpodautoscaler_status_desired_replicas",
 				"kube_horizontalpodautoscaler_status_condition",

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -217,7 +217,7 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="transactions_processed",metric_target_type="average",namespace="ns1"} 33
 				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.007
 				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 26335914.666
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 2.6335914666e+07
 				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="false"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="true"} 1
@@ -375,12 +375,12 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 75
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 100
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 100
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="value",namespace="ns1"} 847775744
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="value",namespace="ns1"} 28
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="value",namespace="ns1"} 0.062
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="value",namespace="ns1"} 6
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 2.9
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="average",namespace="ns1"} 8.47775744e+08
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 28
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.062
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 6
 				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 0
+				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="average",namespace="ns1"} 2.9
 				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="false"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="true"} 1

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -42,7 +42,7 @@ func TestHPAStore(t *testing.T) {
 		# HELP kube_horizontalpodautoscaler_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
 		# HELP kube_horizontalpodautoscaler_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
 		# HELP kube_horizontalpodautoscaler_spec_target_metric The metric specifications used by this autoscaler when calculating the desired replica count.
-		# HELP kube_horizontalpodautoscaler_status_current_target_metric The metric current status used by this autoscaler when calculating the desired replica count.
+		# HELP kube_horizontalpodautoscaler_status_current_metric The metric current status used by this autoscaler when calculating the desired replica count.
 		# HELP kube_horizontalpodautoscaler_status_condition The condition of this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_current_replicas Current number of replicas of pods managed by this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
@@ -53,7 +53,7 @@ func TestHPAStore(t *testing.T) {
 		# TYPE kube_horizontalpodautoscaler_spec_max_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_spec_min_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_spec_target_metric gauge
-		# TYPE kube_horizontalpodautoscaler_status_current_target_metric gauge
+		# TYPE kube_horizontalpodautoscaler_status_current_metric gauge
 		# TYPE kube_horizontalpodautoscaler_status_condition gauge
 		# TYPE kube_horizontalpodautoscaler_status_current_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_status_desired_replicas gauge
@@ -215,10 +215,10 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="sqs_jobs",metric_target_type="value",namespace="ns1"} 30
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="transactions_processed",metric_target_type="average",namespace="ns1"} 33
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.007
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 2.6335914666e+07
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.007
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 2.6335914666e+07
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="false"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="true"} 1
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="unknown"} 0
@@ -231,7 +231,7 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_spec_max_replicas",
 				"kube_horizontalpodautoscaler_spec_min_replicas",
 				"kube_horizontalpodautoscaler_spec_target_metric",
-				"kube_horizontalpodautoscaler_status_current_target_metric",
+				"kube_horizontalpodautoscaler_status_current_metric",
 				"kube_horizontalpodautoscaler_status_current_replicas",
 				"kube_horizontalpodautoscaler_status_desired_replicas",
 				"kube_horizontalpodautoscaler_status_condition",
@@ -375,13 +375,13 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 75
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 100
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 100
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="average",namespace="ns1"} 8.47775744e+08
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 28
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.062
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 6
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 0
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="average",namespace="ns1"} 2.9
-				kube_horizontalpodautoscaler_status_current_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 0
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="average",namespace="ns1"} 8.47775744e+08
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 28
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.062
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 6
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 0
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="average",namespace="ns1"} 2.9
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="false"} 0
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="true"} 1
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="unknown"} 0
@@ -394,7 +394,7 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_spec_max_replicas",
 				"kube_horizontalpodautoscaler_spec_min_replicas",
 				"kube_horizontalpodautoscaler_spec_target_metric",
-				"kube_horizontalpodautoscaler_status_current_target_metric",
+				"kube_horizontalpodautoscaler_status_current_metric",
 				"kube_horizontalpodautoscaler_status_current_replicas",
 				"kube_horizontalpodautoscaler_status_desired_replicas",
 				"kube_horizontalpodautoscaler_status_condition",


### PR DESCRIPTION
Signed-off-by: Tanguy Falconnet <tfalconnet.externe@bedrockstreaming.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

We want to be able to have current status of target metrics used by HPA.
We are currently not able to know if our HPA target metrics are healthy or in `<unknown>` state. Used in pair with prometheus-adapter for custom metric scaling, this is an important metric to check to monitor our clusters.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

Increases, as it adds a new metric `kube_horizontalpodautoscaler_status_current_target_metric`, mostly the same as `kube_horizontalpodautoscaler_spec_target_metric`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
