### PR TITLE
add ContainerResourceSourceType for hpa metrics

### DIFF
--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -131,46 +131,39 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				ms := make([]*metric.Metric, 0, len(a.Spec.Metrics))
 				for _, m := range a.Spec.Metrics {
 					var metricName string
-
+					var metricTarget autoscaling.MetricTarget
 					// The variable maps the type of metric to the corresponding value
 					metricMap := make(map[metricTargetType]float64)
 
 					switch m.Type {
 					case autoscaling.ObjectMetricSourceType:
 						metricName = m.Object.Metric.Name
-
-						if m.Object.Target.Value != nil {
-							metricMap[value] = float64(m.Object.Target.Value.MilliValue()) / 1000
-						}
-						if m.Object.Target.AverageValue != nil {
-							metricMap[average] = float64(m.Object.Target.AverageValue.MilliValue()) / 1000
-						}
+						metricTarget = m.Object.Target
 					case autoscaling.PodsMetricSourceType:
 						metricName = m.Pods.Metric.Name
-
-						metricMap[average] = float64(m.Pods.Target.AverageValue.MilliValue()) / 1000
+						metricTarget = m.Pods.Target
 					case autoscaling.ResourceMetricSourceType:
 						metricName = string(m.Resource.Name)
-
-						if m.Resource.Target.AverageUtilization != nil {
-							metricMap[utilization] = float64(*m.Resource.Target.AverageUtilization)
-						}
-
-						if m.Resource.Target.AverageValue != nil {
-							metricMap[average] = float64(m.Resource.Target.AverageValue.MilliValue()) / 1000
-						}
+						metricTarget = m.Resource.Target
+					case autoscaling.ContainerResourceMetricSourceType:
+						metricName = string(m.ContainerResource.Name)
+						metricTarget = m.ContainerResource.Target
 					case autoscaling.ExternalMetricSourceType:
 						metricName = m.External.Metric.Name
-
-						if m.External.Target.Value != nil {
-							metricMap[value] = float64(m.External.Target.Value.MilliValue()) / 1000
-						}
-						if m.External.Target.AverageValue != nil {
-							metricMap[average] = float64(m.External.Target.AverageValue.MilliValue()) / 1000
-						}
+						metricTarget = m.External.Target
 					default:
 						// Skip unsupported metric type
 						continue
+					}
+
+					if metricTarget.Value != nil {
+						metricMap[value] = float64(metricTarget.Value.MilliValue()) / 1000
+					}
+					if metricTarget.AverageValue != nil {
+						metricMap[average] = float64(metricTarget.AverageValue.MilliValue()) / 1000
+					}
+					if metricTarget.AverageUtilization != nil {
+						metricMap[utilization] = float64(*metricTarget.AverageUtilization)
 					}
 
 					for metricTypeIndex, metricValue := range metricMap {
@@ -193,46 +186,39 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
 				for _, m := range a.Status.CurrentMetrics {
 					var metricName string
-
+					var currentMetric autoscaling.MetricValueStatus
 					// The variable maps the type of metric to the corresponding value
 					metricMap := make(map[metricTargetType]float64)
 
 					switch m.Type {
 					case autoscaling.ObjectMetricSourceType:
 						metricName = m.Object.Metric.Name
-
-						if m.Object.Current.Value != nil {
-							metricMap[value] = float64(m.Object.Current.Value.MilliValue()) / 1000
-						}
-						if m.Object.Current.AverageValue != nil {
-							metricMap[average] = float64(m.Object.Current.AverageValue.MilliValue()) / 1000
-						}
+						currentMetric = m.Object.Current
 					case autoscaling.PodsMetricSourceType:
 						metricName = m.Pods.Metric.Name
-
-						metricMap[average] = float64(m.Pods.Current.AverageValue.MilliValue()) / 1000
+						currentMetric = m.Pods.Current
 					case autoscaling.ResourceMetricSourceType:
 						metricName = string(m.Resource.Name)
-
-						if m.Resource.Current.AverageUtilization != nil {
-							metricMap[utilization] = float64(*m.Resource.Current.AverageUtilization)
-						}
-
-						if m.Resource.Current.AverageValue != nil {
-							metricMap[average] = float64(m.Resource.Current.AverageValue.MilliValue()) / 1000
-						}
+						currentMetric = m.Resource.Current
+					case autoscaling.ContainerResourceMetricSourceType:
+						metricName = string(m.ContainerResource.Name)
+						currentMetric = m.ContainerResource.Current
 					case autoscaling.ExternalMetricSourceType:
 						metricName = m.External.Metric.Name
-
-						if m.External.Current.Value != nil {
-							metricMap[value] = float64(m.External.Current.Value.MilliValue()) / 1000
-						}
-						if m.External.Current.AverageValue != nil {
-							metricMap[average] = float64(m.External.Current.AverageValue.MilliValue()) / 1000
-						}
+						currentMetric = m.External.Current
 					default:
 						// Skip unsupported metric type
 						continue
+					}
+
+					if currentMetric.Value != nil {
+						metricMap[value] = float64(currentMetric.Value.MilliValue()) / 1000
+					}
+					if currentMetric.AverageValue != nil {
+						metricMap[average] = float64(currentMetric.AverageValue.MilliValue()) / 1000
+					}
+					if currentMetric.AverageUtilization != nil {
+						metricMap[utilization] = float64(*currentMetric.AverageUtilization)
 					}
 
 					for metricTypeIndex, metricValue := range metricMap {

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -128,6 +128,16 @@ func TestHPAStore(t *testing.T) {
 								},
 							},
 						},
+						{
+							Type: autoscaling.ContainerResourceMetricSourceType,
+							ContainerResource: &autoscaling.ContainerResourceMetricSource{
+								Name:      "cpu",
+								Container: "container1",
+								Target: autoscaling.MetricTarget{
+									AverageUtilization: int32ptr(80),
+								},
+							},
+						},
 						// No targets, this metric should be ignored
 						{
 							Type: autoscaling.ResourceMetricSourceType,
@@ -211,6 +221,7 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="hits",metric_target_type="value",namespace="ns1"} 10
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="connections",metric_target_type="average",namespace="ns1"} 0.7
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="connections",metric_target_type="value",namespace="ns1"} 0.5
+				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 80
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="average",namespace="ns1"} 819200
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 80
 				kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="hpa1",metric_name="sqs_jobs",metric_target_type="value",namespace="ns1"} 30
