### PR TITLE
customresourcestate: Use pluralize logic from k8s/apimachinery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/dgryski/go-jump v0.0.0-20211018200510-ba001c3ffce0
 	github.com/fsnotify/fsnotify v1.6.0
-	github.com/gobuffalo/flect v1.0.2
 	github.com/google/go-cmp v0.5.9
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,6 @@ github.com/go-openapi/jsonreference v0.20.1 h1:FBLnyygC4/IZZr893oiomc9XaghoveYTr
 github.com/go-openapi/jsonreference v0.20.1/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
-github.com/gobuffalo/flect v1.0.2 h1:eqjPGSo2WmjgY2XlpGwo2NXgL3RucAKo4k4qQMNA5sA=
-github.com/gobuffalo/flect v1.0.2/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=

--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -18,9 +18,9 @@ package customresourcestate
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/gobuffalo/flect"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
 	"k8s.io/kube-state-metrics/v2/pkg/customresource"
@@ -78,8 +78,9 @@ func (r Resource) GetResourceName() string {
 	if r.ResourcePlural != "" {
 		return r.ResourcePlural
 	}
-	// kubebuilder default:
-	return strings.ToLower(flect.Pluralize(r.GroupVersionKind.Kind))
+	// kubernetes/apimachinery default:
+	plural, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind(r.GroupVersionKind))
+	return plural.String()
 }
 
 // GroupVersionKind is the Kubernetes group, version, and kind of a resource.


### PR DESCRIPTION
**What this PR does / why we need it**:

kubernetes and kubebuilder use a different logic to generate / guess plurals. The goal of this PR is to use the same logic as Kubernetes.

Kubernetes: https://github.com/kubernetes/apimachinery/blob/master/pkg/api/meta/restmapper.go#L126
Kubebuilder: https://github.com/gobuffalo/flect

See also:
https://github.com/kubernetes-sigs/kubebuilder/issues/3402
https://github.com/kubernetes-sigs/kubebuilder/pull/3408


**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None
