### PR TITLE
Add Metrics for EndpointSlices

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ See each file for specific documentation about the exposed metrics:
 
 - [ClusterRole Metrics](clusterrole-metrics.md)
 - [ClusterRoleBinding Metrics](clusterrolebinding-metrics.md)
+- [EndpointSlice Metrics](endpointslice-metrics.md)
 - [IngressClass Metrics](ingressclass-metrics.md)
 - [Role Metrics](role-metrics.md)
 - [RoleBinding Metrics](rolebinding-metrics.md)

--- a/docs/endpointslice-metrics.md
+++ b/docs/endpointslice-metrics.md
@@ -1,0 +1,10 @@
+# Endpoint Metrics
+
+| Metric name| Metric type | Labels/tags | Status |
+| ---------- | ----------- | ----------- | ----------- |
+| kube_endpointslice_annotations | Gauge | `endpointslice`=&lt;endpointslice-name&gt; <br> `namespace`=&lt;endpointslice-namespace&gt; <br> `annotation_ENDPOINTSLICE_ANNOTATION`=&lt;ENDPOINTSLICE_ANNOTATION&gt;  | EXPERIMENTAL |
+| kube_endpointslice_info | Gauge | `endpointslice`=&lt;endpointslice-name&gt; <br> `namespace`=&lt;endpointslice-namespace&gt;  | EXPERIMENTAL |
+| kube_endpointslice_ports | Gauge | `endpointslice`=&lt;endpointslice-name&gt; <br> `namespace`=&lt;endpointslice-namespace&gt; <br> `port_name`=&lt;endpointslice-port-name&gt; <br> `port_protocol`=&lt;endpointslice-port-protocol&gt; <br> `port_number`=&lt;endpointslice-port-number&gt; | EXPERIMENTAL |
+| kube_endpointslice_endpoints | Gauge | `endpointslice`=&lt;endpointslice-name&gt; <br> `namespace`=&lt;endpointslice-namespace&gt; <br> `ready`=&lt;endpointslice-ready&gt; <br> `serving`=&lt;endpointslice-serving&gt; <br> `terminating`=&lt;endpointslice-terminating&gt; <br> `hostname`=&lt;endpointslice-hostname&gt; <br> `targetref_kind`=&lt;endpointslice-targetref-kind&gt; <br> `targetref_name`=&lt;endpointslice-targetref-name&gt; <br> `targetref_namespace`=&lt;endpointslice-targetref-namespace&gt; <br> `nodename`=&lt;endpointslice-nodename&gt; <br> `endpoint_zone`=&lt;endpointslice-zone&gt;  | EXPERIMENTAL |
+| kube_endpointslice_labels | Gauge | `endpointslice`=&lt;endpointslice-name&gt; <br> `namespace`=&lt;endpointslice-namespace&gt; <br> `label_ENDPOINTSLICE_LABEL`=&lt;ENDPOINTSLICE_LABEL&gt;  | EXPERIMENTAL |
+| kube_endpointslice_created | Gauge | `endpointslice`=&lt;endpointslice-name&gt; <br> `namespace`=&lt;endpointslice-namespace&gt; | EXPERIMENTAL |

--- a/examples/autosharding/cluster-role.yaml
+++ b/examples/autosharding/cluster-role.yaml
@@ -78,6 +78,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses

