### PR TITLE
Add_Push_MetricsToPushgateway_Mode

### DIFF
--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -329,7 +329,8 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		WebSystemdSocket:   new(bool),
 		WebConfigFile:      &tlsConfig,
 	}
-
+	// Start to push the metrics to pushgateway
+	m.PushMetrics()
 	// Run Telemetry server
 	{
 		g.Add(func() error {

--- a/pkg/metrics_store/metrics_writer.go
+++ b/pkg/metrics_store/metrics_writer.go
@@ -69,6 +69,7 @@ func (m MetricsWriter) Push(pushgateway string) error{
 	}
 	return nil
 }
+
 // WriteAll writes out metrics from the underlying stores to the given writer.
 //
 // WriteAll writes metrics so that the ones with the same name

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -178,6 +178,7 @@ func (m *MetricsHandler) Run(ctx context.Context) error {
 	<-ctx.Done()
 	return ctx.Err()
 }
+
 // Get metrics data and push to pushgateway!
 func (m *MetricsHandler) PushMetrics() {
 	if m.opts.PushGatewayURL == ""{ 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -55,7 +55,9 @@ type Options struct {
 	TelemetryPort            int             `yaml:"telemetry_port"`
 	TotalShards              int             `yaml:"total_shards"`
 	UseAPIServerCache        bool            `yaml:"use_api_server_cache"`
-
+	PushGatewayURL           string          `yaml:"pushgateway"`
+	PushJobName                  string          `yaml:"pushjobname"`
+	PushInstance                 string          `yaml:"pushinstance"`     
 	Config string
 
 	cmd *cobra.Command
@@ -117,7 +119,9 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	o.cmd.Flags().Lookup("logtostderr").NoOptDefVal = "true"
 
 	autoshardingNotice := "When set, it is expected that --pod and --pod-namespace are both set. Most likely this should be passed via the downward API. This is used for auto-detecting sharding. If set, this has preference over statically configured sharding. This is experimental, it may be removed without notice."
-
+	o.cmd.Flags().StringVar(&o.PushJobName, "pushjobname", "kube-state-metrics", `The name of job corresponding to specified metrics`)
+	o.cmd.Flags().StringVar(&o.PushInstance, "pushinstance", getInstanceIpAddress(), `The URL of instance(machine)`)
+	o.cmd.Flags().StringVar(&o.PushGatewayURL, "pushgateway", "", `The URL of the pushgateway`)
 	o.cmd.Flags().BoolVar(&o.CustomResourcesOnly, "custom-resource-state-only", false, "Only provide Custom Resource State metrics (experimental)")
 	o.cmd.Flags().BoolVar(&o.EnableGZIPEncoding, "enable-gzip-encoding", false, "Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.")
 	o.cmd.Flags().BoolVarP(&o.Help, "help", "h", false, "Print Help text")
@@ -171,3 +175,4 @@ func (o *Options) Validate() error {
 	}
 	return nil
 }
+

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -56,8 +56,8 @@ type Options struct {
 	TotalShards              int             `yaml:"total_shards"`
 	UseAPIServerCache        bool            `yaml:"use_api_server_cache"`
 	PushGatewayURL           string          `yaml:"pushgateway"`
-	PushJobName                  string          `yaml:"pushjobname"`
-	PushInstance                 string          `yaml:"pushinstance"`     
+	PushJobName              string          `yaml:"pushjobname"`
+	PushInstance             string          `yaml:"pushinstance"`     
 	Config string
 
 	cmd *cobra.Command

--- a/pkg/options/resource.go
+++ b/pkg/options/resource.go
@@ -17,7 +17,11 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
+	"net"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"qoobing.com/gomod/log"
 )
 
 var (
@@ -56,3 +60,19 @@ var (
 		"volumeattachments":               struct{}{},
 	}
 )
+
+// Get instance ip address
+func getInstanceIpAddress() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		log.Warningf(fmt.Sprintf("getInstanceIpAddress failed: [%s]", err))
+	}
+	for _, addr := range addrs {
+        if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+            if ipnet.IP.To4() != nil {
+				return ipnet.IP.String()
+            }
+        }
+    }
+	return ""
+}

--- a/pkg/options/resource.go
+++ b/pkg/options/resource.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"qoobing.com/gomod/log"
 )
-
 var (
 	// DefaultNamespaces is the default namespace selector for selecting and filtering across all namespaces.
 	DefaultNamespaces = NamespaceList{metav1.NamespaceAll}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Added function: allow push metrics to pushgateway
Input cml args format：
If you want to start with push mode, you must specify args --pushgateway.
./kube-state-metrics <other commands> --pushgateway= <destination url>
The args pushjobname and pushinstance are optional. 
Default value for pushjobname is "kube-state-metrics" and default value for pushinstance is the instance address of running machine.
If you want to start with pull mode, you just do not add args --pushgateway and act as normal 
