### PR TITLE
Do not expose info metric for nil objects

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -269,6 +269,9 @@ func (c *compiledInfo) Values(v interface{}) (result []eachValue, errs []error) 
 }
 
 func (c *compiledInfo) values(v interface{}) (result []eachValue, err []error) {
+	if v == nil {
+		return
+	}
 	value := eachValue{Value: 1, Labels: map[string]string{}}
 	addPathLabels(v, c.labelFromPath, value.Labels)
 	result = append(result, value)

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -209,6 +209,11 @@ func Test_values(t *testing.T) {
 		}, wantResult: []eachValue{
 			newEachValue(t, 1, "version", "v0.0.0"),
 		}},
+		{name: "info nil path", each: &compiledInfo{
+			compiledCommon{
+				path: mustCompilePath(t, "does", "not", "exist"),
+			},
+		}, wantResult: nil},
 		{name: "stateset", each: &compiledStateSet{
 			compiledCommon: compiledCommon{
 				path: mustCompilePath(t, "status", "phase"),


### PR DESCRIPTION
**What this PR does / why we need it**:

Small follow-up to #1777 .

The current code exposes info metrics independent of the value of the object referenced by `path`.
With this change, it won't expose an info metric, if the object's value at `path` is nil. If `path` is not set, it will always expose a metric because we at least have metadata at the object.

**Use case is the following:**

In Cluster API there is an annotation which is used to pause objects (`cluster.x-k8s.io/paused`). The value of the annotation could be the empty string.

A use case is to have a metric to see if objects are paused (`cluster.x-k8s.io/paused` label exists, independent of the value, which includes the empty string `""` as value).

So the challenge here is to determine if the label exists or not.
Currently we could expose the label as label on the metric, but the empty string would be semantically equal to the label not being set at all when querying using prometheus.

An example:

Consider the following objects:
```
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  name: paused-1
  labels:
    cluster.x-k8s.io/paused: ""
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  name: paused-2
  labels:
    cluster.x-k8s.io/paused: "foo"
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  name: not-paused
  labels: {}
```

And the following CR configuration:
```yaml
kind: CustomResourceStateMetrics
spec:
  resources:
  - groupVersionKind:
      group: cluster.x-k8s.io
      kind: Cluster
      version: v1beta1
    metricNamePrefix: capi_cluster
    labelsFromPath:
      name: [metadata, name]
      namespace: [metadata, namespace]
      uid: [metadata, uid]
    metrics:
    - each:
        info:
          path:
          - metadata
          - annotations
          - cluster.x-k8s.io/paused
          labelsFromPath:
            value: []
        type: Info
      name: annotation_paused
```

**Without** this change, the created metrics would be as follows (I removed the `namespace` and `uid` labels):

```
capi_cluster_annotation_paused{name="paused-1",value=""} 1
capi_cluster_annotation_paused{name="paused-2",value="foo"} 1
capi_cluster_annotation_paused{name="not-paused"} 1
```

PromQL queries will result in the following, which makes it impossible to see if `paused-1` is really paused:
```
capi_cluster_annotation_paused{name="paused-1"} 1
capi_cluster_annotation_paused{name="paused-2",value="foo"} 1
capi_cluster_annotation_paused{name="not-paused"} 1
```

**With** this change, the created metrics wqould be as follows (again, I removed the `namespace` and `uid` labels):

```
capi_cluster_annotation_paused{name="paused-1",value=""} 1
capi_cluster_annotation_paused{name="paused-2",value="foo"} 1
```


**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

May decrease number of metrics for CR configured Info metrics which define a path.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
