### PR TITLE
Add node deletionTimestamp metric

### DIFF
--- a/docs/node-metrics.md
+++ b/docs/node-metrics.md
@@ -12,3 +12,4 @@
 | kube_node_status_allocatable | Gauge | The allocatable for different resources of a node that are available for scheduling | `cpu`=&lt;core&gt; <br> `ephemeral_storage`=&lt;byte&gt; <br> `pods`=&lt;integer&gt; <br> `attachable_volumes_*`=&lt;byte&gt; <br> `hugepages_*`=&lt;byte&gt; <br> `memory`=&lt;byte&gt; |`node`=&lt;node-address&gt; <br> `resource`=&lt;resource-name&gt; <br> `unit`=&lt;resource-unit&gt;| STABLE |
 | kube_node_status_condition | Gauge | The condition of a cluster node | |`node`=&lt;node-address&gt; <br> `condition`=&lt;node-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_node_created | Gauge | Unix creation timestamp | seconds |`node`=&lt;node-address&gt;| STABLE |
+| kube_node_deletion_timestamp | Gauge | Unix creation timestamp | seconds |`node`=&lt;node-address&gt;| STABLE |


### PR DESCRIPTION
**What this PR does / why we need it**: Adds deletionTimestamp metric, for nodes.

**How does this change affect the cardinality of KSM**: No change (no variable labels were introduced).

**Which issue(s) this PR fixes**: Fixes #1889.