### PR TITLE
Prevent definition of same gvk in custom resource configuration

### DIFF
--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -9,12 +9,14 @@ A YAML configuration file described below is required to define your custom reso
 
 Two flags can be used:
 
- * `--custom-resource-state-config "inline yaml (see example)"` or
- * `--custom-resource-state-config-file /path/to/config.yaml`
+* `--custom-resource-state-config "inline yaml (see example)"` or
+* `--custom-resource-state-config-file /path/to/config.yaml`
 
 If both flags are provided, the inline configuration will take precedence.
+When multiple entries for the same resource exist, kube-state-metrics will exit with an error.
+This includes configuration which refers to a different API version.
 
-In addition to specifying one of `--custom-resource-state-config*` flags, you should also add the custom resource *Kind*s in plural form to the list of exposed resources in the `--resources` flag. If you don't specify `--resources`, then all known custom resources configured in `--custom-resource-state-config-*` and all available default kubernetes objects will be taken into account by kube-state-metrics.
+In addition to specifying one of `--custom-resource-state-config*` flags, you should also add the custom resource *Kind*s in plural form to the list of exposed resources in the `--resources` flag. If you don't specify `--resources`, then all known custom resources configured in `--custom-resource-state-config*` and all available default kubernetes objects will be taken into account by kube-state-metrics.
 
 ```yaml
 apiVersion: apps/v1


### PR DESCRIPTION
I hope it is okay that I directly created a PR for this. I can also create an issue for that first if this is preferred 👍 

**What this PR does / why we need it**:

This PR adjusts the options for custom resource configuration to allow defining them multiple times.
This allows to split potentially large configurations to multiple files.

It also adds validation to detect if the configuration includes multiple definitions for the same resource name.
This prevents the following unexpected behaviour:

Configuration:
```yaml
kind: CustomResourceStateMetrics
spec:
  resources:
  - groupVersionKind:
      group: cluster.x-k8s.io
      kind: Cluster
      version: v1beta1
    metrics:
    - each:
        info: {}
        type: Info
      name: foo
  - groupVersionKind:
      group: cluster.x-k8s.io
      kind: Cluster
      version: v1beta1
    metrics:
    - each:
        info: {}
        type: Info
      name: bar
```

Expected result:
* either return an error and fail to start (like proposed in the PR)
* or the following metrics:
    ```
    # HELP kube_cluster_x_k8s_io_v1beta1_Cluster_bar
    # TYPE kube_cluster_x_k8s_io_v1beta1_Cluster_bar gauge
    kube_cluster_x_k8s_io_v1beta1_Cluster_bar 1
    kube_cluster_x_k8s_io_v1beta1_Cluster_bar 1
    # HELP kube_cluster_x_k8s_io_v1beta1_Cluster_foo
    # TYPE kube_cluster_x_k8s_io_v1beta1_Cluster_foo gauge
    kube_cluster_x_k8s_io_v1beta1_Cluster_foo 1
    kube_cluster_x_k8s_io_v1beta1_Cluster_foo 1
    ```

Actual result metrics:

```
# HELP kube_cluster_x_k8s_io_v1beta1_Cluster_bar
# TYPE kube_cluster_x_k8s_io_v1beta1_Cluster_bar gauge
kube_cluster_x_k8s_io_v1beta1_Cluster_bar 1
kube_cluster_x_k8s_io_v1beta1_Cluster_bar 1
# HELP kube_cluster_x_k8s_io_v1beta1_Cluster_bar
# TYPE kube_cluster_x_k8s_io_v1beta1_Cluster_bar gauge
kube_cluster_x_k8s_io_v1beta1_Cluster_bar 1
kube_cluster_x_k8s_io_v1beta1_Cluster_bar 1
```


**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

No changes to cardinality

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
