### PR TITLE
feat(CustomResourceState): Support quantities and percentages

### DIFF
--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -255,6 +255,7 @@ Supported types are:
   * `"true"` and `"yes"` are mapped to `1.0` and `"false"` and `"no"` are mapped to `0.0` (all case insensitive)
   * RFC3339 times are parsed to float timestamp  
   * Quantities like "250m" or "512Gi" are parsed to float using https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go
+  * Percentages ending with a "%" are parsed to float
   * finally the string is parsed to float using https://pkg.go.dev/strconv#ParseFloat which should support all common number formats. If that fails an error is yielded
 
 ##### Example for status conditions on Kubernetes Controllers

--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -254,6 +254,7 @@ Supported types are:
 * for string the following logic applies
   * `"true"` and `"yes"` are mapped to `1.0` and `"false"` and `"no"` are mapped to `0.0` (all case insensitive)
   * RFC3339 times are parsed to float timestamp  
+  * Quantities like "250m" or "512Gi" are parsed to float using https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go
   * finally the string is parsed to float using https://pkg.go.dev/strconv#ParseFloat which should support all common number formats. If that fails an error is yielded
 
 ##### Example for status conditions on Kubernetes Controllers

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 
@@ -690,6 +691,7 @@ func toFloat64(value interface{}, nilIsZero bool) (float64, error) {
 		}
 		return 0, nil
 	case string:
+		// The string contains a boolean as a string
 		normalized := strings.ToLower(value.(string))
 		if normalized == "true" || normalized == "yes" {
 			return 1, nil
@@ -697,8 +699,13 @@ func toFloat64(value interface{}, nilIsZero bool) (float64, error) {
 		if normalized == "false" || normalized == "no" {
 			return 0, nil
 		}
+		// The string contains a RFC3339 timestamp
 		if t, e := time.Parse(time.RFC3339, value.(string)); e == nil {
 			return float64(t.Unix()), nil
+		}
+		// The string contains a quantity with a suffix like "25m" (milli) or "5Gi" (binarySI)
+		if t, e := resource.ParseQuantity(value.(string)); e == nil {
+			return t.AsApproximateFloat64(), nil
 		}
 		return strconv.ParseFloat(value.(string), 64)
 	case byte:

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
@@ -707,6 +708,12 @@ func toFloat64(value interface{}, nilIsZero bool) (float64, error) {
 		if t, e := resource.ParseQuantity(value.(string)); e == nil {
 			return t.AsApproximateFloat64(), nil
 		}
+		// The string contains a percentage with a suffix "%"
+		if e := validation.IsValidPercent(value.(string)); len(e) == 0 {
+			t, e := strconv.ParseFloat(strings.TrimRight(value.(string), "%"), 64)
+			return t / 100, e
+		}
+
 		return strconv.ParseFloat(value.(string), 64)
 	case byte:
 		v = float64(vv)

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -67,6 +67,7 @@ func init() {
 			"uptime":            43.21,
 			"quantity_milli":    "250m",
 			"quantity_binarySI": "5Gi",
+			"percentage":        "28%",
 			"condition_values": Array{
 				Obj{
 					"name":  "a",
@@ -97,6 +98,7 @@ func init() {
 				"qux": "quxx",
 				"bar": "baz",
 			},
+			"percentage":        "39%",
 			"creationTimestamp": "2022-06-28T00:00:00Z",
 		},
 	})
@@ -240,6 +242,24 @@ func Test_values(t *testing.T) {
 			},
 		}, wantResult: []eachValue{
 			newEachValue(t, 5.36870912e+09),
+		}},
+		{name: "percentage", each: &compiledGauge{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "status", "percentage"),
+			},
+		}, wantResult: []eachValue{
+			newEachValue(t, 0.28),
+		}},
+		{name: "path-relative valueFrom percentage", each: &compiledGauge{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "metadata"),
+				labelFromPath: map[string]valuePath{
+					"name": mustCompilePath(t, "name"),
+				},
+			},
+			ValueFrom: mustCompilePath(t, "percentage"),
+		}, wantResult: []eachValue{
+			newEachValue(t, 0.39, "name", "foo"),
 		}},
 		{name: "boolean_string", each: &compiledGauge{
 			compiledCommon: compiledCommon{

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -64,7 +64,9 @@ func init() {
 					"ready":  4,
 				},
 			},
-			"uptime": 43.21,
+			"uptime":            43.21,
+			"quantity_milli":    "250m",
+			"quantity_binarySI": "5Gi",
 			"condition_values": Array{
 				Obj{
 					"name":  "a",
@@ -224,6 +226,20 @@ func Test_values(t *testing.T) {
 			},
 		}, wantResult: []eachValue{
 			newEachValue(t, 1656374400),
+		}},
+		{name: "quantity_milli", each: &compiledGauge{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "status", "quantity_milli"),
+			},
+		}, wantResult: []eachValue{
+			newEachValue(t, 0.25),
+		}},
+		{name: "quantity_binarySI", each: &compiledGauge{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "status", "quantity_binarySI"),
+			},
+		}, wantResult: []eachValue{
+			newEachValue(t, 5.36870912e+09),
 		}},
 		{name: "boolean_string", each: &compiledGauge{
 			compiledCommon: compiledCommon{


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to be able to deprecate the VPA completely, CRS needs to be aware of quantities. See https://github.com/kubernetes/kube-state-metrics/issues/1790#issuecomment-1228477919

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See also https://github.com/kubernetes/kube-state-metrics/issues/1790
