### PR TITLE
pkg/customresourcestate implement info and stateSet metric type and refactor configuration file

### DIFF
--- a/pkg/customresourcestate/config_metrics_types.go
+++ b/pkg/customresourcestate/config_metrics_types.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customresourcestate
+
+// MetricType is the type of a metric.
+type MetricType string
+
+// Supported metric types.
+const (
+	MetricTypeGauge    MetricType = "Gauge"
+	MetricTypeStateSet MetricType = "StateSet"
+	MetricTypeInfo     MetricType = "Info"
+)
+
+// MetricMeta are variables which may used for any metric type.
+type MetricMeta struct {
+	// LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
+	LabelsFromPath map[string][]string `yaml:"labelsFromPath" json:"labelsFromPath"`
+	// Path is the path to to generate metric(s) for.
+	Path []string `yaml:"path" json:"path"`
+}
+
+// MetricGauge targets a Path that may be a single value, array, or object. Arrays and objects will generate a metric per element.
+// Ref: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#gauge
+type MetricGauge struct {
+	MetricMeta `yaml:",inline" json:",inline"`
+
+	// ValueFrom is the path to a numeric field under Path that will be the metric value.
+	ValueFrom []string `yaml:"valueFrom" json:"valueFrom"`
+	// LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+	LabelFromKey string `yaml:"labelFromKey" json:"labelFromKey"`
+	// NilIsZero indicates that if a value is nil it will be treated as zero value.
+	NilIsZero bool `yaml:"nilIsZero" json:"nilIsZero"`
+}
+
+// MetricInfo is a metric which is used to expose textual information.
+// Ref: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#info
+type MetricInfo struct {
+	MetricMeta `yaml:",inline" json:",inline"`
+}
+
+// MetricStateSet is a metric which represent a series of related boolean values, also called a bitset.
+// Ref: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#stateset
+type MetricStateSet struct {
+	MetricMeta `yaml:",inline" json:",inline"`
+
+	// List is the list of values to expose a value for.
+	List []string `yaml:"list" json:"list"`
+	// LabelName is the key of the label which is used for each entry in List to expose the value.
+	LabelName string `yaml:"labelName" json:"labelName"`
+	// ValueFrom is the subpath to compare the list to.
+	ValueFrom []string `yaml:"valueFrom" json:"valueFrom"`
+}

--- a/pkg/customresourcestate/config_test.go
+++ b/pkg/customresourcestate/config_test.go
@@ -35,21 +35,21 @@ func Test_Metrics_deserialization(t *testing.T) {
 	assert.Equal(t, "active_count", m.Spec.Resources[0].Metrics[0].Name)
 
 	t.Run("can create resource factory", func(t *testing.T) {
-		rf, err := NewFieldMetrics(m.Spec.Resources[0])
+		rf, err := NewCustomResourceMetrics(m.Spec.Resources[0])
 		assert.NoError(t, err)
 
 		t.Run("labels are merged", func(t *testing.T) {
 			assert.Equal(t, map[string]string{
 				"name": mustCompilePath(t, "metadata", "name").String(),
-			}, toPaths(rf.(*fieldMetrics).Families[1].LabelFromPath))
+			}, toPaths(rf.(*customResourceMetrics).Families[1].LabelFromPath))
 		})
 
 		t.Run("errorLogV", func(t *testing.T) {
-			assert.Equal(t, klog.Level(5), rf.(*fieldMetrics).Families[1].ErrorLogV)
+			assert.Equal(t, klog.Level(5), rf.(*customResourceMetrics).Families[1].ErrorLogV)
 		})
 
 		t.Run("resource name", func(t *testing.T) {
-			assert.Equal(t, rf.(*fieldMetrics).ResourceName, "foos")
+			assert.Equal(t, rf.(*customResourceMetrics).ResourceName, "foos")
 		})
 	})
 }

