### PR TITLE
fix: Add filtering for Lease metrics

### DIFF
--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -116,13 +116,15 @@ func wrapLeaseFunc(f func(*coordinationv1.Lease) *metric.Family) func(interface{
 	}
 }
 
-func createLeaseListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createLeaseListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.CoordinationV1().Leases("").List(context.TODO(), opts)
+			opts.FieldSelector = fieldSelector
+			return kubeClient.CoordinationV1().Leases(ns).List(context.TODO(), opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.CoordinationV1().Leases("").Watch(context.TODO(), opts)
+			opts.FieldSelector = fieldSelector
+			return kubeClient.CoordinationV1().Leases(ns).Watch(context.TODO(), opts)
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Lease metrics are filtered by namespaces when `--namespaces` or `--namespaces-denylist` is specified.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2121
