### PR TITLE
Increase timeout and update cloudbuild image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,9 +1,9 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1800s
+timeout: 2400s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230522-312425ae46'
     entrypoint: make
     env:
     - TAG=$_PULL_BASE_REF


### PR DESCRIPTION
**What this PR does / why we need it**:
The v2.9.0 tag failed to build because of a timeout. This change increases the timeout by 10 more minutes and updates to a more recent baseimage that is used to build.
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
