### PR TITLE
feat: Enable semantic commit messages

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,17 @@
+name: "Lint pull request title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title for semantic commit message
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We have full documentation on how to get started contributing here:
 
 ### Semantic Commit Messages
 
-We use [semantic commit messages](https://www.conventionalcommits.org/en/v1.0.0/)  in this repository.
+We use [semantic commit messages](https://www.conventionalcommits.org/en/v1.0.0/) in this repository.
 
 They follow this format: `<type>[optional scope]: <description>`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,40 @@ _As contributors and maintainers of this project, and in the interest of fosteri
 
 ## Getting Started
 
-We have full documentation on how to get started contributing here: 
+We have full documentation on how to get started contributing here:
 
-<!---
-If your repo has certain guidelines for contribution, put them here ahead of the general k8s resources
--->
+### Semantic Commit Messages
+
+We use [semantic commit messages](https://www.conventionalcommits.org/en/v1.0.0/)  in this repository.
+
+They follow this format: `<type>[optional scope]: <description>`
+
+Examples for commit messages following this are:
+
+`feat: allow provided config object to extend other configs`
+
+You can also include a scope within parenthesis:
+
+`fix(scope): Prevent wrong calculation of storage`
+
+Here's a list of types that we use:
+
+| Type | Explanation |
+|---|---|
+| feat | A new feature |
+| fix | A bug fix |
+| docs | Documentation only changes |
+| style | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
+| refactor | A code change that neither fixes a bug nor adds a feature |
+| perf |  A code change that improves performance |
+| test | Adding missing tests or correcting existing tests |
+| build |Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm) |
+| ci | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs) |
+| chore | Other changes that don't modify src or test files |
+| revert | Reverts a previous commit |
+
+
+### Further Information
 
 - [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
 - [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](http://git.k8s.io/community/contributors/guide#contributing)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds documentation and a CI check for semantic commit messages.


**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1987
