### PR TITLE
Validate metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,4 +214,4 @@ jobs:
 
     - name: End-to-end tests
       run: |
-        make e2e
+        CHECK_METRICS=true make e2e

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ _testmain.go
 *.iml
 .idea/
 
-# Generated CLI help file
+# Generated artefacts
+promtool
 help.txt
 
 # jsonnet dependency management

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,9 @@ clean:
 	git clean -Xfd .
 
 e2e:
+	@if [ -n "${CHECK_METRICS}" ]; then \
+		$(MAKE) install-promtool; \
+	fi
 	./tests/e2e.sh
 
 generate: build-local

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -162,6 +162,10 @@ mkdir -p ${KUBE_STATE_METRICS_LOG_DIR}
 # TODO: re-implement the following test cases in Go with the goal of removing this file.
 echo "access kube-state-metrics metrics endpoint"
 curl -s "http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy/metrics" >${KUBE_STATE_METRICS_LOG_DIR}/metrics
+if [[ -n "${CHECK_METRICS}" ]]; then
+ echo "validating metrics in ${KUBE_STATE_METRICS_LOG_DIR}/metrics"
+ ./promtool check metrics --extended <${KUBE_STATE_METRICS_LOG_DIR}/metrics
+fi
 
 KUBE_STATE_METRICS_STATUS=$(curl -s "http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy/healthz")
 if [[ "${KUBE_STATE_METRICS_STATUS}" == "OK" ]]; then


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Validate metrics that are served over the metrics endpoint using promtool in the e2e test flow.

**How does this change affect the cardinality of KSM**: No change.

**Which issue(s) this PR fixes**: Fixes #1793 
