### PR TITLE
add new kube_endpoint_address metric

### DIFF
--- a/docs/endpoint-metrics.md
+++ b/docs/endpoint-metrics.md
@@ -9,3 +9,4 @@
 | kube_endpoint_labels | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `label_ENDPOINT_LABEL`=&lt;ENDPOINT_LABEL&gt;  | STABLE |
 | kube_endpoint_created | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; | STABLE |
 | kube_endpoint_ports | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `port_name`=&lt;endpoint-port-name&gt; <br> `port_protocol`=&lt;endpoint-port-protocol&gt; <br> `port_number`=&lt;endpoint-port-number&gt; | EXPERIMENTAL |
+| kube_endpoint_address | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `available_ip`=&lt;endpoint-available-ip&gt; <br> `unavailable_ip`=&lt;endpoint-unavailable_ip&gt; | EXPERIMENTAL |

--- a/docs/endpoint-metrics.md
+++ b/docs/endpoint-metrics.md
@@ -9,4 +9,4 @@
 | kube_endpoint_labels | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `label_ENDPOINT_LABEL`=&lt;ENDPOINT_LABEL&gt;  | STABLE |
 | kube_endpoint_created | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; | STABLE |
 | kube_endpoint_ports | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `port_name`=&lt;endpoint-port-name&gt; <br> `port_protocol`=&lt;endpoint-port-protocol&gt; <br> `port_number`=&lt;endpoint-port-number&gt; | EXPERIMENTAL |
-| kube_endpoint_address | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `available_ip`=&lt;endpoint-available-ip&gt; <br> `unavailable_ip`=&lt;endpoint-unavailable_ip&gt; | EXPERIMENTAL |
+| kube_endpoint_address | Gauge | `endpoint`=&lt;endpoint-name&gt; <br> `namespace`=&lt;endpoint-namespace&gt; <br> `ip`=&lt;endpoint-ip&gt; <br> `ready`=&lt;true if available, false if unavailalbe&gt; | EXPERIMENTAL |

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -161,15 +161,15 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 				for _, s := range e.Subsets {
 					for _, available := range s.Addresses {
 						ms = append(ms, &metric.Metric{
-							LabelValues: []string{available.IP},
-							LabelKeys:   []string{"available_ip"},
+							LabelValues: []string{available.IP, "true"},
+							LabelKeys:   []string{"ip", "ready"},
 							Value:       1,
 						})
 					}
 					for _, notReadyAddresses := range s.NotReadyAddresses {
 						ms = append(ms, &metric.Metric{
-							LabelValues: []string{notReadyAddresses.IP},
-							LabelKeys:   []string{"unavailable_ip"},
+							LabelValues: []string{notReadyAddresses.IP, "false"},
+							LabelKeys:   []string{"ip", "ready"},
 							Value:       1,
 						})
 					}

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -152,6 +152,34 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			}),
 		),
 		*generator.NewFamilyGenerator(
+			"kube_endpoint_address",
+			"Information about Endpoint available and non available addresses.",
+			metric.Gauge,
+			"",
+			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+				ms := []*metric.Metric{}
+				for _, s := range e.Subsets {
+					for _, available := range s.Addresses {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{available.IP},
+							LabelKeys:   []string{"available_ip"},
+							Value:       1,
+						})
+					}
+					for _, notReadyAddresses := range s.NotReadyAddresses {
+						ms = append(ms, &metric.Metric{
+							LabelValues: []string{notReadyAddresses.IP},
+							LabelKeys:   []string{"unavailable_ip"},
+							Value:       1,
+						})
+					}
+				}
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGenerator(
 			"kube_endpoint_ports",
 			"Information about the Endpoint ports.",
 			metric.Gauge,

--- a/internal/store/endpoint_test.go
+++ b/internal/store/endpoint_test.go
@@ -101,12 +101,12 @@ func TestEndpointStore(t *testing.T) {
 				kube_endpoint_ports{endpoint="test-endpoint",namespace="default",port_name="prometheus",port_protocol="TCP",port_number="9090"} 1
 				kube_endpoint_ports{endpoint="test-endpoint",namespace="default",port_name="syslog",port_protocol="UDP",port_number="1234"} 1
 				kube_endpoint_ports{endpoint="test-endpoint",namespace="default",port_name="syslog-tcp",port_protocol="TCP",port_number="5678"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",available_ip="127.0.0.1"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",available_ip="10.0.0.1"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",available_ip="172.22.23.202"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",unavailable_ip="192.168.1.3"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",unavailable_ip="192.168.2.2"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",unavailable_ip="10.0.0.10"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="127.0.0.1",ready="true"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="10.0.0.1",ready="true"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="172.22.23.202",ready="true"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="192.168.1.3",ready="false"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="192.168.2.2",ready="false"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="10.0.0.10",ready="false"} 1
 			`,
 		},
 		{
@@ -141,9 +141,9 @@ func TestEndpointStore(t *testing.T) {
 				kube_endpoint_info{endpoint="single-port-endpoint",namespace="default"} 1
 				kube_endpoint_labels{endpoint="single-port-endpoint",namespace="default"} 1
 				kube_endpoint_ports{endpoint="single-port-endpoint",namespace="default",port_name="",port_number="8080",port_protocol="TCP"} 1
-				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",available_ip="127.0.0.1"} 1
-				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",available_ip="10.0.0.1"} 1
-				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",unavailable_ip="10.0.0.10"} 1
+				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",ip="127.0.0.1",ready="true"} 1
+				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",ip="10.0.0.1",ready="true"} 1
+				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",ip="10.0.0.10",ready="false"} 1
 			`,
 		},
 	}
