### PR TITLE
Allow optional VK in CR metrics

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2023 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package discovery provides a discovery and resolution logic for GVKs.
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"k8s.io/kube-state-metrics/v2/internal/store"
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	"k8s.io/kube-state-metrics/v2/pkg/metricshandler"
+	"k8s.io/kube-state-metrics/v2/pkg/options"
+	"k8s.io/kube-state-metrics/v2/pkg/util"
+)
+
+// Interval is the time interval between two cache sync checks.
+const Interval = 3 * time.Second
+
+// StartDiscovery starts the discovery process, fetching all the objects that can be listed from the apiserver, every `Interval` seconds.
+// resolveGVK needs to be called after StartDiscovery to generate factories.
+func (r *CRDiscoverer) StartDiscovery(ctx context.Context, config *rest.Config) error {
+	client := dynamic.NewForConfigOrDie(config)
+	factory := dynamicinformer.NewFilteredDynamicInformer(client, schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}, "", 0, nil, nil)
+	informer := factory.Informer()
+	stopper := make(chan struct{})
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			objSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
+			for _, version := range objSpec["versions"].([]interface{}) {
+				g := objSpec["group"].(string)
+				v := version.(map[string]interface{})["name"].(string)
+				k := objSpec["names"].(map[string]interface{})["kind"].(string)
+				p := objSpec["names"].(map[string]interface{})["plural"].(string)
+				gotGVKP := groupVersionKindPlural{
+					GroupVersionKind: schema.GroupVersionKind{
+						Group:   g,
+						Version: v,
+						Kind:    k,
+					},
+					Plural: p,
+				}
+				r.AppendToMap(gotGVKP)
+				r.SafeWrite(func() {
+					r.WasUpdated = true
+				})
+			}
+			r.SafeWrite(func() {
+				r.CRDsAddEventsCounter.Inc()
+				r.CRDsCacheCountGauge.Inc()
+			})
+		},
+		DeleteFunc: func(obj interface{}) {
+			objSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
+			for _, version := range objSpec["versions"].([]interface{}) {
+				g := objSpec["group"].(string)
+				v := version.(map[string]interface{})["name"].(string)
+				k := objSpec["names"].(map[string]interface{})["kind"].(string)
+				p := objSpec["names"].(map[string]interface{})["plural"].(string)
+				gotGVKP := groupVersionKindPlural{
+					GroupVersionKind: schema.GroupVersionKind{
+						Group:   g,
+						Version: v,
+						Kind:    k,
+					},
+					Plural: p,
+				}
+				r.RemoveFromMap(gotGVKP)
+				r.SafeWrite(func() {
+					r.WasUpdated = true
+				})
+			}
+			r.SafeWrite(func() {
+				r.CRDsDeleteEventsCounter.Inc()
+				r.CRDsCacheCountGauge.Dec()
+			})
+		},
+	})
+	if err != nil {
+		return err
+	}
+	// Respect context cancellation.
+	go func() {
+		for range ctx.Done() {
+			klog.InfoS("context cancelled, stopping discovery")
+			close(stopper)
+			return
+		}
+	}()
+	go informer.Run(stopper)
+	return nil
+}
+
+// ResolveGVKToGVKPs resolves the variable VKs to a GVK list, based on the current cache.
+func (r *CRDiscoverer) ResolveGVKToGVKPs(gvk schema.GroupVersionKind) (resolvedGVKPs []groupVersionKindPlural, err error) { // nolint:revive
+	g := gvk.Group
+	v := gvk.Version
+	k := gvk.Kind
+	if g == "" || g == "*" {
+		return nil, fmt.Errorf("group is required in the defined GVK %v", gvk)
+	}
+	hasVersion := v != "" && v != "*"
+	hasKind := k != "" && k != "*"
+	// No need to resolve, return.
+	if hasVersion && hasKind {
+		var p string
+		for _, el := range r.Map[g][v] {
+			if el.Kind == k {
+				p = el.Plural
+				break
+			}
+		}
+		return []groupVersionKindPlural{
+			{
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   g,
+					Version: v,
+					Kind:    k,
+				},
+				Plural: p,
+			},
+		}, nil
+	}
+	if hasVersion && !hasKind {
+		kinds := r.Map[g][v]
+		for _, el := range kinds {
+			resolvedGVKPs = append(resolvedGVKPs, groupVersionKindPlural{
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   g,
+					Version: v,
+					Kind:    el.Kind,
+				},
+				Plural: el.Plural,
+			})
+		}
+	}
+	if !hasVersion && hasKind {
+		versions := r.Map[g]
+		for version, kinds := range versions {
+			for _, el := range kinds {
+				if el.Kind == k {
+					resolvedGVKPs = append(resolvedGVKPs, groupVersionKindPlural{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   g,
+							Version: version,
+							Kind:    k,
+						},
+						Plural: el.Plural,
+					})
+				}
+			}
+		}
+	}
+	if !hasVersion && !hasKind {
+		versions := r.Map[g]
+		for version, kinds := range versions {
+			for _, el := range kinds {
+				resolvedGVKPs = append(resolvedGVKPs, groupVersionKindPlural{
+					GroupVersionKind: schema.GroupVersionKind{
+						Group:   g,
+						Version: version,
+						Kind:    el.Kind,
+					},
+					Plural: el.Plural,
+				})
+			}
+		}
+	}
+	return
+}
+
+// PollForCacheUpdates polls the cache for updates and updates the stores accordingly.
+func (r *CRDiscoverer) PollForCacheUpdates(
+	ctx context.Context,
+	opts *options.Options,
+	storeBuilder *store.Builder,
+	m *metricshandler.MetricsHandler,
+	factoryGenerator func() ([]customresource.RegistryFactory, error),
+) {
+	// The interval at which we will check the cache for updates.
+	t := time.NewTicker(Interval)
+	// Track previous context to allow refreshing cache.
+	olderContext, olderCancel := context.WithCancel(ctx)
+	// Prevent context leak (kill the last metric handler instance).
+	defer olderCancel()
+	generateMetrics := func() {
+		// Get families for discovered factories.
+		customFactories, err := factoryGenerator()
+		if err != nil {
+			klog.ErrorS(err, "failed to update custom resource stores")
+		}
+		// Update the list of enabled custom resources.
+		var enabledCustomResources []string
+		for _, factory := range customFactories {
+			gvrString := util.GVRFromType(factory.Name(), factory.ExpectedType()).String()
+			enabledCustomResources = append(enabledCustomResources, gvrString)
+		}
+		// Create clients for discovered factories.
+		discoveredCustomResourceClients, err := util.CreateCustomResourceClients(opts.Apiserver, opts.Kubeconfig, customFactories...)
+		if err != nil {
+			klog.ErrorS(err, "failed to update custom resource stores")
+		}
+		// Update the store builder with the new clients.
+		storeBuilder.WithCustomResourceClients(discoveredCustomResourceClients)
+		// Inject families' constructors to the existing set of stores.
+		storeBuilder.WithCustomResourceStoreFactories(customFactories...)
+		// Update the store builder with the new custom resources.
+		if err := storeBuilder.WithEnabledResources(enabledCustomResources); err != nil {
+			klog.ErrorS(err, "failed to update custom resource stores")
+		}
+		// Configure the generation function for the custom resource stores.
+		storeBuilder.WithGenerateCustomResourceStoresFunc(storeBuilder.DefaultGenerateCustomResourceStoresFunc())
+		// Reset the flag, if there were no errors. Else, we'll try again on the next tick.
+		// Keep retrying if there were errors.
+		r.SafeWrite(func() {
+			r.WasUpdated = false
+		})
+		// Run the metrics handler with updated configs.
+		olderContext, olderCancel = context.WithCancel(ctx)
+		go func() {
+			// Blocks indefinitely until the unbuffered context is cancelled to serve metrics for that duration.
+			err = m.Run(olderContext)
+			if err != nil {
+				// Check if context was cancelled.
+				select {
+				case <-olderContext.Done():
+					// Context cancelled, don't really need to log this though.
+				default:
+					klog.ErrorS(err, "failed to run metrics handler")
+				}
+			}
+		}()
+	}
+	go func() {
+		for range t.C {
+			select {
+			case <-ctx.Done():
+				klog.InfoS("context cancelled")
+				t.Stop()
+				return
+			default:
+				// Check if cache has been updated.
+				shouldGenerateMetrics := false
+				r.SafeRead(func() {
+					shouldGenerateMetrics = r.WasUpdated
+				})
+				if shouldGenerateMetrics {
+					olderCancel()
+					generateMetrics()
+					klog.InfoS("discovery finished, cache updated")
+				}
+			}
+		}
+	}()
+}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2023 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGVKMapsResolveGVK(t *testing.T) {
+	type testcase struct {
+		desc    string
+		gvkmaps *CRDiscoverer
+		gvk     schema.GroupVersionKind
+		got     []groupVersionKindPlural
+		want    []groupVersionKindPlural
+	}
+	testcases := []testcase{
+		{
+			desc: "variable version and kind",
+			gvkmaps: &CRDiscoverer{
+				Map: map[string]map[string][]kindPlural{
+					"apps": {
+						"v1": {
+							kindPlural{
+								Kind:   "Deployment",
+								Plural: "deployments",
+							},
+							kindPlural{
+								Kind:   "StatefulSet",
+								Plural: "statefulsets",
+							},
+						},
+					},
+				},
+			},
+			gvk: schema.GroupVersionKind{Group: "apps", Version: "*", Kind: "*"},
+			want: []groupVersionKindPlural{
+				{
+					GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+					Plural:           "deployments",
+				},
+				{
+					GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+					Plural:           "statefulsets",
+				},
+			},
+		},
+		{
+			desc: "variable version",
+			gvkmaps: &CRDiscoverer{
+				Map: map[string]map[string][]kindPlural{
+					"testgroup": {
+						"v1": {
+							kindPlural{
+								Kind:   "TestObject1",
+								Plural: "testobjects1",
+							},
+							kindPlural{
+								Kind:   "TestObject2",
+								Plural: "testobjects2",
+							},
+						},
+						"v1alpha1": {
+							kindPlural{
+								Kind:   "TestObject1",
+								Plural: "testobjects1",
+							},
+						},
+					},
+				},
+			},
+			gvk: schema.GroupVersionKind{Group: "testgroup", Version: "*", Kind: "TestObject1"},
+			want: []groupVersionKindPlural{
+				{
+					GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
+					Plural:           "testobjects1",
+				},
+				{
+					GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1alpha1", Kind: "TestObject1"},
+					Plural:           "testobjects1",
+				},
+			},
+		},
+		{
+			desc: "variable kind",
+			gvkmaps: &CRDiscoverer{
+				Map: map[string]map[string][]kindPlural{
+					"testgroup": {
+						"v1": {
+							kindPlural{
+								Kind:   "TestObject1",
+								Plural: "testobjects1",
+							},
+							kindPlural{
+								Kind:   "TestObject2",
+								Plural: "testobjects2",
+							},
+						},
+						"v1alpha1": {
+							kindPlural{
+								Kind:   "TestObject1",
+								Plural: "testobjects1",
+							},
+						},
+					},
+				},
+			},
+			gvk: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "*"},
+			want: []groupVersionKindPlural{
+				{
+					GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
+					Plural:           "testobjects1",
+				},
+				{
+					GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject2"},
+					Plural:           "testobjects2",
+				},
+			},
+		},
+		{
+			desc: "fixed version and kind",
+			gvkmaps: &CRDiscoverer{
+				Map: map[string]map[string][]kindPlural{
+					"testgroup": {
+						"v1": {
+							kindPlural{
+								Kind:   "TestObject1",
+								Plural: "testobjects1",
+							},
+							kindPlural{
+								Kind:   "TestObject2",
+								Plural: "testobjects2",
+							},
+						},
+						"v1alpha1": {
+							kindPlural{
+								Kind:   "TestObject1",
+								Plural: "testobjects1",
+							},
+						},
+					},
+				},
+			},
+			gvk: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
+			want: []groupVersionKindPlural{
+				{
+					GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
+					Plural:           "testobjects1",
+				},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		got, err := tc.gvkmaps.ResolveGVKToGVKPs(tc.gvk)
+		if err != nil {
+			t.Errorf("testcase: %s: got error %v", tc.desc, err)
+		}
+		// Sort got and tc.want to ensure the order of the elements.
+		sort.Slice(got, func(i, j int) bool {
+			return got[i].String() < got[j].String()
+		})
+		sort.Slice(tc.want, func(i, j int) bool {
+			return tc.want[i].String() < tc.want[j].String()
+		})
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("testcase: %s: got %v, want %v", tc.desc, got, tc.want)
+		}
+	}
+}

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2023 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type groupVersionKindPlural struct {
+	schema.GroupVersionKind
+	Plural string
+}
+
+func (g groupVersionKindPlural) String() string {
+	return fmt.Sprintf("%s/%s, Kind=%s, Plural=%s", g.Group, g.Version, g.Kind, g.Plural)
+}
+
+type kindPlural struct {
+	Kind   string
+	Plural string
+}
+
+// CRDiscoverer provides a cache of the collected GVKs, along with helper utilities.
+type CRDiscoverer struct {
+	// m is a mutex to protect the cache.
+	m sync.RWMutex
+	// Map is a cache of the collected GVKs.
+	Map map[string]map[string][]kindPlural
+	// ShouldUpdate is a flag that indicates whether the cache was updated.
+	WasUpdated bool
+	// CRDsAddEventsCounter tracks the number of times that the CRD informer triggered the "add" event.
+	CRDsAddEventsCounter prometheus.Counter
+	// CRDsDeleteEventsCounter tracks the number of times that the CRD informer triggered the "remove" event.
+	CRDsDeleteEventsCounter prometheus.Counter
+	// CRDsCacheCountGauge tracks the net amount of CRDs affecting the cache at this point.
+	CRDsCacheCountGauge prometheus.Gauge
+}
+
+// SafeRead executes the given function while holding a read lock.
+func (r *CRDiscoverer) SafeRead(f func()) {
+	r.m.RLock()
+	defer r.m.RUnlock()
+	f()
+}
+
+// SafeWrite executes the given function while holding a write lock.
+func (r *CRDiscoverer) SafeWrite(f func()) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	f()
+}
+
+// AppendToMap appends the given GVKs to the cache.
+func (r *CRDiscoverer) AppendToMap(gvkps ...groupVersionKindPlural) {
+	if r.Map == nil {
+		r.Map = map[string]map[string][]kindPlural{}
+	}
+	for _, gvkp := range gvkps {
+		if _, ok := r.Map[gvkp.Group]; !ok {
+			r.Map[gvkp.Group] = map[string][]kindPlural{}
+		}
+		if _, ok := r.Map[gvkp.Group][gvkp.Version]; !ok {
+			r.Map[gvkp.Group][gvkp.Version] = []kindPlural{}
+		}
+		r.Map[gvkp.Group][gvkp.Version] = append(r.Map[gvkp.Group][gvkp.Version], kindPlural{Kind: gvkp.Kind, Plural: gvkp.Plural})
+	}
+}
+
+// RemoveFromMap removes the given GVKs from the cache.
+func (r *CRDiscoverer) RemoveFromMap(gvkps ...groupVersionKindPlural) {
+	for _, gvkp := range gvkps {
+		if _, ok := r.Map[gvkp.Group]; !ok {
+			continue
+		}
+		if _, ok := r.Map[gvkp.Group][gvkp.Version]; !ok {
+			continue
+		}
+		for i, el := range r.Map[gvkp.Group][gvkp.Version] {
+			if el.Kind == gvkp.Kind {
+				if len(r.Map[gvkp.Group][gvkp.Version]) == 1 {
+					delete(r.Map[gvkp.Group], gvkp.Version)
+					if len(r.Map[gvkp.Group]) == 0 {
+						delete(r.Map, gvkp.Group)
+					}
+					break
+				}
+				r.Map[gvkp.Group][gvkp.Version] = append(r.Map[gvkp.Group][gvkp.Version][:i], r.Map[gvkp.Group][gvkp.Version][i+1:]...)
+				break
+			}
+		}
+	}
+}

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -37,6 +38,10 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -47,8 +52,15 @@ import (
 	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
 	"k8s.io/kube-state-metrics/v2/pkg/options"
 	"k8s.io/kube-state-metrics/v2/pkg/sharding"
+	"k8s.io/kube-state-metrics/v2/pkg/util"
 	"k8s.io/kube-state-metrics/v2/pkg/watch"
 )
