### PR TITLE
Incorporate Cobra

### DIFF
--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -24,7 +24,18 @@ spec:
 [embedmd]:# (../help.txt)
 ```txt
 $ kube-state-metrics -h
-Usage of ./kube-state-metrics:
+kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
+
+Usage:
+  kube-state-metrics [flags]
+  kube-state-metrics [command]
+
+Available Commands:
+  completion  Generate completion script for kube-state-metrics.
+  help        Help about any command
+  version     Print version information.
+
+Flags:
       --add_dir_header                             If true, adds the file directory to the header of the log messages
       --alsologtostderr                            log to standard error as well as files (no effect when -logtostderr=true)
       --apiserver string                           The URL of the apiserver to use as a master
@@ -65,4 +76,6 @@ Usage of ./kube-state-metrics:
   -v, --v Level                                    number for the log level verbosity
       --version                                    kube-state-metrics build version information
       --vmodule moduleSpec                         comma-separated list of pattern=N settings for file-filtered logging
+
+Use "kube-state-metrics [command] --help" for more information about a command.
 ```

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/prometheus/common v0.37.0
 	github.com/prometheus/exporter-toolkit v0.8.1
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/perf v0.0.0-20220920022801-e8d778a60d07
 	gopkg.in/yaml.v3 v3.0.1
@@ -62,6 +62,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/safehtml v0.0.2 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -76,6 +77,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a // indirect
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,7 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/coreos/go-systemd/v22 v22.4.0 h1:y9YHcjnjynCd/DVbg5j9L/33jQM3MxJlbj/zWskzfGU=
 github.com/coreos/go-systemd/v22 v22.4.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -275,6 +276,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
@@ -383,6 +386,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
@@ -391,6 +395,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=

--- a/pkg/options/autoload.go
+++ b/pkg/options/autoload.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2022 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+const autoloadZsh = `Generate the autocompletion script for the zsh shell.
+
+If shell completion is not already enabled in your environment you will need
+to enable it.  You can execute the following once:
+
+        echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To load completions in your current shell session:
+
+        source <(kube-state-metrics completion zsh); compdef _kube-state-metrics kube-state-metrics
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+        kube-state-metrics completion zsh > "${fpath[1]}/_kube-state-metrics"
+
+#### macOS:
+
+        kube-state-metrics completion zsh > $(brew --prefix)/share/zsh/site-functions/_kube-state-metrics
+
+You will need to start a new shell for this setup to take effect.
+
+Usage:
+  kube-state-metrics completion zsh [flags]
+
+Flags:
+  --no-descriptions   disable completion descriptions
+`
+const autoloadBash = `Generate the autocompletion script for the bash shell.
+
+This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.
+
+To load completions in your current shell session:
+
+        source <(kube-state-metrics completion bash)
+
+To load completions for every new session, execute once:
+
+#### Linux:
+
+        kube-state-metrics completion bash > /etc/bash_completion.d/kube-state-metrics
+
+#### macOS:
+
+        kube-state-metrics completion bash > $(brew --prefix)/etc/bash_completion.d/kube-state-metrics
+
+You will need to start a new shell for this setup to take effect.
+
+Usage:
+  kube-state-metrics completion bash
+
+Flags:
+  --no-descriptions   disable completion descriptions
+`
+
+const autoloadFish = `Generate the autocompletion script for the fish shell.
+
+To load completions in your current shell session:
+
+        kube-state-metrics completion fish | source
+
+To load completions for every new session, execute once:
+
+        kube-state-metrics completion fish > ~/.config/fish/completions/kube-state-metrics.fish
+
+You will need to start a new shell for this setup to take effect.
+
+Usage:
+  kube-state-metrics completion fish [flags]
+
+Flags:
+  --no-descriptions   disable completion descriptions
+`
+
+// FetchLoadInstructions returns instructions for enabling autocompletion for a particular shell.
+func FetchLoadInstructions(shell string) string {
+	switch shell {
+	case "zsh":
+		return autoloadZsh
+	case "bash":
+		return autoloadBash
+	case "fish":
+		return autoloadFish
+	default:
+		return ""
+	}
+}
+
+var completionCommand = &cobra.Command{
+	Use:                   "completion [bash|zsh|fish]",
+	Short:                 "Generate completion script for kube-state-metrics.",
+	DisableFlagsInUseLine: true,
+	Aliases:               []string{"comp", "c"},
+	ValidArgs:             []string{"bash", "zsh", "fish"},
+	Args:                  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			_ = cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			_ = cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			_ = cmd.Root().GenFishCompletion(os.Stdout, true)
+		}
+		klog.FlushAndExit(klog.ExitFlushTimeout, 0)
+	},
+	Example: "kube-state-metrics completion bash > /tmp/kube-state-metrics.bash && source /tmp/kube-state-metrics.bash # for shells compatible with bash",
+}
+
+// InitCommand defines the root command that others will latch onto.
+var InitCommand = &cobra.Command{
+	Use:   "kube-state-metrics",
+	Short: "Add-on agent to generate and expose cluster-level metrics.",
+	Long:  "kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.",
+	Args:  cobra.NoArgs,
+}

--- a/scripts/generate-help-text.sh
+++ b/scripts/generate-help-text.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 echo "$ kube-state-metrics -h" > help.txt
-./kube-state-metrics -h 2>> help.txt
+./kube-state-metrics -h >> help.txt
 exit 0


### PR DESCRIPTION
s/pflags/cobra/g:
* Use spf13/cobra to handle all flags and sub-commands.
* Remove all spf13/pflag usage, and fallback to the in-build flag package if, and when needed.
* Add completion support.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**How does this change affect the cardinality of KSM**: No change.

**Which issue(s) this PR fixes**: Partially targets #1791 (intentially leaving out the `fixes` keyword here, since this issue to targeted by multiple PRs: https://github.com/kubernetes/kube-state-metrics/issues/1791#issuecomment-1247326376).
