### PR TITLE
Detect vulns actually used by KSM

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,26 @@
+name: cron
+
+on:
+  schedule:
+    # Run every Monday
+    - cron: '0 0 * * 1'
+
+env:
+  GO_VERSION: "^1.19"
+
+jobs:
+  ci-security-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout code
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install govulncheck binary
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run security checks
+        run: |
+          govulncheck -v ./...


### PR DESCRIPTION
Add a cron-job to detect vulns that are actually present in the code that KSM uses (for eg., the functions and procedures it actually calls, etc.), and not just false positives due to considering the entire package in general. cc @dgrisonnet 

Caveats: https://pkg.go.dev/golang.org/x/vuln@v0.0.0-20221103225512-4f561ca73b59/cmd/govulncheck#hdr-Limitations.

***

Visual: https://github.com/kubernetes/kube-state-metrics/pull/1883#issuecomment-1303472700.