### PR TITLE
feat: allow field KV general matching

### DIFF
--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -522,6 +522,9 @@ Examples:
 
 # if the value to be matched is a number or boolean, the value is compared as a number or boolean  
 [status, conditions, "[value=66]", name]  # status.conditions[1].name = "b"
+
+# For generally matching against a field in an object schema, use the following syntax:
+[metadata, "name=foo"] # if v, ok := metadata[name]; ok && v == "foo" { return v; } else { /* ignore */ }
 ```
 
 ### Wildcard matching of version and kind fields

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -623,6 +623,16 @@ func compilePath(path []string) (out valuePath, _ error) {
 				part: part,
 				op: func(m interface{}) interface{} {
 					if mp, ok := m.(map[string]interface{}); ok {
+						kv := strings.Split(part, "=")
+						if len(kv) == 2 /* k=v */ {
+							key := kv[0]
+							val := kv[1]
+							if v, ok := mp[key]; ok {
+								if v == val {
+									return v
+								}
+							}
+						}
 						return mp[part]
 					} else if s, ok := m.([]interface{}); ok {
 						i, err := strconv.Atoi(part)

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -349,6 +349,15 @@ func Test_values(t *testing.T) {
 			newEachValue(t, 0, "type", "Provisioned"),
 			newEachValue(t, 1, "type", "Ready"),
 		}},
+		{name: "= expression matching", each: &compiledInfo{
+			compiledCommon: compiledCommon{
+				labelFromPath: map[string]valuePath{
+					"bar": mustCompilePath(t, "metadata", "annotations", "bar=baz"),
+				},
+			},
+		}, wantResult: []eachValue{
+			newEachValue(t, 1, "bar", "baz"),
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**: Currently all matching support is limited to map-list representations; this adds support for a more general "key:value" based matching expression for any `interface{}` field (non-map-list-like).

**How does this change affect the cardinality of KSM**: No change.
