### PR TITLE
build: Reorder CI steps to use go mod cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,14 @@ jobs:
     name: ci-go-lint
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Setup environment
       run: |
@@ -50,14 +50,14 @@ jobs:
     name: ci-validate-manifests
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Setup environment
       run: |
@@ -71,14 +71,14 @@ jobs:
     name: ci-validate-go-modules
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Setup environment
       run: |
@@ -92,14 +92,14 @@ jobs:
     name: ci-validate-docs
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Setup environment
       run: |
@@ -113,14 +113,14 @@ jobs:
     name: ci-unit-tests
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Setup environment
       run: |
@@ -149,14 +149,14 @@ jobs:
     name: ci-benchmark-tests
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Setup environment
       run: |
@@ -170,14 +170,14 @@ jobs:
     name: ci-build-kube-state-metrics
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Setup environment
       run: |
@@ -191,14 +191,14 @@ jobs:
     name: ci-e2e-tests
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Setup environment
       run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

According to https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs we need to checkout before we setup go to make use of go.mod caching.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
