### PR TITLE
Deprecate VPA

### DIFF
--- a/docs/verticalpodautoscaler-metrics.md
+++ b/docs/verticalpodautoscaler-metrics.md
@@ -1,16 +1,53 @@
 # Vertical Pod Autoscaler Metrics
 
-| Metric name                                                                | Metric type | Labels/tags                                                                                                                                                                                                                                                | Status                                                                                                                                                      |
-| --------------------------------                                           | ----------- | -------------------------------------------------------------                                                                                                                                                                                              | ------                                                                                                                                                      |
-| kube_verticalpodautoscaler_annotations                                          | Gauge       | `annotation_app`=&lt;foo&gt; <br> `namespace`=&lt;namespace&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;   | EXPERIMENTAL                                                                                                                                                |
-| kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed                   | Gauge       | `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;                | EXPERIMENTAL |
-| kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed                   | Gauge       | `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;                | EXPERIMENTAL |
-| kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound     | Gauge       | `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;                | EXPERIMENTAL |
-| kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target          | Gauge       | `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;                | EXPERIMENTAL |
-| kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget | Gauge       | `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;                | EXPERIMENTAL |
-| kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound     | Gauge       | `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;                | EXPERIMENTAL |
-| kube_verticalpodautoscaler_labels                                          | Gauge       | `label_app`=&lt;foo&gt; <br> `namespace`=&lt;namespace&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;   | EXPERIMENTAL                                                                                                                                                |
-| kube_verticalpodautoscaler_spec_updatepolicy_updatemode                                     | Gauge       | `namespace`=&lt;namespace&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `update_mode`=&lt;foo&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt; | EXPERIMENTAL                                                                                                                                                |
+## DEPRECATION NOTICE
+
+From v2.9.0 onwards, `vericalpodautoscalers` will be removed from the list of default resources. This means that specifying that in the `--resource` flag will **not** generate metrics for the same. In order to generate `verticalpodautoscalers` metrics, you will have to explicitly specify it in `--custom-resource-state-config*` (either the inline yaml, or the configuration file), like so:
+```yaml
+# Using --resource=verticalpodautoscalers, we get the following output:
+# HELP kube_verticalpodautoscaler_annotations (Deprecated since v2.9.0) Kubernetes annotations converted to Prometheus labels.
+# TYPE kube_verticalpodautoscaler_annotations gauge
+# kube_verticalpodautoscaler_annotations{namespace="default",verticalpodautoscaler="hamster-vpa",target_api_version="apps/v1",target_kind="Deployment",target_name="hamster"} 1
+# A similar result can be achieved by specifying the following in --custom-resource-state-config:
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: autoscaling.k8s.io
+        kind: "VerticalPodAutoscaler"
+        version: "v1"
+      labelsFromPath:
+        verticalpodautoscaler: [metadata, name]
+        namespace: [metadata, namespace]
+        target_api_version: [apiVersion]
+        target_kind: [spec, targetRef, kind]
+        target_name: [spec, targetRef, name]
+      metrics:
+        - name: "annotations"
+          help: "Kubernetes annotations converted to Prometheus labels."
+          each:
+            type: Gauge
+            gauge:
+              path: [metadata, annotations]
+# This will output the following metric:
+# HELP kube_crd_autoscaling_k8s_io_v1_VerticalPodAutoscaler_annotations Kubernetes annotations converted to Prometheus labels.
+# TYPE kube_crd_autoscaling_k8s_io_v1_VerticalPodAutoscaler_annotations gauge
+# kube_crd_autoscaling_k8s_io_v1_VerticalPodAutoscaler_annotations{namespace="default",target_api_version="autoscaling.k8s.io/v1",target_kind="Deployment",target_name="hamster",verticalpodautoscaler="hamster-vpa"} 123
+```
+PS. The above configuration was tested on [this](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/examples/hamster.yaml) VPA configuration, with an added annotation (`foo: 123`).
+***
+
+| Metric name                                                                               |  Metric type  |  Labels/tags                                                                                                                                                                                                                                                                                                                           |  Status     |
+| --------------------------------                                                          |  -----------  |  -------------------------------------------------------------                                                                                                                                                                                                                                                                         |  ------     |
+| kube_verticalpodautoscaler_annotations                                                    |  Gauge        |  `annotation_app`=&lt;foo&gt; <br> `namespace`=&lt;namespace&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;                                                                         |  DEPRECATED |
+| kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed              |  Gauge        |  `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;  |  DEPRECATED |
+| kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed              |  Gauge        |  `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;  |  DEPRECATED |
+| kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound      |  Gauge        |  `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;  |  DEPRECATED |
+| kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target          |  Gauge        |  `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;  |  DEPRECATED |
+| kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget  |  Gauge        |  `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;  |  DEPRECATED |
+| kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound      |  Gauge        |  `container`=&lt;container name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;cpu memory&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `unit`=&lt;core byte&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;  |  DEPRECATED |
+| kube_verticalpodautoscaler_labels                                                         |  Gauge        |  `label_app`=&lt;foo&gt; <br> `namespace`=&lt;namespace&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;                                                                              |  DEPRECATED |
+| kube_verticalpodautoscaler_spec_updatepolicy_updatemode                                   |  Gauge        |  `namespace`=&lt;namespace&gt; <br> `target_api_version`=&lt;api version&gt; <br> `target_kind`=&lt;target kind&gt; <br> `target_name`=&lt;target name&gt; <br> `update_mode`=&lt;foo&gt; <br> `verticalpodautoscaler`=&lt;vertical pod autoscaler name&gt;                                                                            |  DEPRECATED |
 
 ## Configuration
 

--- a/internal/store/verticalpodautoscaler.go
+++ b/internal/store/verticalpodautoscaler.go
@@ -48,7 +48,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			descVerticalPodAutoscalerAnnotationsName,
 			descVerticalPodAutoscalerAnnotationsHelp,
 			metric.Gauge,
-			"",
+			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", a.Annotations, allowAnnotationsList)
 				return &metric.Family{
@@ -66,7 +66,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			descVerticalPodAutoscalerLabelsName,
 			descVerticalPodAutoscalerLabelsHelp,
 			metric.Gauge,
-			"",
+			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", a.Labels, allowLabelsList)
 				return &metric.Family{
@@ -84,7 +84,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_spec_updatepolicy_updatemode",
 			"Update mode of the VerticalPodAutoscaler.",
 			metric.Gauge,
-			"",
+			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -122,7 +122,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed",
 			"Minimum resources the VerticalPodAutoscaler can set for containers matching the name.",
 			metric.Gauge,
-			"",
+			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Spec.ResourcePolicy == nil || a.Spec.ResourcePolicy.ContainerPolicies == nil {
@@ -144,7 +144,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed",
 			"Maximum resources the VerticalPodAutoscaler can set for containers matching the name.",
 			metric.Gauge,
-			"",
+			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Spec.ResourcePolicy == nil || a.Spec.ResourcePolicy.ContainerPolicies == nil {
@@ -165,7 +165,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound",
 			"Minimum resources the container can use before the VerticalPodAutoscaler updater evicts it.",
 			metric.Gauge,
-			"",
+			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
@@ -186,7 +186,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound",
 			"Maximum resources the container can use before the VerticalPodAutoscaler updater evicts it.",
 			metric.Gauge,
-			"",
+			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
@@ -207,7 +207,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target",
 			"Target resources the VerticalPodAutoscaler recommends for the container.",
 			metric.Gauge,
-			"",
+			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {
@@ -227,7 +227,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget",
 			"Target resources the VerticalPodAutoscaler recommends for the container ignoring bounds.",
 			metric.Gauge,
-			"",
+			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
 				if a.Status.Recommendation == nil || a.Status.Recommendation.ContainerRecommendations == nil {

--- a/internal/store/verticalpodautoscaler_test.go
+++ b/internal/store/verticalpodautoscaler_test.go
@@ -30,14 +30,14 @@ import (
 
 func TestVPAStore(t *testing.T) {
 	const metadata = `
