### PR TITLE
Add namespace label to `kube_lease_renew_time`

### DIFF
--- a/docs/lease-metrics.md
+++ b/docs/lease-metrics.md
@@ -3,4 +3,4 @@
 | Metric name| Metric type | Labels/tags                                                                                                                               | Status |
 | ---------- | ----------- |-------------------------------------------------------------------------------------------------------------------------------------------| ----------- |
 | kube_lease_owner | Gauge | `lease`=&lt;lease-name&gt; <br> `owner_kind`=&lt;onwer kind&gt; <br> `owner_name`=&lt;owner name&gt; <br> `namespace` = &lt;namespace&gt; <br> `lease_holder`=&lt;lease holder name&gt;| EXPERIMENTAL |
-| kube_lease_renew_time | Gauge | `lease`=&lt;lease-name&gt;                                                                                                              | EXPERIMENTAL |
+| kube_lease_renew_time | Gauge | `lease`=&lt;lease-name&gt;  <br> `namespace` = &lt;namespace&gt;                                                                        | EXPERIMENTAL |

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -83,11 +83,15 @@ var (
 			basemetrics.ALPHA,
 			"",
 			wrapLeaseFunc(func(l *coordinationv1.Lease) *metric.Family {
+				labelKeys := []string{"namespace"}
+
 				ms := []*metric.Metric{}
 
 				if !l.Spec.RenewTime.IsZero() {
 					ms = append(ms, &metric.Metric{
-						Value: float64(l.Spec.RenewTime.Unix()),
+						LabelKeys:   labelKeys,
+						LabelValues: []string{l.Namespace},
+						Value:       float64(l.Spec.RenewTime.Unix()),
 					})
 				}
 				return &metric.Family{

--- a/internal/store/lease_test.go
+++ b/internal/store/lease_test.go
@@ -57,7 +57,7 @@ func TestLeaseStore(t *testing.T) {
 				},
 				Want: metadata + `
                     kube_lease_owner{lease="kube-master",owner_kind="Node",owner_name="kube-master",namespace="default",lease_holder="kube-master"} 1
-                    kube_lease_renew_time{lease="kube-master"} 1.5e+09
+                    kube_lease_renew_time{lease="kube-master",namespace="default"} 1.5e+09
 			`,
 				MetricNames: []string{
 					"kube_lease_owner",
@@ -84,7 +84,7 @@ func TestLeaseStore(t *testing.T) {
 				},
 				Want: metadata + `
                     kube_lease_owner{lease="kube-master",owner_kind="Node",owner_name="kube-master",namespace="default",lease_holder=""} 1
-                    kube_lease_renew_time{lease="kube-master"} 1.5e+09
+                    kube_lease_renew_time{lease="kube-master",namespace="default"} 1.5e+09
 			`,
 				MetricNames: []string{
 					"kube_lease_owner",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This patch adds the namespace label to the `kube_lease_renew_time` and
updates unit tests to validate the changes.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

N/A

**Which issue(s) this PR fixes** 
Fixes https://github.com/kubernetes/kube-state-metrics/issues/2071