--- a/pkg/customresourcestate/custom_resource_metrics.go
+++ b/pkg/customresourcestate/custom_resource_metrics.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customresourcestate
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+)
+
+// customResourceMetrics is an implementation of the customresource.RegistryFactory
+// interface which provides metrics for custom resources defined in a configuration file.
+type customResourceMetrics struct {
+	MetricNamePrefix string
+	GroupVersionKind schema.GroupVersionKind
+	ResourceName     string
+	Families         []compiledFamily
+}
+
+var _ customresource.RegistryFactory = &customResourceMetrics{}
+
+// NewCustomResourceMetrics creates a customresource.RegistryFactory from a configuration object.
+func NewCustomResourceMetrics(resource Resource) (customresource.RegistryFactory, error) {
+	compiled, err := compile(resource)
+	if err != nil {
+		return nil, err
+	}
+	gvk := schema.GroupVersionKind(resource.GroupVersionKind)
+	return &customResourceMetrics{
+		MetricNamePrefix: resource.GetMetricNamePrefix(),
+		GroupVersionKind: gvk,
+		Families:         compiled,
+		ResourceName:     resource.GetResourceName(),
+	}, nil
+}
+
+func (s customResourceMetrics) Name() string {
+	return s.ResourceName
+}
+
+func (s customResourceMetrics) CreateClient(cfg *rest.Config) (interface{}, error) {
+	c, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return c.Resource(schema.GroupVersionResource{
+		Group:    s.GroupVersionKind.Group,
+		Version:  s.GroupVersionKind.Version,
+		Resource: s.ResourceName,
+	}), nil
+}
+
+func (s customResourceMetrics) MetricFamilyGenerators(_, _ []string) (result []generator.FamilyGenerator) {
+	klog.InfoS("Custom resource state added metrics", "familyNames", s.names())
+	for _, f := range s.Families {
+		result = append(result, famGen(f))
+	}
+
+	return result
+}
+
+func (s customResourceMetrics) ExpectedType() interface{} {
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(s.GroupVersionKind)
+	return &u
+}
+
+func (s customResourceMetrics) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
+	api := customResourceClient.(dynamic.NamespaceableResourceInterface).Namespace(ns)
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+			return api.List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+			return api.Watch(ctx, options)
+		},
+	}
+}
+
+func (s customResourceMetrics) names() (names []string) {
+	for _, family := range s.Families {
+		names = append(names, family.Name)
+	}
+	return names
+}

--- a/pkg/customresourcestate/example_config.yaml
+++ b/pkg/customresourcestate/example_config.yaml
@@ -26,11 +26,13 @@ spec:
         - name: "active_count"
           help: "Number Foo Bars active"
           each:
-            path: [status, active]
-            labelFromKey: type
-            labelsFromPath:
-              bar: [bar]
-            value: [count]
+            type: Gauge
+            gauge:
+              path: [status, active]
+              labelFromKey: type
+              labelsFromPath:
+                bar: [bar]
+              value: [count]
           commonLabels:
             custom_metric: "yes"
 
@@ -40,6 +42,23 @@ spec:
 
         - name: "other_count"
           each:
-            path: [status, other]
+            type: Gauge
+            gauge:
+              path: [status, other]
           errorLogV: 5
 
+        - name: "info"
+          each:
+            type: Info
+            info:
+              path: [spec, version]
+          errorLogV: 5
+
+        - name: "phase"
+          each:
+            type: StateSet
+            stateSet:
+              path: [status, phase]
+              labelName: phase
+              list: [Active, Running, Terminating]
+          errorLogV: 5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

* Adds detection of booleans in string format to getNum.
* Refactors configuration file to allow definition of different metric types
  having different configuration variables.
* Refactor order of types and funcs / file structure in pkg/customersourcestate.

I'm opening this PR to start discussing possible solutions :-) I'm open to all feedback 👍

From a user perspective, this PR basically refactors the layout of the custom resource config file.

It introduces a `type` variable as well as typed metric configuration for `Gauge`, `Info` and `StateSet` metrics, which aligns its naming from the [OpenMetrics specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md).

The `type` variable aligns with the recommendations of the sig-api-machinery regarding the [discriminator field](
https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/1027-api-unions/README.md).

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

Does not change cardinality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1755
Fixes #1762

