### PR TITLE
Allow Lease metrics to be exported across all namespaces

### DIFF
--- a/docs/lease-metrics.md
+++ b/docs/lease-metrics.md
@@ -2,5 +2,5 @@
 
 | Metric name| Metric type | Labels/tags                                                                                                                               | Status |
 | ---------- | ----------- |-------------------------------------------------------------------------------------------------------------------------------------------| ----------- |
-| kube_lease_owner | Gauge | `lease`=&lt;lease-name&gt; <br> `owner_kind`=&lt;onwer kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `namespace` = &lt;namespace&gt; | EXPERIMENTAL |
+| kube_lease_owner | Gauge | `lease`=&lt;lease-name&gt; <br> `owner_kind`=&lt;onwer kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `namespace` = &lt;namespace&gt; <br> `lease_holder`=&lt;lease holder name&gt;| EXPERIMENTAL |
 | kube_lease_renew_time | Gauge | `lease`=&lt;lease-name&gt;                                                                                                              | EXPERIMENTAL |

--- a/docs/lease-metrics.md
+++ b/docs/lease-metrics.md
@@ -1,6 +1,6 @@
 # Lease Metrics
 
-| Metric name| Metric type | Labels/tags | Status |
-| ---------- | ----------- | ----------- | ----------- |
-| kube_lease_owner | Gauge | `lease`=&lt;lease-name&gt; <br> `owner_kind`=&lt;onwer kind&gt; <br> `owner_name`=&lt;owner name&gt; | EXPERIMENTAL |
-| kube_lease_renew_time | Gauge | `lease`=&lt;lease-name&gt; | EXPERIMENTAL |
+| Metric name| Metric type | Labels/tags                                                                                                                               | Status |
+| ---------- | ----------- |-------------------------------------------------------------------------------------------------------------------------------------------| ----------- |
+| kube_lease_owner | Gauge | `lease`=&lt;lease-name&gt; <br> `owner_kind`=&lt;onwer kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `namespace` = &lt;namespace&gt; | EXPERIMENTAL |
+| kube_lease_renew_time | Gauge | `lease`=&lt;lease-name&gt; <br> `namespace` = &lt;namespace&gt;                                                                                                               | EXPERIMENTAL |

--- a/docs/lease-metrics.md
+++ b/docs/lease-metrics.md
@@ -3,4 +3,4 @@
 | Metric name| Metric type | Labels/tags                                                                                                                               | Status |
 | ---------- | ----------- |-------------------------------------------------------------------------------------------------------------------------------------------| ----------- |
 | kube_lease_owner | Gauge | `lease`=&lt;lease-name&gt; <br> `owner_kind`=&lt;onwer kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `namespace` = &lt;namespace&gt; | EXPERIMENTAL |
