### PR TITLE
promote namespace annotations metrics

### DIFF
--- a/docs/namespace-metrics.md
+++ b/docs/namespace-metrics.md
@@ -2,7 +2,7 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
-| kube_namespace_annotations | Gauge | `namespace`=&lt;namespace-name&gt; <br> `label_NS_ANNOTATION`=&lt;NS_ANNOTATION&gt;  | EXPERIMENTAL |
+| kube_namespace_annotations | Gauge | `namespace`=&lt;namespace-name&gt; <br> `label_NS_ANNOTATION`=&lt;NS_ANNOTATION&gt;  | STABLE |
 | kube_namespace_created | Gauge | `namespace`=&lt;namespace-name&gt; | STABLE |
 | kube_namespace_labels | Gauge | `namespace`=&lt;namespace-name&gt; <br> `label_NS_LABEL`=&lt;NS_LABEL&gt; | STABLE |
 | kube_namespace_status_condition | Gauge | `namespace`=&lt;namespace-name&gt; <br> `condition`=&lt;NamespaceDeletionDiscoveryFailure\|NamespaceDeletionContentFailure\|NamespaceDeletionGroupVersionParsingFailure&gt;  <br> `status`=&lt;true\|false\|unknown&gt; | EXPERIMENTAL |


### PR DESCRIPTION
**What this PR does / why we need it**:
Promotes kube_namespace_annotations to stable. For KSM to act as an e2e monitoring solution of kubernetes state, we need this metric to be stable.  Read more about the why in the linked issue.
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Does not Change cardinality as metrics are already in the metrics endpoint, we are just promoting them
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1940

Regarding #1792