### PR TITLE
[FEATURE] Add kube_*_labels for custom resources if enabled

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -181,9 +181,13 @@ func (b *Builder) WithCustomResourceStoreFactories(fs ...customresource.Registry
 			klog.InfoS("The internal resource store already exists and is overridden by a custom resource store with the same name, please make sure it meets your expectation", "registryName", f.Name())
 		}
 		availableStores[f.Name()] = func(b *Builder) []cache.Store {
+			metricFamilyGenerators := f.MetricFamilyGenerators(b.allowAnnotationsList[f.Name()], b.allowLabelsList[f.Name()])
+			if f.IsLabelsMetricEnabled() {
+				metricFamilyGenerators = append(metricFamilyGenerators, customResourceMetricFamilies(f.Name(), b.allowAnnotationsList[f.Name()], b.allowLabelsList[f.Name()])...)
+			}
 			return b.buildCustomResourceStoresFunc(
 				f.Name(),
-				f.MetricFamilyGenerators(b.allowAnnotationsList[f.Name()], b.allowLabelsList[f.Name()]),
+				metricFamilyGenerators,
 				f.ExpectedType(),
 				f.ListWatch,
 				b.useAPIServerCache,

--- a/internal/store/customresource.go
+++ b/internal/store/customresource.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors All rights reserved.
+Copyright 2022 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/store/customresource.go
+++ b/internal/store/customresource.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+)
+
+var (
+	descCustomResourceLabelsName = "kube_%s_labels"
+	descCustomResourceLabelsHelp = "Kubernetes labels converted to Prometheus labels."
+)
+
+func customResourceMetricFamilies(customResourceName string, _, allowLabelsList []string) []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
+		*generator.NewFamilyGenerator(
+			fmt.Sprintf(descCustomResourceLabelsName, customResourceName),
+			descCustomResourceLabelsHelp,
+			metric.Gauge,
+			"",
+			wrapCustomResourceFunc(func(obj metav1.Object) *metric.Family {
+				labelKeys, labelValues := createPrometheusLabelKeysValues("label", obj.GetLabels(), allowLabelsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+	}
+}
+
+func wrapCustomResourceFunc(f func(metav1.Object) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		metaObject := obj.(metav1.Object)
+
+		metricFamily := f(metaObject)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys, m.LabelValues = mergeKeyValues(m.LabelKeys, m.LabelValues)
+		}
+
+		return metricFamily
+	}
+}

--- a/internal/store/customresource_test.go
+++ b/internal/store/customresource_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+)
+
+func TestCustomResourceSetStore(t *testing.T) {
+	cases := []generateMetricsTestCase{
+		{
+			AllowLabelsList: []string{
+				"app.k8s.io/owner",
+			},
+			Obj: &v1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ds1",
+					Namespace: "ns1",
+					Labels: map[string]string{
+						"app":              "example1",
+						"app.k8s.io/owner": "@foo",
+					},
+				},
+			},
+			Want: `
+				# HELP kube_daemonset_labels Kubernetes labels converted to Prometheus labels.
+				# TYPE kube_daemonset_labels gauge
+				kube_daemonset_labels{label_app_k8s_io_owner="@foo"} 1
+`,
+			MetricNames: []string{
+				"kube_daemonset_labels",
+			},
+		},
+	}
+	for i, c := range cases {
+		c.Func = generator.ComposeMetricGenFuncs(customResourceMetricFamilies("daemonset", c.AllowAnnotationsList, c.AllowLabelsList))
+		c.Headers = generator.ExtractMetricFamilyHeaders(customResourceMetricFamilies("daemonset", c.AllowAnnotationsList, c.AllowLabelsList))
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+	}
+}

--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -81,7 +81,6 @@ func compareOutput(expected, actual string) error {
 func sortLabels(s string) string {
 	sorted := []string{}
 
-	fmt.Println(s)
 	for _, line := range strings.Split(s, "\n") {
 		// skipping if its headers
 		if strings.HasPrefix(line, "# ") {

--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -81,6 +81,7 @@ func compareOutput(expected, actual string) error {
 func sortLabels(s string) string {
 	sorted := []string{}
 
+	fmt.Println(s)
 	for _, line := range strings.Split(s, "\n") {
 		// skipping if its headers
 		if strings.HasPrefix(line, "# ") {

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -915,6 +915,10 @@ func (f *fooFactory) ExpectedType() interface{} {
 	return &samplev1alpha1.Foo{}
 }
 
+func (f *fooFactory) IsLabelsMetricEnabled() bool {
+	return true
+}
+
 func (f *fooFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
 	client := customResourceClient.(*samplefake.Clientset)
 	return &cache.ListWatch{

--- a/pkg/customresource/registry_factory.go
+++ b/pkg/customresource/registry_factory.go
@@ -95,6 +95,15 @@ type RegistryFactory interface {
 	// }
 	ExpectedType() interface{}
 
+	// IsLabelsMetricEnabled returns true if the custom resource labels must be created as a metric
+	//
+	// Example:
+	//
+	// func (f *FooFactory) IsLabelsMetricEnabled() bool {
+	//	return false
+	// }
+	IsLabelsMetricEnabled() bool
+
 	// ListWatch constructs a cache.ListerWatcher of the custom resource object.
 	//
 	// Example:

--- a/pkg/customresource/registry_factory.go
+++ b/pkg/customresource/registry_factory.go
@@ -95,7 +95,7 @@ type RegistryFactory interface {
 	// }
 	ExpectedType() interface{}
 
-	// IsLabelsMetricEnabled returns true if the custom resource labels must be created as a metric
+	// IsLabelsMetricEnabled returns true if the custom resource labels should be exposed as a metric.
 	//
 	// Example:
 	//

--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -52,6 +52,9 @@ type Resource struct {
 	// Labels are added to all metrics. If the same key is used in a metric, the value from the metric will overwrite the value here.
 	Labels `yaml:",inline" json:",inline"`
 
+	// Enable kube_*_labels metrics for custom resources.
+	EnableLabelsMetric bool `yaml:"enableLabelsMetric" json:"enableLabelsMetric"`
+
 	// Metrics are the custom resource fields to be collected.
 	Metrics []Generator `yaml:"metrics" json:"metrics"`
 	// ErrorLogV defines the verbosity threshold for errors logged for this resource.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR allows the creation of a kube_*_ labels metrics for the custom resources

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
This change will add a new metric per enabled CRD in KSM

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1832
