### PR TITLE
To support read the timestamp fields of custom resources

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -499,6 +500,9 @@ func getNum(value interface{}) (float64, error) {
 		}
 		return 0, nil
 	case string:
+		if t, e := time.Parse(time.RFC3339, value.(string)); e == nil {
+			return float64(t.Unix()), nil
+		}
 		return strconv.ParseFloat(value.(string), 64)
 	case byte:
 		v = float64(vv)

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -81,6 +81,7 @@ func init() {
 				"qux": "quxx",
 				"bar": "baz",
 			},
+			"creationTimestamp": "2022-06-28T00:00:00Z",
 		},
 	})
 	if err != nil {
@@ -187,6 +188,42 @@ func Test_compiledEach_Values(t *testing.T) {
 			val(45, "name", "a"),
 			val(66, "name", "b"),
 		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult, gotErrors := tt.each.Values(cr)
+			assert.Equal(t, tt.wantResult, gotResult)
+			assert.Equal(t, tt.wantErrors, gotErrors)
+		})
+	}
+}
+
+func Test_compiledEach_Timestamp(t *testing.T) {
+	type tc struct {
+		name       string
+		each       compiledEach
+		wantResult []eachValue
+		wantErrors []error
+	}
+	val := func(value float64, labels ...string) eachValue {
+		t.Helper()
+		if len(labels)%2 != 0 {
+			t.Fatalf("labels must be even: %v", labels)
+		}
+		m := make(map[string]string)
+		for i := 0; i < len(labels); i += 2 {
+			m[labels[i]] = labels[i+1]
+		}
+		return eachValue{
+			Value:  value,
+			Labels: m,
+		}
+	}
+
+	tests := []tc{
+		{name: "single_timestamp", each: compiledEach{
+			Path: mustCompilePath(t, "metadata", "creationTimestamp"),
+		}, wantResult: []eachValue{val(1656374400)}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This is to fix the issue #1765 

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
N/A

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
