### PR TITLE
fixed a small typo 'ready' should be 'active'

### DIFF
--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -126,8 +126,8 @@ spec:
       labelsFromPath:
         name: [metadata, name]
       metrics:
-        - name: "ready_count"
-          help: "Number Foo Bars ready"
+        - name: "active_count"
+          help: "Number Foo Bars active"
           each:
             # targeting an object or array will produce a metric for each element
             # labelsFromPath and value are relative to this path


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes a typo in the documentation - `ready` should be replaced with`active`.
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
does not change cardinality
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
