### PR TITLE
Improve wording for Prometheus rule example in pod-metrics

### DIFF
--- a/docs/pod-metrics.md
+++ b/docs/pod-metrics.md
@@ -67,17 +67,17 @@ For example:
 
 * For Pods in `Terminating` state: `count(kube_pod_deletion_timestamp) by (namespace, pod) * count(kube_pod_status_reason{reason="NodeLost"} == 0) by (namespace, pod)`
 
-Here is an example of a Prometheus rule that can be used to alert on a Pod that has been in the `Terminated` state for more than `5m`.
+Here is an example of a Prometheus rule that can be used to alert on a Pod that has been in the `Terminating` state for more than `5m`.
 
 ```yaml
 groups:
 - name: Pod state
   rules:
-  - alert: PodsBlockInTerminatingState
+  - alert: PodsBlockedInTerminatingState
     expr: count(kube_pod_deletion_timestamp) by (namespace, pod) * count(kube_pod_status_reason{reason="NodeLost"} == 0) by (namespace, pod) > 0
     for: 5m
     labels:
       severity: page
     annotations:
-      summary: Pod {{$labels.namespace}}/{{$labels.pod}} block in Terminating state.
+      summary: Pod {{$labels.namespace}}/{{$labels.pod}} blocked in Terminating state.
 ```


### PR DESCRIPTION
**What this PR does / why we need it**: it clarifies the intention of a useful Prometheus rule.

**How does this change affect the cardinality of KSM**: n/a - documentation change only.

