### PR TITLE
Add retention policy metrics for KEP-1847

### DIFF
--- a/docs/statefulset-metrics.md
+++ b/docs/statefulset-metrics.md
@@ -11,6 +11,7 @@
 | kube_statefulset_status_observed_generation | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_replicas | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_metadata_generation | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
+| kube_statefulset_persistentvolumeclaim_retention_policy | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt; <br> `when_deleted`=&lt;statefulset-when-deleted-pvc-policy&gt; <br> `when_scaled`=&lt;statefulset-when-scaled-pvc-policy&gt; | ALPHA |
 | kube_statefulset_created | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_labels | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt; <br> `label_STATEFULSET_LABEL`=&lt;STATEFULSET_LABEL&gt; | STABLE |
 | kube_statefulset_status_current_revision | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt; <br> `revision`=&lt;statefulset-current-revision&gt; | STABLE |

--- a/internal/store/statefulset_test.go
+++ b/internal/store/statefulset_test.go
@@ -63,6 +63,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# HELP kube_statefulset_created [STABLE] Unix creation timestamp
 				# HELP kube_statefulset_labels [STABLE] Kubernetes labels converted to Prometheus labels.
 				# HELP kube_statefulset_metadata_generation [STABLE] Sequence number representing a specific generation of the desired state for the StatefulSet.
+				# HELP kube_statefulset_persistentvolumeclaim_retention_policy Count of retention policy for StatefulSet template PVCs
 				# HELP kube_statefulset_replicas [STABLE] Number of desired pods for a StatefulSet.
 				# HELP kube_statefulset_status_current_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
 				# HELP kube_statefulset_status_observed_generation [STABLE] The generation observed by the StatefulSet controller.
@@ -75,6 +76,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# TYPE kube_statefulset_created gauge
 				# TYPE kube_statefulset_labels gauge
 				# TYPE kube_statefulset_metadata_generation gauge
+				# TYPE kube_statefulset_persistentvolumeclaim_retention_policy gauge
 				# TYPE kube_statefulset_replicas gauge
 				# TYPE kube_statefulset_status_current_revision gauge
 				# TYPE kube_statefulset_status_observed_generation gauge
