### PR TITLE
Migrate all NewFamilyGenerator to NewFamilyGeneratorWithStability

### DIFF
--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -42,10 +42,11 @@ var (
 
 func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descCSRAnnotationsName,
 			descCSRAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapCSRFunc(func(j *certv1.CertificateSigningRequest) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)

--- a/internal/store/clusterrole.go
+++ b/internal/store/clusterrole.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -40,10 +41,11 @@ var (
 
 func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descClusterRoleAnnotationsName,
 			descClusterRoleAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
@@ -58,10 +60,11 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descClusterRoleLabelsName,
 			descClusterRoleLabelsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
@@ -76,10 +79,11 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_clusterrole_info",
 			"Information about cluster role.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
 				return &metric.Family{
@@ -91,10 +95,11 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_clusterrole_created",
 			"Unix creation timestamp",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
 				ms := []*metric.Metric{}
@@ -112,10 +117,11 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_clusterrole_metadata_resource_version",
 			"Resource version representing a specific version of the cluster role.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
 				return &metric.Family{

--- a/internal/store/clusterrolebinding.go
+++ b/internal/store/clusterrolebinding.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -40,10 +41,11 @@ var (
 
 func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descClusterRoleBindingAnnotationsName,
 			descClusterRoleBindingAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
@@ -58,10 +60,11 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descClusterRoleBindingLabelsName,
 			descClusterRoleBindingLabelsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
@@ -76,10 +79,11 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_clusterrolebinding_info",
 			"Information about clusterrolebinding.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				labelKeys := []string{"roleref_kind", "roleref_name"}
@@ -93,10 +97,11 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_clusterrolebinding_created",
 			"Unix creation timestamp",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				ms := []*metric.Metric{}
@@ -114,10 +119,11 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_clusterrolebinding_metadata_resource_version",
 			"Resource version representing a specific version of the clusterrolebinding.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				return &metric.Family{

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -37,10 +37,11 @@ var (
 
 func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_configmap_annotations",
 			"Kubernetes annotations converted to Prometheus labels.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", c.Annotations, allowAnnotationsList)
@@ -112,10 +113,11 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_configmap_metadata_resource_version",
 			"Resource version representing a specific version of the configmap.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				return &metric.Family{

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -45,10 +45,11 @@ var (
 
 func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descCronJobAnnotationsName,
 			descCronJobAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
@@ -161,10 +162,11 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_cronjob_status_last_successful_time",
 			"LastSuccessfulTime keeps information of when was the last time the job was completed successfully.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
@@ -265,10 +267,11 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_cronjob_spec_successful_job_history_limit",
 			"Successful job history limit tells the controller how many completed jobs should be preserved.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
@@ -286,10 +289,11 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_cronjob_spec_failed_job_history_limit",
 			"Failed job history limit tells the controller how many failed jobs should be preserved.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -223,10 +223,11 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descDaemonSetAnnotationsName,
 			descDaemonSetAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -283,10 +283,11 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descDeploymentAnnotationsName,
 			descDeploymentAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -79,10 +79,11 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descEndpointAnnotationsName,
 			descEndpointAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", e.Annotations, allowAnnotationsList)
@@ -116,10 +117,11 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_endpoint_address_available",
 			"Number of addresses available in endpoint.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.6.0",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				var available int
@@ -136,10 +138,11 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_endpoint_address_not_ready",
 			"Number of addresses not ready in endpoint",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.6.0",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				var notReady int

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -55,10 +55,11 @@ var (
 
 func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_horizontalpodautoscaler_info",
 			"Information about this autoscaler.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				labelKeys := []string{"scaletargetref_kind", "scaletargetref_name"}
@@ -126,10 +127,11 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_horizontalpodautoscaler_spec_target_metric",
 			"The metric specifications used by this autoscaler when calculating the desired replica count.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				ms := make([]*metric.Metric, 0, len(a.Spec.Metrics))
@@ -181,10 +183,11 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				return &metric.Family{Metrics: ms}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_horizontalpodautoscaler_status_target_metric",
 			"The current metric status used by this autoscaler when calculating the desired replica count.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
@@ -268,10 +271,11 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descHorizontalPodAutoscalerAnnotationsName,
 			descHorizontalPodAutoscalerAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", a.Annotations, allowAnnotationsList)

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -68,10 +68,11 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 					}}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descIngressAnnotationsName,
 			descIngressAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", i.Annotations, allowAnnotationsList)
@@ -125,10 +126,11 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_ingress_metadata_resource_version",
 			"Resource version representing a specific version of ingress.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				return &metric.Family{

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -44,10 +44,11 @@ var (
 
 func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descJobAnnotationsName,
 			descJobAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -34,10 +35,11 @@ var (
 	descLeaseLabelsDefaultLabels = []string{"lease"}
 
 	leaseMetricFamilies = []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_lease_owner",
 			"Information about the Lease's owner.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "namespace", "lease_holder"}
@@ -74,10 +76,11 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_lease_renew_time",
 			"Kube lease renew time.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -34,10 +35,11 @@ var (
 	descMutatingWebhookConfigurationDefaultLabels = []string{"namespace", "mutatingwebhookconfiguration"}
 
 	mutatingWebhookConfigurationMetricFamilies = []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_mutatingwebhookconfiguration_info",
 			"Information about the MutatingWebhookConfiguration.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
@@ -49,10 +51,11 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_mutatingwebhookconfiguration_created",
 			"Unix creation timestamp.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				ms := []*metric.Metric{}
@@ -67,10 +70,11 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_mutatingwebhookconfiguration_metadata_resource_version",
 			"Resource version representing a specific version of the MutatingWebhookConfiguration.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -61,10 +61,11 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descNamespaceAnnotationsName,
 			descNamespaceAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
@@ -125,10 +126,11 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_namespace_status_condition",
 			"The condition of a namespace.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := make([]*metric.Metric, len(n.Status.Conditions)*len(conditionStatuses))

--- a/internal/store/networkpolicy.go
+++ b/internal/store/networkpolicy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -40,10 +41,11 @@ var (
 
 func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_networkpolicy_created",
 			"Unix creation timestamp of network policy",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				return &metric.Family{
@@ -57,10 +59,11 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descNetworkPolicyAnnotationsName,
 			descNetworkPolicyAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
@@ -75,10 +78,11 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descNetworkPolicyLabelsName,
 			descNetworkPolicyLabelsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", n.Labels, allowLabelsList)
@@ -93,10 +97,11 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_networkpolicy_spec_ingress_rules",
 			"Number of ingress rules on the networkpolicy",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				return &metric.Family{
@@ -110,10 +115,11 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_networkpolicy_spec_egress_rules",
 			"Number of egress rules on the networkpolicy",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				return &metric.Family{

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -157,10 +157,11 @@ func createNodeInfoFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createNodeAnnotationsGenerator(allowAnnotationsList []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		descNodeAnnotationsName,
 		descNodeAnnotationsHelp,
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
@@ -200,10 +201,11 @@ func createNodeLabelsGenerator(allowLabelsList []string) generator.FamilyGenerat
 }
 
 func createNodeRoleFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_node_role",
 		"The role of a cluster node.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			const prefix = "node-role.kubernetes.io/"

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -78,10 +78,11 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descPersistentVolumeAnnotationsName,
 			descPersistentVolumeAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
@@ -298,10 +299,11 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_persistentvolume_created",
 			"Unix creation timestamp",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -61,10 +61,11 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descPersistentVolumeClaimAnnotationsName,
 			descPersistentVolumeClaimAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
@@ -181,10 +182,11 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_persistentvolumeclaim_status_condition",
 			"Information about status of different conditions of persistent volume claim.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.Conditions)*len(conditionStatuses))
@@ -207,10 +209,11 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_persistentvolumeclaim_created",
 			"Unix creation timestamp",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -161,10 +161,11 @@ func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_container_resource_limits",
 		"The number of requested limit resource by a container. It is recommended to use the kube_pod_resource_limits metric exposed by kube-scheduler instead, as it is more precise.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -224,10 +225,11 @@ func createPodContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator
 }
 
 func createPodContainerResourceRequestsFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_container_resource_requests",
 		"The number of requested request resource by a container. It is recommended to use the kube_pod_resource_requests metric exposed by kube-scheduler instead, as it is more precise.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -319,10 +321,11 @@ func createPodContainerStateStartedFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodContainerStatusLastTerminatedReasonFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_container_status_last_terminated_reason",
 		"Describes the last reason the container was in terminated state.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.ContainerStatuses))
@@ -344,10 +347,11 @@ func createPodContainerStatusLastTerminatedReasonFamilyGenerator() generator.Fam
 }
 
 func createPodContainerStatusLastTerminatedExitCodeFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_container_status_last_terminated_exitcode",
 		"Describes the exit code for the last container in terminated state.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.ContainerStatuses))
@@ -467,10 +471,11 @@ func createPodContainerStatusTerminatedFamilyGenerator() generator.FamilyGenerat
 }
 
 func createPodContainerStatusTerminatedReasonFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_container_status_terminated_reason",
 		"Describes the reason the container is currently in terminated state.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.ContainerStatuses))
@@ -568,10 +573,11 @@ func createPodCreatedFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodDeletionTimestampFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_deletion_timestamp",
 		"Unix deletion timestamp",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -625,10 +631,11 @@ func createPodInfoFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodIPFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_ips",
 		"Pod IP addresses",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.PodIPs))
@@ -690,10 +697,11 @@ func createPodInitContainerInfoFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodInitContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_init_container_resource_limits",
 		"The number of requested limit resource by an init container.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -753,10 +761,11 @@ func createPodInitContainerResourceLimitsFamilyGenerator() generator.FamilyGener
 }
 
 func createPodInitContainerResourceRequestsFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_init_container_resource_requests",
 		"The number of requested request resource by an init container.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -815,10 +824,11 @@ func createPodInitContainerResourceRequestsFamilyGenerator() generator.FamilyGen
 }
 
 func createPodInitContainerStatusLastTerminatedReasonFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_init_container_status_last_terminated_reason",
 		"Describes the last reason the init container was in terminated state.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.InitContainerStatuses))
@@ -938,10 +948,11 @@ func createPodInitContainerStatusTerminatedFamilyGenerator() generator.FamilyGen
 }
 
 func createPodInitContainerStatusTerminatedReasonFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_init_container_status_terminated_reason",
 		"Describes the reason the init container is currently in terminated state.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.InitContainerStatuses))
@@ -988,10 +999,11 @@ func createPodInitContainerStatusWaitingFamilyGenerator() generator.FamilyGenera
 }
 
 func createPodInitContainerStatusWaitingReasonFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_init_container_status_waiting_reason",
 		"Describes the reason the init container is currently in waiting state.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.InitContainerStatuses))
@@ -1014,10 +1026,11 @@ func createPodInitContainerStatusWaitingReasonFamilyGenerator() generator.Family
 }
 
 func createPodAnnotationsGenerator(allowAnnotations []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_annotations",
 		"Kubernetes annotations converted to Prometheus labels.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotations)
@@ -1055,10 +1068,11 @@ func createPodLabelsGenerator(allowLabelsList []string) generator.FamilyGenerato
 }
 
 func createPodOverheadCPUCoresFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_overhead_cpu_cores",
 		"The pod overhead in regards to cpu cores associated with running a pod.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1080,10 +1094,11 @@ func createPodOverheadCPUCoresFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodOverheadMemoryBytesFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_overhead_memory_bytes",
 		"The pod overhead in regards to memory associated with running a pod.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1175,10 +1190,11 @@ func createPodRestartPolicyFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodRuntimeClassNameInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_runtimeclass_name_info",
 		"The runtimeclass associated with the pod.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1353,6 +1369,7 @@ func createPodStatusReadyTimeFamilyGenerator() generator.FamilyGenerator {
 		"Readiness achieved time in unix timestamp for a pod.",
 		metric.Gauge,
 		basemetrics.ALPHA,
+
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1446,10 +1463,11 @@ func createPodStatusReadyFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodStatusReasonFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_status_reason",
 		"The pod status reasons",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1557,10 +1575,11 @@ func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodTolerationsFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_tolerations",
 		"Information about the pod tolerations",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			var ms []*metric.Metric
@@ -1617,6 +1636,7 @@ func createPodNodeSelectorsFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_nodeselectors",
 		"Describes the Pod nodeSelectors.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			labelKeys, labelValues := kubeMapToPrometheusLabels("nodeselector", p.Spec.NodeSelector)

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -41,10 +41,11 @@ var (
 
 func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descPodDisruptionBudgetAnnotationsName,
 			descPodDisruptionBudgetAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
@@ -59,10 +60,11 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descPodDisruptionBudgetLabelsName,
 			descPodDisruptionBudgetLabelsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -209,10 +209,11 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descReplicaSetAnnotationsName,
 			descReplicaSetAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -172,10 +172,11 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_replicationcontroller_owner",
 			"Information about the ReplicationController's owner.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -40,10 +41,11 @@ var (
 
 func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descRoleAnnotationsName,
 			descRoleAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
@@ -58,10 +60,11 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descRoleLabelsName,
 			descRoleLabelsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
@@ -76,10 +79,11 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_role_info",
 			"Information about role.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
 				return &metric.Family{
@@ -91,10 +95,11 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_role_created",
 			"Unix creation timestamp",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
 				ms := []*metric.Metric{}
@@ -112,10 +117,11 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_role_metadata_resource_version",
 			"Resource version representing a specific version of the role.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
 				return &metric.Family{

--- a/internal/store/rolebinding.go
+++ b/internal/store/rolebinding.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -40,10 +41,11 @@ var (
 
 func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descRoleBindingAnnotationsName,
 			descRoleBindingAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
@@ -58,10 +60,11 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descRoleBindingLabelsName,
 			descRoleBindingLabelsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
@@ -76,10 +79,11 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_rolebinding_info",
 			"Information about rolebinding.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				labelKeys := []string{"roleref_kind", "roleref_name"}
@@ -93,10 +97,11 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_rolebinding_created",
 			"Unix creation timestamp",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				ms := []*metric.Metric{}
@@ -114,10 +119,11 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_rolebinding_metadata_resource_version",
 			"Resource version representing a specific version of the rolebinding.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				return &metric.Family{

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -75,10 +75,11 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descSecretAnnotationsName,
 			descSecretAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
@@ -134,10 +135,11 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_secret_metadata_resource_version",
 			"Resource version representing a specific version of secret.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				return &metric.Family{

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -90,10 +90,11 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descServiceAnnotationsName,
 			descServiceAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)

--- a/internal/store/serviceaccount.go
+++ b/internal/store/serviceaccount.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -48,10 +49,11 @@ func serviceAccountMetricFamilies(allowAnnotationsList, allowLabelsList []string
 }
 
 func createServiceAccountInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_serviceaccount_info",
 		"Information about a service account",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			var labelKeys []string
@@ -74,10 +76,11 @@ func createServiceAccountInfoFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createServiceAccountCreatedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_serviceaccount_created",
 		"Unix creation timestamp",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			var ms []*metric.Metric
@@ -98,10 +101,11 @@ func createServiceAccountCreatedFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createServiceAccountDeletedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_serviceaccount_deleted",
 		"Unix deletion timestamp",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			var ms []*metric.Metric
@@ -122,10 +126,11 @@ func createServiceAccountDeletedFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createServiceAccountSecretFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_serviceaccount_secret",
 		"Secret being referenced by a service account",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			var ms []*metric.Metric
@@ -146,10 +151,11 @@ func createServiceAccountSecretFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createServiceAccountImagePullSecretFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_serviceaccount_image_pull_secret",
 		"Secret being referenced by a service account for the purpose of pulling images",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			var ms []*metric.Metric
@@ -170,10 +176,11 @@ func createServiceAccountImagePullSecretFamilyGenerator() generator.FamilyGenera
 }
 
 func createServiceAccountAnnotationsGenerator(allowAnnotations []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_serviceaccount_annotations",
 		"Kubernetes annotations converted to Prometheus labels.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", sa.Annotations, allowAnnotations)
@@ -190,10 +197,11 @@ func createServiceAccountAnnotationsGenerator(allowAnnotations []string) generat
 }
 
 func createServiceAccountLabelsGenerator(allowLabelsList []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGenerator(
+	return *generator.NewFamilyGeneratorWithStability(
 		"kube_serviceaccount_labels",
 		"Kubernetes labels converted to Prometheus labels.",
 		metric.Gauge,
+		basemetrics.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			labelKeys, labelValues := createPrometheusLabelKeysValues("label", sa.Labels, allowLabelsList)

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -78,10 +78,11 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_statefulset_status_replicas_available",
 			"The number of available replicas per StatefulSet.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
@@ -198,6 +199,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"Count of retention policy for StatefulSet template PVCs",
 			metric.Gauge,
 			basemetrics.ALPHA,
+
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				deletedPolicyLabel := ""
@@ -219,10 +221,11 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descStatefulSetAnnotationsName,
 			descStatefulSetAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)

--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -85,10 +85,11 @@ func storageClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descStorageClassAnnotationsName,
 			descStorageClassAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -34,10 +35,11 @@ var (
 	descValidatingWebhookConfigurationDefaultLabels = []string{"namespace", "validatingwebhookconfiguration"}
 
 	validatingWebhookConfigurationMetricFamilies = []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_validatingwebhookconfiguration_info",
 			"Information about the ValidatingWebhookConfiguration.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
@@ -49,10 +51,11 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_validatingwebhookconfiguration_created",
 			"Unix creation timestamp.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				ms := []*metric.Metric{}
@@ -67,10 +70,11 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_validatingwebhookconfiguration_metadata_resource_version",
 			"Resource version representing a specific version of the ValidatingWebhookConfiguration.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{

--- a/internal/store/verticalpodautoscaler.go
+++ b/internal/store/verticalpodautoscaler.go
@@ -28,6 +28,7 @@ import (
 	vpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/constant"
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
@@ -44,10 +45,11 @@ var (
 
 func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descVerticalPodAutoscalerAnnotationsName,
 			descVerticalPodAutoscalerAnnotationsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", a.Annotations, allowAnnotationsList)
@@ -62,10 +64,11 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descVerticalPodAutoscalerLabelsName,
 			descVerticalPodAutoscalerLabelsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", a.Labels, allowLabelsList)
@@ -80,10 +83,11 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_verticalpodautoscaler_spec_updatepolicy_updatemode",
 			"Update mode of the VerticalPodAutoscaler.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -118,10 +122,11 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed",
 			"Minimum resources the VerticalPodAutoscaler can set for containers matching the name.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -140,10 +145,11 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed",
 			"Maximum resources the VerticalPodAutoscaler can set for containers matching the name.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -161,10 +167,11 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound",
 			"Minimum resources the container can use before the VerticalPodAutoscaler updater evicts it.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -182,10 +189,11 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound",
 			"Maximum resources the container can use before the VerticalPodAutoscaler updater evicts it.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -203,10 +211,11 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target",
 			"Target resources the VerticalPodAutoscaler recommends for the container.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -223,10 +232,11 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget",
 			"Target resources the VerticalPodAutoscaler recommends for the container ignoring bounds.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/volumeattachment.go
+++ b/internal/store/volumeattachment.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -36,10 +37,11 @@ var (
 	descVolumeAttachmentLabelsDefaultLabels = []string{"volumeattachment"}
 
 	volumeAttachmentMetricFamilies = []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			descVolumeAttachmentLabelsName,
 			descVolumeAttachmentLabelsHelp,
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				labelKeys, labelValues := kubeMapToPrometheusLabels("label", va.Labels)
@@ -54,10 +56,11 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_volumeattachment_info",
 			"Information about volumeattachment.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				return &metric.Family{
@@ -71,10 +74,11 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_volumeattachment_created",
 			"Unix creation timestamp",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				if !va.CreationTimestamp.IsZero() {
@@ -88,10 +92,11 @@ var (
 				return &metric.Family{Metrics: []*metric.Metric{}}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_volumeattachment_spec_source_persistentvolume",
 			"PersistentVolume source reference.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				if va.Spec.Source.PersistentVolumeName != nil {
@@ -108,10 +113,11 @@ var (
 				return &metric.Family{}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_volumeattachment_status_attached",
 			"Information about volumeattachment.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				return &metric.Family{
@@ -125,10 +131,11 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_volumeattachment_status_attachment_metadata",
 			"volumeattachment metadata.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				labelKeys, labelValues := mapToPrometheusLabels(va.Status.AttachmentMetadata, "metadata")

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -43,6 +43,8 @@ import (
 	samplev1alpha1 "k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1"
 	samplefake "k8s.io/sample-controller/pkg/generated/clientset/versioned/fake"
 
+	basemetrics "k8s.io/component-base/metrics"
+
 	"k8s.io/kube-state-metrics/v2/internal/store"
 	"k8s.io/kube-state-metrics/v2/pkg/allowdenylist"
 	"k8s.io/kube-state-metrics/v2/pkg/customresource"
@@ -891,10 +893,11 @@ func (f *fooFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
 
 func (f *fooFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_foo_spec_replicas",
 			"Number of desired replicas for a foo.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapFooFunc(func(f *samplev1alpha1.Foo) *metric.Family {
 				return &metric.Family{
@@ -906,10 +909,11 @@ func (f *fooFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsLis
 				}
 			}),
 		),
-		*generator.NewFamilyGenerator(
+		*generator.NewFamilyGeneratorWithStability(
 			"kube_foo_status_replicas_available",
 			"The number of available replicas per foo.",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			wrapFooFunc(func(f *samplev1alpha1.Foo) *metric.Family {
 				return &metric.Family{

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -57,14 +57,10 @@ func NewFamilyGeneratorWithStability(name string, help string, metricType metric
 	return f
 }
 
-// NewFamilyGenerator creates new FamilyGenerator instances.
-func NewFamilyGenerator(name string, help string, metricType metric.Type, deprecatedVersion string, generateFunc func(obj interface{}) *metric.Family) *FamilyGenerator {
-	return NewFamilyGeneratorWithStability(name, help, metricType, basemetrics.ALPHA, deprecatedVersion, generateFunc)
-}
-
 // NewOptInFamilyGenerator creates new FamilyGenerator instances for opt-in metric families.
-func NewOptInFamilyGenerator(name string, help string, metricType metric.Type, deprecatedVersion string, generateFunc func(obj interface{}) *metric.Family) *FamilyGenerator {
-	f := NewFamilyGenerator(name, help, metricType, deprecatedVersion, generateFunc)
+func NewOptInFamilyGenerator(name string, help string, metricType metric.Type, stabilityLevel basemetrics.StabilityLevel, deprecatedVersion string, generateFunc func(obj interface{}) *metric.Family) *FamilyGenerator {
+	f := NewFamilyGeneratorWithStability(name, help, metricType, stabilityLevel,
+		deprecatedVersion, generateFunc)
 	f.OptIn = true
 	return f
 }

--- a/pkg/optin/optin_test.go
+++ b/pkg/optin/optin_test.go
@@ -19,6 +19,8 @@ package optin
 import (
 	"testing"
 
+	basemetrics "k8s.io/component-base/metrics"
+
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
 )
@@ -44,10 +46,11 @@ func TestFilter(t *testing.T) {
 			t.Errorf("did not expect NewMetricFamilyFilter to fail, the error is %v", err)
 		}
 
-		optInFamilyGenerator := *generator.NewFamilyGenerator(
+		optInFamilyGenerator := *generator.NewFamilyGeneratorWithStability(
 			test.MetricFamily,
 			"",
 			metric.Gauge,
+			basemetrics.ALPHA,
 			"",
 			func(_ interface{}) *metric.Family {
 				return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: #1833. So that metric stability level is required when add a new metric.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)* No

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1833
