### PR TITLE
Add StatefulSet Start Ordinal metrics for KEP-3335

### DIFF
--- a/docs/statefulset-metrics.md
+++ b/docs/statefulset-metrics.md
@@ -10,6 +10,7 @@
 | kube_statefulset_status_replicas_updated | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_status_observed_generation | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_replicas | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
+| kube_statefulset_ordinal_start | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | ALPHA |
 | kube_statefulset_metadata_generation | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_persistentvolumeclaim_retention_policy | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt; <br> `when_deleted`=&lt;statefulset-when-deleted-pvc-policy&gt; <br> `when_scaled`=&lt;statefulset-when-scaled-pvc-policy&gt; | EXPERIMENTAL |
 | kube_statefulset_created | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |

--- a/docs/statefulset-metrics.md
+++ b/docs/statefulset-metrics.md
@@ -10,7 +10,7 @@
 | kube_statefulset_status_replicas_updated | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_status_observed_generation | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_replicas | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
-| kube_statefulset_ordinal_start | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | ALPHA |
+| kube_statefulset_ordinals_start | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | ALPHA |
 | kube_statefulset_metadata_generation | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |
 | kube_statefulset_persistentvolumeclaim_retention_policy | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt; <br> `when_deleted`=&lt;statefulset-when-deleted-pvc-policy&gt; <br> `when_scaled`=&lt;statefulset-when-scaled-pvc-policy&gt; | EXPERIMENTAL |
 | kube_statefulset_created | Gauge | `statefulset`=&lt;statefulset-name&gt; <br> `namespace`=&lt;statefulset-namespace&gt;  | STABLE |

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -179,6 +179,26 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			}),
 		),
 		*generator.NewFamilyGeneratorWithStability(
+			"kube_statefulset_ordinals_start",
+			"Start ordinal of the StatefulSet.",
+			metric.Gauge,
+			basemetrics.ALPHA,
+			"",
+			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if s.Spec.Ordinals != nil {
+					ms = append(ms, &metric.Metric{
+						Value: float64(s.Spec.Ordinals.Start),
+					})
+				}
+
+				return &metric.Family{
+					Metrics: ms,
+				}
+			}),
+		),
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_statefulset_metadata_generation",
 			"Sequence number representing a specific generation of the desired state for the StatefulSet.",
 			metric.Gauge,

--- a/internal/store/statefulset_test.go
+++ b/internal/store/statefulset_test.go
@@ -65,7 +65,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# HELP kube_statefulset_metadata_generation [STABLE] Sequence number representing a specific generation of the desired state for the StatefulSet.
 				# HELP kube_statefulset_persistentvolumeclaim_retention_policy Count of retention policy for StatefulSet template PVCs
 				# HELP kube_statefulset_replicas [STABLE] Number of desired pods for a StatefulSet.
-                # HELP kube_statefulset_ordinals_start Start ordinal of the StatefulSet.
+				# HELP kube_statefulset_ordinals_start Start ordinal of the StatefulSet.
 				# HELP kube_statefulset_status_current_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
 				# HELP kube_statefulset_status_observed_generation [STABLE] The generation observed by the StatefulSet controller.
 				# HELP kube_statefulset_status_replicas [STABLE] The number of replicas per StatefulSet.
@@ -368,7 +368,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# HELP kube_statefulset_metadata_generation [STABLE] Sequence number representing a specific generation of the desired state for the StatefulSet.
 				# HELP kube_statefulset_persistentvolumeclaim_retention_policy Count of retention policy for StatefulSet template PVCs
 				# HELP kube_statefulset_replicas [STABLE] Number of desired pods for a StatefulSet.
-                # HELP kube_statefulset_ordinals_start Start ordinal of the StatefulSet.
+				# HELP kube_statefulset_ordinals_start Start ordinal of the StatefulSet.
 				# HELP kube_statefulset_status_current_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
 				# HELP kube_statefulset_status_replicas [STABLE] The number of replicas per StatefulSet.
 				# HELP kube_statefulset_status_replicas_available The number of available replicas per StatefulSet.

--- a/internal/store/statefulset_test.go
+++ b/internal/store/statefulset_test.go
@@ -65,6 +65,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# HELP kube_statefulset_metadata_generation [STABLE] Sequence number representing a specific generation of the desired state for the StatefulSet.
 				# HELP kube_statefulset_persistentvolumeclaim_retention_policy Count of retention policy for StatefulSet template PVCs
 				# HELP kube_statefulset_replicas [STABLE] Number of desired pods for a StatefulSet.
+                # HELP kube_statefulset_ordinals_start Start ordinal of the StatefulSet.
 				# HELP kube_statefulset_status_current_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
 				# HELP kube_statefulset_status_observed_generation [STABLE] The generation observed by the StatefulSet controller.
 				# HELP kube_statefulset_status_replicas [STABLE] The number of replicas per StatefulSet.
