### PR TITLE
endpoint: Rename createEndpointsListWatch() to createEndpointListWatch()

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -352,7 +352,7 @@ func (b *Builder) buildDeploymentStores() []cache.Store {
 }
 
 func (b *Builder) buildEndpointsStores() []cache.Store {
-	return b.buildStoresFunc(endpointMetricFamilies(b.allowAnnotationsList["endpoints"], b.allowLabelsList["endpoints"]), &v1.Endpoints{}, createEndpointsListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(endpointMetricFamilies(b.allowAnnotationsList["endpoints"], b.allowLabelsList["endpoints"]), &v1.Endpoints{}, createEndpointListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildHPAStores() []cache.Store {

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -223,7 +223,7 @@ func wrapEndpointFunc(f func(*v1.Endpoints) *metric.Family) func(interface{}) *m
 	}
 }
 
-func createEndpointsListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createEndpointListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector


### PR DESCRIPTION
Small change for consistency.

All other ListWatch functions use the singular for the resource they watch in their function name.