--- a/examples/standard/cluster-role.yaml
+++ b/examples/standard/cluster-role.yaml
@@ -78,6 +78,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -32,6 +32,7 @@ import (
 	certv1 "k8s.io/api/certificates/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -293,6 +294,7 @@ var availableStores = map[string]func(f *Builder) []cache.Store{
 	"daemonsets":                      func(b *Builder) []cache.Store { return b.buildDaemonSetStores() },
 	"deployments":                     func(b *Builder) []cache.Store { return b.buildDeploymentStores() },
 	"endpoints":                       func(b *Builder) []cache.Store { return b.buildEndpointsStores() },
+	"endpointslices":                  func(b *Builder) []cache.Store { return b.buildEndpointSlicesStores() },
 	"horizontalpodautoscalers":        func(b *Builder) []cache.Store { return b.buildHPAStores() },
 	"ingresses":                       func(b *Builder) []cache.Store { return b.buildIngressStores() },
 	"ingressclasses":                  func(b *Builder) []cache.Store { return b.buildIngressClassStores() },
@@ -353,6 +355,10 @@ func (b *Builder) buildDeploymentStores() []cache.Store {
 
 func (b *Builder) buildEndpointsStores() []cache.Store {
 	return b.buildStoresFunc(endpointMetricFamilies(b.allowAnnotationsList["endpoints"], b.allowLabelsList["endpoints"]), &v1.Endpoints{}, createEndpointsListWatch, b.useAPIServerCache)
+}
+
+func (b *Builder) buildEndpointSlicesStores() []cache.Store {
+	return b.buildStoresFunc(endpointSliceMetricFamilies(b.allowAnnotationsList["endpointslices"], b.allowLabelsList["endpointslices"]), &discoveryv1.EndpointSlice{}, createEndpointSliceListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildHPAStores() []cache.Store {

--- a/internal/store/endpointslice.go
+++ b/internal/store/endpointslice.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2022 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"context"
+	"strconv"
+
+	basemetrics "k8s.io/component-base/metrics"
+
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	descEndpointSliceAnnotationsName     = "kube_endpointslice_annotations"
+	descEndpointSliceAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
+	descEndpointSliceLabelsName          = "kube_endpointslice_labels"
+	descEndpointSliceLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descEndpointSliceLabelsDefaultLabels = []string{"endpointslice"}
+)
+
+func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
+		*generator.NewFamilyGeneratorWithStability(
+			"kube_endpointslice_info",
+			"Information about endpointslice.",
+			metric.Gauge,
+			basemetrics.ALPHA,
+			"",
+			wrapEndpointSliceFunc(func(s *discoveryv1.EndpointSlice) *metric.Family {
+
+				m := metric.Metric{
+					LabelKeys:   []string{"addresstype"},
+					LabelValues: []string{string(s.AddressType)},
+					Value:       1,
+				}
+				return &metric.Family{Metrics: []*metric.Metric{&m}}
+			}),
+		),
+		*generator.NewFamilyGeneratorWithStability(
+			"kube_endpointslice_created",
+			"Unix creation timestamp",
+			metric.Gauge,
+			basemetrics.ALPHA,
+			"",
+			wrapEndpointSliceFunc(func(s *discoveryv1.EndpointSlice) *metric.Family {
+				ms := []*metric.Metric{}
+				if !s.CreationTimestamp.IsZero() {
+					ms = append(ms, &metric.Metric{
+						Value: float64(s.CreationTimestamp.Unix()),
+					})
+				}
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGeneratorWithStability(
+			"kube_endpointslice_endpoints",
+			"Endpoints attached to the endpointslice.",
+			metric.Gauge,
+			basemetrics.ALPHA,
+			"",
+			wrapEndpointSliceFunc(func(e *discoveryv1.EndpointSlice) *metric.Family {
+				m := []*metric.Metric{}
+				for _, ep := range e.Endpoints {
+					var (
+						labelKeys,
+						labelValues []string
+					)
+
+					if ep.Conditions.Ready != nil {
+						labelKeys = append(labelKeys, "ready")
+						labelValues = append(labelValues, strconv.FormatBool(*ep.Conditions.Ready))
+					}
+					if ep.Conditions.Serving != nil {
+						labelKeys = append(labelKeys, "serving")
+						labelValues = append(labelValues, strconv.FormatBool(*ep.Conditions.Serving))
+					}
+					if ep.Conditions.Terminating != nil {
+						labelKeys = append(labelKeys, "terminating")
+						labelValues = append(labelValues, strconv.FormatBool(*ep.Conditions.Terminating))
+					}
+
+					if ep.Hostname != nil {
+						labelKeys = append(labelKeys, "hostname")
+						labelValues = append(labelValues, *ep.Hostname)
+					}
+
+					if ep.TargetRef != nil {
+						if ep.TargetRef.Kind != "" {
+							labelKeys = append(labelKeys, "targetref_kind")
+							labelValues = append(labelValues, ep.TargetRef.Kind)
+						}
+						if ep.TargetRef.Name != "" {
+							labelKeys = append(labelKeys, "targetref_name")
+							labelValues = append(labelValues, ep.TargetRef.Name)
+						}
+						if ep.TargetRef.Namespace != "" {
+							labelKeys = append(labelKeys, "targetref_namespace")
+							labelValues = append(labelValues, ep.TargetRef.Namespace)
+						}
+					}
+
+					if ep.NodeName != nil {
+						labelKeys = append(labelKeys, "endpoint_nodename")
+						labelValues = append(labelValues, *ep.NodeName)
+					}
+
+					if ep.Zone != nil {
+						labelKeys = append(labelKeys, "endpoint_zone")
+						labelValues = append(labelValues, *ep.Zone)
+					}
+					labelKeys = append(labelKeys, "address")
+					for _, address := range ep.Addresses {
+						newlabelValues := make([]string, len(labelValues))
+						copy(newlabelValues, labelValues)
+						m = append(m, &metric.Metric{
+							LabelKeys:   labelKeys,
+							LabelValues: append(newlabelValues, address),
+							Value:       1,
+						})
+					}
+				}
+				return &metric.Family{
+					Metrics: m,
+				}
+			}),
+		),
+
+		*generator.NewFamilyGeneratorWithStability(
+			"kube_endpointslice_ports",
+			"Ports attached to the endpointslice.",
+			metric.Gauge,
+			basemetrics.ALPHA,
+			"",
+			wrapEndpointSliceFunc(func(e *discoveryv1.EndpointSlice) *metric.Family {
+				m := []*metric.Metric{}
+				for _, port := range e.Ports {
+					m = append(m, &metric.Metric{
+						LabelValues: []string{*port.Name, string(*port.Protocol), strconv.FormatInt(int64(*port.Port), 10)},
+						LabelKeys:   []string{"port_name", "port_protocol", "port_number"},
+						Value:       1,
+					})
+				}
+				return &metric.Family{
+					Metrics: m,
+				}
+			}),
+		),
+		*generator.NewFamilyGeneratorWithStability(
+			descEndpointSliceAnnotationsName,
+			descEndpointSliceAnnotationsHelp,
+			metric.Gauge,
+			basemetrics.ALPHA,
+			"",
+			wrapEndpointSliceFunc(func(s *discoveryv1.EndpointSlice) *metric.Family {
+				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   annotationKeys,
+							LabelValues: annotationValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+		*generator.NewFamilyGeneratorWithStability(
+			descEndpointSliceLabelsName,
+			descEndpointSliceLabelsHelp,
+			metric.Gauge,
+			basemetrics.ALPHA,
+			"",
+			wrapEndpointSliceFunc(func(s *discoveryv1.EndpointSlice) *metric.Family {
+				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
+				return &metric.Family{
+					Metrics: []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: labelValues,
+							Value:       1,
+						},
+					},
+				}
+			}),
+		),
+	}
+}
+
+func wrapEndpointSliceFunc(f func(*discoveryv1.EndpointSlice) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		endpointSlice := obj.(*discoveryv1.EndpointSlice)
+
+		metricFamily := f(endpointSlice)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys, m.LabelValues = mergeKeyValues(descEndpointSliceLabelsDefaultLabels, []string{endpointSlice.Name}, m.LabelKeys, m.LabelValues)
+		}
+
+		return metricFamily
+	}
+}
+
+func createEndpointSliceListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.DiscoveryV1().EndpointSlices(ns).List(context.TODO(), opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.DiscoveryV1().EndpointSlices(ns).Watch(context.TODO(), opts)
+		},
+	}
+}

--- a/internal/store/endpointslice_test.go
+++ b/internal/store/endpointslice_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2022 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+)
+
+func TestEndpointSliceStore(t *testing.T) {
+	startTime := 1501569018
+	metav1StartTime := metav1.Unix(int64(startTime), 0)
+	portname := "http"
+	portnumber := int32(80)
+	portprotocol := corev1.Protocol("TCP")
+	nodename := "node"
+	hostname := "host"
+	zone := "west"
+	ready := true
+	terminating := false
+	addresses := []string{"10.0.0.1", "192.168.1.10"}
+
+	cases := []generateMetricsTestCase{
+		{
+			Obj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test_endpointslice-info",
+				},
+				AddressType: "IPv4",
+			},
+			Want: `
+					# HELP kube_endpointslice_info Information about endpointslice.
+					# TYPE kube_endpointslice_info gauge
+					kube_endpointslice_info{endpointslice="test_endpointslice-info",addresstype="IPv4"} 1
+				`,
+			MetricNames: []string{
+				"kube_endpointslice_info",
+			},
+		},
+		{
+			Obj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test_kube_endpointslice-created",
+					CreationTimestamp: metav1StartTime,
+				},
+				AddressType: "IPv4",
+			},
+			Want: `
+					# HELP kube_endpointslice_created Unix creation timestamp
+					# TYPE kube_endpointslice_created gauge
+					kube_endpointslice_created{endpointslice="test_kube_endpointslice-created"} 1.501569018e+09
+				`,
+			MetricNames: []string{
+				"kube_endpointslice_created",
+			},
+		},
+		{
+			Obj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test_endpointslice-ports",
+				},
+				AddressType: "IPv4",
+				Ports: []discoveryv1.EndpointPort{
+					{Name: &portname,
+						Port:     &portnumber,
+						Protocol: &portprotocol,
+					},
+				},
+			},
+			Want: `
+					# HELP kube_endpointslice_ports Ports attached to the endpointslice.
+					# TYPE kube_endpointslice_ports gauge
+					kube_endpointslice_ports{endpointslice="test_endpointslice-ports",port_name="http",port_protocol="TCP",port_number="80"} 1
+				`,
+			MetricNames: []string{
+				"kube_endpointslice_ports",
+			},
+		},
+		{
+			Obj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test_endpointslice-endpoints",
+				},
+				AddressType: "IPv4",
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						NodeName: &nodename,
+						Conditions: discoveryv1.EndpointConditions{
+							Ready:       &ready,
+							Terminating: &terminating,
+						},
+						Hostname:  &hostname,
+						Zone:      &zone,
+						Addresses: addresses,
+					},
+				},
+			},
+			Want: `
+					# HELP kube_endpointslice_endpoints Endpoints attached to the endpointslice.
+					# TYPE kube_endpointslice_endpoints gauge
+					kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false"} 1
+					kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false"} 1
+				  `,
+
+			MetricNames: []string{
+				"kube_endpointslice_endpoints",
+			},
+		},
+		{
+			AllowAnnotationsList: []string{
+				"foo",
+			},
+			Obj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test_endpointslice-labels",
+					Annotations: map[string]string{
+						"foo": "baz",
+					},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				AddressType: "IPv4",
+			},
+			Want: `
+					# HELP kube_endpointslice_annotations Kubernetes annotations converted to Prometheus labels.
+					# HELP kube_endpointslice_labels Kubernetes labels converted to Prometheus labels.
+					# TYPE kube_endpointslice_annotations gauge
+					# TYPE kube_endpointslice_labels gauge
+					kube_endpointslice_annotations{endpointslice="test_endpointslice-labels",annotation_foo="baz"} 1
+					kube_endpointslice_labels{endpointslice="test_endpointslice-labels"} 1
+				`,
+			MetricNames: []string{
+				"kube_endpointslice_annotations", "kube_endpointslice_labels",
+			},
+		},
+	}
+	for i, c := range cases {
+		c.Func = generator.ComposeMetricGenFuncs(endpointSliceMetricFamilies(c.AllowAnnotationsList, nil))
+		c.Headers = generator.ExtractMetricFamilyHeaders(endpointSliceMetricFamilies(c.AllowAnnotationsList, nil))
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+	}
+}

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -115,6 +115,13 @@
         verbs: ['list', 'watch'],
       },
       {
+        apiGroups: ['discovery.k8s.io'],
+        resources: [
+          'endpointslices',
+        ],
+        verbs: ['list', 'watch'],
+      },
+      {
         apiGroups: ['storage.k8s.io'],
         resources: [
           'storageclasses',

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -256,6 +256,7 @@ func TestDefaultCollectorMetricsAvailable(t *testing.T) {
 	nonDefaultResources := map[string]bool{
 		"clusterrole":           true,
 		"clusterrolebinding":    true,
+		"endpointslice":         true,
 		"ingressclass":          true,
 		"role":                  true,
 		"rolebinding":           true,

--- a/tests/manifests/endpointslice.yaml
+++ b/tests/manifests/endpointslice.yaml
@@ -1,0 +1,13 @@
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: example-endpointslice
+  namespace: default
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.0.0.2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Implements https://pkg.go.dev/k8s.io/api/discovery/v1#EndpointSlice
Metrics from endpointslices can be used to identify if specific pods are part of an endpoint and thus discoverable through a service.

```
kube_endpointslice_info{endpointslice="my-app-75zcw",addresstype="IPv4"} 1
kube_endpointslice_created{endpointslice="my-app-75zcw"} 1.605287362e+09
kube_endpointslice_endpoints{endpointslice="my-app-75zcw",ready="true",serving="true",terminating="false",targetref_kind="Pod",targetref_name="my-app-73967648-75dgx",targetref_namespace="my-namespace",endpoint_nodename="my-node",endpoint_zone="west",address="192.168.1.1"} 1
kube_endpointslice_ports{endpointslice="my-app-75zcw",port_name="http",port_protocol="TCP",port_number="8080"} 1
```

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
This resource type is disabled by default as they are very verbose and have a high cardinality.