### PR TITLE
[waiting KSM 3.x] Map KSM STABLE metrics to k8s BETA metrics and declare meaning of KSM STABLE metrics

### DIFF
--- a/docs/developer/guide.md
+++ b/docs/developer/guide.md
@@ -28,6 +28,6 @@ The following steps are needed to introduce a new resource and its respective re
 
 | Metric stability level |                    |
 |------------------------|--------------------|
-| EXPERIMENTAL           | basemetrics.ALPHA  |
-| STABLE                 | basemetrics.STABLE |
+| EXPERIMENTAL           | metricsstability.ALPHA  |
+| STABLE                 | metricsstability.STABLE |
 

--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -19,7 +19,7 @@ package store
 import (
 	"context"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -46,7 +46,7 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			descCSRAnnotationsName,
 			descCSRAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapCSRFunc(func(j *certv1.CertificateSigningRequest) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
@@ -65,7 +65,7 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			descCSRLabelsName,
 			descCSRLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCSRFunc(func(j *certv1.CertificateSigningRequest) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", j.Labels, allowLabelsList)
@@ -84,7 +84,7 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_certificatesigningrequest_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCSRFunc(func(csr *certv1.CertificateSigningRequest) *metric.Family {
 				ms := []*metric.Metric{}
@@ -105,7 +105,7 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_certificatesigningrequest_condition",
 			"The number of each certificatesigningrequest condition",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCSRFunc(func(csr *certv1.CertificateSigningRequest) *metric.Family {
 				return &metric.Family{
@@ -117,7 +117,7 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_certificatesigningrequest_cert_length",
 			"Length of the issued cert",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCSRFunc(func(csr *certv1.CertificateSigningRequest) *metric.Family {
 				return &metric.Family{

--- a/internal/store/clusterrole.go
+++ b/internal/store/clusterrole.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -45,7 +46,7 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			descClusterRoleAnnotationsName,
 			descClusterRoleAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
@@ -64,7 +65,7 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			descClusterRoleLabelsName,
 			descClusterRoleLabelsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
@@ -83,7 +84,7 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_clusterrole_info",
 			"Information about cluster role.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
 				return &metric.Family{
@@ -99,7 +100,7 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_clusterrole_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
 				ms := []*metric.Metric{}
@@ -121,7 +122,7 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_clusterrole_metadata_resource_version",
 			"Resource version representing a specific version of the cluster role.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
 				return &metric.Family{

--- a/internal/store/clusterrolebinding.go
+++ b/internal/store/clusterrolebinding.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -45,7 +46,7 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 			descClusterRoleBindingAnnotationsName,
 			descClusterRoleBindingAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
@@ -64,7 +65,7 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 			descClusterRoleBindingLabelsName,
 			descClusterRoleBindingLabelsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
@@ -83,7 +84,7 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 			"kube_clusterrolebinding_info",
 			"Information about clusterrolebinding.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				labelKeys := []string{"roleref_kind", "roleref_name"}
@@ -101,7 +102,7 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 			"kube_clusterrolebinding_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				ms := []*metric.Metric{}
@@ -123,7 +124,7 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 			"kube_clusterrolebinding_metadata_resource_version",
 			"Resource version representing a specific version of the clusterrolebinding.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				return &metric.Family{

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -41,7 +42,7 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_configmap_annotations",
 			"Kubernetes annotations converted to Prometheus labels.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", c.Annotations, allowAnnotationsList)
@@ -60,7 +61,7 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_configmap_labels",
 			"Kubernetes labels converted to Prometheus labels.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", c.Labels, allowLabelsList)
@@ -79,7 +80,7 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_configmap_info",
 			"Information about configmap.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				return &metric.Family{
@@ -95,7 +96,7 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_configmap_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				ms := []*metric.Metric{}
@@ -117,7 +118,7 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_configmap_metadata_resource_version",
 			"Resource version representing a specific version of the configmap.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				return &metric.Family{

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -29,7 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -49,7 +50,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			descCronJobAnnotationsName,
 			descCronJobAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
@@ -68,7 +69,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			descCronJobLabelsName,
 			descCronJobLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", j.Labels, allowLabelsList)
@@ -87,7 +88,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_info",
 			"Info about cronjob.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
@@ -105,7 +106,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
@@ -126,7 +127,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_status_active",
 			"Active holds pointers to currently running jobs.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
@@ -144,7 +145,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_status_last_schedule_time",
 			"LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
@@ -166,7 +167,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_status_last_successful_time",
 			"LastSuccessfulTime keeps information of when was the last time the job was completed successfully.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
@@ -188,7 +189,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_spec_suspend",
 			"Suspend flag tells the controller to suspend subsequent executions.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
@@ -210,7 +211,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_spec_starting_deadline_seconds",
 			"Deadline in seconds for starting the job if it misses scheduled time for any reason.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
@@ -233,7 +234,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_next_schedule_time",
 			"Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
@@ -259,7 +260,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_metadata_resource_version",
 			"Resource version representing a specific version of the cronjob.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
@@ -271,7 +272,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_spec_successful_job_history_limit",
 			"Successful job history limit tells the controller how many completed jobs should be preserved.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
@@ -293,7 +294,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_cronjob_spec_failed_job_history_limit",
 			"Failed job history limit tells the controller how many failed jobs should be preserved.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -45,7 +46,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_daemonset_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				ms := []*metric.Metric{}
@@ -67,7 +68,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_daemonset_status_current_number_scheduled",
 			"The number of nodes running at least one daemon pod and are supposed to.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
@@ -85,7 +86,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_daemonset_status_desired_number_scheduled",
 			"The number of nodes that should be running the daemon pod.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
@@ -103,7 +104,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_daemonset_status_number_available",
 			"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
@@ -121,7 +122,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_daemonset_status_number_misscheduled",
 			"The number of nodes running a daemon pod but are not supposed to.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
@@ -139,7 +140,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_daemonset_status_number_ready",
 			"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
@@ -157,7 +158,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_daemonset_status_number_unavailable",
 			"The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
@@ -175,7 +176,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_daemonset_status_observed_generation",
 			"The most recent generation observed by the daemon set controller.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
@@ -193,7 +194,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_daemonset_status_updated_number_scheduled",
 			"The total number of nodes that are running updated daemon pod",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
@@ -209,7 +210,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_daemonset_metadata_generation",
 			"Sequence number representing a specific generation of the desired state.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
@@ -227,7 +228,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			descDaemonSetAnnotationsName,
 			descDaemonSetAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)
@@ -246,7 +247,7 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			descDaemonSetLabelsName,
 			descDaemonSetLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", d.Labels, allowLabelsList)

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -19,7 +19,7 @@ package store
 import (
 	"context"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -47,7 +47,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := []*metric.Metric{}
@@ -67,7 +67,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_status_replicas",
 			"The number of replicas per deployment.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
@@ -83,7 +83,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_status_replicas_ready",
 			"The number of ready replicas per deployment.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
@@ -99,7 +99,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_status_replicas_available",
 			"The number of available replicas per deployment.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
@@ -115,7 +115,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_status_replicas_unavailable",
 			"The number of unavailable replicas per deployment.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
@@ -131,7 +131,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_status_replicas_updated",
 			"The number of updated replicas per deployment.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
@@ -147,7 +147,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_status_observed_generation",
 			"The generation observed by the deployment controller.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
@@ -163,7 +163,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_status_condition",
 			"The current status conditions of a deployment.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := make([]*metric.Metric, len(d.Status.Conditions)*len(conditionStatuses))
@@ -189,7 +189,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_spec_replicas",
 			"Number of desired pods for a deployment.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
@@ -205,7 +205,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_spec_paused",
 			"Whether the deployment is paused and will not be processed by the deployment controller.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
@@ -221,7 +221,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
 			"Maximum number of unavailable replicas during a rolling update of a deployment.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.Spec.Strategy.RollingUpdate == nil {
@@ -246,7 +246,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_spec_strategy_rollingupdate_max_surge",
 			"Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.Spec.Strategy.RollingUpdate == nil {
@@ -271,7 +271,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_deployment_metadata_generation",
 			"Sequence number representing a specific generation of the desired state.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
@@ -287,7 +287,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			descDeploymentAnnotationsName,
 			descDeploymentAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)
@@ -306,7 +306,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			descDeploymentLabelsName,
 			descDeploymentLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", d.Labels, allowLabelsList)

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -26,7 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -46,7 +47,7 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			"kube_endpoint_info",
 			"Information about endpoint.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				return &metric.Family{
@@ -62,7 +63,7 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			"kube_endpoint_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				ms := []*metric.Metric{}
@@ -83,7 +84,7 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			descEndpointAnnotationsName,
 			descEndpointAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", e.Annotations, allowAnnotationsList)
@@ -102,7 +103,7 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			descEndpointLabelsName,
 			descEndpointLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", e.Labels, allowLabelsList)
@@ -121,7 +122,7 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			"kube_endpoint_address_available",
 			"Number of addresses available in endpoint.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.6.0",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				var available int
@@ -142,7 +143,7 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			"kube_endpoint_address_not_ready",
 			"Number of addresses not ready in endpoint",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.6.0",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				var notReady int
@@ -162,7 +163,7 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			"kube_endpoint_address",
 			"Information about Endpoint available and non available addresses.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				ms := []*metric.Metric{}
@@ -191,7 +192,7 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			"kube_endpoint_ports",
 			"Information about the Endpoint ports.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/endpointslice.go
+++ b/internal/store/endpointslice.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"strconv"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -44,7 +44,7 @@ func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			"kube_endpointslice_info",
 			"Information about endpointslice.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapEndpointSliceFunc(func(s *discoveryv1.EndpointSlice) *metric.Family {
 
@@ -60,7 +60,7 @@ func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			"kube_endpointslice_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapEndpointSliceFunc(func(s *discoveryv1.EndpointSlice) *metric.Family {
 				ms := []*metric.Metric{}
@@ -78,7 +78,7 @@ func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			"kube_endpointslice_endpoints",
 			"Endpoints attached to the endpointslice.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapEndpointSliceFunc(func(e *discoveryv1.EndpointSlice) *metric.Family {
 				m := []*metric.Metric{}
@@ -151,7 +151,7 @@ func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			"kube_endpointslice_ports",
 			"Ports attached to the endpointslice.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapEndpointSliceFunc(func(e *discoveryv1.EndpointSlice) *metric.Family {
 				m := []*metric.Metric{}
@@ -171,7 +171,7 @@ func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			descEndpointSliceAnnotationsName,
 			descEndpointSliceAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapEndpointSliceFunc(func(s *discoveryv1.EndpointSlice) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
@@ -190,7 +190,7 @@ func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			descEndpointSliceLabelsName,
 			descEndpointSliceLabelsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapEndpointSliceFunc(func(s *discoveryv1.EndpointSlice) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -59,7 +60,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_horizontalpodautoscaler_info",
 			"Information about this autoscaler.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				labelKeys := []string{"scaletargetref_kind", "scaletargetref_name"}
@@ -83,7 +84,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_horizontalpodautoscaler_metadata_generation",
 			"The generation observed by the HorizontalPodAutoscaler controller.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				return &metric.Family{
@@ -99,7 +100,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_horizontalpodautoscaler_spec_max_replicas",
 			"Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				return &metric.Family{
@@ -115,7 +116,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_horizontalpodautoscaler_spec_min_replicas",
 			"Lower limit for the number of pods that can be set by the autoscaler, default 1.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				return &metric.Family{
@@ -131,7 +132,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_horizontalpodautoscaler_spec_target_metric",
 			"The metric specifications used by this autoscaler when calculating the desired replica count.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				ms := make([]*metric.Metric, 0, len(a.Spec.Metrics))
@@ -187,7 +188,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_horizontalpodautoscaler_status_target_metric",
 			"The current metric status used by this autoscaler when calculating the desired replica count.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
@@ -243,7 +244,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_horizontalpodautoscaler_status_current_replicas",
 			"Current number of replicas of pods managed by this autoscaler.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				return &metric.Family{
@@ -259,7 +260,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_horizontalpodautoscaler_status_desired_replicas",
 			"Desired number of replicas of pods managed by this autoscaler.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				return &metric.Family{
@@ -275,7 +276,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			descHorizontalPodAutoscalerAnnotationsName,
 			descHorizontalPodAutoscalerAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", a.Annotations, allowAnnotationsList)
@@ -294,7 +295,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			descHorizontalPodAutoscalerLabelsName,
 			descHorizontalPodAutoscalerLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", a.Labels, allowLabelsList)
@@ -313,7 +314,7 @@ func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_horizontalpodautoscaler_status_condition",
 			"The condition of this autoscaler.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 				ms := make([]*metric.Metric, 0, len(a.Status.Conditions)*len(conditionStatuses))

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strconv"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -47,7 +47,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_ingress_info",
 			"Information about ingress.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				ingressClassName := "_default"
@@ -72,7 +72,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			descIngressAnnotationsName,
 			descIngressAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", i.Annotations, allowAnnotationsList)
@@ -91,7 +91,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			descIngressLabelsName,
 			descIngressLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", i.Labels, allowLabelsList)
@@ -110,7 +110,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_ingress_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				ms := []*metric.Metric{}
@@ -130,7 +130,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_ingress_metadata_resource_version",
 			"Resource version representing a specific version of ingress.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				return &metric.Family{
@@ -142,7 +142,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_ingress_path",
 			"Ingress host, paths and backend service information.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				ms := []*metric.Metric{}
@@ -174,7 +174,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_ingress_tls",
 			"Ingress TLS host and secret information.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/ingressclass.go
+++ b/internal/store/ingressclass.go
@@ -16,7 +16,7 @@ package store
 import (
 	"context"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -43,7 +43,7 @@ func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			"kube_ingressclass_info",
 			"Information about ingressclass.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapIngressClassFunc(func(s *networkingv1.IngressClass) *metric.Family {
 
@@ -59,7 +59,7 @@ func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			"kube_ingressclass_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapIngressClassFunc(func(s *networkingv1.IngressClass) *metric.Family {
 				ms := []*metric.Metric{}
@@ -77,7 +77,7 @@ func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			descIngressClassAnnotationsName,
 			descIngressClassAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapIngressClassFunc(func(s *networkingv1.IngressClass) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
@@ -96,7 +96,7 @@ func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			descIngressClassLabelsName,
 			descIngressClassLabelsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapIngressClassFunc(func(s *networkingv1.IngressClass) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strconv"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -48,7 +48,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			descJobAnnotationsName,
 			descJobAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
@@ -67,7 +67,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			descJobLabelsName,
 			descJobLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", j.Labels, allowLabelsList)
@@ -86,7 +86,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_info",
 			"Information about job.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				return &metric.Family{
@@ -102,7 +102,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
@@ -122,7 +122,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_spec_parallelism",
 			"The maximum desired number of pods the job should run at any given time.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
@@ -142,7 +142,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_spec_completions",
 			"The desired number of successfully finished pods the job should be run with.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
@@ -162,7 +162,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_spec_active_deadline_seconds",
 			"The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
@@ -182,7 +182,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_status_succeeded",
 			"The number of pods which reached Phase Succeeded.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				return &metric.Family{
@@ -198,7 +198,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_status_failed",
 			"The number of pods which reached Phase Failed and the reason for failure.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				var ms []*metric.Metric
@@ -247,7 +247,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_status_active",
 			"The number of actively running pods.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				return &metric.Family{
@@ -263,7 +263,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_complete",
 			"The job has completed its execution.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
@@ -287,7 +287,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_failed",
 			"The job has failed its execution.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
@@ -312,7 +312,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_status_start_time",
 			"StartTime represents time when the job was acknowledged by the Job Manager.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
@@ -333,7 +333,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_status_completion_time",
 			"CompletionTime represents time when the job was completed.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
@@ -353,7 +353,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_job_owner",
 			"Information about the Job's owner.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -39,7 +40,7 @@ var (
 			"kube_lease_owner",
 			"Information about the Lease's owner.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "namespace", "lease_holder"}
@@ -80,7 +81,7 @@ var (
 			"kube_lease_renew_time",
 			"Kube lease renew time.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/limitrange.go
+++ b/internal/store/limitrange.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -39,7 +40,7 @@ var (
 			"kube_limitrange",
 			"Information about limit range.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
 				ms := []*metric.Metric{}
@@ -95,7 +96,7 @@ var (
 			"kube_limitrange_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -39,7 +40,7 @@ var (
 			"kube_mutatingwebhookconfiguration_info",
 			"Information about the MutatingWebhookConfiguration.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
@@ -55,7 +56,7 @@ var (
 			"kube_mutatingwebhookconfiguration_created",
 			"Unix creation timestamp.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				ms := []*metric.Metric{}
@@ -74,7 +75,7 @@ var (
 			"kube_mutatingwebhookconfiguration_metadata_resource_version",
 			"Resource version representing a specific version of the MutatingWebhookConfiguration.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -19,7 +19,7 @@ package store
 import (
 	"context"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -46,7 +46,7 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_namespace_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := []*metric.Metric{}
@@ -65,7 +65,7 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			descNamespaceAnnotationsName,
 			descNamespaceAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
@@ -84,7 +84,7 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			descNamespaceLabelsName,
 			descNamespaceLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", n.Labels, allowLabelsList)
@@ -103,7 +103,7 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_namespace_status_phase",
 			"kubernetes namespace status phase.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := []*metric.Metric{
@@ -130,7 +130,7 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			"kube_namespace_status_condition",
 			"The condition of a namespace.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := make([]*metric.Metric, len(n.Status.Conditions)*len(conditionStatuses))

--- a/internal/store/networkpolicy.go
+++ b/internal/store/networkpolicy.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -45,7 +46,7 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			"kube_networkpolicy_created",
 			"Unix creation timestamp of network policy",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				return &metric.Family{
@@ -63,7 +64,7 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			descNetworkPolicyAnnotationsName,
 			descNetworkPolicyAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
@@ -82,7 +83,7 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			descNetworkPolicyLabelsName,
 			descNetworkPolicyLabelsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", n.Labels, allowLabelsList)
@@ -101,7 +102,7 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			"kube_networkpolicy_spec_ingress_rules",
 			"Number of ingress rules on the networkpolicy",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				return &metric.Family{
@@ -119,7 +120,7 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			"kube_networkpolicy_spec_egress_rules",
 			"Number of egress rules on the networkpolicy",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
 				return &metric.Family{

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strings"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/constant"
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
@@ -63,7 +63,7 @@ func createNodeDeletionTimestampFamilyGenerator() generator.FamilyGenerator {
 		"kube_node_deletion_timestamp",
 		"Unix deletion timestamp",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			var ms []*metric.Metric
@@ -86,7 +86,7 @@ func createNodeCreatedFamilyGenerator() generator.FamilyGenerator {
 		"kube_node_created",
 		"Unix creation timestamp",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := []*metric.Metric{}
@@ -110,7 +110,7 @@ func createNodeInfoFamilyGenerator() generator.FamilyGenerator {
 		"kube_node_info",
 		"Information about a cluster node.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			labelKeys := []string{
@@ -161,7 +161,7 @@ func createNodeAnnotationsGenerator(allowAnnotationsList []string) generator.Fam
 		descNodeAnnotationsName,
 		descNodeAnnotationsHelp,
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
@@ -183,7 +183,7 @@ func createNodeLabelsGenerator(allowLabelsList []string) generator.FamilyGenerat
 		descNodeLabelsName,
 		descNodeLabelsHelp,
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			labelKeys, labelValues := createPrometheusLabelKeysValues("label", n.Labels, allowLabelsList)
@@ -205,7 +205,7 @@ func createNodeRoleFamilyGenerator() generator.FamilyGenerator {
 		"kube_node_role",
 		"The role of a cluster node.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			const prefix = "node-role.kubernetes.io/"
@@ -231,7 +231,7 @@ func createNodeSpecTaintFamilyGenerator() generator.FamilyGenerator {
 		"kube_node_spec_taint",
 		"The taint of a cluster node.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := make([]*metric.Metric, len(n.Spec.Taints))
@@ -259,7 +259,7 @@ func createNodeSpecUnschedulableFamilyGenerator() generator.FamilyGenerator {
 		"kube_node_spec_unschedulable",
 		"Whether a node can schedule new pods.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			return &metric.Family{
@@ -278,7 +278,7 @@ func createNodeStatusAllocatableFamilyGenerator() generator.FamilyGenerator {
 		"kube_node_status_allocatable",
 		"The allocatable for different resources of a node that are available for scheduling.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := []*metric.Metric{}
@@ -362,7 +362,7 @@ func createNodeStatusCapacityFamilyGenerator() generator.FamilyGenerator {
 		"kube_node_status_capacity",
 		"The capacity for different resources of a node.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := []*metric.Metric{}
@@ -449,7 +449,7 @@ func createNodeStatusConditionFamilyGenerator() generator.FamilyGenerator {
 		"kube_node_status_condition",
 		"The condition of a cluster node.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := make([]*metric.Metric, len(n.Status.Conditions)*len(conditionStatuses))

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strconv"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -51,7 +51,7 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 			descPersistentVolumeClaimRefName,
 			descPersistentVolumeClaimRefHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				claimRef := p.Spec.ClaimRef
@@ -82,7 +82,7 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 			descPersistentVolumeAnnotationsName,
 			descPersistentVolumeAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
@@ -101,7 +101,7 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 			descPersistentVolumeLabelsName,
 			descPersistentVolumeLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
@@ -120,7 +120,7 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 			"kube_persistentvolume_status_phase",
 			"The phase indicates if a volume is available, bound to a claim, or released by a claim.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				phase := p.Status.Phase
@@ -168,7 +168,7 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 			"kube_persistentvolume_info",
 			"Information about persistentvolume.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				var (
@@ -286,7 +286,7 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 			"kube_persistentvolume_capacity_bytes",
 			"Persistentvolume capacity in bytes.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				storage := p.Spec.Capacity[v1.ResourceStorage]
@@ -303,7 +303,7 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 			"kube_persistentvolume_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -19,7 +19,7 @@ package store
 import (
 	"context"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -46,7 +46,7 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			descPersistentVolumeClaimLabelsName,
 			descPersistentVolumeClaimLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
@@ -65,7 +65,7 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			descPersistentVolumeClaimAnnotationsName,
 			descPersistentVolumeClaimAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
@@ -84,7 +84,7 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			"kube_persistentvolumeclaim_info",
 			"Information about persistent volume claim.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				storageClassName := getPersistentVolumeClaimClass(p)
@@ -104,7 +104,7 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			"kube_persistentvolumeclaim_status_phase",
 			"The phase the persistent volume claim is currently in.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				phase := p.Status.Phase
@@ -144,7 +144,7 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			"kube_persistentvolumeclaim_resource_requests_storage_bytes",
 			"The capacity of storage requested by the persistent volume claim.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := []*metric.Metric{}
@@ -164,7 +164,7 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			"kube_persistentvolumeclaim_access_mode",
 			"The access mode(s) specified by the persistent volume claim.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Spec.AccessModes))
@@ -186,7 +186,7 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			"kube_persistentvolumeclaim_status_condition",
 			"Information about status of different conditions of persistent volume claim.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Status.Conditions)*len(conditionStatuses))
@@ -213,7 +213,7 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			"kube_persistentvolumeclaim_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"strconv"
 
-	basemetrics "k8s.io/component-base/metrics"
 	"k8s.io/utils/net"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/constant"
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
@@ -100,7 +101,7 @@ func createPodCompletionTimeFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_completion_time",
 		"Completion time in unix timestamp for a pod.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -135,7 +136,7 @@ func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_container_info",
 		"Information about a container in a pod.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -165,7 +166,7 @@ func createPodContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator
 		"kube_pod_container_resource_limits",
 		"The number of requested limit resource by a container. It is recommended to use the kube_pod_resource_limits metric exposed by kube-scheduler instead, as it is more precise.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -229,7 +230,7 @@ func createPodContainerResourceRequestsFamilyGenerator() generator.FamilyGenerat
 		"kube_pod_container_resource_requests",
 		"The number of requested request resource by a container. It is recommended to use the kube_pod_resource_requests metric exposed by kube-scheduler instead, as it is more precise.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -292,7 +293,7 @@ func createPodContainerStateStartedFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_container_state_started",
 		"Start time in unix timestamp for a pod container.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -325,7 +326,7 @@ func createPodContainerStatusLastTerminatedReasonFamilyGenerator() generator.Fam
 		"kube_pod_container_status_last_terminated_reason",
 		"Describes the last reason the container was in terminated state.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.ContainerStatuses))
@@ -351,7 +352,7 @@ func createPodContainerStatusLastTerminatedExitCodeFamilyGenerator() generator.F
 		"kube_pod_container_status_last_terminated_exitcode",
 		"Describes the exit code for the last container in terminated state.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.ContainerStatuses))
@@ -377,7 +378,7 @@ func createPodContainerStatusReadyFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_container_status_ready",
 		"Describes whether the containers readiness check succeeded.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
@@ -400,7 +401,7 @@ func createPodContainerStatusRestartsTotalFamilyGenerator() generator.FamilyGene
 	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_container_status_restarts_total",
 		"The number of container restarts per container.",
-		metric.Counter, basemetrics.STABLE,
+		metric.Counter, metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
@@ -425,7 +426,7 @@ func createPodContainerStatusRunningFamilyGenerator() generator.FamilyGenerator 
 		"kube_pod_container_status_running",
 		"Describes whether the container is currently in running state.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
@@ -450,7 +451,7 @@ func createPodContainerStatusTerminatedFamilyGenerator() generator.FamilyGenerat
 		"kube_pod_container_status_terminated",
 		"Describes whether the container is currently in terminated state.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
@@ -475,7 +476,7 @@ func createPodContainerStatusTerminatedReasonFamilyGenerator() generator.FamilyG
 		"kube_pod_container_status_terminated_reason",
 		"Describes the reason the container is currently in terminated state.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.ContainerStatuses))
@@ -501,7 +502,7 @@ func createPodContainerStatusWaitingFamilyGenerator() generator.FamilyGenerator 
 		"kube_pod_container_status_waiting",
 		"Describes whether the container is currently in waiting state.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
@@ -526,7 +527,7 @@ func createPodContainerStatusWaitingReasonFamilyGenerator() generator.FamilyGene
 		"kube_pod_container_status_waiting_reason",
 		"Describes the reason the container is currently in waiting state.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.ContainerStatuses))
@@ -552,7 +553,7 @@ func createPodCreatedFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_created",
 		"Unix creation timestamp",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -577,7 +578,7 @@ func createPodDeletionTimestampFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_deletion_timestamp",
 		"Unix deletion timestamp",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -602,7 +603,7 @@ func createPodInfoFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_info",
 		"Information about pod.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			createdBy := metav1.GetControllerOf(p)
@@ -635,7 +636,7 @@ func createPodIPFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_ips",
 		"Pod IP addresses",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.PodIPs))
@@ -670,7 +671,7 @@ func createPodInitContainerInfoFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_init_container_info",
 		"Information about an init container in a pod.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -701,7 +702,7 @@ func createPodInitContainerResourceLimitsFamilyGenerator() generator.FamilyGener
 		"kube_pod_init_container_resource_limits",
 		"The number of requested limit resource by an init container.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -765,7 +766,7 @@ func createPodInitContainerResourceRequestsFamilyGenerator() generator.FamilyGen
 		"kube_pod_init_container_resource_requests",
 		"The number of requested request resource by an init container.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -828,7 +829,7 @@ func createPodInitContainerStatusLastTerminatedReasonFamilyGenerator() generator
 		"kube_pod_init_container_status_last_terminated_reason",
 		"Describes the last reason the init container was in terminated state.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.InitContainerStatuses))
@@ -853,7 +854,7 @@ func createPodInitContainerStatusReadyFamilyGenerator() generator.FamilyGenerato
 		"kube_pod_init_container_status_ready",
 		"Describes whether the init containers readiness check succeeded.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
@@ -877,7 +878,7 @@ func createPodInitContainerStatusRestartsTotalFamilyGenerator() generator.Family
 	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_init_container_status_restarts_total",
 		"The number of restarts for the init container.",
-		metric.Counter, basemetrics.STABLE,
+		metric.Counter, metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
@@ -902,7 +903,7 @@ func createPodInitContainerStatusRunningFamilyGenerator() generator.FamilyGenera
 		"kube_pod_init_container_status_running",
 		"Describes whether the init container is currently in running state.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
@@ -927,7 +928,7 @@ func createPodInitContainerStatusTerminatedFamilyGenerator() generator.FamilyGen
 		"kube_pod_init_container_status_terminated",
 		"Describes whether the init container is currently in terminated state.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
@@ -952,7 +953,7 @@ func createPodInitContainerStatusTerminatedReasonFamilyGenerator() generator.Fam
 		"kube_pod_init_container_status_terminated_reason",
 		"Describes the reason the init container is currently in terminated state.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.InitContainerStatuses))
@@ -978,7 +979,7 @@ func createPodInitContainerStatusWaitingFamilyGenerator() generator.FamilyGenera
 		"kube_pod_init_container_status_waiting",
 		"Describes whether the init container is currently in waiting state.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
@@ -1003,7 +1004,7 @@ func createPodInitContainerStatusWaitingReasonFamilyGenerator() generator.Family
 		"kube_pod_init_container_status_waiting_reason",
 		"Describes the reason the init container is currently in waiting state.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.InitContainerStatuses))
@@ -1030,7 +1031,7 @@ func createPodAnnotationsGenerator(allowAnnotations []string) generator.FamilyGe
 		"kube_pod_annotations",
 		"Kubernetes annotations converted to Prometheus labels.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotations)
@@ -1051,7 +1052,7 @@ func createPodLabelsGenerator(allowLabelsList []string) generator.FamilyGenerato
 		"kube_pod_labels",
 		"Kubernetes labels converted to Prometheus labels.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
@@ -1072,7 +1073,7 @@ func createPodOverheadCPUCoresFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_overhead_cpu_cores",
 		"The pod overhead in regards to cpu cores associated with running a pod.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1098,7 +1099,7 @@ func createPodOverheadMemoryBytesFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_overhead_memory_bytes",
 		"The pod overhead in regards to memory associated with running a pod.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1125,7 +1126,7 @@ func createPodOwnerFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_owner",
 		"Information about the Pod's owner.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
@@ -1173,7 +1174,7 @@ func createPodRestartPolicyFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_restart_policy",
 		"Describes the restart policy in use by this pod.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			return &metric.Family{
@@ -1194,7 +1195,7 @@ func createPodRuntimeClassNameInfoFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_runtimeclass_name_info",
 		"The runtimeclass associated with the pod.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1219,7 +1220,7 @@ func createPodSpecVolumesPersistentVolumeClaimsInfoFamilyGenerator() generator.F
 		"kube_pod_spec_volumes_persistentvolumeclaims_info",
 		"Information about persistentvolumeclaim volumes in a pod.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1246,7 +1247,7 @@ func createPodSpecVolumesPersistentVolumeClaimsReadonlyFamilyGenerator() generat
 		"kube_pod_spec_volumes_persistentvolumeclaims_readonly",
 		"Describes whether a persistentvolumeclaim is mounted read only.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1273,7 +1274,7 @@ func createPodStartTimeFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_start_time",
 		"Start time in unix timestamp for a pod.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1297,7 +1298,7 @@ func createPodStatusPhaseFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_status_phase",
 		"The pods current phase.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			phase := p.Status.Phase
@@ -1341,7 +1342,7 @@ func createPodStatusContainerReadyTimeFamilyGenerator() generator.FamilyGenerato
 		"kube_pod_status_container_ready_time",
 		"Readiness achieved time in unix timestamp for a pod containers.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1368,7 +1369,7 @@ func createPodStatusReadyTimeFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_status_ready_time",
 		"Readiness achieved time in unix timestamp for a pod.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
@@ -1396,7 +1397,7 @@ func createPodStatusQosClassFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_status_qos_class",
 		"The pods current qosClass.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			class := p.Status.QOSClass
@@ -1438,7 +1439,7 @@ func createPodStatusReadyFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_status_ready",
 		"Describes whether the pod is ready to serve requests.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1467,7 +1468,7 @@ func createPodStatusReasonFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_status_reason",
 		"The pod status reasons",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1496,7 +1497,7 @@ func createPodStatusScheduledFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_status_scheduled",
 		"Describes the status of the scheduling process for the pod.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1525,7 +1526,7 @@ func createPodStatusScheduledTimeFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_status_scheduled_time",
 		"Unix timestamp when pod moved into scheduled status",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1552,7 +1553,7 @@ func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_status_unschedulable",
 		"Describes the unschedulable status for the pod.",
 		metric.Gauge,
-		basemetrics.STABLE,
+		metricsstability.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
@@ -1579,7 +1580,7 @@ func createPodTolerationsFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_tolerations",
 		"Information about the pod tolerations",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			var ms []*metric.Metric
@@ -1636,7 +1637,7 @@ func createPodNodeSelectorsFamilyGenerator() generator.FamilyGenerator {
 		"kube_pod_nodeselectors",
 		"Describes the Pod nodeSelectors.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			labelKeys, labelValues := kubeMapToPrometheusLabels("nodeselector", p.Spec.NodeSelector)

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -45,7 +46,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			descPodDisruptionBudgetAnnotationsName,
 			descPodDisruptionBudgetAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
@@ -64,7 +65,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			descPodDisruptionBudgetLabelsName,
 			descPodDisruptionBudgetLabelsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
@@ -83,7 +84,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"kube_poddisruptionbudget_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				ms := []*metric.Metric{}
@@ -103,7 +104,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"kube_poddisruptionbudget_status_current_healthy",
 			"Current number of healthy pods",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
@@ -119,7 +120,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"kube_poddisruptionbudget_status_desired_healthy",
 			"Minimum desired number of healthy pods",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
@@ -135,7 +136,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"kube_poddisruptionbudget_status_pod_disruptions_allowed",
 			"Number of pod disruptions that are currently allowed",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
@@ -151,7 +152,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"kube_poddisruptionbudget_status_expected_pods",
 			"Total number of pods counted by this disruption budget",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
@@ -167,7 +168,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"kube_poddisruptionbudget_status_observed_generation",
 			"Most recent generation observed when updating this PDB status",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strconv"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -47,7 +47,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_replicaset_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
@@ -68,7 +68,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_replicaset_status_replicas",
 			"The number of replicas per ReplicaSet.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
@@ -84,7 +84,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_replicaset_status_fully_labeled_replicas",
 			"The number of fully labeled replicas per ReplicaSet.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
@@ -100,7 +100,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_replicaset_status_ready_replicas",
 			"The number of ready replicas per ReplicaSet.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
@@ -116,7 +116,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_replicaset_status_observed_generation",
 			"The generation observed by the ReplicaSet controller.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
@@ -132,7 +132,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_replicaset_spec_replicas",
 			"Number of desired pods for a ReplicaSet.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
@@ -152,7 +152,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_replicaset_metadata_generation",
 			"Sequence number representing a specific generation of the desired state.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
@@ -168,7 +168,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			"kube_replicaset_owner",
 			"Information about the ReplicaSet's owner.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				owners := r.GetOwnerReferences()
@@ -213,7 +213,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			descReplicaSetAnnotationsName,
 			descReplicaSetAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
@@ -232,7 +232,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			descReplicaSetLabelsName,
 			descReplicaSetLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -26,7 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -40,7 +41,7 @@ var (
 			"kube_replicationcontroller_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				ms := []*metric.Metric{}
@@ -60,7 +61,7 @@ var (
 			"kube_replicationcontroller_status_replicas",
 			"The number of replicas per ReplicationController.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
@@ -76,7 +77,7 @@ var (
 			"kube_replicationcontroller_status_fully_labeled_replicas",
 			"The number of fully labeled replicas per ReplicationController.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
@@ -92,7 +93,7 @@ var (
 			"kube_replicationcontroller_status_ready_replicas",
 			"The number of ready replicas per ReplicationController.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
@@ -108,7 +109,7 @@ var (
 			"kube_replicationcontroller_status_available_replicas",
 			"The number of available replicas per ReplicationController.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
@@ -124,7 +125,7 @@ var (
 			"kube_replicationcontroller_status_observed_generation",
 			"The generation observed by the ReplicationController controller.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
@@ -140,7 +141,7 @@ var (
 			"kube_replicationcontroller_spec_replicas",
 			"Number of desired pods for a ReplicationController.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				ms := []*metric.Metric{}
@@ -160,7 +161,7 @@ var (
 			"kube_replicationcontroller_metadata_generation",
 			"Sequence number representing a specific generation of the desired state.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
@@ -176,7 +177,7 @@ var (
 			"kube_replicationcontroller_owner",
 			"Information about the ReplicationController's owner.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}

--- a/internal/store/resourcequota.go
+++ b/internal/store/resourcequota.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -39,7 +40,7 @@ var (
 			"kube_resourcequota_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
 				ms := []*metric.Metric{}
@@ -60,7 +61,7 @@ var (
 			"kube_resourcequota",
 			"Information about resource quota.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -45,7 +46,7 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 			descRoleAnnotationsName,
 			descRoleAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
@@ -64,7 +65,7 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 			descRoleLabelsName,
 			descRoleLabelsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
@@ -83,7 +84,7 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 			"kube_role_info",
 			"Information about role.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
 				return &metric.Family{
@@ -99,7 +100,7 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 			"kube_role_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
 				ms := []*metric.Metric{}
@@ -121,7 +122,7 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 			"kube_role_metadata_resource_version",
 			"Resource version representing a specific version of the role.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
 				return &metric.Family{

--- a/internal/store/rolebinding.go
+++ b/internal/store/rolebinding.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -45,7 +46,7 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			descRoleBindingAnnotationsName,
 			descRoleBindingAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
@@ -64,7 +65,7 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			descRoleBindingLabelsName,
 			descRoleBindingLabelsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
@@ -83,7 +84,7 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_rolebinding_info",
 			"Information about rolebinding.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				labelKeys := []string{"roleref_kind", "roleref_name"}
@@ -101,7 +102,7 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_rolebinding_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				ms := []*metric.Metric{}
@@ -123,7 +124,7 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_rolebinding_metadata_resource_version",
 			"Resource version representing a specific version of the rolebinding.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				return &metric.Family{

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -45,7 +46,7 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 			"kube_secret_info",
 			"Information about secret.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				return &metric.Family{
@@ -61,7 +62,7 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 			"kube_secret_type",
 			"Type about secret.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				return &metric.Family{
@@ -79,7 +80,7 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 			descSecretAnnotationsName,
 			descSecretAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
@@ -99,7 +100,7 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 			descSecretLabelsName,
 			descSecretLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
@@ -119,7 +120,7 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 			"kube_secret_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				ms := []*metric.Metric{}
@@ -139,7 +140,7 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 			"kube_secret_metadata_resource_version",
 			"Resource version representing a specific version of secret.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				return &metric.Family{

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -45,7 +46,7 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_service_info",
 			"Information about service.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				m := metric.Metric{
@@ -60,7 +61,7 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_service_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if !s.CreationTimestamp.IsZero() {
@@ -78,7 +79,7 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_service_spec_type",
 			"Type about service.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				m := metric.Metric{
@@ -94,7 +95,7 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			descServiceAnnotationsName,
 			descServiceAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
@@ -110,7 +111,7 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			descServiceLabelsName,
 			descServiceLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
@@ -126,7 +127,7 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_service_spec_external_ip",
 			"Service external ips. One series for each ip",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if len(s.Spec.ExternalIPs) == 0 {
@@ -154,7 +155,7 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"kube_service_status_load_balancer_ingress",
 			"Service load balancer ingress status",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if len(s.Status.LoadBalancer.Ingress) == 0 {

--- a/internal/store/serviceaccount.go
+++ b/internal/store/serviceaccount.go
@@ -26,7 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -53,7 +54,7 @@ func createServiceAccountInfoFamilyGenerator() generator.FamilyGenerator {
 		"kube_serviceaccount_info",
 		"Information about a service account",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			var labelKeys []string
@@ -80,7 +81,7 @@ func createServiceAccountCreatedFamilyGenerator() generator.FamilyGenerator {
 		"kube_serviceaccount_created",
 		"Unix creation timestamp",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			var ms []*metric.Metric
@@ -105,7 +106,7 @@ func createServiceAccountDeletedFamilyGenerator() generator.FamilyGenerator {
 		"kube_serviceaccount_deleted",
 		"Unix deletion timestamp",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			var ms []*metric.Metric
@@ -130,7 +131,7 @@ func createServiceAccountSecretFamilyGenerator() generator.FamilyGenerator {
 		"kube_serviceaccount_secret",
 		"Secret being referenced by a service account",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			var ms []*metric.Metric
@@ -155,7 +156,7 @@ func createServiceAccountImagePullSecretFamilyGenerator() generator.FamilyGenera
 		"kube_serviceaccount_image_pull_secret",
 		"Secret being referenced by a service account for the purpose of pulling images",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			var ms []*metric.Metric
@@ -180,7 +181,7 @@ func createServiceAccountAnnotationsGenerator(allowAnnotations []string) generat
 		"kube_serviceaccount_annotations",
 		"Kubernetes annotations converted to Prometheus labels.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", sa.Annotations, allowAnnotations)
@@ -201,7 +202,7 @@ func createServiceAccountLabelsGenerator(allowLabelsList []string) generator.Fam
 		"kube_serviceaccount_labels",
 		"Kubernetes labels converted to Prometheus labels.",
 		metric.Gauge,
-		basemetrics.ALPHA,
+		metricsstability.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
 			labelKeys, labelValues := createPrometheusLabelKeysValues("label", sa.Labels, allowLabelsList)

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -19,7 +19,7 @@ package store
 import (
 	"context"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -46,7 +46,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
@@ -66,7 +66,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_status_replicas",
 			"The number of replicas per StatefulSet.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
@@ -82,7 +82,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_status_replicas_available",
 			"The number of available replicas per StatefulSet.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
@@ -98,7 +98,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_status_replicas_current",
 			"The number of current replicas per StatefulSet.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
@@ -114,7 +114,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_status_replicas_ready",
 			"The number of ready replicas per StatefulSet.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
@@ -130,7 +130,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_status_replicas_updated",
 			"The number of updated replicas per StatefulSet.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
@@ -146,7 +146,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_status_observed_generation",
 			"The generation observed by the StatefulSet controller.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
@@ -162,7 +162,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_replicas",
 			"Number of desired pods for a StatefulSet.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
@@ -182,7 +182,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_metadata_generation",
 			"Sequence number representing a specific generation of the desired state for the StatefulSet.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
@@ -198,7 +198,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_persistentvolumeclaim_retention_policy",
 			"Count of retention policy for StatefulSet template PVCs",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
@@ -225,7 +225,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			descStatefulSetAnnotationsName,
 			descStatefulSetAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
@@ -244,7 +244,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			descStatefulSetLabelsName,
 			descStatefulSetLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
@@ -263,7 +263,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_status_current_revision",
 			"Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
@@ -281,7 +281,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			"kube_statefulset_status_update_revision",
 			"Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{

--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -16,7 +16,7 @@ package store
 import (
 	"context"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -46,7 +46,7 @@ func storageClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			"kube_storageclass_info",
 			"Information about storageclass.",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 
@@ -71,7 +71,7 @@ func storageClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			"kube_storageclass_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 				ms := []*metric.Metric{}
@@ -89,7 +89,7 @@ func storageClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			descStorageClassAnnotationsName,
 			descStorageClassAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
@@ -108,7 +108,7 @@ func storageClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			descStorageClassLabelsName,
 			descStorageClassLabelsHelp,
 			metric.Gauge,
-			basemetrics.STABLE,
+			metricsstability.STABLE,
 			"",
 			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -39,7 +40,7 @@ var (
 			"kube_validatingwebhookconfiguration_info",
 			"Information about the ValidatingWebhookConfiguration.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{
@@ -55,7 +56,7 @@ var (
 			"kube_validatingwebhookconfiguration_created",
 			"Unix creation timestamp.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				ms := []*metric.Metric{}
@@ -74,7 +75,7 @@ var (
 			"kube_validatingwebhookconfiguration_metadata_resource_version",
 			"Resource version representing a specific version of the ValidatingWebhookConfiguration.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
 				return &metric.Family{

--- a/internal/store/verticalpodautoscaler.go
+++ b/internal/store/verticalpodautoscaler.go
@@ -28,7 +28,8 @@ import (
 	vpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/constant"
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
@@ -49,7 +50,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			descVerticalPodAutoscalerAnnotationsName,
 			descVerticalPodAutoscalerAnnotationsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", a.Annotations, allowAnnotationsList)
@@ -68,7 +69,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			descVerticalPodAutoscalerLabelsName,
 			descVerticalPodAutoscalerLabelsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", a.Labels, allowLabelsList)
@@ -87,7 +88,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_spec_updatepolicy_updatemode",
 			"Update mode of the VerticalPodAutoscaler.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -126,7 +127,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed",
 			"Minimum resources the VerticalPodAutoscaler can set for containers matching the name.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -149,7 +150,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed",
 			"Maximum resources the VerticalPodAutoscaler can set for containers matching the name.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -171,7 +172,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound",
 			"Minimum resources the container can use before the VerticalPodAutoscaler updater evicts it.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -193,7 +194,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound",
 			"Maximum resources the container can use before the VerticalPodAutoscaler updater evicts it.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -215,7 +216,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target",
 			"Target resources the VerticalPodAutoscaler recommends for the container.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}
@@ -236,7 +237,7 @@ func vpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			"kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget",
 			"Target resources the VerticalPodAutoscaler recommends for the container ignoring bounds.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"v2.9.0",
 			wrapVPAFunc(func(a *autoscaling.VerticalPodAutoscaler) *metric.Family {
 				ms := []*metric.Metric{}

--- a/internal/store/volumeattachment.go
+++ b/internal/store/volumeattachment.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	basemetrics "k8s.io/component-base/metrics"
+
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -41,7 +42,7 @@ var (
 			descVolumeAttachmentLabelsName,
 			descVolumeAttachmentLabelsHelp,
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				labelKeys, labelValues := kubeMapToPrometheusLabels("label", va.Labels)
@@ -60,7 +61,7 @@ var (
 			"kube_volumeattachment_info",
 			"Information about volumeattachment.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				return &metric.Family{
@@ -78,7 +79,7 @@ var (
 			"kube_volumeattachment_created",
 			"Unix creation timestamp",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				if !va.CreationTimestamp.IsZero() {
@@ -96,7 +97,7 @@ var (
 			"kube_volumeattachment_spec_source_persistentvolume",
 			"PersistentVolume source reference.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				if va.Spec.Source.PersistentVolumeName != nil {
@@ -117,7 +118,7 @@ var (
 			"kube_volumeattachment_status_attached",
 			"Information about volumeattachment.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				return &metric.Family{
@@ -135,7 +136,7 @@ var (
 			"kube_volumeattachment_status_attachment_metadata",
 			"volumeattachment metadata.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapVolumeAttachmentFunc(func(va *storagev1.VolumeAttachment) *metric.Family {
 				labelKeys, labelValues := mapToPrometheusLabels(va.Status.AttachmentMetadata, "metadata")

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -43,7 +43,7 @@ import (
 	samplev1alpha1 "k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1"
 	samplefake "k8s.io/sample-controller/pkg/generated/clientset/versioned/fake"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/internal/store"
 	"k8s.io/kube-state-metrics/v2/pkg/allowdenylist"
@@ -897,7 +897,7 @@ func (f *fooFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsLis
 			"kube_foo_spec_replicas",
 			"Number of desired replicas for a foo.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapFooFunc(func(f *samplev1alpha1.Foo) *metric.Family {
 				return &metric.Family{
@@ -913,7 +913,7 @@ func (f *fooFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsLis
 			"kube_foo_status_replicas_available",
 			"The number of available replicas per foo.",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			wrapFooFunc(func(f *samplev1alpha1.Foo) *metric.Family {
 				return &metric.Family{

--- a/pkg/customresource/registry_factory.go
+++ b/pkg/customresource/registry_factory.go
@@ -56,7 +56,7 @@ type RegistryFactory interface {
 	//			"kube_foo_spec_replicas",
 	//			"Number of desired replicas for a foo.",
 	//			metric.Gauge,
-	//			basemetrics.ALPHA,
+	//			metricsstability.ALPHA,
 	//			"",
 	//			wrapFooFunc(func(f *samplev1alpha1.Foo) *metric.Family {
 	//				return &metric.Family{
@@ -72,7 +72,7 @@ type RegistryFactory interface {
 	//			"kube_foo_status_replicas_available",
 	//			"The number of available replicas per foo.",
 	//			metric.Gauge,
-	//			basemetrics.ALPHA,
+	//			metricsstability.ALPHA,
 	//			"",
 	//			wrapFooFunc(func(f *samplev1alpha1.Foo) *metric.Family {
 	//				return &metric.Family{

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -20,9 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	basemetrics "k8s.io/component-base/metrics"
-
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 )
 
 // FamilyGenerator provides everything needed to generate a metric family with a
@@ -35,19 +34,19 @@ type FamilyGenerator struct {
 	Type              metric.Type
 	OptIn             bool
 	DeprecatedVersion string
-	StabilityLevel    basemetrics.StabilityLevel
+	Stability         metricsstability.Stability
 	GenerateFunc      func(obj interface{}) *metric.Family
 }
 
 // NewFamilyGeneratorWithStability creates new FamilyGenerator instances with metric
 // stabilityLevel.
-func NewFamilyGeneratorWithStability(name string, help string, metricType metric.Type, stabilityLevel basemetrics.StabilityLevel, deprecatedVersion string, generateFunc func(obj interface{}) *metric.Family) *FamilyGenerator {
+func NewFamilyGeneratorWithStability(name string, help string, metricType metric.Type, stabilityLevel metricsstability.Stability, deprecatedVersion string, generateFunc func(obj interface{}) *metric.Family) *FamilyGenerator {
 	f := &FamilyGenerator{
 		Name:              name,
 		Type:              metricType,
 		Help:              help,
 		OptIn:             false,
-		StabilityLevel:    stabilityLevel,
+		Stability:         stabilityLevel,
 		DeprecatedVersion: deprecatedVersion,
 		GenerateFunc:      generateFunc,
 	}
@@ -58,7 +57,7 @@ func NewFamilyGeneratorWithStability(name string, help string, metricType metric
 }
 
 // NewOptInFamilyGenerator creates new FamilyGenerator instances for opt-in metric families.
-func NewOptInFamilyGenerator(name string, help string, metricType metric.Type, stabilityLevel basemetrics.StabilityLevel, deprecatedVersion string, generateFunc func(obj interface{}) *metric.Family) *FamilyGenerator {
+func NewOptInFamilyGenerator(name string, help string, metricType metric.Type, stabilityLevel metricsstability.Stability, deprecatedVersion string, generateFunc func(obj interface{}) *metric.Family) *FamilyGenerator {
 	f := NewFamilyGeneratorWithStability(name, help, metricType, stabilityLevel,
 		deprecatedVersion, generateFunc)
 	f.OptIn = true
@@ -82,9 +81,9 @@ func (g *FamilyGenerator) generateHeader() string {
 	header.WriteString(g.Name)
 	header.WriteByte(' ')
 	// TODO(#1833): remove if-else after all metrics are attached with right
-	// StabilityLevel.
-	if g.StabilityLevel == basemetrics.STABLE {
-		header.WriteString(fmt.Sprintf("[%v] %v", g.StabilityLevel, g.Help))
+	// Stability.
+	if g.Stability == metricsstability.STABLE {
+		header.WriteString(fmt.Sprintf("[%s] %v", "STABLE", g.Help))
 	} else {
 		header.WriteString(g.Help)
 	}

--- a/pkg/optin/optin_test.go
+++ b/pkg/optin/optin_test.go
@@ -19,7 +19,7 @@ package optin
 import (
 	"testing"
 
-	basemetrics "k8s.io/component-base/metrics"
+	metricsstability "k8s.io/kube-state-metrics/v2/pkg/stability"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -50,7 +50,7 @@ func TestFilter(t *testing.T) {
 			test.MetricFamily,
 			"",
 			metric.Gauge,
-			basemetrics.ALPHA,
+			metricsstability.ALPHA,
 			"",
 			func(_ interface{}) *metric.Family {
 				return nil

--- a/pkg/stability/stability.go
+++ b/pkg/stability/stability.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stability
+
+import (
+	basemetrics "k8s.io/component-base/metrics"
+)
+
+// Stability represents the API guarantees for a given defined metric.
+type Stability basemetrics.StabilityLevel
+
+const (
+	// ALPHA metrics have no stability guarantees, as such, labels may
+	// be arbitrarily added/removed and the metric may be deleted at any time.
+	ALPHA Stability = Stability(basemetrics.ALPHA)
+	// STABLE metrics can be changed in few cases when alerts won't be
+	// broken.
+	// The deprecation policy outlined in the below or check
+	// definition of basemetrics.BETA.
+	//
+	// Allowed changes:
+	// - Additional labels are allowed
+	// - Bug fixes to the implementation (e.g. change specific label values or edge cases on nil value)
+	// - Description change
+	// - Deprecation. Stable metric can be deprecated in minor release: Lifecycle is: STABLE (2.n)-> DEPRECATED (2.n+1)-> REMOVED (2.n+2). A removal is a breaking change and will be announced prominently in the CHANGELOG.
+	//
+	// Not allowed changes:
+	// - Renaming, dropping of labels
+	// - Changing metric name, metric type or metric meaning
+	STABLE Stability = Stability(basemetrics.BETA)
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: https://github.com/kubernetes/kube-state-metrics/issues/1995


**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)* No

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1995

```
	ALPHA Stability = Stability(basemetrics.ALPHA)
	STABLE Stability = Stability(basemetrics.BETA)
```

