### PR TITLE
[FEAT] expose current metric values

### DIFF
--- a/docs/horizontalpodautoscaler-metrics.md
+++ b/docs/horizontalpodautoscaler-metrics.md
@@ -12,3 +12,4 @@
 | kube_horizontalpodautoscaler_status_condition         | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `condition`=&lt;hpa-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_horizontalpodautoscaler_status_current_replicas  | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
 | kube_horizontalpodautoscaler_status_desired_replicas  | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; | STABLE |
+| kube_horizontalpodautoscaler_status_current_metric    | Gauge       | `horizontalpodautoscaler`=&lt;hpa-name&gt; <br> `namespace`=&lt;hpa-namespace&gt; <br> `metric_name`=&lt;metric-name&gt; <br> `metric_target_type`=&lt;metric-target-type&gt;  | EXPERIMENTAL |

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -45,6 +45,7 @@ func TestHPAStore(t *testing.T) {
 		# HELP kube_horizontalpodautoscaler_status_condition The condition of this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_current_replicas Current number of replicas of pods managed by this autoscaler.
 		# HELP kube_horizontalpodautoscaler_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
+		# HELP kube_horizontalpodautoscaler_status_current_metric The current value of the metric defined in the spec.
 		# TYPE kube_horizontalpodautoscaler_info gauge
 		# TYPE kube_horizontalpodautoscaler_annotations gauge
 		# TYPE kube_horizontalpodautoscaler_labels gauge
@@ -55,6 +56,7 @@ func TestHPAStore(t *testing.T) {
 		# TYPE kube_horizontalpodautoscaler_status_condition gauge
 		# TYPE kube_horizontalpodautoscaler_status_current_replicas gauge
 		# TYPE kube_horizontalpodautoscaler_status_desired_replicas gauge
+		# TYPE kube_horizontalpodautoscaler_status_current_metric gauge
 	`
 	cases := []generateMetricsTestCase{
 		{
@@ -218,6 +220,10 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa1",namespace="ns1",status="unknown"} 0
 				kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
 				kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.007
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 0
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 2.6335914666e+07
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 0
 			`,
 			MetricNames: []string{
 				"kube_horizontalpodautoscaler_info",
@@ -230,6 +236,7 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_status_condition",
 				"kube_horizontalpodautoscaler_annotations",
 				"kube_horizontalpodautoscaler_labels",
+				"kube_horizontalpodautoscaler_status_current_metric",
 			},
 		},
 		{
@@ -373,6 +380,13 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_status_condition{condition="AbleToScale",horizontalpodautoscaler="hpa2",namespace="ns1",status="unknown"} 0
 				kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
 				kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.062
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 6
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="average",namespace="ns1"} 8.47775744e+08
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 28
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 0
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="average",namespace="ns1"} 2.9
+				kube_horizontalpodautoscaler_status_current_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 0
 			`,
 			MetricNames: []string{
 				"kube_horizontalpodautoscaler_info",
@@ -385,6 +399,7 @@ func TestHPAStore(t *testing.T) {
 				"kube_horizontalpodautoscaler_status_condition",
 				"kube_horizontalpodautoscaler_annotation",
 				"kube_horizontalpodautoscaler_labels",
+				"kube_horizontalpodautoscaler_status_current_metric",
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR exports the current values of the metrics. We already have the spec target values exported. Together with this PR, the user will be able to have complete information on current vs target more easily.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Increase metric count, cardinality remains equal to spec_target.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
