### PR TITLE
Fix Unknown and Terminating query examples

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -57,9 +57,9 @@ So to mimic the [logic](https://github.com/kubernetes/kubernetes/blob/v1.17.3/pk
 
 For example:
 
-* To get the list of pods that are in the `Unknown` state, you can run the following PromQL query: `sum(kube_pod_status_phase{phase="Unknown"}) by (namespace, pod) or (count(kube_pod_deletion_timestamp) by (namespace, pod) * sum(kube_pod_status_reason{reason="NodeLost"}) by(namespace, pod))`
+* To get the list of pods that are in the `Unknown` state, you can run the following PromQL query: `kube_pod_status_phase{phase="Unknown"} or count(kube_pod_deletion_timestamp) by (namespace, podname) * sum(kube_pod_status_reason{reason="NodeLost"}) by(namespace, podname)`
 
-* For Pods in `Terminating` state: `count(kube_pod_deletion_timestamp) by (namespace, pod) * count(kube_pod_status_reason{reason="NodeLost"} == 0) by (namespace, pod)`
+* For Pods in `Terminating` state: `count(kube_pod_deletion_timestamp) by (namespace, podname) * count(kube_pod_status_reason{reason="NodeLost"} == 0) by (namespace, podname)`
 
 Here is an example of a Prometheus rule that can be used to alert on a Pod that has been in the `Terminated` state for more than `5m`.
 

--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -68,7 +68,7 @@ groups:
 - name: Pod state
   rules:
   - alert: PodsBlockInTerminatingState
-    expr: count(kube_pod_deletion_timestamp) by (namespace, pod) * count(kube_pod_status_reason{reason="NodeLost"} == 0) by (namespace, pod) > 0
+    expr: count(kube_pod_deletion_timestamp) by (namespace, podname) * count(kube_pod_status_reason{reason="NodeLost"} == 0) by (namespace, podname) > 0
     for: 5m
     labels:
       severity: page


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This fixes the example queries for getting list of `Unknown` or `Terminating` pods.

It seems `pod` has been changed to `podname`, so the examples don't work.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Not applicable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Not applicable.