### PR TITLE
internal/store: fix metrics slice length for init containers

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -587,19 +587,19 @@ func createPodInitContainerInfoFamilyGenerator() generator.FamilyGenerator {
 		metric.Gauge,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
-			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
+			ms := []*metric.Metric{}
 			labelKeys := []string{"container", "image_spec", "image", "image_id", "container_id"}
 
-			for i, c := range p.Spec.InitContainers {
+			for _, c := range p.Spec.InitContainers {
 				for _, cs := range p.Status.InitContainerStatuses {
 					if cs.Name != c.Name {
 						continue
 					}
-					ms[i] = &metric.Metric{
+					ms = append(ms, &metric.Metric{
 						LabelKeys:   labelKeys,
 						LabelValues: []string{cs.Name, c.Image, cs.Image, cs.ImageID, cs.ContainerID},
 						Value:       1,
-					}
+					})
 				}
 			}
 


### PR DESCRIPTION
In #1731  ,
the dynamic slice was introduced to fix potential panic under
Spec.Containers scenario, however there may be same panic for
Spec.InitContainers.

This patch fix it referring to #1731 

<!--  Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

fix potential panic when there exists disconnect of `Spec.InitContainers` and `Status.InitContainerStatuses`

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