@@ -234,12 +234,12 @@ func TestEndpointStoreWithLabels(t *testing.T) {
 				kube_endpoint_ports{endpoint="test-endpoint",namespace="default",port_name="prometheus",port_protocol="TCP",port_number="9090"} 1
 				kube_endpoint_ports{endpoint="test-endpoint",namespace="default",port_name="syslog",port_protocol="UDP",port_number="1234"} 1
 				kube_endpoint_ports{endpoint="test-endpoint",namespace="default",port_name="syslog-tcp",port_protocol="TCP",port_number="5678"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",available_ip="127.0.0.1"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",available_ip="10.0.0.1"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",available_ip="172.22.23.202"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",unavailable_ip="192.168.1.3"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",unavailable_ip="192.168.2.2"} 1
-				kube_endpoint_address{endpoint="test-endpoint",namespace="default",unavailable_ip="10.0.0.10"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="127.0.0.1",ready="true"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="10.0.0.1",ready="true"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="172.22.23.202",ready="true"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="192.168.1.3",ready="false"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="192.168.2.2",ready="false"} 1
+				kube_endpoint_address{endpoint="test-endpoint",namespace="default",ip="10.0.0.10",ready="false"} 1
 			`,
 		},
 		{
@@ -277,9 +277,9 @@ func TestEndpointStoreWithLabels(t *testing.T) {
 				kube_endpoint_info{endpoint="single-port-endpoint",namespace="default"} 1
 				kube_endpoint_labels{endpoint="single-port-endpoint",label_app="single-foobar",namespace="default"} 1
 				kube_endpoint_ports{endpoint="single-port-endpoint",namespace="default",port_name="",port_number="8080",port_protocol="TCP"} 1
-				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",available_ip="127.0.0.1"} 1
-				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",available_ip="10.0.0.1"} 1
-				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",unavailable_ip="10.0.0.10"} 1
+				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",ip="127.0.0.1",ready="true"} 1
+				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",ip="10.0.0.1",ready="true"} 1
+				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",ip="10.0.0.10",ready="false"} 1
 			`,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

As KSM shouldn't be responsible for computation of metrics, a new metric
is needed to expose available and unavailable addresses of an endpoint.

This new metric is generated as a future replacement for
kube_endpoint_address_available and kube_endpoint_address_not_ready.

Signed-off-by: Mario Constanti <mario@constanti.de>

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

Increases the cardinality of KSM: sum of all IPs in an endpoint subset (`endpoints.subsets.addresses.ip` and `endpoints.subsets.notReadyAddresses.ip`)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially solves #1624 
