### PR TITLE
docs: Document RBAC and remove outdated info

### DIFF
--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -16,8 +16,6 @@ If both flags are provided, the inline configuration will take precedence.
 When multiple entries for the same resource exist, kube-state-metrics will exit with an error.
 This includes configuration which refers to a different API version.
 
-In addition to specifying one of `--custom-resource-state-config*` flags, you should also add the custom resource *Kind*s in plural form to the list of exposed resources in the `--resources` flag. If you don't specify `--resources`, then all known custom resources configured in `--custom-resource-state-config*` and all available default kubernetes objects will be taken into account by kube-state-metrics.
-
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -46,7 +44,6 @@ spec:
                         each:
                           type: Gauge
                           ...
-          - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,foos,horizontalpodautoscalers,ingresses,jobs,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
 ```
 
 It's also possible to configure kube-state-metrics to run in a `custom-resource-mode` only. In addition to specifying one of `--custom-resource-state-config*` flags, you could set `--custom-resource-state-only` to `true`.
@@ -84,6 +81,11 @@ spec:
 ```
 
 NOTE: The `customresource_group`, `customresource_version`, and `customresource_kind` common labels are reserved, and will be overwritten by the values from the `groupVersionKind` field.
+
+### RBAC-enabled Clusters
+
+Please be aware that kube-state-metrics needs list and watch permissions granted to `customresourcedefinitions.apiextensions.k8s.io` as well as to the resources you want to gather metrics from.
+
 
 ### Examples
 


### PR DESCRIPTION


**What this PR does / why we need it**:
Adds a paragraph on RBAC and removes the outdated information on setting the customresource in the --resources flag.
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2100
