### PR TITLE
Add metrics for config file changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ please check the blog post [here](https://www.robustperception.io/exposing-the-s
 Sharding metrics expose `--shard` and `--total-shards` flags and can be used to validate
 run-time configuration, see [`/examples/prometheus-alerting-rules`](./examples/prometheus-alerting-rules).
 
+kube-state-metrics also exposes metrics about it config file: 
+
+```
+kube_state_metrics_config_hash{type="config", filename="config.yml"} 4.0061079457904e+13
+kube_state_metrics_config_last_reload_success_timestamp_seconds{type="config", filename="config.yml"} 1.6697483049487052e+09
+kube_state_metrics_config_last_reload_successful{type="config", filename="config.yml"} 1
+```
+
 ### Scaling kube-state-metrics
 
 #### Resource recommendation

--- a/internal/wrapper.go
+++ b/internal/wrapper.go
@@ -54,7 +54,7 @@ func RunKubeStateMetricsWrapper(opts *options.Options) {
 		}
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	if file := options.GetOptsConfigFile(*opts); file != "" {
+	if file := options.GetConfigFile(*opts); file != "" {
 		viper.SetConfigType("yaml")
 		viper.SetConfigFile(file)
 		if err := viper.ReadInConfig(); err != nil {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -62,8 +62,8 @@ type Options struct {
 	cmd *cobra.Command
 }
 
-// GetOptsConfigFile is the getter for --options-config-file value.
-func GetOptsConfigFile(opt Options) string {
+// GetConfigFile is the getter for --config value.
+func GetConfigFile(opt Options) string {
 	return opt.Config
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Provides metrics for config file updates when viper picks up a new config.

This uses code pieces from prometheus/alertmanager in https://github.com/prometheus/alertmanager/blob/main/config/coordinator.go#LL56C26-L56C26 licensed under Apache-2.0.

kube_state_metrics_config_hash 4.0061079457904e+13 kube_state_metrics_config_last_reload_success_timestamp_seconds 1.6697483049487052e+09 kube_state_metrics_config_last_reload_successful 1


**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Adds three metric series to the ksm exporter, not the kubernetes exporter. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1893
