### PR TITLE
docs: fix yaml for new 'type' in custom metrics

### DIFF
--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -43,7 +43,8 @@ spec:
                     metrics:
                       - name: active_count
                         help: "Count of active Foo"
-                        type: Gauge
+                        each:
+                          type: Gauge
                         ...
           - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,foos,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments,verticalpodautoscalers
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix a docs typo introduced with this PR: https://github.com/kubernetes/kube-state-metrics/pull/1777

The new 'type' field should be under 'each', see:

https://github.com/kubernetes/kube-state-metrics/blob/master/pkg/customresourcestate/registry_factory.go#L65
https://github.com/kubernetes/kube-state-metrics/blob/master/pkg/customresourcestate/registry_factory.go#L136

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
None