### PR TITLE
Update golangci-lint version to 1.51.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   E2E_SETUP_KUBECTL: yes
   SUDO: sudo
   GO_VERSION: "^1.19"
-  GOLANGCI_LINT_VERSION: "v1.50.1"
+  GOLANGCI_LINT_VERSION: "v1.51.2"
 
 jobs:
   ci-go-lint:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR upgrades the version of `golangci-lint` from `1.50.1` to `1.51.2`.
I've noticed on [another PR](https://github.com/kubernetes/kube-state-metrics/pull/2018) that the check [failed](https://github.com/kubernetes/kube-state-metrics/actions/runs/4364726522/jobs/7633514185). Looking at the [logs](https://pipelines.actions.githubusercontent.com/serviceHosts/5fcb76a1-0fc8-41d3-8f0f-63d273caf10b/_apis/pipelines/1/runs/2105/signedlogcontent/4?urlExpires=2023-03-13T08%3A48%3A07.1066623Z&urlSigningMethod=HMACV1&urlSignature=NXM5sUIKvQceNa4FeoYkZbqGH1aVdrtJaEF8ERtHDFc%3D), it seems it was killed:

> 2023-03-08T14:21:57.6271384Z ##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
> 2023-03-08T14:21:57.8289726Z make: *** [Makefile:45: lint] Killed
> 2023-03-08T14:21:57.8849728Z ##[error]The operation was canceled.

There are many occurrances such as [[1]](https://github.com/kubernetes/kube-state-metrics/actions/runs/4369343082/jobs/7643032821).

I suppose the runner memory limits are being pushed. Before trying to tune `GOGC`, it might be worth updating to the latest version of `golangci-lint` since there's some [indications](https://github.com/golangci/golangci-lint-action/issues/297#issuecomment-1424597616) that there were performance improvements.

**How does this change affect the cardinality of KSM**: N/A