### PR TITLE
Add `rexagod` to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@ approvers:
   - dgrisonnet
   - fpetkovski
   - mrueg
+  - rexagod
 emeritus_approvers:
   - LiliC
   - andyxning


### PR DESCRIPTION
Based on the nomination proposed by @mrueg on the Slack channel (thanks, Manuel!).