@@ -110,6 +112,7 @@ func TestStatefulSetStore(t *testing.T) {
 				"kube_statefulset_status_replicas_updated",
 				"kube_statefulset_status_update_revision",
 				"kube_statefulset_status_current_revision",
+				"kube_statefulset_persistentvolumeclaim_retention_policy",
 			},
 		},
 		{
@@ -140,6 +143,7 @@ func TestStatefulSetStore(t *testing.T) {
 			Want: `
 				# HELP kube_statefulset_labels [STABLE] Kubernetes labels converted to Prometheus labels.
 				# HELP kube_statefulset_metadata_generation [STABLE] Sequence number representing a specific generation of the desired state for the StatefulSet.
+				# HELP kube_statefulset_persistentvolumeclaim_retention_policy Count of retention policy for StatefulSet template PVCs
 				# HELP kube_statefulset_replicas [STABLE] Number of desired pods for a StatefulSet.
 				# HELP kube_statefulset_status_current_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
 				# HELP kube_statefulset_status_observed_generation [STABLE] The generation observed by the StatefulSet controller.
@@ -151,6 +155,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# HELP kube_statefulset_status_update_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
 				# TYPE kube_statefulset_labels gauge
 				# TYPE kube_statefulset_metadata_generation gauge
+				# TYPE kube_statefulset_persistentvolumeclaim_retention_policy gauge
 				# TYPE kube_statefulset_replicas gauge
 				# TYPE kube_statefulset_status_current_revision gauge
 				# TYPE kube_statefulset_status_observed_generation gauge
@@ -161,14 +166,14 @@ func TestStatefulSetStore(t *testing.T) {
 				# TYPE kube_statefulset_status_replicas_updated gauge
 				# TYPE kube_statefulset_status_update_revision gauge
 				kube_statefulset_status_update_revision{namespace="ns2",revision="ur2",statefulset="statefulset2"} 1
- 				kube_statefulset_status_replicas{namespace="ns2",statefulset="statefulset2"} 5
+				kube_statefulset_status_replicas{namespace="ns2",statefulset="statefulset2"} 5
 				kube_statefulset_status_replicas_available{namespace="ns2",statefulset="statefulset2"} 4
 				kube_statefulset_status_replicas_current{namespace="ns2",statefulset="statefulset2"} 2
 				kube_statefulset_status_replicas_ready{namespace="ns2",statefulset="statefulset2"} 5
 				kube_statefulset_status_replicas_updated{namespace="ns2",statefulset="statefulset2"} 3
- 				kube_statefulset_status_observed_generation{namespace="ns2",statefulset="statefulset2"} 2
- 				kube_statefulset_replicas{namespace="ns2",statefulset="statefulset2"} 6
- 				kube_statefulset_metadata_generation{namespace="ns2",statefulset="statefulset2"} 21
+				kube_statefulset_status_observed_generation{namespace="ns2",statefulset="statefulset2"} 2
+				kube_statefulset_replicas{namespace="ns2",statefulset="statefulset2"} 6
+				kube_statefulset_metadata_generation{namespace="ns2",statefulset="statefulset2"} 21
 				kube_statefulset_labels{namespace="ns2",statefulset="statefulset2"} 1
 				kube_statefulset_status_current_revision{namespace="ns2",revision="cr2",statefulset="statefulset2"} 1
 `,
@@ -184,6 +189,7 @@ func TestStatefulSetStore(t *testing.T) {
 				"kube_statefulset_status_replicas_updated",
 				"kube_statefulset_status_update_revision",
 				"kube_statefulset_status_current_revision",
+				"kube_statefulset_persistentvolumeclaim_retention_policy",
 			},
 		},
 		{
@@ -210,6 +216,7 @@ func TestStatefulSetStore(t *testing.T) {
 			Want: `
 				# HELP kube_statefulset_labels [STABLE] Kubernetes labels converted to Prometheus labels.
 				# HELP kube_statefulset_metadata_generation [STABLE] Sequence number representing a specific generation of the desired state for the StatefulSet.
+				# HELP kube_statefulset_persistentvolumeclaim_retention_policy Count of retention policy for StatefulSet template PVCs
 				# HELP kube_statefulset_replicas [STABLE] Number of desired pods for a StatefulSet.
 				# HELP kube_statefulset_status_current_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
 				# HELP kube_statefulset_status_replicas [STABLE] The number of replicas per StatefulSet.
@@ -220,6 +227,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# HELP kube_statefulset_status_update_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
 				# TYPE kube_statefulset_labels gauge
 				# TYPE kube_statefulset_metadata_generation gauge
+				# TYPE kube_statefulset_persistentvolumeclaim_retention_policy gauge
 				# TYPE kube_statefulset_replicas gauge
 				# TYPE kube_statefulset_status_current_revision gauge
 				# TYPE kube_statefulset_status_replicas gauge
@@ -229,13 +237,13 @@ func TestStatefulSetStore(t *testing.T) {
 				# TYPE kube_statefulset_status_replicas_updated gauge
 				# TYPE kube_statefulset_status_update_revision gauge
 				kube_statefulset_status_update_revision{namespace="ns3",revision="ur3",statefulset="statefulset3"} 1
- 				kube_statefulset_status_replicas{namespace="ns3",statefulset="statefulset3"} 7
+				kube_statefulset_status_replicas{namespace="ns3",statefulset="statefulset3"} 7
 				kube_statefulset_status_replicas_available{namespace="ns3",statefulset="statefulset3"} 0
 				kube_statefulset_status_replicas_current{namespace="ns3",statefulset="statefulset3"} 0
 				kube_statefulset_status_replicas_ready{namespace="ns3",statefulset="statefulset3"} 0
 				kube_statefulset_status_replicas_updated{namespace="ns3",statefulset="statefulset3"} 0
- 				kube_statefulset_replicas{namespace="ns3",statefulset="statefulset3"} 9
- 				kube_statefulset_metadata_generation{namespace="ns3",statefulset="statefulset3"} 36
+				kube_statefulset_replicas{namespace="ns3",statefulset="statefulset3"} 9
+				kube_statefulset_metadata_generation{namespace="ns3",statefulset="statefulset3"} 36
 				kube_statefulset_labels{namespace="ns3",statefulset="statefulset3"} 1
 				kube_statefulset_status_current_revision{namespace="ns3",revision="cr3",statefulset="statefulset3"} 1
  			`,
@@ -250,6 +258,81 @@ func TestStatefulSetStore(t *testing.T) {
 				"kube_statefulset_status_replicas_updated",
 				"kube_statefulset_status_update_revision",
 				"kube_statefulset_status_current_revision",
+				"kube_statefulset_persistentvolumeclaim_retention_policy",
+			},
+		},
+		{
+			Obj: &v1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "statefulset4",
+					Namespace: "ns4",
+					Labels: map[string]string{
+						"app": "example4",
+					},
+					Generation: 1,
+				},
+				Spec: v1.StatefulSetSpec{
+					Replicas:    &statefulSet1Replicas,
+					ServiceName: "statefulset4service",
+					PersistentVolumeClaimRetentionPolicy: &v1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+						WhenDeleted: v1.RetainPersistentVolumeClaimRetentionPolicyType,
+						WhenScaled:  v1.DeletePersistentVolumeClaimRetentionPolicyType,
+					},
+				},
+				Status: v1.StatefulSetStatus{
+					ObservedGeneration: 0,
+					Replicas:           7,
+					UpdateRevision:     "ur3",
+					CurrentRevision:    "cr3",
+				},
+			},
+			Want: `
+				# HELP kube_statefulset_labels [STABLE] Kubernetes labels converted to Prometheus labels.
+				# HELP kube_statefulset_metadata_generation [STABLE] Sequence number representing a specific generation of the desired state for the StatefulSet.
+				# HELP kube_statefulset_persistentvolumeclaim_retention_policy Count of retention policy for StatefulSet template PVCs
+				# HELP kube_statefulset_replicas [STABLE] Number of desired pods for a StatefulSet.
+				# HELP kube_statefulset_status_current_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+				# HELP kube_statefulset_status_replicas [STABLE] The number of replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_available The number of available replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_current [STABLE] The number of current replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_ready [STABLE] The number of ready replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_updated [STABLE] The number of updated replicas per StatefulSet.
+				# HELP kube_statefulset_status_update_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+				# TYPE kube_statefulset_labels gauge
+				# TYPE kube_statefulset_metadata_generation gauge
+				# TYPE kube_statefulset_persistentvolumeclaim_retention_policy gauge
+				# TYPE kube_statefulset_replicas gauge
+				# TYPE kube_statefulset_status_current_revision gauge
+				# TYPE kube_statefulset_status_replicas gauge
+				# TYPE kube_statefulset_status_replicas_available gauge
+				# TYPE kube_statefulset_status_replicas_current gauge
+				# TYPE kube_statefulset_status_replicas_ready gauge
+				# TYPE kube_statefulset_status_replicas_updated gauge
+				# TYPE kube_statefulset_status_update_revision gauge
+				kube_statefulset_status_update_revision{namespace="ns4",revision="ur3",statefulset="statefulset4"} 1
+				kube_statefulset_status_replicas{namespace="ns4",statefulset="statefulset4"} 7
+				kube_statefulset_status_replicas_available{namespace="ns4",statefulset="statefulset4"} 0
+				kube_statefulset_status_replicas_current{namespace="ns4",statefulset="statefulset4"} 0
+				kube_statefulset_status_replicas_ready{namespace="ns4",statefulset="statefulset4"} 0
+				kube_statefulset_status_replicas_updated{namespace="ns4",statefulset="statefulset4"} 0
+				kube_statefulset_replicas{namespace="ns4",statefulset="statefulset4"} 3
+ 				kube_statefulset_metadata_generation{namespace="ns4",statefulset="statefulset4"} 1
+ 				kube_statefulset_persistentvolumeclaim_retention_policy{namespace="ns4",statefulset="statefulset4",when_deleted="Retain",when_scaled="Delete"} 1
+				kube_statefulset_labels{namespace="ns4",statefulset="statefulset4"} 1
+				kube_statefulset_status_current_revision{namespace="ns4",revision="cr3",statefulset="statefulset4"} 1
+ 			`,
+			MetricNames: []string{
+				"kube_statefulset_labels",
+				"kube_statefulset_metadata_generation",
+				"kube_statefulset_replicas",
+				"kube_statefulset_status_replicas",
+				"kube_statefulset_status_replicas_available",
+				"kube_statefulset_status_replicas_current",
+				"kube_statefulset_status_replicas_ready",
+				"kube_statefulset_status_replicas_updated",
+				"kube_statefulset_status_update_revision",
+				"kube_statefulset_status_current_revision",
+				"kube_statefulset_persistentvolumeclaim_retention_policy",
 			},
 		},
 	}
@@ -257,7 +340,7 @@ func TestStatefulSetStore(t *testing.T) {
 		c.Func = generator.ComposeMetricGenFuncs(statefulSetMetricFamilies(nil, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(statefulSetMetricFamilies(nil, nil))
 		if err := c.run(); err != nil {
-			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+			t.Errorf("unexpected collecting result for statefulset%d run:\n%s", i+1, err)
 		}
 	}
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

Add metrics for new StatefulSet fields from [KEP-1847](https://github.com/kubernetes/enhancements/issues/1847).

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Increases it by adding a new metric that has a cardinality of 5 x # stateful sets.

