### PR TITLE
Reload CustomResourceState Config File on Change

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -271,7 +271,7 @@ func TestDefaultCollectorMetricsAvailable(t *testing.T) {
 
 	files, err := os.ReadDir("../../internal/store/")
 	if err != nil {
-		t.Fatalf("failed to read dir to get all resouces name: %v", err)
+		t.Fatalf("failed to read dir to get all resources name: %v", err)
 	}
 
 	re := regexp.MustCompile(`^([a-z]+).go$`)


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds hot reloading support for the customresourcestate config file.


It also resolves a bug in which the customresourcestate config file was
included in the ksm config file, in which it did not get detected.

It also resolves a bug in which customresourcestatemetrics were not
added when resources were non-default resources.

Code for this file change detection was reused from https://github.com/spf13/viper licensed under MIT license.



**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1892
