### PR TITLE
feat: Support list expansions

### DIFF
--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -552,8 +552,11 @@ path: [status, namespaces, "*", status]
 labelsFromPath:
   # this can be combined with the wildcard prefixes feature introduced in #2052
   "available_*": [available]
+  "lorem_*": [pending]
+# this can be combined with dynamic valueFrom expressions introduced in #2068
+valueFrom: [lorem_resourceB] # or [available_resourceB]
 # outputs:
-...{...,available_resourceA="10",available_resourceB="20",...} ...
+...{...,available_resourceA="10",available_resourceB="20",lorem_resourceA="0",lorem_resourceB="6"...} 6
 ```
 
 ### Wildcard matching of version and kind fields

--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -531,6 +531,29 @@ Examples:
 
 # For generally matching against a field in an object schema, use the following syntax:
 [metadata, "name=foo"] # if v, ok := metadata[name]; ok && v == "foo" { return v; } else { /* ignore */ }
+
+# expand a list
+[spec, order, "*", value] # syntax
+# for the object snippet below
+...
+status:
+  namespaces:
+  - namespace: "foo"
+    status:
+      available:
+        resourceA: '10'
+        resourceB: '20'
+      pending:
+        resourceA: '0'
+        resourceB: '6'
+...
+# resolves to: [status, namespaces, <range len(namespaces)>, status] (a multi-dimensional array)
+path: [status, namespaces, "*", status]
+labelsFromPath:
+  # this can be combined with the wildcard prefixes feature introduced in #2052
+  "available_*": [available]
+# outputs:
+...{...,available_resourceA="10",available_resourceB="20",...} ...
 ```
 
 ### Wildcard matching of version and kind fields

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -41,10 +41,20 @@ func init() {
 				Obj{
 					"id":    1,
 					"value": true,
+					"arr": Array{
+						Obj{
+							"foo": "bar",
+						},
+					},
 				},
 				Obj{
 					"id":    3,
 					"value": false,
+					"arr": Array{
+						Obj{
+							"foo": "baz",
+						},
+					},
 				},
 			},
 		},
@@ -527,6 +537,46 @@ func Test_valuePath_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := mustCompilePath(t, tt.p...)
 			assert.Equal(t, tt.want, p.Get(cr))
+		})
+	}
+}
+
+func Test_resolveWildcard(t *testing.T) {
+	tests := []struct {
+		path valuePath
+		want []valuePath
+		name string
+	}{
+		{
+			name: "wildcard not at the boundary",
+			path: mustCompilePath(t, "spec", "order", "*", "value"),
+			want: []valuePath{
+				mustCompilePath(t, "spec", "order", "0", "value"),
+				mustCompilePath(t, "spec", "order", "1", "value"),
+			},
+		},
+		{
+			name: "wildcard at the boundary",
+			path: mustCompilePath(t, "spec", "order", "*"),
+			want: []valuePath{
+				mustCompilePath(t, "spec", "order", "0"),
+				mustCompilePath(t, "spec", "order", "1"),
+			},
+		},
+		{
+			name: "multiple wildcards",
+			path: mustCompilePath(t, "spec", "order", "*", "arr", "*", "foo"),
+			want: []valuePath{
+				mustCompilePath(t, "spec", "order", "0", "arr", "0", "foo"),
+				mustCompilePath(t, "spec", "order", "1", "arr", "0", "foo"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveWildcard(tt.path, cr)
+			reflect.DeepEqual(got, tt.want)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Allow CRS configuration to take in path values for lists, denoted by "*". This means it's possible to specify `[..., <list>, "*", foo, ...]` in the configuration to dynamically generate multiple metrics that reflect different states of `foo` in various list elements.

**How does this change affect the cardinality of KSM**: No change.
