### PR TITLE
introduce custom-resources-only flag ...

### DIFF
--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -30,6 +30,7 @@ Usage of ./kube-state-metrics:
       --apiserver string                           The URL of the apiserver to use as a master
       --custom-resource-state-config string        Inline Custom Resource State Metrics config YAML (experimental)
       --custom-resource-state-config-file string   Path to a Custom Resource State Metrics config file (experimental)
+      --custom-resource-state-only                 Only provide Custom Resource State metrics (experimental)
       --enable-gzip-encoding                       Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.
   -h, --help                                       Print Help text
       --host string                                Host to expose metrics on. (default "::")

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -88,14 +88,21 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options, factories .
 	storeBuilder.WithMetrics(ksmMetricsRegistry)
 
 	var resources []string
-	if len(opts.Resources) == 0 {
+	switch {
+	case len(opts.Resources) == 0 && !opts.CustomResourcesOnly:
 		klog.InfoS("Used default resources")
 		resources = options.DefaultResources.AsSlice()
 		// enable custom resource
 		for _, factory := range factories {
 			resources = append(resources, factory.Name())
 		}
-	} else {
+	case opts.CustomResourcesOnly:
+		// enable custom resource only
+		for _, factory := range factories {
+			resources = append(resources, factory.Name())
+		}
+		klog.InfoS("Used CRD resources only", "resources", resources)
+	default:
 		klog.InfoS("Used resources", "resources", opts.Resources.String())
 		resources = opts.Resources.AsSlice()
 	}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -56,6 +56,7 @@ type Options struct {
 
 	CustomResourceConfig     string
 	CustomResourceConfigFile string
+	CustomResourcesOnly      bool
 
 	flags *pflag.FlagSet
 }
@@ -120,6 +121,7 @@ func (o *Options) AddFlags() {
 
 	o.flags.StringVar(&o.CustomResourceConfig, "custom-resource-state-config", "", "Inline Custom Resource State Metrics config YAML (experimental)")
 	o.flags.StringVar(&o.CustomResourceConfigFile, "custom-resource-state-config-file", "", "Path to a Custom Resource State Metrics config file (experimental)")
+	o.flags.BoolVar(&o.CustomResourcesOnly, "custom-resource-state-only", false, "Only provide Custom Resource State metrics (experimental)")
 }
 
 // Parse parses the flag definitions from the argument list.


### PR DESCRIPTION
... to only monitor all known custom-resource configurations instead of
listing each of them explicitly

Signed-off-by: Mario Constanti <mario@constanti.de>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1778
