### PR TITLE
.github/workflows: Update golangci-lint to v1.46.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   E2E_SETUP_KUBECTL: yes
   SUDO: sudo
   GO_VERSION: "^1.18"
-  GOLANGCI_LINT_VERSION: "v1.45.2"
+  GOLANGCI_LINT_VERSION: "v1.46.2"
 
 jobs:
   ci-go-lint:
@@ -41,7 +41,7 @@ jobs:
 
     - name: Lint
       run: |
-        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${{ env.GOLANGCI_LINT_VERSION }}
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${{ env.GOLANGCI_LINT_VERSION }}
         make lint
 
   ci-validate-manifests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates URL (as described in https://golangci-lint.run/usage/install/#ci-installation) and updates golangci-lint to 1.46.2
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
