### PR TITLE
Don't crash on non-existent path values

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -434,7 +434,7 @@ func (c compiledGauge) value(it interface{}) (*eachValue, error) {
 		if it == nil {
 			return nil, fmt.Errorf("got nil while resolving path")
 		}
-		// Don't error if there was not a type-casting issue (`toFloat64`), but rather a failed lookup.
+		// Don't error if there was not a type-casting issue (`toFloat64`).
 		return nil, nil
 	}
 	value, err := toFloat64(got, c.NilIsZero)

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -430,6 +430,10 @@ func (c compiledGauge) value(it interface{}) (*eachValue, error) {
 				Value:  0,
 			}, nil
 		}
+		// no it means no iterables were passed down, meaning that the path resolution never happened
+		if it == nil {
+			return nil, fmt.Errorf("got nil while resolving path")
+		}
 		// Don't error if there was not a type-casting issue (`toFloat64`), but rather a failed lookup.
 		return nil, nil
 	}

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -18,6 +18,7 @@ package customresourcestate
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -193,6 +194,17 @@ func Test_values(t *testing.T) {
 			ValueFrom: mustCompilePath(t, "creationTimestamp"),
 		}, wantResult: []eachValue{
 			newEachValue(t, 1.6563744e+09),
+		}},
+		{name: "non-existent path", each: &compiledGauge{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "foo"),
+				labelFromPath: map[string]valuePath{
+					"name": mustCompilePath(t, "name"),
+				},
+			},
+			ValueFrom: mustCompilePath(t, "creationTimestamp"),
+		}, wantResult: nil, wantErrors: []error{
+			errors.New("[foo]: got nil while resolving path"),
 		}},
 		{name: "array", each: &compiledGauge{
 			compiledCommon: compiledCommon{


### PR DESCRIPTION
**What this PR does / why we need it**: Don't crash on non-existent path values in CRS.

**How does this change affect the cardinality of KSM**: No.

**Which issue(s) this PR fixes**: Fixes #1992 