### PR TITLE
Add missing LastSuccessfulTime metric

### DIFF
--- a/docs/cronjob-metrics.md
+++ b/docs/cronjob-metrics.md
@@ -9,6 +9,7 @@
 | kube_cronjob_next_schedule_time  | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; | STABLE
 | kube_cronjob_status_active | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; | STABLE
 | kube_cronjob_status_last_schedule_time | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; | STABLE
+| kube_cronjob_status_last_successful_time  | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; | EXPERIMENTAL
 | kube_cronjob_spec_suspend | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; | STABLE
 | kube_cronjob_spec_starting_deadline_seconds | Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; | STABLE
 | kube_cronjob_metadata_resource_version| Gauge | `cronjob`=&lt;cronjob-name&gt; <br> `namespace`=&lt;cronjob-namespace&gt; | STABLE

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -155,6 +155,27 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			}),
 		),
 		*generator.NewFamilyGenerator(
+			"kube_cronjob_status_last_successful_time",
+			"LastSuccessfulTime keeps information of when was the last time the job was completed successfully.",
+			metric.Gauge,
+			"",
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if j.Status.LastSuccessfulTime != nil {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{},
+						LabelValues: []string{},
+						Value:       float64(j.Status.LastSuccessfulTime.Unix()),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
 			"kube_cronjob_spec_suspend",
 			"Suspend flag tells the controller to suspend subsequent executions.",
 			metric.Gauge,

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -121,8 +121,9 @@ func TestCronJobStore(t *testing.T) {
 					},
 				},
 				Status: batchv1.CronJobStatus{
-					Active:           []v1.ObjectReference{{Name: "FakeJob1"}, {Name: "FakeJob2"}},
-					LastScheduleTime: &metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
+					Active:             []v1.ObjectReference{{Name: "FakeJob1"}, {Name: "FakeJob2"}},
+					LastScheduleTime:   &metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
+					LastSuccessfulTime: nil,
 				},
 				Spec: batchv1.CronJobSpec{
 					StartingDeadlineSeconds:    &StartingDeadlineSeconds300,
@@ -197,8 +198,9 @@ func TestCronJobStore(t *testing.T) {
 					},
 				},
 				Status: batchv1.CronJobStatus{
-					Active:           []v1.ObjectReference{},
-					LastScheduleTime: &metav1.Time{Time: SuspendedCronJob1LastScheduleTime},
+					Active:             []v1.ObjectReference{},
+					LastScheduleTime:   &metav1.Time{Time: SuspendedCronJob1LastScheduleTime},
+					LastSuccessfulTime: nil,
 				},
 				Spec: batchv1.CronJobSpec{
 					StartingDeadlineSeconds:    &StartingDeadlineSeconds300,
@@ -220,6 +222,7 @@ func TestCronJobStore(t *testing.T) {
 				# HELP kube_cronjob_status_active Active holds pointers to currently running jobs.
                 # HELP kube_cronjob_metadata_resource_version Resource version representing a specific version of the cronjob.
 				# HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
+				# HELP kube_cronjob_status_last_successful_time LastSuccessfulTime keeps information of when was the last time the job was completed successfully.
 				# TYPE kube_cronjob_created gauge
 				# TYPE kube_cronjob_info gauge
 				# TYPE kube_cronjob_labels gauge
@@ -230,6 +233,7 @@ func TestCronJobStore(t *testing.T) {
 				# TYPE kube_cronjob_status_active gauge
                 # TYPE kube_cronjob_metadata_resource_version gauge
 				# TYPE kube_cronjob_status_last_schedule_time gauge
+				# TYPE kube_cronjob_status_last_successful_time gauge
 				kube_cronjob_info{concurrency_policy="Forbid",cronjob="SuspendedCronJob1",namespace="ns1",schedule="0 */3 * * *"} 1
 				kube_cronjob_labels{cronjob="SuspendedCronJob1",namespace="ns1"} 1
 				kube_cronjob_spec_failed_job_history_limit{cronjob="SuspendedCronJob1",namespace="ns1"} 1
@@ -240,7 +244,68 @@ func TestCronJobStore(t *testing.T) {
 				kube_cronjob_metadata_resource_version{cronjob="SuspendedCronJob1",namespace="ns1"} 22222
 				kube_cronjob_status_last_schedule_time{cronjob="SuspendedCronJob1",namespace="ns1"} 1.520762696e+09
 `,
-			MetricNames: []string{"kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_metadata_resource_version", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels", "kube_cronjob_status_last_schedule_time", "kube_cronjob_spec_successful_job_history_limit", "kube_cronjob_spec_failed_job_history_limit"},
+			MetricNames: []string{"kube_cronjob_status_last_successful_time", "kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_metadata_resource_version", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels", "kube_cronjob_status_last_schedule_time", "kube_cronjob_spec_successful_job_history_limit", "kube_cronjob_spec_failed_job_history_limit"},
+		},
+		{
+			Obj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "SuspendedCronJob1",
+					Namespace:       "ns1",
+					Generation:      1,
+					ResourceVersion: "22222",
+					Labels: map[string]string{
+						"app": "example-suspended-1",
+					},
+				},
+				Status: batchv1.CronJobStatus{
+					Active:             []v1.ObjectReference{},
+					LastScheduleTime:   &metav1.Time{Time: SuspendedCronJob1LastScheduleTime},
+					LastSuccessfulTime: &metav1.Time{Time: SuspendedCronJob1LastScheduleTime},
+				},
+				Spec: batchv1.CronJobSpec{
+					StartingDeadlineSeconds:    &StartingDeadlineSeconds300,
+					ConcurrencyPolicy:          "Forbid",
+					Suspend:                    &SuspendTrue,
+					Schedule:                   "0 */3 * * *",
+					SuccessfulJobsHistoryLimit: &SuccessfulJobHistoryLimit3,
+					FailedJobsHistoryLimit:     &FailedJobHistoryLimit1,
+				},
+			},
+			Want: `
+				# HELP kube_cronjob_created Unix creation timestamp
+				# HELP kube_cronjob_info Info about cronjob.
+				# HELP kube_cronjob_labels Kubernetes labels converted to Prometheus labels.
+				# HELP kube_cronjob_spec_failed_job_history_limit Failed job history limit tells the controller how many failed jobs should be preserved.
+				# HELP kube_cronjob_spec_starting_deadline_seconds Deadline in seconds for starting the job if it misses scheduled time for any reason.
+				# HELP kube_cronjob_spec_successful_job_history_limit Successful job history limit tells the controller how many completed jobs should be preserved.
+				# HELP kube_cronjob_spec_suspend Suspend flag tells the controller to suspend subsequent executions.
+				# HELP kube_cronjob_status_active Active holds pointers to currently running jobs.
+                # HELP kube_cronjob_metadata_resource_version Resource version representing a specific version of the cronjob.
+				# HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
+				# HELP kube_cronjob_status_last_successful_time LastSuccessfulTime keeps information of when was the last time the job was completed successfully.
+				# TYPE kube_cronjob_created gauge
+				# TYPE kube_cronjob_info gauge
+				# TYPE kube_cronjob_labels gauge
+				# TYPE kube_cronjob_spec_failed_job_history_limit gauge
+				# TYPE kube_cronjob_spec_starting_deadline_seconds gauge
+				# TYPE kube_cronjob_spec_successful_job_history_limit gauge
+				# TYPE kube_cronjob_spec_suspend gauge
+				# TYPE kube_cronjob_status_active gauge
+                # TYPE kube_cronjob_metadata_resource_version gauge
+				# TYPE kube_cronjob_status_last_schedule_time gauge
+				# TYPE kube_cronjob_status_last_successful_time gauge
+				kube_cronjob_info{concurrency_policy="Forbid",cronjob="SuspendedCronJob1",namespace="ns1",schedule="0 */3 * * *"} 1
+				kube_cronjob_labels{cronjob="SuspendedCronJob1",namespace="ns1"} 1
+				kube_cronjob_spec_failed_job_history_limit{cronjob="SuspendedCronJob1",namespace="ns1"} 1
+				kube_cronjob_spec_starting_deadline_seconds{cronjob="SuspendedCronJob1",namespace="ns1"} 300
+				kube_cronjob_spec_successful_job_history_limit{cronjob="SuspendedCronJob1",namespace="ns1"} 3
+				kube_cronjob_spec_suspend{cronjob="SuspendedCronJob1",namespace="ns1"} 1
+				kube_cronjob_status_active{cronjob="SuspendedCronJob1",namespace="ns1"} 0
+				kube_cronjob_metadata_resource_version{cronjob="SuspendedCronJob1",namespace="ns1"} 22222
+				kube_cronjob_status_last_schedule_time{cronjob="SuspendedCronJob1",namespace="ns1"} 1.520762696e+09
+				kube_cronjob_status_last_successful_time{cronjob="SuspendedCronJob1",namespace="ns1"} 1.520762696e+09
+`,
+			MetricNames: []string{"kube_cronjob_status_last_successful_time", "kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_metadata_resource_version", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels", "kube_cronjob_status_last_schedule_time", "kube_cronjob_spec_successful_job_history_limit", "kube_cronjob_spec_failed_job_history_limit"},
 		},
 		{
 			Obj: &batchv1.CronJob{
@@ -255,8 +320,9 @@ func TestCronJobStore(t *testing.T) {
 					},
 				},
 				Status: batchv1.CronJobStatus{
-					Active:           []v1.ObjectReference{},
-					LastScheduleTime: nil,
+					Active:             []v1.ObjectReference{},
+					LastScheduleTime:   nil,
+					LastSuccessfulTime: nil,
 				},
 				Spec: batchv1.CronJobSpec{
 					StartingDeadlineSeconds:    &StartingDeadlineSeconds300,
@@ -277,6 +343,7 @@ func TestCronJobStore(t *testing.T) {
 				# HELP kube_cronjob_spec_successful_job_history_limit Successful job history limit tells the controller how many completed jobs should be preserved.
 				# HELP kube_cronjob_spec_suspend Suspend flag tells the controller to suspend subsequent executions.
 				# HELP kube_cronjob_status_active Active holds pointers to currently running jobs.
+				# HELP kube_cronjob_status_last_successful_time LastSuccessfulTime keeps information of when was the last time the job was completed successfully.
                 # HELP kube_cronjob_metadata_resource_version Resource version representing a specific version of the cronjob.
 				# TYPE kube_cronjob_created gauge
 				# TYPE kube_cronjob_info gauge
@@ -288,6 +355,7 @@ func TestCronJobStore(t *testing.T) {
 				# TYPE kube_cronjob_spec_suspend gauge
 				# TYPE kube_cronjob_status_active gauge
                 # TYPE kube_cronjob_metadata_resource_version gauge
+				# TYPE kube_cronjob_status_last_successful_time gauge
 				kube_cronjob_spec_starting_deadline_seconds{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 300
 				kube_cronjob_status_active{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 0
 				kube_cronjob_metadata_resource_version{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 33333
@@ -300,7 +368,7 @@ func TestCronJobStore(t *testing.T) {
 ` +
 				fmt.Sprintf("kube_cronjob_next_schedule_time{cronjob=\"ActiveCronJob1NoLastScheduled\",namespace=\"ns1\"} %ve+09\n",
 					float64(ActiveCronJob1NoLastScheduledNextScheduleTime.Unix())/math.Pow10(9)),
-			MetricNames: []string{"kube_cronjob_next_schedule_time", "kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_metadata_resource_version", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels", "kube_cronjob_spec_successful_job_history_limit", "kube_cronjob_spec_failed_job_history_limit"},
+			MetricNames: []string{"kube_cronjob_status_last_successful_time", "kube_cronjob_next_schedule_time", "kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_metadata_resource_version", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels", "kube_cronjob_spec_successful_job_history_limit", "kube_cronjob_spec_failed_job_history_limit"},
 		},
 	}
 	for i, c := range cases {


### PR DESCRIPTION
**What this PR does / why we need it**:

A metric for CronJob LastSuccessfulTime is missing.

This is needed to evaluate cronjob rules (such as backup job must be run every $x hours)

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

This increases the metrics output per CronJob by one.