Example configuration:
```yaml
kind: CustomResourceStateMetrics
spec: 
  resources: 
    - subsystem: machinedeployment
      namespace: capi
      groupVersionKind: 
        group: cluster.x-k8s.io
        kind: MachineDeployment
        version: v1beta1
      metrics:
        # a gauge per metric
        - name: status_conditions
          each: 
            type: Gauge
            gauge:
              path: 
                - status
                - conditions
              valueFrom:
                - status
              labelFromKey: reason
              labelsFromPath:
                type: [type]
        # a gauge metric
        - name: spec_replicas
          each: 
            type: Gauge
            gauge:
              path: 
                - spec
                - replicas
        # a info metric
        - name: info
          each: 
            type: Info
            info:
              labelsFromPath:
                version: [spec, template, spec, version]
        # a stateSet metric
        - name: phase
          each: 
            type: StateSet
            stateSet:
              path:
              - status
              - phase
              list:
              - Running
              - ScalingUp
              labelName: phase
```

Example resulting metrics:

```
# HELP capi_machinedeployment_status_conditions
# TYPE capi_machinedeployment_status_conditions gauge
capi_machinedeployment_status_conditions{type="Available"} 1
capi_machinedeployment_status_conditions{type="Ready"} 1
# HELP capi_machinedeployment_spec_replicas
# TYPE capi_machinedeployment_spec_replicas gauge
capi_machinedeployment_spec_replicas 3
# HELP capi_machinedeployment_info
# TYPE capi_machinedeployment_info gauge
capi_machinedeployment_info{version="v1.23.3"} 1
# HELP capi_machinedeployment_phase
# TYPE capi_machinedeployment_phase gauge
capi_machinedeployment_phase{phase="Running"} 1
capi_machinedeployment_phase{phase="ScalingUp"} 0
```

Example object

<details>

```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: MachineDeployment
metadata:
  annotations:
    machinedeployment.clusters.x-k8s.io/revision: "1"
  creationTimestamp: "2022-07-01T15:53:43Z"
  generation: 1
  labels:
    cluster.x-k8s.io/cluster-name: capi-quickstart
    topology.cluster.x-k8s.io/deployment-name: md-0
    topology.cluster.x-k8s.io/owned: ""
  name: capi-quickstart-md-0-ttbq9
  namespace: default
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta1
    kind: Cluster
    name: capi-quickstart
    uid: f6edeaf4-3dfd-4454-86f1-ee47b5d4ff94
  resourceVersion: "372237"
  uid: fb42cf9b-ecb7-4484-b81c-6d945bb2dc00
spec:
  clusterName: capi-quickstart
  minReadySeconds: 0
  progressDeadlineSeconds: 600
  replicas: 3
  revisionHistoryLimit: 1
  selector:
    matchLabels:
      cluster.x-k8s.io/cluster-name: capi-quickstart
      topology.cluster.x-k8s.io/deployment-name: md-0
      topology.cluster.x-k8s.io/owned: ""
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 0
    type: RollingUpdate
  template:
    metadata:
      labels:
        cluster.x-k8s.io/cluster-name: capi-quickstart
        topology.cluster.x-k8s.io/deployment-name: md-0
        topology.cluster.x-k8s.io/owned: ""
    spec:
      bootstrap:
        configRef:
          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
          kind: KubeadmConfigTemplate
          name: capi-quickstart-md-0-bootstrap-7tv7j
          namespace: default
      clusterName: capi-quickstart
      infrastructureRef:
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
        kind: DockerMachineTemplate
        name: capi-quickstart-md-0-infra-tqqbt
        namespace: default
      version: v1.23.3
status:
  availableReplicas: 3
  conditions:
  - lastTransitionTime: "2022-07-04T06:44:42Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2022-07-04T06:44:42Z"
    status: "True"
    type: Available
  observedGeneration: 1
  phase: Running
  readyReplicas: 3
  replicas: 3
  selector: cluster.x-k8s.io/cluster-name=capi-quickstart,topology.cluster.x-k8s.io/deployment-name=md-0,topology.cluster.x-k8s.io/owned=
  unavailableReplicas: 0
  updatedReplicas: 3
```


</details>