### PR TITLE
Empty string for "owner_*" dimensions in all metrics.

### DIFF
--- a/docs/persistentvolumeclaim-metrics.md
+++ b/docs/persistentvolumeclaim-metrics.md
@@ -13,4 +13,4 @@
 
 Note:
 
-- A special `<none>` string will be used if PVC has no storage class.
+- An empty string will be used if PVC has no storage class.

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -364,7 +364,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 						Metrics: []*metric.Metric{
 							{
 								LabelKeys:   labelKeys,
-								LabelValues: []string{"<none>", "<none>", "<none>"},
+								LabelValues: []string{"", "", ""},
 								Value:       1,
 							},
 						},

--- a/internal/store/job_test.go
+++ b/internal/store/job_test.go
@@ -154,7 +154,7 @@ func TestJobStore(t *testing.T) {
 			},
 			Want: metadata + `
 				kube_job_annotations{job_name="SuccessfulJob1",namespace="ns1"} 1
-				kube_job_owner{job_name="SuccessfulJob1",namespace="ns1",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>"} 1
+				kube_job_owner{job_name="SuccessfulJob1",namespace="ns1",owner_is_controller="",owner_kind="",owner_name=""} 1
 				kube_job_complete{condition="false",job_name="SuccessfulJob1",namespace="ns1"} 0
 				kube_job_complete{condition="true",job_name="SuccessfulJob1",namespace="ns1"} 1
 				kube_job_complete{condition="unknown",job_name="SuccessfulJob1",namespace="ns1"} 0
@@ -198,7 +198,7 @@ func TestJobStore(t *testing.T) {
 			},
 			Want: metadata + `
 				kube_job_annotations{job_name="FailedJob1",namespace="ns1"} 1
