### PR TITLE
Switch registry from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ release.
 #### Container Image
 
 The latest container image can be found at:
-* `k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0` (arch: `amd64`, `arm`, `arm64`, `ppc64le` and `s390x`)
+* `registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0` (arch: `amd64`, `arm`, `arm64`, `ppc64le` and `s390x`)
 
 ### Metrics Documentation
 

--- a/examples/autosharding/statefulset.yaml
+++ b/examples/autosharding/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/standard/deployment.yaml
+++ b/examples/standard/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       automountServiceAccountToken: true
       containers:
-      - image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+      - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/scripts/standard.jsonnet
+++ b/scripts/standard.jsonnet
@@ -5,5 +5,5 @@ ksm {
   name:: 'kube-state-metrics',
   namespace:: 'kube-system',
   version:: version,
-  image:: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v' + version,
+  image:: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v' + version,
 }

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -26,8 +26,8 @@ esac
 NODE_IMAGE_NAME="docker.io/kindest/node"
 KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.24.0"}
 KUBE_STATE_METRICS_LOG_DIR=./log
-KUBE_STATE_METRICS_CURRENT_IMAGE_NAME="k8s.gcr.io/kube-state-metrics/kube-state-metrics"
-KUBE_STATE_METRICS_IMAGE_NAME="k8s.gcr.io/kube-state-metrics/kube-state-metrics-${ARCH}"
+KUBE_STATE_METRICS_CURRENT_IMAGE_NAME="registry.k8s.io/kube-state-metrics/kube-state-metrics"
+KUBE_STATE_METRICS_IMAGE_NAME="registry.k8s.io/kube-state-metrics/kube-state-metrics-${ARCH}"
 E2E_SETUP_KIND=${E2E_SETUP_KIND:-}
 E2E_SETUP_KUBECTL=${E2E_SETUP_KUBECTL:-}
 KIND_VERSION=v0.14.0
@@ -97,7 +97,7 @@ set -e
 kubectl version
 
 # query kube-state-metrics image tag
-REGISTRY="k8s.gcr.io/kube-state-metrics" make container
+REGISTRY="registry.k8s.io/kube-state-metrics" make container
 docker images -a
 KUBE_STATE_METRICS_IMAGE_TAG=$(docker images -a|grep "${KUBE_STATE_METRICS_IMAGE_NAME}" |grep -v 'latest'|awk '{print $2}'|sort -u)
 echo "local kube-state-metrics image tag: $KUBE_STATE_METRICS_IMAGE_TAG"


### PR DESCRIPTION
**What this PR does / why we need it**:
Use new domain for k8s image registry, as per https://groups.google.com/a/kubernetes.io/g/dev/c/DYZYNQ_A6_c/m/FpHqeVR2BAAJ

More context: https://github.com/kubernetes/kubernetes/pull/109938

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
