### PR TITLE
fix customresourcestate metric names to not contain underscores

### DIFF
--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -132,6 +132,7 @@ func (r Resource) GetSubsystem() string {
 		return strings.NewReplacer(
 			"/", "_",
 			".", "_",
+			"-", "_",
 		).Replace(fmt.Sprintf("%s_%s_%s", r.GroupVersionKind.Group, r.GroupVersionKind.Version, r.GroupVersionKind.Kind))
 	}
 	if r.Subsystem == "_" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes the customresource package to prevent `-` to be contained in created metric names.
It replaces all occurencies of `-` by `_`.

The character `-` is not allowed for metric names according [open metrics ABNF] and [prometheus docs].

[open metrics ABNF]: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#abnf
[prometheus docs]: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

It does not affect the cardinality

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1753