-				kube_job_owner{job_name="FailedJob1",namespace="ns1",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>"} 1
+				kube_job_owner{job_name="FailedJob1",namespace="ns1",owner_is_controller="",owner_kind="",owner_name=""} 1
 				kube_job_failed{condition="false",job_name="FailedJob1",namespace="ns1"} 0
 				kube_job_failed{condition="true",job_name="FailedJob1",namespace="ns1"} 1
 				kube_job_failed{condition="unknown",job_name="FailedJob1",namespace="ns1"} 0
@@ -243,7 +243,7 @@ func TestJobStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_job_owner{job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>"} 1
+				kube_job_owner{job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1",owner_is_controller="",owner_kind="",owner_name=""} 1
 				kube_job_complete{condition="false",job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 0
 				kube_job_complete{condition="true",job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 1
 

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -53,7 +53,7 @@ var (
 						Metrics: []*metric.Metric{
 							{
 								LabelKeys:   labelKeys,
-								LabelValues: []string{"<none>", "<none>", l.Namespace, holder},
+								LabelValues: []string{"", "", l.Namespace, holder},
 								Value:       1,
 							},
 						},

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -270,6 +270,6 @@ func getPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
 		return *claim.Spec.StorageClassName
 	}
 
-	// An empty string indicate absence of storage class.
+	// An empty string indicates the absence of storage class.
 	return ""
 }

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -270,6 +270,6 @@ func getPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
 		return *claim.Spec.StorageClassName
 	}
 
-	// Special non-empty string to indicate absence of storage class.
-	return "<none>"
+	// An empty string indicate absence of storage class.
+	return ""
 }

--- a/internal/store/persistentvolumeclaim_test.go
+++ b/internal/store/persistentvolumeclaim_test.go
@@ -257,7 +257,7 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 				# TYPE kube_persistentvolumeclaim_status_phase gauge
 				# TYPE kube_persistentvolumeclaim_status_condition gauge
 				kube_persistentvolumeclaim_created{namespace="",persistentvolumeclaim="mongo-data"} 1.5e+09
-				kube_persistentvolumeclaim_info{namespace="",persistentvolumeclaim="mongo-data",storageclass="<none>",volumename=""} 1
+				kube_persistentvolumeclaim_info{namespace="",persistentvolumeclaim="mongo-data",storageclass="",volumename=""} 1
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Bound"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Lost"} 1
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Pending"} 0

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -597,8 +597,8 @@ func createPodInfoFamilyGenerator() generator.FamilyGenerator {
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			createdBy := metav1.GetControllerOf(p)
-			createdByKind := "<none>"
-			createdByName := "<none>"
+			createdByKind := ""
+			createdByName := ""
 			if createdBy != nil {
 				if createdBy.Kind != "" {
 					createdByKind = createdBy.Kind
@@ -1118,7 +1118,7 @@ func createPodOwnerFamilyGenerator() generator.FamilyGenerator {
 					Metrics: []*metric.Metric{
 						{
 							LabelKeys:   labelKeys,
-							LabelValues: []string{"<none>", "<none>", "<none>"},
+							LabelValues: []string{"", "", ""},
 							Value:       1,
 						},
 					},

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1032,11 +1032,11 @@ func TestPodStore(t *testing.T) {
 				# TYPE kube_pod_owner gauge
 				# TYPE kube_pod_start_time gauge
 				kube_pod_created{namespace="ns1",pod="pod1",uid="abc-123-xxx"} 1.5e+09
-				kube_pod_info{created_by_kind="<none>",created_by_name="<none>",host_ip="1.1.1.1",namespace="ns1",node="node1",pod="pod1",pod_ip="1.2.3.4",uid="abc-123-xxx",priority_class="system-node-critical",host_network="true"} 1
+				kube_pod_info{created_by_kind="",created_by_name="",host_ip="1.1.1.1",namespace="ns1",node="node1",pod="pod1",pod_ip="1.2.3.4",uid="abc-123-xxx",priority_class="system-node-critical",host_network="true"} 1
 				kube_pod_ips{namespace="ns1",pod="pod1",uid="abc-123-xxx",ip="1.2.3.4",ip_family="4"} 1
 				kube_pod_ips{namespace="ns1",pod="pod1",uid="abc-123-xxx",ip="fc00:1234:5678:90ab:cdef:cafe:f00d:d00d",ip_family="6"} 1
 				kube_pod_start_time{namespace="ns1",pod="pod1",uid="abc-123-xxx"} 1.501569018e+09
-				kube_pod_owner{namespace="ns1",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>",pod="pod1",uid="abc-123-xxx"} 1
+				kube_pod_owner{namespace="ns1",owner_is_controller="",owner_kind="",owner_name="",pod="pod1",uid="abc-123-xxx"} 1
 `,
 			MetricNames: []string{"kube_pod_created", "kube_pod_info", "kube_pod_ips", "kube_pod_start_time", "kube_pod_completion_time", "kube_pod_owner"},
 		},

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -178,7 +178,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 						Metrics: []*metric.Metric{
 							{
 								LabelKeys:   []string{"owner_kind", "owner_name", "owner_is_controller"},
-								LabelValues: []string{"<none>", "<none>", "<none>"},
+								LabelValues: []string{"", "", ""},
 								Value:       1,
 							},
 						},

--- a/internal/store/replicaset_test.go
+++ b/internal/store/replicaset_test.go
@@ -129,7 +129,7 @@ func TestReplicaSetStore(t *testing.T) {
 				kube_replicaset_status_fully_labeled_replicas{namespace="ns2",replicaset="rs2"} 5
 				kube_replicaset_status_ready_replicas{namespace="ns2",replicaset="rs2"} 0
 				kube_replicaset_spec_replicas{namespace="ns2",replicaset="rs2"} 0
-				kube_replicaset_owner{namespace="ns2",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>",replicaset="rs2"} 1
+				kube_replicaset_owner{namespace="ns2",owner_is_controller="",owner_kind="",owner_name="",replicaset="rs2"} 1
 			`,
 		},
 	}

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -185,7 +185,7 @@ var (
 				if len(owners) == 0 {
 					ms = append(ms, &metric.Metric{
 						LabelKeys:   labelKeys,
-						LabelValues: []string{"<none>", "<none>", "<none>"},
+						LabelValues: []string{"", "", ""},
 						Value:       1,
 					})
 				} else {

--- a/internal/store/replicationcontroller_test.go
+++ b/internal/store/replicationcontroller_test.go
@@ -116,7 +116,7 @@ func TestReplicationControllerStore(t *testing.T) {
 			},
 			Want: metadata + `
 				kube_replicationcontroller_metadata_generation{namespace="ns2",replicationcontroller="rc2"} 14
-				kube_replicationcontroller_owner{namespace="ns2",owner_is_controller="<none>",owner_kind="<none>",owner_name="<none>",replicationcontroller="rc2"} 1
+				kube_replicationcontroller_owner{namespace="ns2",owner_is_controller="",owner_kind="",owner_name="",replicationcontroller="rc2"} 1
 				kube_replicationcontroller_status_replicas{namespace="ns2",replicationcontroller="rc2"} 0
 				kube_replicationcontroller_status_observed_generation{namespace="ns2",replicationcontroller="rc2"} 5
 				kube_replicationcontroller_status_fully_labeled_replicas{namespace="ns2",replicationcontroller="rc2"} 5

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -322,9 +322,9 @@ kube_pod_container_status_waiting_reason{namespace="default",pod="pod0",uid="abc
 kube_pod_container_status_waiting{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1"} 1
 kube_pod_container_status_waiting{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2"} 0
 kube_pod_created{namespace="default",pod="pod0",uid="abc-0"} 1.5e+09
-kube_pod_info{namespace="default",pod="pod0",uid="abc-0",host_ip="1.1.1.1",pod_ip="1.2.3.4",node="node1",created_by_kind="<none>",created_by_name="<none>",priority_class="",host_network="false"} 1
+kube_pod_info{namespace="default",pod="pod0",uid="abc-0",host_ip="1.1.1.1",pod_ip="1.2.3.4",node="node1",created_by_kind="",created_by_name="",priority_class="",host_network="false"} 1
 kube_pod_labels{namespace="default",pod="pod0",uid="abc-0"} 1
-kube_pod_owner{namespace="default",pod="pod0",uid="abc-0",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="default",pod="pod0",uid="abc-0",owner_kind="",owner_name="",owner_is_controller=""} 1
 kube_pod_restart_policy{namespace="default",pod="pod0",uid="abc-0",type="Always"} 1
 kube_pod_status_phase{namespace="default",pod="pod0",uid="abc-0",phase="Failed"} 0
 kube_pod_status_phase{namespace="default",pod="pod0",uid="abc-0",phase="Pending"} 0


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace "<none>" with empty string for "owner_kind", "owner_name" and "owner_is_controller" dimensions for all metrics.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Does not change cardinality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1919