-		# HELP kube_verticalpodautoscaler_labels Kubernetes labels converted to Prometheus labels.
-        # HELP kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed Maximum resources the VerticalPodAutoscaler can set for containers matching the name.
-        # HELP kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed Minimum resources the VerticalPodAutoscaler can set for containers matching the name.
-        # HELP kube_verticalpodautoscaler_spec_updatepolicy_updatemode Update mode of the VerticalPodAutoscaler.
-        # HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound Minimum resources the container can use before the VerticalPodAutoscaler updater evicts it.
-        # HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target Target resources the VerticalPodAutoscaler recommends for the container.
-        # HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget Target resources the VerticalPodAutoscaler recommends for the container ignoring bounds.
-        # HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound Maximum resources the container can use before the VerticalPodAutoscaler updater evicts it.
+		# HELP kube_verticalpodautoscaler_labels (Deprecated since v2.9.0) Kubernetes labels converted to Prometheus labels.
+        # HELP kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed (Deprecated since v2.9.0) Maximum resources the VerticalPodAutoscaler can set for containers matching the name.
+        # HELP kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed (Deprecated since v2.9.0) Minimum resources the VerticalPodAutoscaler can set for containers matching the name.
+        # HELP kube_verticalpodautoscaler_spec_updatepolicy_updatemode (Deprecated since v2.9.0) Update mode of the VerticalPodAutoscaler.
+        # HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound (Deprecated since v2.9.0) Minimum resources the container can use before the VerticalPodAutoscaler updater evicts it.
+        # HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target (Deprecated since v2.9.0) Target resources the VerticalPodAutoscaler recommends for the container.
+        # HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget (Deprecated since v2.9.0) Target resources the VerticalPodAutoscaler recommends for the container ignoring bounds.
+        # HELP kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound (Deprecated since v2.9.0) Maximum resources the container can use before the VerticalPodAutoscaler updater evicts it.
         # TYPE kube_verticalpodautoscaler_labels gauge
         # TYPE kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed gauge
         # TYPE kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed gauge


### PR DESCRIPTION
- [x] Deprecate VPA metrics.
- [x] Inform users about the deprecation (print a warning to `stdout`).
- [x] Document an alternative approach using the CRD capabilities we have now.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**How does this change affect the cardinality of KSM**: No change (VPA metrics will be removed in v2.9.0).

**Which issue(s) this PR fixes**: Partially targets #1718.
