### PR TITLE
Fix casing while scraping failure reason for `kube_job_status_failed`

### DIFF
--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -19,6 +19,7 @@ package store
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	basemetrics "k8s.io/component-base/metrics"
 
@@ -39,7 +40,7 @@ var (
 	descJobLabelsName          = "kube_job_labels"
 	descJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descJobLabelsDefaultLabels = []string{"namespace", "job_name"}
-	jobFailureReasons          = []string{"BackoffLimitExceeded", "DeadLineExceeded", "Evicted"}
+	jobFailureReasons          = []string{"BackoffLimitExceeded", "DeadlineExceeded", "Evicted"}
 )
 
 func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -429,5 +430,5 @@ func failureReason(jc *v1batch.JobCondition, reason string) bool {
 	if jc == nil {
 		return false
 	}
-	return jc.Reason == reason
+	return strings.EqualFold(jc.Reason, reason)
 }

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -19,7 +19,6 @@ package store
 import (
 	"context"
 	"strconv"
-	"strings"
 
 	basemetrics "k8s.io/component-base/metrics"
 
@@ -430,5 +429,5 @@ func failureReason(jc *v1batch.JobCondition, reason string) bool {
 	if jc == nil {
 		return false
 	}
-	return strings.EqualFold(jc.Reason, reason)
+	return jc.Reason == reason
 }

--- a/internal/store/job_test.go
+++ b/internal/store/job_test.go
@@ -210,7 +210,7 @@ func TestJobStore(t *testing.T) {
 				kube_job_status_active{job_name="FailedJob1",namespace="ns1"} 0
 				kube_job_status_completion_time{job_name="FailedJob1",namespace="ns1"} 1.495810807e+09
 				kube_job_status_failed{job_name="FailedJob1",namespace="ns1",reason="BackoffLimitExceeded"} 1
-				kube_job_status_failed{job_name="FailedJob1",namespace="ns1",reason="DeadLineExceeded"} 0
+				kube_job_status_failed{job_name="FailedJob1",namespace="ns1",reason="DeadlineExceeded"} 0
 				kube_job_status_failed{job_name="FailedJob1",namespace="ns1",reason="Evicted"} 0
 				kube_job_status_start_time{job_name="FailedJob1",namespace="ns1"} 1.495807207e+09
 				kube_job_status_succeeded{job_name="FailedJob1",namespace="ns1"} 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When scraping the failure reason for a job, KSM does a [case-sensitive search](https://github.com/kubernetes/kube-state-metrics/blob/main/internal/store/job.go#L432) for the [keyword `DeadLineExceeded`](https://github.com/kubernetes/kube-state-metrics/blob/main/internal/store/job.go#L42). Since Kubernetes is generating the string `DeadlineExceeded`, the search fails to scrape the reason. This PR proposes to do a case-insensitive search instead, so changes in casing do not affect the scraping of the reason.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Does not change cardinality

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2045