@@ -78,6 +79,7 @@ func TestStatefulSetStore(t *testing.T) {
 				# TYPE kube_statefulset_metadata_generation gauge
 				# TYPE kube_statefulset_persistentvolumeclaim_retention_policy gauge
 				# TYPE kube_statefulset_replicas gauge
+				# TYPE kube_statefulset_ordinals_start gauge
 				# TYPE kube_statefulset_status_current_revision gauge
 				# TYPE kube_statefulset_status_observed_generation gauge
 				# TYPE kube_statefulset_status_replicas gauge
@@ -104,6 +106,7 @@ func TestStatefulSetStore(t *testing.T) {
 				"kube_statefulset_labels",
 				"kube_statefulset_metadata_generation",
 				"kube_statefulset_replicas",
+				"kube_statefulset_ordinals_start",
 				"kube_statefulset_status_observed_generation",
 				"kube_statefulset_status_replicas",
 				"kube_statefulset_status_replicas_available",
@@ -325,6 +328,83 @@ func TestStatefulSetStore(t *testing.T) {
 				"kube_statefulset_labels",
 				"kube_statefulset_metadata_generation",
 				"kube_statefulset_replicas",
+				"kube_statefulset_status_replicas",
+				"kube_statefulset_status_replicas_available",
+				"kube_statefulset_status_replicas_current",
+				"kube_statefulset_status_replicas_ready",
+				"kube_statefulset_status_replicas_updated",
+				"kube_statefulset_status_update_revision",
+				"kube_statefulset_status_current_revision",
+				"kube_statefulset_persistentvolumeclaim_retention_policy",
+			},
+		},
+		{
+			// Validate kube_statefulset_ordinals_start metric.
+			Obj: &v1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "statefulset5",
+					Namespace: "ns5",
+					Labels: map[string]string{
+						"app": "example5",
+					},
+					Generation: 1,
+				},
+				Spec: v1.StatefulSetSpec{
+					Replicas:    &statefulSet1Replicas,
+					ServiceName: "statefulset5service",
+					Ordinals: &v1.StatefulSetOrdinals{
+						Start: 2,
+					},
+				},
+				Status: v1.StatefulSetStatus{
+					ObservedGeneration: 0,
+					Replicas:           3,
+					UpdateRevision:     "ur5",
+					CurrentRevision:    "cr5",
+				},
+			},
+			Want: `
+				# HELP kube_statefulset_labels [STABLE] Kubernetes labels converted to Prometheus labels.
+				# HELP kube_statefulset_metadata_generation [STABLE] Sequence number representing a specific generation of the desired state for the StatefulSet.
+				# HELP kube_statefulset_persistentvolumeclaim_retention_policy Count of retention policy for StatefulSet template PVCs
+				# HELP kube_statefulset_replicas [STABLE] Number of desired pods for a StatefulSet.
+                # HELP kube_statefulset_ordinals_start Start ordinal of the StatefulSet.
+				# HELP kube_statefulset_status_current_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+				# HELP kube_statefulset_status_replicas [STABLE] The number of replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_available The number of available replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_current [STABLE] The number of current replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_ready [STABLE] The number of ready replicas per StatefulSet.
+				# HELP kube_statefulset_status_replicas_updated [STABLE] The number of updated replicas per StatefulSet.
+				# HELP kube_statefulset_status_update_revision [STABLE] Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+				# TYPE kube_statefulset_labels gauge
+				# TYPE kube_statefulset_metadata_generation gauge
+				# TYPE kube_statefulset_persistentvolumeclaim_retention_policy gauge
+				# TYPE kube_statefulset_replicas gauge
+				# TYPE kube_statefulset_ordinals_start gauge
+				# TYPE kube_statefulset_status_current_revision gauge
+				# TYPE kube_statefulset_status_replicas gauge
+				# TYPE kube_statefulset_status_replicas_available gauge
+				# TYPE kube_statefulset_status_replicas_current gauge
+				# TYPE kube_statefulset_status_replicas_ready gauge
+				# TYPE kube_statefulset_status_replicas_updated gauge
+				# TYPE kube_statefulset_status_update_revision gauge
+				kube_statefulset_status_update_revision{namespace="ns5",revision="ur5",statefulset="statefulset5"} 1
+				kube_statefulset_status_replicas{namespace="ns5",statefulset="statefulset5"} 3
+				kube_statefulset_status_replicas_available{namespace="ns5",statefulset="statefulset5"} 0
+				kube_statefulset_status_replicas_current{namespace="ns5",statefulset="statefulset5"} 0
+				kube_statefulset_status_replicas_ready{namespace="ns5",statefulset="statefulset5"} 0
+				kube_statefulset_status_replicas_updated{namespace="ns5",statefulset="statefulset5"} 0
+				kube_statefulset_replicas{namespace="ns5",statefulset="statefulset5"} 3
+				kube_statefulset_ordinals_start{namespace="ns5",statefulset="statefulset5"} 2
+ 				kube_statefulset_metadata_generation{namespace="ns5",statefulset="statefulset5"} 1
+				kube_statefulset_labels{namespace="ns5",statefulset="statefulset5"} 1
+				kube_statefulset_status_current_revision{namespace="ns5",revision="cr5",statefulset="statefulset5"} 1
+ 			`,
+			MetricNames: []string{
+				"kube_statefulset_labels",
+				"kube_statefulset_metadata_generation",
+				"kube_statefulset_replicas",
+				"kube_statefulset_ordinals_start",
 				"kube_statefulset_status_replicas",
 				"kube_statefulset_status_replicas_available",
 				"kube_statefulset_status_replicas_current",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add metrics for new StatefulSet fields from KEP-3335
 * KEP: https://github.com/kubernetes/enhancements/issues/3335

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Does not change the cardinality of KSM