-| kube_lease_renew_time | Gauge | `lease`=&lt;lease-name&gt; <br> `namespace` = &lt;namespace&gt;                                                                                                               | EXPERIMENTAL |
+| kube_lease_renew_time | Gauge | `lease`=&lt;lease-name&gt;                                                                                                              | EXPERIMENTAL |

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -40,7 +40,7 @@ var (
 			metric.Gauge,
 			"",
 			wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
-				labelKeys := []string{"owner_kind", "owner_name", "namespace"}
+				labelKeys := []string{"owner_kind", "owner_name", "namespace", "lease_holder"}
 
 				owners := l.GetOwnerReferences()
 				if len(owners) == 0 {
@@ -48,7 +48,7 @@ var (
 						Metrics: []*metric.Metric{
 							{
 								LabelKeys:   labelKeys,
-								LabelValues: []string{"<none>", "<none>", l.Namespace},
+								LabelValues: []string{"<none>", "<none>", l.Namespace, *l.Spec.HolderIdentity},
 								Value:       1,
 							},
 						},
@@ -59,7 +59,7 @@ var (
 				for i, owner := range owners {
 					ms[i] = &metric.Metric{
 						LabelKeys:   labelKeys,
-						LabelValues: []string{owner.Kind, owner.Name, l.Namespace},
+						LabelValues: []string{owner.Kind, owner.Name, l.Namespace, *l.Spec.HolderIdentity},
 						Value:       1,
 					}
 				}

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -42,13 +42,18 @@ var (
 			wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "namespace", "lease_holder"}
 
+				var holder string
+				if l.Spec.HolderIdentity != nil {
+					holder = *l.Spec.HolderIdentity
+				}
+
 				owners := l.GetOwnerReferences()
 				if len(owners) == 0 {
 					return &metric.Family{
 						Metrics: []*metric.Metric{
 							{
 								LabelKeys:   labelKeys,
-								LabelValues: []string{"<none>", "<none>", l.Namespace, *l.Spec.HolderIdentity},
+								LabelValues: []string{"<none>", "<none>", l.Namespace, holder},
 								Value:       1,
 							},
 						},
@@ -59,7 +64,7 @@ var (
 				for i, owner := range owners {
 					ms[i] = &metric.Metric{
 						LabelKeys:   labelKeys,
-						LabelValues: []string{owner.Kind, owner.Name, l.Namespace, *l.Spec.HolderIdentity},
+						LabelValues: []string{owner.Kind, owner.Name, l.Namespace, holder},
 						Value:       1,
 					}
 				}

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -40,7 +40,7 @@ var (
 			metric.Gauge,
 			"",
 			wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
-				labelKeys := []string{"owner_kind", "owner_name"}
+				labelKeys := []string{"owner_kind", "owner_name", "namespace"}
 
 				owners := l.GetOwnerReferences()
 				if len(owners) == 0 {
@@ -48,7 +48,7 @@ var (
 						Metrics: []*metric.Metric{
 							{
 								LabelKeys:   labelKeys,
-								LabelValues: []string{"<none>", "<none>"},
+								LabelValues: []string{"<none>", "<none>", l.Namespace},
 								Value:       1,
 							},
 						},
@@ -59,7 +59,7 @@ var (
 				for i, owner := range owners {
 					ms[i] = &metric.Metric{
 						LabelKeys:   labelKeys,
-						LabelValues: []string{owner.Kind, owner.Name},
+						LabelValues: []string{owner.Kind, owner.Name, l.Namespace},
 						Value:       1,
 					}
 				}

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -107,10 +107,10 @@ func wrapLeaseFunc(f func(*coordinationv1.Lease) *metric.Family) func(interface{
 func createLeaseListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.CoordinationV1().Leases("kube-node-lease").List(context.TODO(), opts)
+			return kubeClient.CoordinationV1().Leases("").List(context.TODO(), opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.CoordinationV1().Leases("kube-node-lease").Watch(context.TODO(), opts)
+			return kubeClient.CoordinationV1().Leases("").Watch(context.TODO(), opts)
 		},
 	}
 }

--- a/internal/store/lease_test.go
+++ b/internal/store/lease_test.go
@@ -64,6 +64,33 @@ func TestLeaseStore(t *testing.T) {
 					"kube_lease_renew_time",
 				},
 			},
+			{
+				Obj: &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation:        2,
+						Name:              "kube-master",
+						Namespace:         "default",
+						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "Node",
+								Name: leaseOwner,
+							},
+						},
+					},
+					Spec: coordinationv1.LeaseSpec{
+						RenewTime: &metav1.MicroTime{Time: time.Unix(1500000000, 0)},
+					},
+				},
+				Want: metadata + `
+                    kube_lease_owner{lease="kube-master",owner_kind="Node",owner_name="kube-master",namespace="default",lease_holder=""} 1
+                    kube_lease_renew_time{lease="kube-master"} 1.5e+09
+			`,
+				MetricNames: []string{
+					"kube_lease_owner",
+					"kube_lease_renew_time",
+				},
+			},
 		}
 	)
 	for i, c := range cases {

--- a/internal/store/lease_test.go
+++ b/internal/store/lease_test.go
@@ -33,7 +33,7 @@ func TestLeaseStore(t *testing.T) {
         # HELP kube_lease_renew_time Kube lease renew time.
         # TYPE kube_lease_renew_time gauge
 	`
-
+	leaseOwner := "kube-master"
 	var (
 		cases = []generateMetricsTestCase{
 			{
@@ -46,16 +46,17 @@ func TestLeaseStore(t *testing.T) {
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Kind: "Node",
-								Name: "kube-master",
+								Name: leaseOwner,
 							},
 						},
 					},
 					Spec: coordinationv1.LeaseSpec{
-						RenewTime: &metav1.MicroTime{Time: time.Unix(1500000000, 0)},
+						RenewTime:      &metav1.MicroTime{Time: time.Unix(1500000000, 0)},
+						HolderIdentity: &leaseOwner,
 					},
 				},
 				Want: metadata + `
-                    kube_lease_owner{lease="kube-master",owner_kind="Node",owner_name="kube-master",namespace="default"} 1
+                    kube_lease_owner{lease="kube-master",owner_kind="Node",owner_name="kube-master",namespace="default",lease_holder="kube-master"} 1
                     kube_lease_renew_time{lease="kube-master"} 1.5e+09
 			`,
 				MetricNames: []string{

--- a/internal/store/lease_test.go
+++ b/internal/store/lease_test.go
@@ -41,6 +41,7 @@ func TestLeaseStore(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Generation:        2,
 						Name:              "kube-master",
+						Namespace:         "default",
 						CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -54,7 +55,7 @@ func TestLeaseStore(t *testing.T) {
 					},
 				},
 				Want: metadata + `
-                    kube_lease_owner{lease="kube-master",owner_kind="Node",owner_name="kube-master"} 1
+                    kube_lease_owner{lease="kube-master",owner_kind="Node",owner_name="kube-master",namespace="default"} 1
                     kube_lease_renew_time{lease="kube-master"} 1.5e+09
 			`,
 				MetricNames: []string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This PR modifies the Lease store's `createLeaseListWatch()` method so that the metrics for the Lease custom resource to be exported across all namespaces, as opposed to only the `kube-node-lease` namespace. This allows us to get metrics on Lease resources used by pods as well. 

**How does this change affect the cardinality of KSM**: *increases cardinality by the number of namespaces*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
