### PR TITLE
move pod owner-ref to all pod metrics

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -505,20 +505,6 @@ func createPodContainerStatusWaitingFamilyGenerator() generator.FamilyGenerator 
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
-			//createdBy := metav1.GetControllerOf(p)
-			//createdByKind := ""
-			//createdByName := ""
-			//if createdBy != nil {
-			//	if createdBy.Kind != "" {
-			//		createdByKind = createdBy.Kind
-			//	}
-			//	if createdBy.Name != "" {
-			//		createdByName = createdBy.Name
-			//	}
-			//}
-
-			//LabelKeys:   []string{"host_ip", "pod_ip", "node", "created_by_kind", "created_by_name", "priority_class", "host_network"},
-			//LabelValues: []string{p.Status.HostIP, p.Status.PodIP, p.Spec.NodeName, createdByKind, createdByName, p.Spec.PriorityClassName, strconv.FormatBool(p.Spec.HostNetwork)},
 
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	descPodLabelsDefaultLabels = []string{"created_by_kind", "created_by_name", "created_by_uid", "namespace", "pod", "uid"}
+	descPodLabelsDefaultLabels = []string{"created_by_kind", "created_by_name", "namespace", "pod", "uid"}
 	podStatusReasons           = []string{"Evicted", "NodeAffinity", "NodeLost", "Shutdown", "UnexpectedAdmissionError"}
 )
 
@@ -1650,7 +1650,6 @@ func wrapPodFunc(f func(*v1.Pod) *metric.Family) func(interface{}) *metric.Famil
 		createdBy := metav1.GetControllerOf(pod)
 		createdByKind := ""
 		createdByName := ""
-		createdByUID := ""
 		if createdBy != nil {
 			if createdBy.Kind != "" {
 				createdByKind = createdBy.Kind
@@ -1658,13 +1657,10 @@ func wrapPodFunc(f func(*v1.Pod) *metric.Family) func(interface{}) *metric.Famil
 			if createdBy.Name != "" {
 				createdByName = createdBy.Name
 			}
-			if createdBy.UID != "" {
-				createdByUID = string(createdBy.UID)
-			}
 		}
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descPodLabelsDefaultLabels, []string{createdByKind, createdByName, createdByUID, pod.Namespace, pod.Name, string(pod.UID)}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys, m.LabelValues = mergeKeyValues(descPodLabelsDefaultLabels, []string{createdByKind, createdByName, pod.Namespace, pod.Name, string(pod.UID)}, m.LabelKeys, m.LabelValues)
 		}
 
 		return metricFamily


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a Draft PR with a suggested approach to solving #1993 

This PR adds the owner meta to all of the pod metrics. This is useful in situations where a user would like to roll up the pods by their owner (for instance to associate container restarts with a deployment in a multi-tenant namespace). Alternatively to adding the refs to _all_ pod metrics, it could be added to just those which could benefit from the rollup. I would like feedback from the project maintainers as to if the additional labels would cause issues regarding cardinality or otherwise.

The functionality was already written in the `pod_info` metric, I just moved it into the `wrapPodFunc` so it would be exposed to all of the pod metrics.

If this approach is accepted I will fix the tests and clean things up a bit.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

I don't believe this would add much cardnality but would like feedback in this area.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially Fixes #1993
