### PR TITLE
Fix label resolution for maps

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -264,6 +264,8 @@ func (c *compiledGauge) Values(v interface{}) (result []eachValue, errs []error)
 				ev.Labels[c.labelFromKey] = key
 			}
 			addPathLabels(it, c.LabelFromPath(), ev.Labels)
+			// Evaluate path from parent's context as well (search w.r.t. the root element, not just specific fields).
+			addPathLabels(v, c.LabelFromPath(), ev.Labels)
 			result = append(result, *ev)
 		}
 	case []interface{}:

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -193,7 +193,7 @@ func Test_values(t *testing.T) {
 			},
 			ValueFrom: mustCompilePath(t, "creationTimestamp"),
 		}, wantResult: []eachValue{
-			newEachValue(t, 1.6563744e+09),
+			newEachValue(t, 1.6563744e+09, "name", "foo"),
 		}},
 		{name: "non-existent path", each: &compiledGauge{
 			compiledCommon: compiledCommon{


### PR DESCRIPTION
**What this PR does / why we need it**: The `map[string]interface{}` resolution searched for values within various nested fields, but not the relative path itself.

**How does this change affect the cardinality of KSM**: No change.

***
https://github.com/kubernetes/kube-state-metrics/blob/ca1da6b22ed28fe3aa6cac98705cff71c614eac0/pkg/customresourcestate/registry_factory.go#L598-L604