### PR TITLE
support "True" and "False" as string in custom-resource-state

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -635,10 +635,11 @@ func toFloat64(value interface{}, nilIsZero bool) (float64, error) {
 		}
 		return 0, nil
 	case string:
-		if value.(string) == "True" || value.(string) == "true" || value.(string) == "Yes" || value.(string) == "yes" {
+		normalized := strings.ToLower(value.(string))
+		if normalized == "true" || normalized == "yes" {
 			return 1, nil
 		}
-		if value.(string) == "False" || value.(string) == "false" || value.(string) == "No" || value.(string) == "no" {
+		if normalized == "false" || normalized == "no" {
 			return 0, nil
 		}
 		if t, e := time.Parse(time.RFC3339, value.(string)); e == nil {

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -635,6 +635,12 @@ func toFloat64(value interface{}, nilIsZero bool) (float64, error) {
 		}
 		return 0, nil
 	case string:
+		if value.(string) == "True" || value.(string) == "true" || value.(string) == "Yes" || value.(string) == "yes" {
+			return 1, nil
+		}
+		if value.(string) == "False" || value.(string) == "false" || value.(string) == "No" || value.(string) == "no" {
+			return 0, nil
+		}
 		if t, e := time.Parse(time.RFC3339, value.(string)); e == nil {
 			return float64(t.Unix()), nil
 		}

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -64,7 +64,7 @@ func init() {
 				},
 			},
 			"uptime": 43.21,
-			"conditions": Array{
+			"condition_values": Array{
 				Obj{
 					"name":  "a",
 					"value": 45,
@@ -72,6 +72,16 @@ func init() {
 				Obj{
 					"name":  "b",
 					"value": 66,
+				},
+			},
+			"conditions": Array{
+				Obj{
+					"type":   "Ready",
+					"status": "True",
+				},
+				Obj{
+					"type":   "Provisioned",
+					"status": "False",
 				},
 			},
 		},
@@ -175,7 +185,7 @@ func Test_values(t *testing.T) {
 		}},
 		{name: "array", each: &compiledGauge{
 			compiledCommon: compiledCommon{
-				path: mustCompilePath(t, "status", "conditions"),
+				path: mustCompilePath(t, "status", "condition_values"),
 				labelFromPath: map[string]valuePath{
 					"name": mustCompilePath(t, "name"),
 				},
@@ -232,6 +242,25 @@ func Test_values(t *testing.T) {
 		}, wantResult: []eachValue{
 			newEachValue(t, 0, "phase", "bar"),
 			newEachValue(t, 1, "phase", "foo"),
+		}},
+		{name: "status_conditions", each: &compiledGauge{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "status", "conditions", "[type=Ready]", "status"),
+			},
+		}, wantResult: []eachValue{
+			newEachValue(t, 1),
+		}},
+		{name: "status_conditions_all", each: &compiledGauge{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "status", "conditions"),
+				labelFromPath: map[string]valuePath{
+					"type": mustCompilePath(t, "type"),
+				},
+			},
+			ValueFrom: mustCompilePath(t, "status"),
+		}, wantResult: []eachValue{
+			newEachValue(t, 0, "type", "Provisioned"),
+			newEachValue(t, 1, "type", "Ready"),
 		}},
 	}
 	for _, tt := range tests {
@@ -389,7 +418,7 @@ func Test_valuePath_Get(t *testing.T) {
 	}
 	tests := []testCase{
 		tt("obj", float64(1), "spec", "replicas"),
-		tt("array", float64(66), "status", "conditions", "[name=b]", "value"),
+		tt("array", float64(66), "status", "condition_values", "[name=b]", "value"),
 		tt("array index", true, "spec", "order", "0", "value"),
 		tt("string", "bar", "metadata", "labels", "foo"),
 		tt("match number", false, "spec", "order", "[id=3]", "value"),


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes Operators usually store status conditions in the following format:
```
status:
  conditions:
    - lastTransitionTime: "2019-10-22T16:29:31Z"
      status: "True"
      type: Ready
```

Note that `status` is actually a string. This previously broke KSM custom-resource-state gauges because it could not convert strings to float. This PR maps "True", "true", "Yes" and "yes" to `1.0` and "False", "false", "No", "no" to `0.0`. This allows us to use custom-resource-state for all CRD objects of standard kubernetes operators.

For a single condition you can use (as in unit test `status_conditions`):
```
      - --custom-resource-state-config
      # in YAML files, | allows a multi-line string to be passed as a flag value
      # see https://yaml-multiline.info
      -  |
          spec:
            resources:
            - groupVersionKind:
                group: xxxxx.xxx
                kind: "xxx"
                version: "v1"
              metrics:
              - name: "xxx_ready"
                help: "xxx ready state"
                each:
                  type: Gauge
                  gauge:
                    path: [status, conditions, "[type=Ready]", status]
```

To expose one metric per status `type` (as in unit test `status_conditions_all`):
```
      - --custom-resource-state-config
      # in YAML files, | allows a multi-line string to be passed as a flag value
      # see https://yaml-multiline.info
      -  |
          spec:
            resources:
            - groupVersionKind:
                group: xxxxx.xxx
                kind: "xxx"
                version: "v1"
              metrics:
              - name: "xxx_status"
                help: "xxx status"
                each:
                  type: Gauge
                  gauge:
                    path: [status, conditions]
                    labelsFromPath:
                      type: ["type"]
                    valueFrom: ["status"]
```

Guess this could be something for the documentation as it will be a very common usecase for controller CRDs.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
It does not change cardinality. It allows KSM to support `.status.conditions` used by standard kubernetes operators.

**Which issue(s) this PR fixes**
Fixes #1962