+
+// ResourceDiscoveryTimeout is the timeout for the resource discovery.
+const ResourceDiscoveryTimeout = 10 * time.Second
+
+// ResourceDiscoveryInterval is the interval for the resource discovery.
+const ResourceDiscoveryInterval = 100 * time.Millisecond
 
 // Make sure the internal Builder implements the public BuilderInterface.
 // New Builder methods should be added to the public BuilderInterface.
@@ -74,12 +86,21 @@ type Builder struct {
 	allowAnnotationsList          map[string][]string
 	allowLabelsList               map[string][]string
 	useAPIServerCache             bool
+	utilOptions                   *options.Options
 }
 
 // NewBuilder returns a new builder.
 func NewBuilder() *Builder {
 	b := &Builder{}
 	return b
+}
+
+// WithUtilOptions sets the utilOptions property of a Builder.
+// These are the options that are necessary for the util package.
+func (b *Builder) WithUtilOptions(opts *options.Options) {
+	b.utilOptions = options.NewOptions()
+	b.utilOptions.Apiserver = opts.Apiserver
+	b.utilOptions.Kubeconfig = opts.Kubeconfig
 }
 
 // WithMetrics sets the metrics property of a Builder.
@@ -90,18 +111,18 @@ func (b *Builder) WithMetrics(r prometheus.Registerer) {
 
 // WithEnabledResources sets the enabledResources property of a Builder.
 func (b *Builder) WithEnabledResources(r []string) error {
-	for _, col := range r {
-		if !resourceExists(col) {
-			return fmt.Errorf("resource %s does not exist. Available resources: %s", col, strings.Join(availableResources(), ","))
+	for _, resource := range r {
+		if !resourceExists(resource) {
+			return fmt.Errorf("resource %s does not exist. Available resources: %s", resource, strings.Join(availableResources(), ","))
 		}
 	}
 
-	var copy []string
-	copy = append(copy, r...)
+	var sortedResources []string
+	sortedResources = append(sortedResources, r...)
 
-	sort.Strings(copy)
+	sort.Strings(sortedResources)
 
-	b.enabledResources = copy
+	b.enabledResources = append(b.enabledResources, sortedResources...)
 	return nil
 }
 
@@ -180,13 +201,20 @@ func (b *Builder) DefaultGenerateCustomResourceStoresFunc() ksmtypes.BuildCustom
 func (b *Builder) WithCustomResourceStoreFactories(fs ...customresource.RegistryFactory) {
 	for i := range fs {
 		f := fs[i]
-		if _, ok := availableStores[f.Name()]; ok {
-			klog.InfoS("The internal resource store already exists and is overridden by a custom resource store with the same name, please make sure it meets your expectation", "registryName", f.Name())
+		gvr := util.GVRFromType(f.Name(), f.ExpectedType())
+		var gvrString string
+		if gvr != nil {
+			gvrString = gvr.String()
+		} else {
+			gvrString = f.Name()
 		}
-		availableStores[f.Name()] = func(b *Builder) []cache.Store {
+		if _, ok := availableStores[gvrString]; ok {
+			klog.InfoS("Updating store", "GVR", gvrString)
+		}
+		availableStores[gvrString] = func(b *Builder) []cache.Store {
 			return b.buildCustomResourceStoresFunc(
 				f.Name(),
-				f.MetricFamilyGenerators(b.allowAnnotationsList[f.Name()], b.allowLabelsList[f.Name()]),
+				f.MetricFamilyGenerators(),
 				f.ExpectedType(),
 				f.ListWatch,
 				b.useAPIServerCache,
@@ -243,7 +271,9 @@ func (b *Builder) Build() metricsstore.MetricsWriterList {
 		}
 	}
 
-	klog.InfoS("Active resources", "activeStoreNames", strings.Join(activeStoreNames, ","))
+	if len(activeStoreNames) > 0 {
+		klog.InfoS("Active resources", "activeStoreNames", strings.Join(activeStoreNames, ","))
+	}
 
 	return metricsWriters
 }
@@ -513,9 +543,20 @@ func (b *Builder) buildCustomResourceStores(resourceName string,
 ) []cache.Store {
 	metricFamilies = generator.FilterFamilyGenerators(b.familyGeneratorFilter, metricFamilies)
 	composedMetricGenFuncs := generator.ComposeMetricGenFuncs(metricFamilies)
-	familyHeaders := generator.ExtractMetricFamilyHeaders(metricFamilies)
 
-	customResourceClient, ok := b.customResourceClients[resourceName]
+	var familyHeaders []string
+	if b.hasResources(resourceName, expectedType) {
+		familyHeaders = generator.ExtractMetricFamilyHeaders(metricFamilies)
+	}
+
+	gvr := util.GVRFromType(resourceName, expectedType)
+	var gvrString string
+	if gvr != nil {
+		gvrString = gvr.String()
+	} else {
+		gvrString = resourceName
+	}
+	customResourceClient, ok := b.customResourceClients[gvrString]
 	if !ok {
 		klog.InfoS("Custom resource client does not exist", "resourceName", resourceName)
 		return []cache.Store{}
@@ -547,6 +588,65 @@ func (b *Builder) buildCustomResourceStores(resourceName string,
 	}
 
 	return stores
+}
+
+func (b *Builder) hasResources(resourceName string, expectedType interface{}) bool {
+	gvr := util.GVRFromType(resourceName, expectedType)
+	if gvr == nil {
+		return true
+	}
+	discoveryClient, err := util.CreateDiscoveryClient(b.utilOptions.Apiserver, b.utilOptions.Kubeconfig)
+	if err != nil {
+		klog.ErrorS(err, "Failed to create discovery client")
+		return false
+	}
+	g := gvr.Group
+	v := gvr.Version
+	r := gvr.Resource
+	isCRDInstalled, err := discovery.IsResourceEnabled(discoveryClient, schema.GroupVersionResource{
+		Group:    g,
+		Version:  v,
+		Resource: r,
+	})
+	if err != nil {
+		klog.ErrorS(err, "Failed to check if CRD is enabled", "group", g, "version", v, "resource", r)
+		return false
+	}
+	if !isCRDInstalled {
+		klog.InfoS("CRD is not installed", "group", g, "version", v, "resource", r)
+		return false
+	}
+	// Wait for the resource to come up.
+	timer := time.NewTimer(ResourceDiscoveryTimeout)
+	ticker := time.NewTicker(ResourceDiscoveryInterval)
+	dynamicClient, err := util.CreateDynamicClient(b.utilOptions.Apiserver, b.utilOptions.Kubeconfig)
+	if err != nil {
+		klog.ErrorS(err, "Failed to create dynamic client")
+		return false
+	}
+	var list *unstructured.UnstructuredList
+	for range ticker.C {
+		select {
+		case <-timer.C:
+			klog.InfoS("No CRs found for GVR", "group", g, "version", v, "resource", r)
+			return false
+		default:
+			list, err = dynamicClient.Resource(schema.GroupVersionResource{
+				Group:    g,
+				Version:  v,
+				Resource: r,
+			}).List(b.ctx, metav1.ListOptions{})
+			if err != nil {
+				klog.ErrorS(err, "Failed to list objects", "group", g, "version", v, "resource", r)
+				return false
+			}
+		}
+		if len(list.Items) > 0 {
+			break
+		}
+	}
+
+	return true
 }
 
 // startReflector starts a Kubernetes client-go reflector with the given

--- a/main.go
+++ b/main.go
@@ -31,11 +31,9 @@ func main() {
 		internal.RunKubeStateMetricsWrapper(opts)
 	}
 	opts.AddFlags(cmd)
-
 	if err := opts.Parse(); err != nil {
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
-
 	if err := opts.Validate(); err != nil {
 		klog.ErrorS(err, "Validating options error")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -26,12 +26,9 @@ import (
 	"net/http/pprof"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
@@ -40,11 +37,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
-	clientset "k8s.io/client-go/kubernetes"
+	"gopkg.in/yaml.v3"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Initialize common client auth plugins.
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
+	"k8s.io/kube-state-metrics/v2/internal/discovery"
 	"k8s.io/kube-state-metrics/v2/internal/store"
 	"k8s.io/kube-state-metrics/v2/pkg/allowdenylist"
 	"k8s.io/kube-state-metrics/v2/pkg/customresource"
@@ -53,6 +51,7 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/metricshandler"
 	"k8s.io/kube-state-metrics/v2/pkg/optin"
 	"k8s.io/kube-state-metrics/v2/pkg/options"
+	"k8s.io/kube-state-metrics/v2/pkg/util"
 	"k8s.io/kube-state-metrics/v2/pkg/util/proc"
 )
 
@@ -89,9 +88,6 @@ func RunKubeStateMetricsWrapper(ctx context.Context, opts *options.Options) erro
 // which implements customresource.RegistryFactory and pass all factories into this function.
 func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 	promLogger := promLogger{}
-
-	storeBuilder := store.NewBuilder()
-
 	ksmMetricsRegistry := prometheus.NewRegistry()
 	ksmMetricsRegistry.MustRegister(version.NewCollector("kube_state_metrics"))
 	durationVec := promauto.With(ksmMetricsRegistry).NewHistogramVec(
@@ -118,6 +114,20 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 			Help: "Timestamp of the last successful configuration reload.",
 		}, []string{"type", "filename"})
 
+	// Register self-metrics to track the state of the cache.
+	crdsAddEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
+		Name: "kube_state_metrics_custom_resource_state_add_events_total",
+		Help: "Number of times that the CRD informer triggered the add event.",
+	})
+	crdsDeleteEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
+		Name: "kube_state_metrics_custom_resource_state_delete_events_total",
+		Help: "Number of times that the CRD informer triggered the remove event.",
+	})
+	crdsCacheCountGauge := promauto.With(ksmMetricsRegistry).NewGauge(prometheus.GaugeOpts{
+		Name: "kube_state_metrics_custom_resource_state_cache",
+		Help: "Net amount of CRDs affecting the cache currently.",
+	})
+	storeBuilder := store.NewBuilder()
 	storeBuilder.WithMetrics(ksmMetricsRegistry)
 
 	got := options.GetConfigFile(*opts)
@@ -145,6 +155,11 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		}
 	}
 
+	kubeConfig, err := clientcmd.BuildConfigFromFlags(opts.Apiserver, opts.Kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to build config from flags: %v", err)
+	}
+
 	// Loading custom resource state configuration from cli argument or config file
 	config, err := resolveCustomResourceConfig(opts)
 	if err != nil {
@@ -152,14 +167,6 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 	}
 
 	var factories []customresource.RegistryFactory
-
-	if config != nil {
-		factories, err = customresourcestate.FromConfig(config)
-		if err != nil {
-			return fmt.Errorf("Parsing from Custom Resource State Metrics file failed: %v", err)
-		}
-	}
-	storeBuilder.WithCustomResourceStoreFactories(factories...)
 
 	if opts.CustomResourceConfigFile != "" {
 		crcFile, err := os.ReadFile(filepath.Clean(opts.CustomResourceConfigFile))
@@ -184,8 +191,8 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		resources = append(resources, options.DefaultResources.AsSlice()...)
 		klog.InfoS("Used default resources")
 	case opts.CustomResourcesOnly:
-		// enable custom resource only
-		klog.InfoS("Used CRD resources only", "resources", resources)
+		// enable custom resource only, these resources will be populated later on
+		klog.InfoS("Used CRD resources only")
 	default:
 		resources = append(resources, opts.Resources.AsSlice()...)
 		klog.InfoS("Used resources", "resources", resources)
@@ -233,16 +240,15 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	storeBuilder.WithUsingAPIServerCache(opts.UseAPIServerCache)
 	storeBuilder.WithGenerateStoresFunc(storeBuilder.DefaultGenerateStoresFunc())
-	storeBuilder.WithGenerateCustomResourceStoresFunc(storeBuilder.DefaultGenerateCustomResourceStoresFunc())
-
 	proc.StartReaper()
 
-	kubeClient, customResourceClients, err := createKubeClient(opts.Apiserver, opts.Kubeconfig, factories...)
+	storeBuilder.WithUtilOptions(opts)
+	kubeClient, err := util.CreateKubeClient(opts.Apiserver, opts.Kubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %v", err)
 	}
 	storeBuilder.WithKubeClient(kubeClient)
-	storeBuilder.WithCustomResourceClients(customResourceClients)
+
 	storeBuilder.WithSharding(opts.Shard, opts.TotalShards)
 	storeBuilder.WithAllowAnnotations(opts.AnnotationsAllowList)
 	if err := storeBuilder.WithAllowLabels(opts.LabelsAllowList); err != nil {
@@ -263,7 +269,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		opts.EnableGZIPEncoding,
 	)
 	// Run MetricsHandler
-	{
+	if config == nil {
 		ctxMetricsHandler, cancel := context.WithCancel(ctx)
 		g.Add(func() error {
 			return m.Run(ctxMetricsHandler)
@@ -273,6 +279,33 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 	}
 
 	tlsConfig := opts.TLSConfig
+
+	// A nil CRS config implies that we need to hold off on all CRS operations.
+	if config != nil {
+		discovererInstance := &discovery.CRDiscoverer{
+			CRDsAddEventsCounter:    crdsAddEventsCounter,
+			CRDsDeleteEventsCounter: crdsDeleteEventsCounter,
+			CRDsCacheCountGauge:     crdsCacheCountGauge,
+		}
+		// This starts a goroutine that will watch for any new GVKs to extract from CRDs.
+		err = discovererInstance.StartDiscovery(ctx, kubeConfig)
+		if err != nil {
+			return err
+		}
+		// FromConfig will return different behaviours when a G**-based config is supplied (since that is subject to change based on the resources present in the cluster).
+		fn, err := customresourcestate.FromConfig(config, discovererInstance)
+		if err != nil {
+			return err
+		}
+		// This starts a goroutine that will keep the cache up to date.
+		discovererInstance.PollForCacheUpdates(
+			ctx,
+			opts,
+			storeBuilder,
+			m,
+			fn,
+		)
+	}
 
 	telemetryMux := buildTelemetryServer(ksmMetricsRegistry)
 	telemetryListenAddress := net.JoinHostPort(opts.TelemetryHost, strconv.Itoa(opts.TelemetryPort))
@@ -289,8 +322,8 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 	metricsServerListenAddress := net.JoinHostPort(opts.Host, strconv.Itoa(opts.Port))
 	metricsServer := http.Server{
 		Handler:           metricsMux,
-		ReadHeaderTimeout: 5 * time.Second}
-
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 	metricsFlags := web.FlagConfig{
 		WebListenAddresses: &[]string{metricsServerListenAddress},
 		WebSystemdSocket:   new(bool),
@@ -323,46 +356,9 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 	if err := g.Run(); err != nil {
 		return fmt.Errorf("run server group error: %v", err)
 	}
+
 	klog.InfoS("Exited")
 	return nil
-}
-
-func createKubeClient(apiserver string, kubeconfig string, factories ...customresource.RegistryFactory) (clientset.Interface, map[string]interface{}, error) {
-	config, err := clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	config.UserAgent = fmt.Sprintf("%s/%s (%s/%s) kubernetes/%s", "kube-state-metrics", version.Version, runtime.GOOS, runtime.GOARCH, version.Revision)
-	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
-	config.ContentType = "application/vnd.kubernetes.protobuf"
-
-	kubeClient, err := clientset.NewForConfig(config)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	customResourceClients := make(map[string]interface{}, len(factories))
-	for _, f := range factories {
-		customResourceClient, err := f.CreateClient(config)
-		if err != nil {
-			return nil, nil, err
-		}
-		customResourceClients[f.Name()] = customResourceClient
-	}
-
-	// Informers don't seem to do a good job logging error messages when it
-	// can't reach the server, making debugging hard. This makes it easier to
-	// figure out if apiserver is configured incorrectly.
-	klog.InfoS("Tested communication with server")
-	v, err := kubeClient.Discovery().ServerVersion()
-	if err != nil {
-		return nil, nil, fmt.Errorf("error while trying to communicate with apiserver: %w", err)
-	}
-	klog.InfoS("Run with Kubernetes cluster version", "major", v.Major, "minor", v.Minor, "gitVersion", v.GitVersion, "gitTreeState", v.GitTreeState, "gitCommit", v.GitCommit, "platform", v.Platform)
-	klog.InfoS("Communication with server successful")
-
-	return kubeClient, customResourceClients, nil
 }
 
 func buildTelemetryServer(registry prometheus.Gatherer) *http.ServeMux {

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -891,7 +891,7 @@ func (f *fooFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
 	return fooClient, nil
 }
 
-func (f *fooFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+func (f *fooFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
 			"kube_foo_spec_replicas",

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -115,11 +115,6 @@ func (b *Builder) WithGenerateStoresFunc(f ksmtypes.BuildStoresFunc) {
 	b.internal.WithGenerateStoresFunc(f)
 }
 
-// WithGenerateCustomResourceStoresFunc configures a custom generate custom resource store function
-func (b *Builder) WithGenerateCustomResourceStoresFunc(f ksmtypes.BuildCustomResourceStoresFunc) {
-	b.internal.WithGenerateCustomResourceStoresFunc(f)
-}
-
 // DefaultGenerateStoresFunc returns default buildStore function
 func (b *Builder) DefaultGenerateStoresFunc() ksmtypes.BuildStoresFunc {
 	return b.internal.DefaultGenerateStoresFunc()
@@ -145,4 +140,9 @@ func (b *Builder) Build() metricsstore.MetricsWriterList {
 // Returns metric stores.
 func (b *Builder) BuildStores() [][]cache.Store {
 	return b.internal.BuildStores()
+}
+
+// WithGenerateCustomResourceStoresFunc configures a custom generate custom resource store function
+func (b *Builder) WithGenerateCustomResourceStoresFunc(f ksmtypes.BuildCustomResourceStoresFunc) {
+	b.internal.WithGenerateCustomResourceStoresFunc(f)
 }

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -45,12 +45,12 @@ type BuilderInterface interface {
 	WithAllowAnnotations(a map[string][]string)
 	WithAllowLabels(l map[string][]string) error
 	WithGenerateStoresFunc(f BuildStoresFunc)
-	WithGenerateCustomResourceStoresFunc(f BuildCustomResourceStoresFunc)
 	DefaultGenerateStoresFunc() BuildStoresFunc
 	DefaultGenerateCustomResourceStoresFunc() BuildCustomResourceStoresFunc
 	WithCustomResourceStoreFactories(fs ...customresource.RegistryFactory)
 	Build() metricsstore.MetricsWriterList
 	BuildStores() [][]cache.Store
+	WithGenerateCustomResourceStoresFunc(f BuildCustomResourceStoresFunc)
 }
 
 // BuildStoresFunc function signature that is used to return a list of cache.Store

--- a/pkg/customresource/registry_factory.go
+++ b/pkg/customresource/registry_factory.go
@@ -86,7 +86,7 @@ type RegistryFactory interface {
 	//		),
 	//	}
 	// }
-	MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator
+	MetricFamilyGenerators() []generator.FamilyGenerator
 
 	// ExpectedType returns a pointer to an empty custom resource object.
 	//

--- a/pkg/customresourcestate/custom_resource_metrics.go
+++ b/pkg/customresourcestate/custom_resource_metrics.go
@@ -75,7 +75,7 @@ func (s customResourceMetrics) CreateClient(cfg *rest.Config) (interface{}, erro
 	}), nil
 }
 
-func (s customResourceMetrics) MetricFamilyGenerators(_, _ []string) (result []generator.FamilyGenerator) {
+func (s customResourceMetrics) MetricFamilyGenerators() (result []generator.FamilyGenerator) {
 	klog.InfoS("Custom resource state added metrics", "familyNames", s.names())
 	for _, f := range s.Families {
 		result = append(result, famGen(f))

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	basemetrics "k8s.io/component-base/metrics"
+	"k8s.io/klog/v2"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 )
@@ -73,6 +74,10 @@ func (g *FamilyGenerator) Generate(obj interface{}) *metric.Family {
 	family := g.GenerateFunc(obj)
 	family.Name = g.Name
 	family.Type = g.Type
+	// OpenMetrics spec requires that all Info metrics have a _info suffix.
+	if family.Type == metric.Info && !strings.HasSuffix(family.Name, "_info") {
+		klog.InfoS("Info metric %s does not have _info suffix", family.Name)
+	}
 	return family
 }
 

--- a/pkg/metrics_store/metrics_writer.go
+++ b/pkg/metrics_store/metrics_writer.go
@@ -58,8 +58,18 @@ func (m MetricsWriter) WriteAll(w io.Writer) error {
 		}(s)
 	}
 
+	// If the first store has no headers, but has metrics, we need to write out
+	// an empty header to ensure that the metrics are written out correctly.
+	if m.stores[0].headers == nil && m.stores[0].metrics != nil {
+		m.stores[0].headers = []string{""}
+	}
 	for i, help := range m.stores[0].headers {
-		_, err := w.Write([]byte(help + "\n"))
+		if help != "" && help != "\n" {
+			help += "\n"
+		}
+		// TODO: This writes out the help text for each metric family, before checking if the metrics for it exist,
+		// TODO: which is not ideal, and furthermore, diverges from the OpenMetrics standard.
+		_, err := w.Write([]byte(help))
 		if err != nil {
 			return fmt.Errorf("failed to write help text: %v", err)
 		}
@@ -74,4 +84,20 @@ func (m MetricsWriter) WriteAll(w io.Writer) error {
 		}
 	}
 	return nil
+}
+
+// SanitizeHeaders removes duplicate headers from the given MetricsWriterList for the same family (generated through CRS).
+// These are expected to be consecutive since G** resolution generates groups of similar metrics with same headers before moving onto the next G** spec in the CRS configuration.
+func SanitizeHeaders(writers MetricsWriterList) MetricsWriterList {
+	var lastHeader string
+	for _, writer := range writers {
+		for i, header := range writer.stores[0].headers {
+			if header == lastHeader {
+				writer.stores[0].headers[i] = ""
+			} else {
+				lastHeader = header
+			}
+		}
+	}
+	return writers
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2023 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/prometheus/common/version"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+	testUnstructuredMock "k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1"
+
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+)
+
+var config *rest.Config
+var currentKubeClient clientset.Interface
+var currentDiscoveryClient *discovery.DiscoveryClient
+var currentDynamicClient *dynamic.DynamicClient
+
+// CreateKubeClient creates a Kubernetes clientset and a custom resource clientset.
+func CreateKubeClient(apiserver string, kubeconfig string) (clientset.Interface, error) {
+	if currentKubeClient != nil {
+		return currentKubeClient, nil
+	}
+
+	var err error
+
+	if config == nil {
+		config, err = clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	config.UserAgent = fmt.Sprintf("%s/%s (%s/%s) kubernetes/%s", "kube-state-metrics", version.Version, runtime.GOOS, runtime.GOARCH, version.Revision)
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+
+	kubeClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Informers don't seem to do a good job logging error messages when it
+	// can't reach the server, making debugging hard. This makes it easier to
+	// figure out if apiserver is configured incorrectly.
+	klog.InfoS("Tested communication with server")
+	v, err := kubeClient.Discovery().ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("error while trying to communicate with apiserver: %w", err)
+	}
+	klog.InfoS("Run with Kubernetes cluster version", "major", v.Major, "minor", v.Minor, "gitVersion", v.GitVersion, "gitTreeState", v.GitTreeState, "gitCommit", v.GitCommit, "platform", v.Platform)
+	klog.InfoS("Communication with server successful")
+
+	currentKubeClient = kubeClient
+	return kubeClient, nil
+}
+
+// CreateCustomResourceClients creates a custom resource clientset.
+func CreateCustomResourceClients(apiserver string, kubeconfig string, factories ...customresource.RegistryFactory) (map[string]interface{}, error) {
+	// Not relying on memoized clients here because the factories are subject to change.
+	var err error
+	if config == nil {
+		config, err = clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+	customResourceClients := make(map[string]interface{}, len(factories))
+	for _, f := range factories {
+		customResourceClient, err := f.CreateClient(config)
+		if err != nil {
+			return nil, err
+		}
+		gvrString := GVRFromType(f.Name(), f.ExpectedType()).String()
+		customResourceClients[gvrString] = customResourceClient
+	}
+	return customResourceClients, nil
+}
+
+// CreateDiscoveryClient creates a Kubernetes discovery client.
+func CreateDiscoveryClient(apiserver string, kubeconfig string) (*discovery.DiscoveryClient, error) {
+	if currentDiscoveryClient != nil {
+		return currentDiscoveryClient, nil
+	}
+	var err error
+	if config == nil {
+		var err error
+		config, err = clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+	currentDiscoveryClient, err = discovery.NewDiscoveryClientForConfig(config)
+	return currentDiscoveryClient, err
+}
+
+// CreateDynamicClient creates a Kubernetes dynamic client.
+func CreateDynamicClient(apiserver string, kubeconfig string) (*dynamic.DynamicClient, error) {
+	if currentDynamicClient != nil {
+		return currentDynamicClient, nil
+	}
+	var err error
+	if config == nil {
+		config, err = clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+	currentDynamicClient, err = dynamic.NewForConfig(config)
+	return currentDynamicClient, err
+}
+
+// GVRFromType returns the GroupVersionResource for a given type.
+func GVRFromType(resourceName string, expectedType interface{}) *schema.GroupVersionResource {
+	if _, ok := expectedType.(*testUnstructuredMock.Foo); ok {
+		// testUnstructuredMock.Foo is a mock type for testing
+		return nil
+	}
+	apiVersion := expectedType.(*unstructured.Unstructured).Object["apiVersion"].(string)
+	expectedTypeSlice := strings.Split(apiVersion, "/")
+	g := expectedTypeSlice[0]
+	v := expectedTypeSlice[1]
+	if v == "" /* "" group (core) objects */ {
+		v = expectedTypeSlice[0]
+	}
+	r := resourceName
+	return &schema.GroupVersionResource{
+		Group:    g,
+		Version:  v,
+		Resource: r,
+	}
+}

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -179,8 +179,6 @@ echo "make requests to kube-state-metrics"
 set +e
 
 
-
-
 kube_state_metrics_up
 set -e
 
@@ -190,8 +188,6 @@ echo "start e2e test for kube-state-metrics"
 KSM_HTTP_METRICS_URL='http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy'
 KSM_TELEMETRY_URL='http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:telemetry/proxy'
 go test -v ./tests/e2e/main_test.go --ksm-http-metrics-url=${KSM_HTTP_METRICS_URL} --ksm-telemetry-url=${KSM_TELEMETRY_URL}
-go test -v ./tests/e2e/hot-reload_test.go
-
 
 # TODO: re-implement the following test cases in Go with the goal of removing this file.
 echo "access kube-state-metrics metrics endpoint"
@@ -206,6 +202,13 @@ fi
 sleep 33
 klog_err=E$(date +%m%d)
 echo "check for errors in logs"
+
+echo "running discovery tests..."
+go test -race -v ./tests/e2e/discovery_test.go
+
+echo "running hot-reload tests..."
+go test -v ./tests/e2e/hot-reload_test.go
+
 output_logs=$(kubectl --namespace=kube-system logs deployment/kube-state-metrics kube-state-metrics)
 if echo "${output_logs}" | grep "^${klog_err}"; then
     echo ""

--- a/tests/e2e/discovery_test.go
+++ b/tests/e2e/discovery_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2023 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"k8s.io/kube-state-metrics/v2/internal"
+	"k8s.io/kube-state-metrics/v2/internal/discovery"
+	"k8s.io/kube-state-metrics/v2/pkg/options"
+)
+
+// PopulateTimeout is the timeout on populating the cache for the first time.
+const PopulateTimeout = 10 * time.Second
+
+func TestVariableVKsDiscoveryAndResolution(t *testing.T) {
+
+	// Initialise options.
+	opts := options.NewOptions()
+	cmd := options.InitCommand
+	opts.AddFlags(cmd)
+	klog.InfoS("options", "options", opts)
+
+	// Create testdata.
+	crConfigFile, err := os.CreateTemp("", "cr-config.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	crdFile, err := os.CreateTemp("", "crd.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	crFile, err := os.CreateTemp("", "cr.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	klog.InfoS("testdata", "crConfigFile", crConfigFile.Name(), "crdFile", crdFile.Name(), "crFile", crFile.Name())
+
+	// Delete artefacts.
+	defer func() {
+		err := os.Remove(crConfigFile.Name())
+		if err != nil {
+			t.Fatalf("failed to remove CR config: %v", err)
+		}
+		err = os.Remove(crdFile.Name())
+		if err != nil {
+			t.Fatalf("failed to remove CRD manifest: %v", err)
+		}
+		err = os.Remove(crFile.Name())
+		if err != nil {
+			t.Fatalf("failed to remove CR manifest: %v", err)
+		}
+		klog.InfoS("deleted artefacts", "crConfigFile", crConfigFile.Name(), "crdFile", crdFile.Name(), "crFile", crFile.Name())
+	}()
+
+	// Populate options, and parse them.
+	opts.CustomResourceConfigFile = crConfigFile.Name()
+	opts.Kubeconfig = os.Getenv("HOME") + "/.kube/config"
+	if err := opts.Parse(); err != nil {
+		t.Fatalf("failed to parse options: %v", err)
+	}
+	klog.InfoS("parsed options", "options", opts)
+
+	// Write to the config file.
+	crConfig := getCRConfig()
+	err = os.WriteFile(opts.CustomResourceConfigFile, []byte(crConfig), 0600 /* rw------- */)
+	if err != nil {
+		t.Fatalf("cannot write to config file: %v", err)
+	}
+	klog.InfoS("populated cr config file", "crConfigFile", opts.CustomResourceConfigFile)
+
+	// Make the process asynchronous.
+	go internal.RunKubeStateMetricsWrapper(opts)
+	klog.InfoS("started KSM")
+
+	// Wait for port 8080 to come up.
+	err = wait.PollImmediate(1*time.Second, 20*time.Second, func() (bool, error) {
+		conn, err := net.Dial("tcp", "localhost:8080")
+		if err != nil {
+			return false, nil
+		}
+		err = conn.Close()
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed while waiting for port 8080 to come up: %v", err)
+	}
+	klog.InfoS("port 8080 up")
+
+	// Create CRD and CR files.
+	crd := getCRD()
+	cr := getCR()
+	err = os.WriteFile(crdFile.Name(), []byte(crd), 0600 /* rw------- */)
+	if err != nil {
+		t.Fatalf("cannot write to crd file: %v", err)
+	}
+	err = os.WriteFile(crFile.Name(), []byte(cr), 0600 /* rw------- */)
+	if err != nil {
+		t.Fatalf("cannot write to cr file: %v", err)
+	}
+	klog.InfoS("created CR and CRD manifests")
+
+	// Apply CRD and CR to the cluster.
+	err = exec.Command("kubectl", "apply", "-f", crdFile.Name()).Run() //nolint:gosec
+	if err != nil {
+		t.Fatalf("failed to apply crd: %v", err)
+	}
+	err = exec.Command("kubectl", "apply", "-f", crFile.Name()).Run() //nolint:gosec
+	if err != nil {
+		t.Fatalf("failed to apply cr: %v", err)
+	}
+	klog.InfoS("applied CR and CRD manifests")
+
+	// Wait for the metric to be available.
+	ch := make(chan bool, 1)
+	klog.InfoS("waiting for metrics to become available")
+	err = wait.PollImmediate(discovery.Interval, PopulateTimeout, func() (bool, error) {
+		out, err := exec.Command("curl", "localhost:8080/metrics").Output()
+		if err != nil {
+			return false, err
+		}
+		if string(out) == "" {
+			return false, nil
+		}
+		// Note the "{" below. This is to ensure that the metric is not in a comment.
+		if strings.Contains(string(out), "kube_customresource_test_metric{") {
+			klog.InfoS("metrics available", "metric", string(out))
+			// Signal the process to exit, since we know the metrics are being generated as expected.
+			ch <- true
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed while waiting for metrics to be available: %v", err)
+	}
+
+	// Wait for process to exit.
+	select {
+	case <-ch:
+		t.Log("test passed successfully")
+	case <-time.After(PopulateTimeout * 2):
+		t.Fatal("timed out waiting for test to pass, check the logs for more info")
+	}
+}
+
+func getCR() string {
+	return `
+apiVersion: contoso.com/v1alpha1
+kind: MyPlatform
+metadata:
+    name: test-dotnet-app
+spec:
+    appId: testdotnetapp
+    language: csharp
+    os: linux
+    instanceSize: small
+    environmentType: dev
+    replicas: 3
+`
+}
+
+func getCRD() string {
+	return `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+ name: myplatforms.contoso.com
+spec:
+ group: contoso.com
+ names:
+   plural: myplatforms
+   singular: myplatform
+   kind: MyPlatform
+   shortNames:
+   - myp
+ scope: Namespaced
+ versions:
+   - name: v1alpha1
+     served: true
+     storage: true
+     schema:
+       openAPIV3Schema:
+         type: object
+         properties:
+           spec:
+             type: object
+             properties:
+               appId:
+                 type: string
+               language:
+                 type: string
+                 enum:
+                 - csharp
+                 - python
+                 - go
+               os:
+                 type: string
+                 enum:
+                 - windows
+                 - linux
+               instanceSize:
+                 type: string
+                 enum:
+                   - small
+                   - medium
+                   - large
+               environmentType:
+                 type: string
+                 enum:
+                 - dev
+                 - test
+                 - prod
+               replicas:
+                 type: integer
+                 minimum: 1
+             required: ["appId", "language", "environmentType"]
+         required: ["spec"]
+`
+}
+
+func getCRConfig() string {
+	return `
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: "contoso.com"
+        version: "*"
+        kind: "*"
+      metrics:
+        - name: "test_metric"
+          help: "foo baz"
+          each:
+            type: Info
+            info:
+              path: [metadata]
+              labelsFromPath:
+                name: [name]
+`
+}

--- a/tests/e2e/hot-reload_test.go
+++ b/tests/e2e/hot-reload_test.go
@@ -97,14 +97,13 @@ func TestConfigHotReload(t *testing.T) {
 		if err != nil {
 			return false, err
 		}
+		// Indicate that the test has passed.
+		ch <- true
 		return true, nil
 	})
 	if err != nil {
 		t.Fatalf("failed to wait for port 8080 to come up after restarting the process: %v", err)
 	}
-
-	// Indicate that the test has passed.
-	ch <- true
 
 	// Wait for process to exit.
 	select {


### PR DESCRIPTION
**What this PR does / why we need it**: Allow optional VK in CR metrics, while only requiring the group to be fixed. This would allow users to define custom metrics for:
* a specific API version: version is fixed, kind varies.
* all the API versions of a resource: version varies, kind is fixed.
* all the APIs part of an API group: version varies, kind varies.

**How does this change affect the cardinality of KSM**: Increases, or stays the same, depending on the cardinality of the version(s) and/or kind(s), present under a group.

**Which issue(s) this PR fixes**: Fixes #1848