@@ -339,6 +350,17 @@ func TestHPAStore(t *testing.T) {
 							},
 						},
 						{
+							Type: "ContainerResource",
+							ContainerResource: &autoscaling.ContainerResourceMetricStatus{
+								Name:      "cpu",
+								Container: "container1",
+								Current: autoscaling.MetricValueStatus{
+									AverageValue:       resourcePtr(resource.MustParse("80m")),
+									AverageUtilization: int32ptr(10),
+								},
+							},
+						},
+						{
 							Type: "External",
 							External: &autoscaling.ExternalMetricStatus{
 								Metric: autoscaling.MetricIdentifier{
@@ -379,6 +401,8 @@ func TestHPAStore(t *testing.T) {
 				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="memory",metric_target_type="utilization",namespace="ns1"} 28
 				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.062
 				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 6
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="average",namespace="ns1"} 0.08
+				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="cpu",metric_target_type="utilization",namespace="ns1"} 10
 				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="value",namespace="ns1"} 0
 				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_requests_per_second",metric_target_type="average",namespace="ns1"} 2.9
 				kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="hpa2",metric_name="traefik_backend_errors_per_second",metric_target_type="value",namespace="ns1"} 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
kubernetes hpa support ContainerResourceSourceType(https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics) since v1.20, but there is no metrics about it in the kube-state-metrics.
The PR add ContainerResourceSourceType for hpa metrics kube_horizontalpodautoscaler_spec_target_metric and kube_horizontalpodautoscaler_status_target_metric.
Then decrease cyclomatic complexity by reusing metricTarget objects, so as to pass golint-ci.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Increases cardinality.  Add metrics for ContainerResourceSourceType hpa.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
