### PR TITLE
fix: public Builder compatibility with the BuilderInterface

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -32,6 +32,10 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/options"
 )
 
+// Make sure the public Builder implements the public BuilderInterface.
+// New internal Builder methods should be added to the public BuilderInterface.
+var _ ksmtypes.BuilderInterface = &Builder{}
+
 // Builder helps to build store. It follows the builder pattern
 // (https://en.wikipedia.org/wiki/Builder_pattern).
 type Builder struct {
@@ -59,6 +63,11 @@ func (b *Builder) WithEnabledResources(c []string) error {
 // WithNamespaces sets the namespaces property of a Builder.
 func (b *Builder) WithNamespaces(n options.NamespaceList) {
 	b.internal.WithNamespaces(n)
+}
+
+// WithFieldSelectorFilter sets the fieldSelector property of a Builder.
+func (b *Builder) WithFieldSelectorFilter(fieldSelectorFilter string) {
+	b.internal.WithFieldSelectorFilter(fieldSelectorFilter)
 }
 
 // WithSharding sets the shard and totalShards property of a Builder.
@@ -103,8 +112,8 @@ func (b *Builder) WithAllowAnnotations(annotations map[string][]string) {
 }
 
 // WithAllowLabels configures which labels can be returned for metrics
-func (b *Builder) WithAllowLabels(l map[string][]string) {
-	b.internal.WithAllowLabels(l)
+func (b *Builder) WithAllowLabels(l map[string][]string) error {
+	return b.internal.WithAllowLabels(l)
 }
 
 // WithGenerateStoresFunc configures a custom generate store function


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request add the changes introduced by https://github.com/kubernetes/kube-state-metrics/pull/1864/ into the "public" Builder (`pkg/builder/Builder`). 

To avoid having future similar issue, this PR also add a interface type check between the `pkg/build/type/BuilderInterface` Interface and the `pkg/build/Builder` struct. It should allow to catch at compilation time any discrepancy. 

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

It doesn't affect cardinality of KSM because it doesn't change any metrics generation logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
