### PR TITLE
feat: Allow prefixing wildcard `labelsFromPath`

### DIFF
--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -193,6 +193,8 @@ spec:
             # whole objects may be copied into labels by prefixing with "*"
             # *anything will be copied into labels, with the highest sorted * strings first
             "*": [metadata, labels]
+            # a prefix before the asterisk will be used as a label prefix
+            "lorem_*": [metadata, annotations]
             "**": [metadata, annotations]
             
             # or specific fields may be copied. these fields will always override values from *s
@@ -203,8 +205,12 @@ spec:
 Produces the following metrics:
 
 ```prometheus
-kube_customresource_ready_count{customresource_group="myteam.io", customresource_kind="Foo", customresource_version="v1", active="1",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-a"} 2
-kube_customresource_ready_count{customresource_group="myteam.io", customresource_kind="Foo", customresource_version="v1", active="3",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-b"} 4
+kube_customresource_ready_count{customresource_group="myteam.io", customresource_kind="Foo", 
+customresource_version="v1", active="1",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-a",
+lorem_bar="baz",lorem_qux="quxx",} 2
+kube_customresource_ready_count{customresource_group="myteam.io", customresource_kind="Foo", 
+customresource_version="v1", active="3",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-b",
+lorem_bar="baz",lorem_qux="quxx",} 4
 ```
 
 #### VerticalPodAutoscaler

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -507,21 +507,24 @@ func addPathLabels(obj interface{}, labels map[string]valuePath, result map[stri
 	// always do that first so other labels can override
 	var stars []string
 	for k := range labels {
-		if strings.HasPrefix(k, "*") {
+		if strings.HasPrefix(k, "*") || strings.HasSuffix(k, "*") {
 			stars = append(stars, k)
 		}
 	}
 	sort.Strings(stars)
-	for _, k := range stars {
-		m := labels[k].Get(obj)
+	for _, star := range stars {
+		m := labels[star].Get(obj)
 		if kv, ok := m.(map[string]interface{}); ok {
 			for k, v := range kv {
+				if strings.HasSuffix(star, "*") {
+					k = star[:len(star)-1] + k
+				}
 				result[store.SanitizeLabelName(k)] = fmt.Sprintf("%v", v)
 			}
 		}
 	}
 	for k, v := range labels {
-		if strings.HasPrefix(k, "*") {
+		if strings.HasPrefix(k, "*") || strings.HasSuffix(k, "*") {
 			continue
 		}
 		value := v.Get(obj)

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -134,12 +134,15 @@ func Test_addPathLabels(t *testing.T) {
 		{name: "*", args: args{
 			obj: cr,
 			labels: map[string]valuePath{
-				"*1":  mustCompilePath(t, "metadata", "annotations"),
-				"bar": mustCompilePath(t, "metadata", "labels", "foo"),
+				"*1":             mustCompilePath(t, "metadata", "annotations"),
+				"bar":            mustCompilePath(t, "metadata", "labels", "foo"),
+				"label_object_*": mustCompilePath(t, "metadata", "annotations"),
 			},
 			want: map[string]string{
-				"qux": "quxx",
-				"bar": "bar",
+				"qux":              "quxx",
+				"bar":              "bar",
+				"label_object_qux": "quxx",
+				"label_object_bar": "baz",
 			},
 		}},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: Allow prefixing * paths, for instance, a "foo_" prefix like so, foo_*: [foo, bar, baz], will result in foo_baz being the key for all object resolutions under baz.

**How does this change affect the cardinality of KSM**: No change.

**Which issue(s) this PR fixes**: Self-driven.
