### PR TITLE
2047: Add LabelsFromPath functionality to Info metrics

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -324,17 +324,25 @@ func (c *compiledInfo) Values(v interface{}) (result []eachValue, errs []error) 
 				continue
 			}
 		}
-		// labelFromKey logic
-		for key := range iter {
+
+		// labelFromKey / labelFromPath logic
+		for key, it := range iter {
+			labels := make(map[string]string)
+
 			if key != "" && c.labelFromKey != "" {
+				labels[c.labelFromKey] = key
+			}
+
+			addPathLabels(it, c.LabelFromPath(), labels)
+
+			if len(labels) > 0 {
 				result = append(result, eachValue{
-					Labels: map[string]string{
-						c.labelFromKey: key,
-					},
-					Value: 1,
+					Labels: labels,
+					Value:  1,
 				})
 			}
 		}
+
 		result = append(result, value...)
 	default:
 		result, errs = c.values(v)

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -292,6 +292,17 @@ func Test_values(t *testing.T) {
 			newEachValue(t, 1, "type", "type-a"),
 			newEachValue(t, 1, "type", "type-b"),
 		}},
+		{name: "info label from path", each: &compiledInfo{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "status", "sub"),
+				labelFromPath: map[string]valuePath{
+					"active": mustCompilePath(t, "active"),
+				},
+			},
+		}, wantResult: []eachValue{
+			newEachValue(t, 1, "active", "1"),
+			newEachValue(t, 1, "active", "3"),
+		}},
 		{name: "stateset", each: &compiledStateSet{
 			compiledCommon: compiledCommon{
 				path: mustCompilePath(t, "status", "phase"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR adds `LabelsFromPath` functionality to Info type metrics defined via a `customresourcestate.Resource`

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

May increase under certain conditions (use of custom resource metrics of type info)

**Which issue(s) this PR fixes** 

Fixes #2047

---

## Testing

- unit tests updated ✅
- manually verified:

```go
package main

import (
	"fmt"
	"strings"

	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
	"k8s.io/kube-state-metrics/v2/pkg/customresourcestate"
)

func main() {

	foo := unstructured.Unstructured{
		Object: map[string]any{
			"status": map[string]any {
				"sub": map[string]any {
					"type-a": map[string]any {
						"active": 1,
						"ready": 2,
					},
					"type-b": map[string]any {
						"active": 3,
						"ready": 4,
					},
				},
			},
		},
	}

	r := customresourcestate.Resource{
		GroupVersionKind: customresourcestate.GroupVersionKind{
			Group: "myteam.io",
			Version: "v1",
			Kind: "Foo",
		},
		Metrics: []customresourcestate.Generator{
			{
				Name: "gauge",
				Each: customresourcestate.Metric{
					Type: customresourcestate.MetricTypeGauge,
					Gauge: &customresourcestate.MetricGauge{
						MetricMeta: customresourcestate.MetricMeta{
							Path: []string{"status", "sub"},
							LabelsFromPath: map[string][]string{
								"active": {"active"},
							},
						},
						LabelFromKey: "type",
						ValueFrom: []string{"ready"},
					},
				},
			},
			{
				Name: "info",
				Each: customresourcestate.Metric{
					Type: customresourcestate.MetricTypeInfo,
					Info: &customresourcestate.MetricInfo{
						MetricMeta: customresourcestate.MetricMeta{
							Path: []string{"status", "sub"},
							LabelsFromPath: map[string][]string{
								"active": {"active"},
							},
						},
						LabelFromKey: "type",
					},
				},
			},
		},
	}

	f, _ := customresourcestate.NewCustomResourceMetrics(r)
	
	fgs := f.MetricFamilyGenerators(nil, nil)

	sb := strings.Builder{}
	for _, fg := range fgs {
		mf := fg.Generate(&foo)
		sb.WriteString(mf.Name + "\n")
		for _, m := range mf.Metrics {
			m.Write(&sb)
		}
	}

	fmt.Println(sb.String())

}
```

#### Before

```
go run foo/foo.go
I0414 15:19:35.573271   76061 custom_resource_metrics.go:79] "Custom resource state added metrics" familyNames=[kube_customresource_gauge kube_customresource_info]
kube_customresource_gauge
{active="1",customresource_group="myteam.io",customresource_kind="Foo",customresource_version="v1",type="type-a"} 2
{active="3",customresource_group="myteam.io",customresource_kind="Foo",customresource_version="v1",type="type-b"} 4
kube_customresource_info
{customresource_group="myteam.io",customresource_kind="Foo",customresource_version="v1",type="type-a"} 1
{customresource_group="myteam.io",customresource_kind="Foo",customresource_version="v1",type="type-b"} 1
```

#### After

```
go run foo/foo.go
I0414 17:18:39.914212   92158 custom_resource_metrics.go:79] "Custom resource state added metrics" familyNames=[kube_customresource_gauge kube_customresource_info]
kube_customresource_gauge
{active="1",customresource_group="myteam.io",customresource_kind="Foo",customresource_version="v1",type="type-a"} 2
{active="3",customresource_group="myteam.io",customresource_kind="Foo",customresource_version="v1",type="type-b"} 4
kube_customresource_info
{active="1",customresource_group="myteam.io",customresource_kind="Foo",customresource_version="v1",type="type-a"} 1
{active="3",customresource_group="myteam.io",customresource_kind="Foo",customresource_version="v1",type="type-b"} 1
```
