### PR TITLE
Represent GVK information as labels

### DIFF
--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -48,6 +48,8 @@ spec:
           - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,foos,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments,verticalpodautoscalers
 ```
 
+NOTE: The `group`, `version`, and `kind` common labels are reserved, and will be overwritten by the values from the `groupVersionKind` field.
+
 ### Examples
 
 The examples in this section will use the following custom resource:
@@ -114,7 +116,7 @@ spec:
 Produces the metric:
 
 ```prometheus
-kube_myteam_io_v1_Foo_uptime 43.21
+uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
 ```
 
 #### Multiple Metrics/Kitchen Sink
@@ -165,8 +167,8 @@ spec:
 Produces the following metrics:
 
 ```prometheus
-kube_myteam_io_v1_Foo_active_count{active="1",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-a"} 1
-kube_myteam_io_v1_Foo_active_count{active="3",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-b"} 3
+active_count{group="myteam.io", kind="Foo", version="v1", active="1",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-a"} 1
+active_count{group="myteam.io", kind="Foo", version="v1", active="3",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-b"} 3
 ```
 
 ### Metric types
@@ -201,7 +203,7 @@ spec:
 Produces the metric:
 
 ```prometheus
-kube_myteam_io_v1_Foo_uptime 43.21
+uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
 ```
 
 #### StateSet
@@ -227,15 +229,15 @@ spec:
               list: [Pending, Bar, Baz]
 ```
 
-Metrics of type `SateSet` will generate a metric for each value defined in `list` for each resource.
+Metrics of type `StateSet` will generate a metric for each value defined in `list` for each resource.
 The value will be 1, if the value matches the one in list.
 
 Produces the metric:
 
 ```prometheus
-kube_myteam_io_v1_Foo_status_phase{phase="Pending"} 1
-kube_myteam_io_v1_Foo_status_phase{phase="Bar"} 0
-kube_myteam_io_v1_Foo_status_phase{phase="Baz"} 0
+status_phase{group="myteam.io", kind="Foo", version="v1", phase="Pending"} 1
+status_phase{group="myteam.io", kind="Foo", version="v1", phase="Bar"} 0
+status_phase{group="myteam.io", kind="Foo", version="v1", phase="Baz"} 0
 ```
 
 #### Info
@@ -265,7 +267,7 @@ spec:
 Produces the metric:
 
 ```prometheus
-kube_myteam_io_v1_Foo_version{version="v1.2.3"} 1
+version{group="myteam.io", kind="Foo", version="v1", version="v1.2.3"} 1
 ```
 
 ### Naming
@@ -287,7 +289,7 @@ spec:
 
 Produces:
 ```prometheus
-myteam_foos_uptime 43.21
+myteam_foos_uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
 ```
 
 To omit namespace and/or subsystem altogether, set them to the empty string:

--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -116,7 +116,7 @@ spec:
 Produces the metric:
 
 ```prometheus
-kube_uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
+kube_crd_uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
 ```
 
 #### Multiple Metrics/Kitchen Sink
@@ -167,8 +167,8 @@ spec:
 Produces the following metrics:
 
 ```prometheus
-kube_active_count{group="myteam.io", kind="Foo", version="v1", active="1",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-a"} 1
-kube_active_count{group="myteam.io", kind="Foo", version="v1", active="3",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-b"} 3
+kube_crd_active_count{group="myteam.io", kind="Foo", version="v1", active="1",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-a"} 1
+kube_crd_active_count{group="myteam.io", kind="Foo", version="v1", active="3",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-b"} 3
 ```
 
 ### Metric types
@@ -203,7 +203,7 @@ spec:
 Produces the metric:
 
 ```prometheus
-kube_uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
+kube_crd_uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
 ```
 
 #### StateSet
@@ -235,9 +235,9 @@ The value will be 1, if the value matches the one in list.
 Produces the metric:
 
 ```prometheus
-kube_status_phase{group="myteam.io", kind="Foo", version="v1", phase="Pending"} 1
-kube_status_phase{group="myteam.io", kind="Foo", version="v1", phase="Bar"} 0
-kube_status_phase{group="myteam.io", kind="Foo", version="v1", phase="Baz"} 0
+kube_crd_status_phase{group="myteam.io", kind="Foo", version="v1", phase="Pending"} 1
+kube_crd_status_phase{group="myteam.io", kind="Foo", version="v1", phase="Bar"} 0
+kube_crd_status_phase{group="myteam.io", kind="Foo", version="v1", phase="Baz"} 0
 ```
 
 #### Info
@@ -267,7 +267,7 @@ spec:
 Produces the metric:
 
 ```prometheus
-kube_version{group="myteam.io", kind="Foo", version="v1", version="v1.2.3"} 1
+kube_crd_version{group="myteam.io", kind="Foo", version="v1", version="v1.2.3"} 1
 ```
 
 ### Naming
@@ -303,6 +303,11 @@ spec:
       metrics:
         - name: uptime
           ...
+```
+
+Produces:
+```prometheus
+uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
 ```
 
 ### Logging

--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -116,7 +116,7 @@ spec:
 Produces the metric:
 
 ```prometheus
-uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
+kube_uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
 ```
 
 #### Multiple Metrics/Kitchen Sink
@@ -167,8 +167,8 @@ spec:
 Produces the following metrics:
 
 ```prometheus
-active_count{group="myteam.io", kind="Foo", version="v1", active="1",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-a"} 1
-active_count{group="myteam.io", kind="Foo", version="v1", active="3",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-b"} 3
+kube_active_count{group="myteam.io", kind="Foo", version="v1", active="1",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-a"} 1
+kube_active_count{group="myteam.io", kind="Foo", version="v1", active="3",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-b"} 3
 ```
 
 ### Metric types
@@ -203,7 +203,7 @@ spec:
 Produces the metric:
 
 ```prometheus
-uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
+kube_uptime{group="myteam.io", kind="Foo", version="v1"} 43.21
 ```
 
 #### StateSet
@@ -235,9 +235,9 @@ The value will be 1, if the value matches the one in list.
 Produces the metric:
 
 ```prometheus
-status_phase{group="myteam.io", kind="Foo", version="v1", phase="Pending"} 1
-status_phase{group="myteam.io", kind="Foo", version="v1", phase="Bar"} 0
-status_phase{group="myteam.io", kind="Foo", version="v1", phase="Baz"} 0
+kube_status_phase{group="myteam.io", kind="Foo", version="v1", phase="Pending"} 1
+kube_status_phase{group="myteam.io", kind="Foo", version="v1", phase="Bar"} 0
+kube_status_phase{group="myteam.io", kind="Foo", version="v1", phase="Baz"} 0
 ```
 
 #### Info
@@ -267,7 +267,7 @@ spec:
 Produces the metric:
 
 ```prometheus
-version{group="myteam.io", kind="Foo", version="v1", version="v1.2.3"} 1
+kube_version{group="myteam.io", kind="Foo", version="v1", version="v1.2.3"} 1
 ```
 
 ### Naming

--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -64,7 +64,7 @@ type Resource struct {
 func (r Resource) GetMetricNamePrefix() string {
 	p := r.MetricNamePrefix
 	if p == nil {
-		return ""
+		return "kube"
 	}
 	return *p
 }

--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -41,9 +41,8 @@ type MetricsSpec struct {
 // Resource configures a custom resource for metric generation.
 type Resource struct {
 	// MetricNamePrefix defines a prefix for all metrics of the resource.
-	// Falls back to the GroupVersionKind string prefixed with "kube_", with invalid characters replaced by _ if nil.
 	// If set to "", no prefix will be added.
-	// Example: If GroupVersionKind is "my-team.io/v1/MyResource", MetricNamePrefix will be "kube_my_team_io_v1_MyResource".
+	// Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
 	MetricNamePrefix *string `yaml:"metricNamePrefix" json:"metricNamePrefix"`
 
 	// GroupVersionKind of the custom resource to be monitored.
@@ -63,17 +62,11 @@ type Resource struct {
 
 // GetMetricNamePrefix returns the prefix to use for metrics.
 func (r Resource) GetMetricNamePrefix() string {
-	if r.MetricNamePrefix == nil {
-		return strings.NewReplacer(
-			"/", "_",
-			".", "_",
-			"-", "_",
-		).Replace(fmt.Sprintf("kube_%s_%s_%s", r.GroupVersionKind.Group, r.GroupVersionKind.Version, r.GroupVersionKind.Kind))
-	}
-	if *r.MetricNamePrefix == "" {
+	p := r.MetricNamePrefix
+	if p == nil {
 		return ""
 	}
-	return *r.MetricNamePrefix
+	return *p
 }
 
 // GetResourceName returns the lowercase, plural form of the resource Kind. This is ResourcePlural if it is set.

--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -64,7 +64,7 @@ type Resource struct {
 func (r Resource) GetMetricNamePrefix() string {
 	p := r.MetricNamePrefix
 	if p == nil {
-		return "kube"
+		return "kube_crd"
 	}
 	return *p
 }

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -34,6 +34,13 @@ import (
 
 func compile(resource Resource) ([]compiledFamily, error) {
 	var families []compiledFamily
+	// Explicitly add GVK labels to all CR metrics.
+	if resource.CommonLabels == nil {
+		resource.CommonLabels = map[string]string{}
+	}
+	resource.CommonLabels["group"] = resource.GroupVersionKind.Group
+	resource.CommonLabels["version"] = resource.GroupVersionKind.Version
+	resource.CommonLabels["kind"] = resource.GroupVersionKind.Kind
 	for _, f := range resource.Metrics {
 		family, err := compileFamily(f, resource)
 		if err != nil {

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -324,7 +324,7 @@ func Test_fullName(t *testing.T) {
 				resource: r(nil),
 				f:        count,
 			},
-			want: "count",
+			want: "kube_count",
 		},
 		{
 			name: "no prefix",

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -324,7 +324,7 @@ func Test_fullName(t *testing.T) {
 				resource: r(nil),
 				f:        count,
 			},
-			want: "kube_count",
+			want: "kube_crd_count",
 		},
 		{
 			name: "no prefix",

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -324,7 +324,7 @@ func Test_fullName(t *testing.T) {
 				resource: r(nil),
 				f:        count,
 			},
-			want: "kube_apps_v1_Deployment_count",
+			want: "count",
 		},
 		{
 			name: "no prefix",


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Represent GVK information as labels in the metrics, instead of appending them to the metric name itself. This would allow users to aggregate varying GVKs of a CR under the same metric, making operations much more easier.

**How does this change affect the cardinality of KSM**: Increases, or stays the same, depending on the cardinality of the group(s), version(s), or kind(s) of a CR present in the cluster at the given time.

**Which issue(s) this PR fixes**: Fixes #1847
