### PR TITLE
feat: disable labels and annotations metrics when metric-annotations-…

### DIFF
--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -49,6 +49,9 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			basemetrics.ALPHA,
 			"",
 			wrapCSRFunc(func(j *certv1.CertificateSigningRequest) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -68,6 +71,9 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			basemetrics.STABLE,
 			"",
 			wrapCSRFunc(func(j *certv1.CertificateSigningRequest) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", j.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/certificatesigningrequest_test.go
+++ b/internal/store/certificatesigningrequest_test.go
@@ -57,7 +57,6 @@ func TestCsrStore(t *testing.T) {
 				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 0
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 0
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
 				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 0
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
@@ -87,7 +86,6 @@ func TestCsrStore(t *testing.T) {
 				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 0
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 1
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
 				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 0
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
@@ -117,7 +115,6 @@ func TestCsrStore(t *testing.T) {
 				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 1
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 0
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
 				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 0
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
@@ -148,7 +145,6 @@ func TestCsrStore(t *testing.T) {
 				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 1
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 0
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
 				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 13
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
@@ -181,7 +177,6 @@ func TestCsrStore(t *testing.T) {
 				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 1
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 1
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
 				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 0
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},
@@ -220,7 +215,6 @@ func TestCsrStore(t *testing.T) {
 				kube_certificatesigningrequest_created{certificatesigningrequest="certificate-test",signer_name="signer"} 1.5e+09
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="approved"} 2
 				kube_certificatesigningrequest_condition{certificatesigningrequest="certificate-test",signer_name="signer",condition="denied"} 2
-				kube_certificatesigningrequest_labels{certificatesigningrequest="certificate-test",signer_name="signer"} 1
 				kube_certificatesigningrequest_cert_length{certificatesigningrequest="certificate-test",signer_name="signer"} 0
 `,
 			MetricNames: []string{"kube_certificatesigningrequest_created", "kube_certificatesigningrequest_condition", "kube_certificatesigningrequest_labels", "kube_certificatesigningrequest_cert_length"},

--- a/internal/store/clusterrole.go
+++ b/internal/store/clusterrole.go
@@ -48,6 +48,9 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -67,6 +70,9 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/clusterrolebinding.go
+++ b/internal/store/clusterrolebinding.go
@@ -48,6 +48,9 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -67,6 +70,9 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -44,6 +44,9 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.ALPHA,
 			"",
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", c.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -63,6 +66,9 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", c.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -52,6 +52,9 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			basemetrics.ALPHA,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -71,6 +74,9 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			basemetrics.STABLE,
 			"",
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", j.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -161,7 +161,6 @@ func TestCronJobStore(t *testing.T) {
 				# TYPE kube_cronjob_status_last_schedule_time gauge
 				kube_cronjob_info{concurrency_policy="Forbid",cronjob="ActiveRunningCronJob1",namespace="ns1",schedule="0 */6 * * *"} 1
 				kube_cronjob_annotations{annotation_app_k8s_io_owner="@foo",cronjob="ActiveRunningCronJob1",namespace="ns1"} 1
-				kube_cronjob_labels{cronjob="ActiveRunningCronJob1",namespace="ns1"} 1
 				kube_cronjob_spec_failed_job_history_limit{cronjob="ActiveRunningCronJob1",namespace="ns1"} 1
 				kube_cronjob_spec_starting_deadline_seconds{cronjob="ActiveRunningCronJob1",namespace="ns1"} 300
 				kube_cronjob_spec_successful_job_history_limit{cronjob="ActiveRunningCronJob1",namespace="ns1"} 3
@@ -235,7 +234,6 @@ func TestCronJobStore(t *testing.T) {
 				# TYPE kube_cronjob_status_last_schedule_time gauge
 				# TYPE kube_cronjob_status_last_successful_time gauge
 				kube_cronjob_info{concurrency_policy="Forbid",cronjob="SuspendedCronJob1",namespace="ns1",schedule="0 */3 * * *"} 1
-				kube_cronjob_labels{cronjob="SuspendedCronJob1",namespace="ns1"} 1
 				kube_cronjob_spec_failed_job_history_limit{cronjob="SuspendedCronJob1",namespace="ns1"} 1
 				kube_cronjob_spec_starting_deadline_seconds{cronjob="SuspendedCronJob1",namespace="ns1"} 300
 				kube_cronjob_spec_successful_job_history_limit{cronjob="SuspendedCronJob1",namespace="ns1"} 3
@@ -295,7 +293,6 @@ func TestCronJobStore(t *testing.T) {
 				# TYPE kube_cronjob_status_last_schedule_time gauge
 				# TYPE kube_cronjob_status_last_successful_time gauge
 				kube_cronjob_info{concurrency_policy="Forbid",cronjob="SuspendedCronJob1",namespace="ns1",schedule="0 */3 * * *"} 1
-				kube_cronjob_labels{cronjob="SuspendedCronJob1",namespace="ns1"} 1
 				kube_cronjob_spec_failed_job_history_limit{cronjob="SuspendedCronJob1",namespace="ns1"} 1
 				kube_cronjob_spec_starting_deadline_seconds{cronjob="SuspendedCronJob1",namespace="ns1"} 300
 				kube_cronjob_spec_successful_job_history_limit{cronjob="SuspendedCronJob1",namespace="ns1"} 3
@@ -364,7 +361,6 @@ func TestCronJobStore(t *testing.T) {
 				kube_cronjob_spec_suspend{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 0
 				kube_cronjob_info{concurrency_policy="Forbid",cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1",schedule="25 * * * *"} 1
 				kube_cronjob_created{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 1.520766296e+09
-				kube_cronjob_labels{cronjob="ActiveCronJob1NoLastScheduled",namespace="ns1"} 1
 ` +
 				fmt.Sprintf("kube_cronjob_next_schedule_time{cronjob=\"ActiveCronJob1NoLastScheduled\",namespace=\"ns1\"} %ve+09\n",
 					float64(ActiveCronJob1NoLastScheduledNextScheduleTime.Unix())/math.Pow10(9)),

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -230,6 +230,9 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.ALPHA,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -249,6 +252,9 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", d.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/daemonset_test.go
+++ b/internal/store/daemonset_test.go
@@ -86,7 +86,6 @@ func TestDaemonSetStore(t *testing.T) {
 				kube_daemonset_status_observed_generation{daemonset="ds1",namespace="ns1"} 2
 				kube_daemonset_status_updated_number_scheduled{daemonset="ds1",namespace="ns1"} 0
 				kube_daemonset_annotations{annotation_app_k8s_io_owner="@foo",daemonset="ds1",namespace="ns1"} 1
-				kube_daemonset_labels{daemonset="ds1",namespace="ns1"} 1
 `,
 			MetricNames: []string{
 				"kube_daemonset_annotations",
@@ -149,7 +148,6 @@ func TestDaemonSetStore(t *testing.T) {
 				kube_daemonset_status_number_ready{daemonset="ds2",namespace="ns2"} 0
 				kube_daemonset_status_number_unavailable{daemonset="ds2",namespace="ns2"} 0
 				kube_daemonset_status_updated_number_scheduled{daemonset="ds2",namespace="ns2"} 0
-				kube_daemonset_labels{daemonset="ds2",namespace="ns2"} 1
 				kube_daemonset_created{namespace="ns2",daemonset="ds2"} 1.5e+09
 `,
 			MetricNames: []string{
@@ -216,7 +214,6 @@ func TestDaemonSetStore(t *testing.T) {
 				kube_daemonset_status_number_ready{daemonset="ds3",namespace="ns3"} 5
 				kube_daemonset_status_number_unavailable{daemonset="ds3",namespace="ns3"} 5
 				kube_daemonset_status_updated_number_scheduled{daemonset="ds3",namespace="ns3"} 5
-				kube_daemonset_labels{daemonset="ds3",namespace="ns3"} 1
 `,
 			MetricNames: []string{
 				"kube_daemonset_created",

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -290,6 +290,9 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.ALPHA,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -309,6 +312,9 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", d.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -115,7 +115,6 @@ func TestDeploymentStore(t *testing.T) {
 			Want: metadata + `
         kube_deployment_annotations{annotation_company_io_team="my-brilliant-team",deployment="depl1",namespace="ns1"} 1
         kube_deployment_created{deployment="depl1",namespace="ns1"} 1.5e+09
-        kube_deployment_labels{deployment="depl1",namespace="ns1"} 1
         kube_deployment_metadata_generation{deployment="depl1",namespace="ns1"} 21
         kube_deployment_spec_paused{deployment="depl1",namespace="ns1"} 0
         kube_deployment_spec_replicas{deployment="depl1",namespace="ns1"} 200
@@ -170,8 +169,6 @@ func TestDeploymentStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-        kube_deployment_annotations{deployment="depl2",namespace="ns2"} 1
-        kube_deployment_labels{deployment="depl2",namespace="ns2"} 1
         kube_deployment_metadata_generation{deployment="depl2",namespace="ns2"} 14
         kube_deployment_spec_paused{deployment="depl2",namespace="ns2"} 1
         kube_deployment_spec_replicas{deployment="depl2",namespace="ns2"} 5

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -86,6 +86,9 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			basemetrics.ALPHA,
 			"",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", e.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -105,6 +108,9 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			basemetrics.STABLE,
 			"",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", e.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/endpoint_test.go
+++ b/internal/store/endpoint_test.go
@@ -89,12 +89,10 @@ func TestEndpointStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_endpoint_annotations{endpoint="test-endpoint",namespace="default"} 1
 				kube_endpoint_address_available{endpoint="test-endpoint",namespace="default"} 6
 				kube_endpoint_address_not_ready{endpoint="test-endpoint",namespace="default"} 6
 				kube_endpoint_created{endpoint="test-endpoint",namespace="default"} 1.5e+09
 				kube_endpoint_info{endpoint="test-endpoint",namespace="default"} 1
-				kube_endpoint_labels{endpoint="test-endpoint",namespace="default"} 1
 				kube_endpoint_ports{endpoint="test-endpoint",namespace="default",port_name="http",port_protocol="TCP",port_number="8080"} 1
 				kube_endpoint_ports{endpoint="test-endpoint",namespace="default",port_name="app",port_protocol="TCP",port_number="8081"} 1
 				kube_endpoint_ports{endpoint="test-endpoint",namespace="default",port_name="https",port_protocol="TCP",port_number="8443"} 1
@@ -134,12 +132,10 @@ func TestEndpointStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_endpoint_annotations{endpoint="single-port-endpoint",namespace="default"} 1
 				kube_endpoint_address_available{endpoint="single-port-endpoint",namespace="default"} 2
 				kube_endpoint_address_not_ready{endpoint="single-port-endpoint",namespace="default"} 1
 				kube_endpoint_created{endpoint="single-port-endpoint",namespace="default"} 1.5e+09
 				kube_endpoint_info{endpoint="single-port-endpoint",namespace="default"} 1
-				kube_endpoint_labels{endpoint="single-port-endpoint",namespace="default"} 1
 				kube_endpoint_ports{endpoint="single-port-endpoint",namespace="default",port_name="",port_number="8080",port_protocol="TCP"} 1
 				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",ip="127.0.0.1",ready="true"} 1
 				kube_endpoint_address{endpoint="single-port-endpoint",namespace="default",ip="10.0.0.1",ready="true"} 1

--- a/internal/store/endpointslice.go
+++ b/internal/store/endpointslice.go
@@ -174,6 +174,9 @@ func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			basemetrics.ALPHA,
 			"",
 			wrapEndpointSliceFunc(func(s *discoveryv1.EndpointSlice) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -193,6 +196,9 @@ func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			basemetrics.ALPHA,
 			"",
 			wrapEndpointSliceFunc(func(s *discoveryv1.EndpointSlice) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/endpointslice_test.go
+++ b/internal/store/endpointslice_test.go
@@ -144,7 +144,6 @@ func TestEndpointSliceStore(t *testing.T) {
 					# TYPE kube_endpointslice_annotations gauge
 					# TYPE kube_endpointslice_labels gauge
 					kube_endpointslice_annotations{endpointslice="test_endpointslice-labels",annotation_foo="baz"} 1
-					kube_endpointslice_labels{endpointslice="test_endpointslice-labels"} 1
 				`,
 			MetricNames: []string{
 				"kube_endpointslice_annotations", "kube_endpointslice_labels",

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -344,6 +344,9 @@ func createHPAAnnotations(allowAnnotationsList []string) generator.FamilyGenerat
 		basemetrics.ALPHA,
 		"",
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+			if len(allowAnnotationsList) == 0 {
+				return &metric.Family{}
+			}
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", a.Annotations, allowAnnotationsList)
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -366,6 +369,9 @@ func createHPALabels(allowLabelsList []string) generator.FamilyGenerator {
 		basemetrics.STABLE,
 		"",
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+			if len(allowLabelsList) == 0 {
+				return &metric.Family{}
+			}
 			labelKeys, labelValues := createPrometheusLabelKeysValues("label", a.Labels, allowLabelsList)
 			return &metric.Family{
 				Metrics: []*metric.Metric{

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -210,8 +210,6 @@ func TestHPAStore(t *testing.T) {
 			},
 			Want: metadata + `
 				kube_horizontalpodautoscaler_info{horizontalpodautoscaler="hpa1",namespace="ns1",scaletargetref_api_version="apps/v1",scaletargetref_kind="Deployment",scaletargetref_name="deployment1"} 1
-				kube_horizontalpodautoscaler_annotations{horizontalpodautoscaler="hpa1",namespace="ns1"} 1
-				kube_horizontalpodautoscaler_labels{horizontalpodautoscaler="hpa1",namespace="ns1"} 1
 				kube_horizontalpodautoscaler_metadata_generation{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
 				kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 4
 				kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="hpa1",namespace="ns1"} 2
@@ -389,7 +387,6 @@ func TestHPAStore(t *testing.T) {
 			Want: metadata + `
 				kube_horizontalpodautoscaler_info{horizontalpodautoscaler="hpa2",namespace="ns1",scaletargetref_kind="Deployment",scaletargetref_name="deployment1"} 1
 				kube_horizontalpodautoscaler_annotations{annotation_app_k8s_io_owner="@foo",horizontalpodautoscaler="hpa2",namespace="ns1"} 1
-				kube_horizontalpodautoscaler_labels{horizontalpodautoscaler="hpa2",namespace="ns1"} 1
 				kube_horizontalpodautoscaler_metadata_generation{horizontalpodautoscaler="hpa2",namespace="ns1"} 2
 				kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 4
 				kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="hpa2",namespace="ns1"} 2

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -75,6 +75,9 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			basemetrics.ALPHA,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", i.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -94,6 +97,9 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			basemetrics.STABLE,
 			"",
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", i.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/ingress_test.go
+++ b/internal/store/ingress_test.go
@@ -75,7 +75,6 @@ func TestIngressStore(t *testing.T) {
 				kube_ingress_info{namespace="ns1",ingress="ingress1",ingressclass="_default"} 1
 				kube_ingress_metadata_resource_version{namespace="ns1",ingress="ingress1"} 0
 				kube_ingress_annotations{annotation_app_k8s_io_owner="@foo",namespace="ns1",ingress="ingress1"} 1
-				kube_ingress_labels{namespace="ns1",ingress="ingress1"} 1
 `,
 			MetricNames: []string{
 				"kube_ingress_info",
@@ -97,7 +96,6 @@ func TestIngressStore(t *testing.T) {
 				kube_ingress_info{namespace="ns2",ingress="ingress2",ingressclass="_default"} 1
 				kube_ingress_created{namespace="ns2",ingress="ingress2"} 1.501569018e+09
 				kube_ingress_metadata_resource_version{namespace="ns2",ingress="ingress2"} 123456
-				kube_ingress_labels{namespace="ns2",ingress="ingress2"} 1
 				`,
 			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_tls"},
 		},
@@ -114,7 +112,6 @@ func TestIngressStore(t *testing.T) {
 			Want: metadata + `
 				kube_ingress_info{namespace="ns3",ingress="ingress3",ingressclass="_default"} 1
 				kube_ingress_created{namespace="ns3",ingress="ingress3"} 1.501569018e+09
-				kube_ingress_labels{namespace="ns3",ingress="ingress3"} 1
 `,
 			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_tls"},
 		},
@@ -167,7 +164,6 @@ func TestIngressStore(t *testing.T) {
 			Want: metadata + `
 				kube_ingress_info{namespace="ns4",ingress="ingress4",ingressclass="_default"} 1
 				kube_ingress_created{namespace="ns4",ingress="ingress4"} 1.501569018e+09
-				kube_ingress_labels{namespace="ns4",ingress="ingress4"} 1
 				kube_ingress_path{namespace="ns4",ingress="ingress4",host="somehost",path="/somepath",service_name="someservice",service_port="1234"} 1
 				kube_ingress_path{namespace="ns4",ingress="ingress4",host="somehost",path="/somepath2",service_name="",service_port=""} 1
 `,
@@ -194,7 +190,6 @@ func TestIngressStore(t *testing.T) {
 			Want: metadata + `
 				kube_ingress_info{namespace="ns5",ingress="ingress5",ingressclass="_default"} 1
 				kube_ingress_created{namespace="ns5",ingress="ingress5"} 1.501569018e+09
-				kube_ingress_labels{namespace="ns5",ingress="ingress5"} 1
 				kube_ingress_tls{namespace="ns5",ingress="ingress5",tls_host="somehost1",secret="somesecret"} 1
 				kube_ingress_tls{namespace="ns5",ingress="ingress5",tls_host="somehost2",secret="somesecret"} 1
 `,
@@ -216,7 +211,6 @@ func TestIngressStore(t *testing.T) {
 				kube_ingress_info{namespace="ns6",ingress="ingress6",ingressclass="test"} 1
 				kube_ingress_created{namespace="ns6",ingress="ingress6"} 1.501569018e+09
 				kube_ingress_metadata_resource_version{namespace="ns6",ingress="ingress6"} 123456
-				kube_ingress_labels{namespace="ns6",ingress="ingress6"} 1
 				`,
 			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_tls"},
 		},
@@ -236,7 +230,6 @@ func TestIngressStore(t *testing.T) {
 				kube_ingress_info{namespace="ns7",ingress="ingress7",ingressclass="test"} 1
 				kube_ingress_created{namespace="ns7",ingress="ingress7"} 1.501569018e+09
 				kube_ingress_metadata_resource_version{namespace="ns7",ingress="ingress7"} 123456
-				kube_ingress_labels{namespace="ns7",ingress="ingress7"} 1
 				`,
 			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_tls"},
 		},

--- a/internal/store/ingressclass.go
+++ b/internal/store/ingressclass.go
@@ -80,6 +80,9 @@ func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			basemetrics.ALPHA,
 			"",
 			wrapIngressClassFunc(func(s *networkingv1.IngressClass) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -99,6 +102,9 @@ func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			basemetrics.ALPHA,
 			"",
 			wrapIngressClassFunc(func(s *networkingv1.IngressClass) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/ingressclass_test.go
+++ b/internal/store/ingressclass_test.go
@@ -88,7 +88,6 @@ func TestIngressClassStore(t *testing.T) {
 					# TYPE kube_ingressclass_annotations gauge
 					# TYPE kube_ingressclass_labels gauge
 					kube_ingressclass_annotations{ingressclass="test_ingressclass-labels",annotation_ingressclass_kubernetes_io_is_default_class="true"} 1
-					kube_ingressclass_labels{ingressclass="test_ingressclass-labels"} 1
 				`,
 			MetricNames: []string{
 				"kube_ingressclass_annotations", "kube_ingressclass_labels",

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -51,6 +51,9 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			basemetrics.ALPHA,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -70,6 +73,9 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			basemetrics.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", j.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/job_test.go
+++ b/internal/store/job_test.go
@@ -112,11 +112,9 @@ func TestJobStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_job_annotations{job_name="RunningJob1",namespace="ns1"} 1
 				kube_job_owner{job_name="RunningJob1",namespace="ns1",owner_is_controller="true",owner_kind="CronJob",owner_name="cronjob-name"} 1
 				kube_job_created{job_name="RunningJob1",namespace="ns1"} 1.5e+09
 				kube_job_info{job_name="RunningJob1",namespace="ns1"} 1
-				kube_job_labels{job_name="RunningJob1",namespace="ns1"} 1
 				kube_job_spec_active_deadline_seconds{job_name="RunningJob1",namespace="ns1"} 900
 				kube_job_spec_completions{job_name="RunningJob1",namespace="ns1"} 1
 				kube_job_spec_parallelism{job_name="RunningJob1",namespace="ns1"} 1
@@ -153,13 +151,11 @@ func TestJobStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_job_annotations{job_name="SuccessfulJob1",namespace="ns1"} 1
 				kube_job_owner{job_name="SuccessfulJob1",namespace="ns1",owner_is_controller="",owner_kind="",owner_name=""} 1
 				kube_job_complete{condition="false",job_name="SuccessfulJob1",namespace="ns1"} 0
 				kube_job_complete{condition="true",job_name="SuccessfulJob1",namespace="ns1"} 1
 				kube_job_complete{condition="unknown",job_name="SuccessfulJob1",namespace="ns1"} 0
 				kube_job_info{job_name="SuccessfulJob1",namespace="ns1"} 1
-				kube_job_labels{job_name="SuccessfulJob1",namespace="ns1"} 1
 				kube_job_spec_active_deadline_seconds{job_name="SuccessfulJob1",namespace="ns1"} 900
 				kube_job_spec_completions{job_name="SuccessfulJob1",namespace="ns1"} 1
 				kube_job_spec_parallelism{job_name="SuccessfulJob1",namespace="ns1"} 1
@@ -197,13 +193,11 @@ func TestJobStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_job_annotations{job_name="FailedJob1",namespace="ns1"} 1
 				kube_job_owner{job_name="FailedJob1",namespace="ns1",owner_is_controller="",owner_kind="",owner_name=""} 1
 				kube_job_failed{condition="false",job_name="FailedJob1",namespace="ns1"} 0
 				kube_job_failed{condition="true",job_name="FailedJob1",namespace="ns1"} 1
 				kube_job_failed{condition="unknown",job_name="FailedJob1",namespace="ns1"} 0
 				kube_job_info{job_name="FailedJob1",namespace="ns1"} 1
-				kube_job_labels{job_name="FailedJob1",namespace="ns1"} 1
 				kube_job_spec_active_deadline_seconds{job_name="FailedJob1",namespace="ns1"} 900
 				kube_job_spec_completions{job_name="FailedJob1",namespace="ns1"} 1
 				kube_job_spec_parallelism{job_name="FailedJob1",namespace="ns1"} 1
@@ -247,10 +241,8 @@ func TestJobStore(t *testing.T) {
 				kube_job_complete{condition="false",job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 0
 				kube_job_complete{condition="true",job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 1
 
-				kube_job_annotations{job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 1
 				kube_job_complete{condition="unknown",job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 0
 				kube_job_info{job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 1
-				kube_job_labels{job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 1
 				kube_job_spec_completions{job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 1
 				kube_job_spec_parallelism{job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 1
 				kube_job_status_active{job_name="SuccessfulJob2NoActiveDeadlineSeconds",namespace="ns1"} 0

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -68,6 +68,10 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.ALPHA,
 			"",
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
+
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -87,6 +91,9 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", n.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/namespace_test.go
+++ b/internal/store/namespace_test.go
@@ -56,8 +56,6 @@ func TestNamespaceStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_namespace_annotations{namespace="nsActiveTest"} 1
-				kube_namespace_labels{namespace="nsActiveTest"} 1
 				kube_namespace_status_phase{namespace="nsActiveTest",phase="Active"} 1
 				kube_namespace_status_phase{namespace="nsActiveTest",phase="Terminating"} 0
 `,
@@ -75,8 +73,6 @@ func TestNamespaceStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_namespace_annotations{namespace="nsTerminateTest"} 1
-				kube_namespace_labels{namespace="nsTerminateTest"} 1
 				kube_namespace_status_phase{namespace="nsTerminateTest",phase="Active"} 0
 				kube_namespace_status_phase{namespace="nsTerminateTest",phase="Terminating"} 1
 `,
@@ -99,8 +95,6 @@ func TestNamespaceStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_namespace_annotations{namespace="nsTerminateWithConditionTest"} 1
-				kube_namespace_labels{namespace="nsTerminateWithConditionTest"} 1
 				kube_namespace_status_phase{namespace="nsTerminateWithConditionTest",phase="Active"} 0
 				kube_namespace_status_phase{namespace="nsTerminateWithConditionTest",phase="Terminating"} 1
 				kube_namespace_status_condition{condition="NamespaceDeletionContentFailure",namespace="nsTerminateWithConditionTest",status="false"} 0
@@ -132,9 +126,7 @@ func TestNamespaceStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_namespace_annotations{namespace="ns1"} 1
 				kube_namespace_created{namespace="ns1"} 1.5e+09
-				kube_namespace_labels{namespace="ns1"} 1
 				kube_namespace_status_phase{namespace="ns1",phase="Active"} 1
 				kube_namespace_status_phase{namespace="ns1",phase="Terminating"} 0
 `,
@@ -156,8 +148,6 @@ func TestNamespaceStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_namespace_annotations{namespace="ns2"} 1
-				kube_namespace_labels{namespace="ns2"} 1
 				kube_namespace_status_phase{namespace="ns2",phase="Active"} 1
 				kube_namespace_status_phase{namespace="ns2",phase="Terminating"} 0
 `,

--- a/internal/store/networkpolicy.go
+++ b/internal/store/networkpolicy.go
@@ -66,6 +66,9 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			basemetrics.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -85,6 +88,9 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			basemetrics.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", n.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/networkpolicy_test.go
+++ b/internal/store/networkpolicy_test.go
@@ -55,7 +55,6 @@ func TestNetworkPolicyStore(t *testing.T) {
 			},
 			Want: `
 			kube_networkpolicy_created{namespace="ns1",networkpolicy="netpol1"} 1.501569018e+09
-			kube_networkpolicy_labels{namespace="ns1",networkpolicy="netpol1"} 1
 			kube_networkpolicy_spec_egress_rules{namespace="ns1",networkpolicy="netpol1"} 3
 			kube_networkpolicy_spec_ingress_rules{namespace="ns1",networkpolicy="netpol1"} 2
 			`,

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -164,6 +164,9 @@ func createNodeAnnotationsGenerator(allowAnnotationsList []string) generator.Fam
 		basemetrics.ALPHA,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			if len(allowAnnotationsList) == 0 {
+				return &metric.Family{}
+			}
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -186,6 +189,9 @@ func createNodeLabelsGenerator(allowLabelsList []string) generator.FamilyGenerat
 		basemetrics.STABLE,
 		"",
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
+			if len(allowLabelsList) == 0 {
+				return &metric.Family{}
+			}
 			labelKeys, labelValues := createPrometheusLabelKeysValues("label", n.Labels, allowLabelsList)
 			return &metric.Family{
 				Metrics: []*metric.Metric{

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -61,7 +61,6 @@ func TestNodeStore(t *testing.T) {
 				# TYPE kube_node_labels gauge
 				# TYPE kube_node_spec_unschedulable gauge
 				kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",pod_cidr="172.24.10.0/24",provider_id="provider://i-uniqueid",internal_ip="1.2.3.4",system_uuid="6a934e21-5207-4a84-baea-3a952d926c80"} 1
-				kube_node_labels{node="127.0.0.1"} 1
 				kube_node_spec_unschedulable{node="127.0.0.1"} 0
 			`,
 			MetricNames: []string{"kube_node_spec_unschedulable", "kube_node_labels", "kube_node_info"},
@@ -142,7 +141,6 @@ func TestNodeStore(t *testing.T) {
 		# TYPE kube_node_status_capacity gauge
 		kube_node_created{node="127.0.0.1"} 1.5e+09
         kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",pod_cidr="172.24.10.0/24",provider_id="provider://i-randomidentifier",internal_ip="1.2.3.4",system_uuid="6a934e21-5207-4a84-baea-3a952d926c80"} 1
-		kube_node_labels{node="127.0.0.1"} 1
 		kube_node_role{node="127.0.0.1",role="master"} 1
         kube_node_spec_unschedulable{node="127.0.0.1"} 1
         kube_node_status_allocatable{node="127.0.0.1",resource="cpu",unit="core"} 3

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -85,6 +85,9 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 			basemetrics.ALPHA,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -104,6 +107,9 @@ func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []stri
 			basemetrics.STABLE,
 			"",
 			wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/persistentvolume_test.go
+++ b/internal/store/persistentvolume_test.go
@@ -522,7 +522,6 @@ func TestPersistentVolumeStore(t *testing.T) {
 			Want: `
 					# HELP kube_persistentvolume_labels [STABLE] Kubernetes labels converted to Prometheus labels.
 					# TYPE kube_persistentvolume_labels gauge
-					kube_persistentvolume_labels{persistentvolume="test-labeled-pv"} 1
 				`,
 			MetricNames: []string{"kube_persistentvolume_labels"},
 		},
@@ -538,7 +537,6 @@ func TestPersistentVolumeStore(t *testing.T) {
 			Want: `
 					# HELP kube_persistentvolume_labels [STABLE] Kubernetes labels converted to Prometheus labels.
 					# TYPE kube_persistentvolume_labels gauge
-					kube_persistentvolume_labels{persistentvolume="test-unlabeled-pv"} 1
 				`,
 			MetricNames: []string{"kube_persistentvolume_labels"},
 		},
@@ -658,8 +656,6 @@ func TestPersistentVolumeStore(t *testing.T) {
 					# HELP kube_persistentvolume_labels [STABLE] Kubernetes labels converted to Prometheus labels.
 					# TYPE kube_persistentvolume_annotations gauge
 					# TYPE kube_persistentvolume_labels gauge
-					kube_persistentvolume_annotations{persistentvolume="test-defaul-labels-annotations"} 1
-					kube_persistentvolume_labels{persistentvolume="test-defaul-labels-annotations"} 1
 `,
 			MetricNames: []string{
 				"kube_persistentvolume_annotations",

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -49,6 +49,9 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			basemetrics.STABLE,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -68,6 +71,9 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 			basemetrics.ALPHA,
 			"",
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/persistentvolumeclaim_test.go
+++ b/internal/store/persistentvolumeclaim_test.go
@@ -90,7 +90,6 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
 				kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
 				kube_persistentvolumeclaim_annotations{annotation_app_k8s_io_owner="@foo",namespace="default",persistentvolumeclaim="mysql-data"} 1
-				kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="mysql-data"} 1
 				kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="mysql-data",access_mode="ReadWriteOnce"} 1
 				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="false",condition="CustomizedType"} 0
 				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="false",condition="FileSystemResizePending"} 1
@@ -161,7 +160,6 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Lost"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="mysql-data",phase="Pending"} 0
 				kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="mysql-data"} 1.073741824e+09
-				kube_persistentvolumeclaim_annotations{namespace="default",persistentvolumeclaim="mysql-data"} 1
 				kube_persistentvolumeclaim_labels{label_app="mysql-server",namespace="default",persistentvolumeclaim="mysql-data"} 1
 				kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="mysql-data",access_mode="ReadWriteOnce"} 1
 				kube_persistentvolumeclaim_status_condition{namespace="default",persistentvolumeclaim="mysql-data",status="false",condition="CustomizedType"} 0
@@ -214,7 +212,6 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Bound"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Lost"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="prometheus-data",phase="Pending"} 1
-				kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="prometheus-data"} 1
 				kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="prometheus-data",access_mode="ReadWriteOnce"} 1
 			`,
 			MetricNames: []string{"kube_persistentvolumeclaim_info", "kube_persistentvolumeclaim_status_phase", "kube_persistentvolumeclaim_resource_requests_storage_bytes", "kube_persistentvolumeclaim_labels", "kube_persistentvolumeclaim_access_mode", "kube_persistentvolumeclaim_status_condition", "kube_persistentvolumeclaim_created"},
@@ -261,8 +258,6 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Bound"} 0
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Lost"} 1
 				kube_persistentvolumeclaim_status_phase{namespace="",persistentvolumeclaim="mongo-data",phase="Pending"} 0
-				kube_persistentvolumeclaim_labels{namespace="",persistentvolumeclaim="mongo-data"} 1
-				kube_persistentvolumeclaim_annotations{namespace="",persistentvolumeclaim="mongo-data"} 1
 				kube_persistentvolumeclaim_access_mode{namespace="",persistentvolumeclaim="mongo-data",access_mode="ReadWriteOnce"} 1
 				kube_persistentvolumeclaim_status_condition{namespace="",persistentvolumeclaim="mongo-data",status="false",condition="CustomizedType"} 1
 				kube_persistentvolumeclaim_status_condition{namespace="",persistentvolumeclaim="mongo-data",status="false",condition="FileSystemResizePending"} 0

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -1034,6 +1034,9 @@ func createPodAnnotationsGenerator(allowAnnotations []string) generator.FamilyGe
 		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			if len(allowAnnotations) == 0 {
+				return &metric.Family{}
+			}
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotations)
 			m := metric.Metric{
 				LabelKeys:   annotationKeys,
@@ -1055,6 +1058,9 @@ func createPodLabelsGenerator(allowLabelsList []string) generator.FamilyGenerato
 		basemetrics.STABLE,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+			if len(allowLabelsList) == 0 {
+				return &metric.Family{}
+			}
 			labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
 			m := metric.Metric{
 				LabelKeys:   labelKeys,

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1826,7 +1826,6 @@ func TestPodStore(t *testing.T) {
 			Want: `
 				# HELP kube_pod_labels [STABLE] Kubernetes labels converted to Prometheus labels.
 				# TYPE kube_pod_labels gauge
-				kube_pod_labels{namespace="ns1",pod="pod1",uid="uid1"} 1
 		`,
 			MetricNames: []string{
 				"kube_pod_labels",

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -48,6 +48,9 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			basemetrics.ALPHA,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -67,6 +70,9 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			basemetrics.ALPHA,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/poddisruptionbudget_test.go
+++ b/internal/store/poddisruptionbudget_test.go
@@ -67,8 +67,6 @@ func TestPodDisruptionBudgetStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-			kube_poddisruptionbudget_annotations{namespace="ns1",poddisruptionbudget="pdb1"} 1
-			kube_poddisruptionbudget_labels{namespace="ns1",poddisruptionbudget="pdb1"} 1
 			kube_poddisruptionbudget_created{namespace="ns1",poddisruptionbudget="pdb1"} 1.5e+09
 			kube_poddisruptionbudget_status_current_healthy{namespace="ns1",poddisruptionbudget="pdb1"} 12
 			kube_poddisruptionbudget_status_desired_healthy{namespace="ns1",poddisruptionbudget="pdb1"} 10
@@ -93,8 +91,6 @@ func TestPodDisruptionBudgetStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_poddisruptionbudget_annotations{namespace="ns2",poddisruptionbudget="pdb2"} 1
-				kube_poddisruptionbudget_labels{namespace="ns2",poddisruptionbudget="pdb2"} 1
 				kube_poddisruptionbudget_status_current_healthy{namespace="ns2",poddisruptionbudget="pdb2"} 8
 				kube_poddisruptionbudget_status_desired_healthy{namespace="ns2",poddisruptionbudget="pdb2"} 9
 				kube_poddisruptionbudget_status_pod_disruptions_allowed{namespace="ns2",poddisruptionbudget="pdb2"} 0

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -216,6 +216,9 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.ALPHA,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -235,6 +238,9 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/replicaset_test.go
+++ b/internal/store/replicaset_test.go
@@ -87,8 +87,6 @@ func TestReplicaSetStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_replicaset_annotations{replicaset="rs1",namespace="ns1"} 1
-				kube_replicaset_labels{replicaset="rs1",namespace="ns1"} 1
 				kube_replicaset_created{namespace="ns1",replicaset="rs1"} 1.5e+09
 				kube_replicaset_metadata_generation{namespace="ns1",replicaset="rs1"} 21
 				kube_replicaset_status_replicas{namespace="ns1",replicaset="rs1"} 5
@@ -121,8 +119,6 @@ func TestReplicaSetStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_replicaset_annotations{replicaset="rs2",namespace="ns2"} 1
-				kube_replicaset_labels{replicaset="rs2",namespace="ns2"} 1
 				kube_replicaset_metadata_generation{namespace="ns2",replicaset="rs2"} 14
 				kube_replicaset_status_replicas{namespace="ns2",replicaset="rs2"} 0
 				kube_replicaset_status_observed_generation{namespace="ns2",replicaset="rs2"} 5

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -48,6 +48,9 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 			basemetrics.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -67,6 +70,9 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 			basemetrics.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/rolebinding.go
+++ b/internal/store/rolebinding.go
@@ -48,6 +48,9 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -67,6 +70,9 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.ALPHA,
 			"",
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -82,6 +82,9 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 			basemetrics.ALPHA,
 			"",
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -102,6 +105,9 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 			basemetrics.STABLE,
 			"",
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/secret_test.go
+++ b/internal/store/secret_test.go
@@ -52,7 +52,6 @@ func TestSecretStore(t *testing.T) {
 				kube_secret_info{namespace="ns1",secret="secret1"} 1
 				kube_secret_type{namespace="ns1",secret="secret1",type="Opaque"} 1
 				kube_secret_metadata_resource_version{namespace="ns1",secret="secret1"} 0
-				kube_secret_labels{namespace="ns1",secret="secret1"} 1
 `,
 			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},
 		},
@@ -80,7 +79,6 @@ func TestSecretStore(t *testing.T) {
 				kube_secret_info{namespace="ns2",secret="secret2"} 1
 				kube_secret_type{namespace="ns2",secret="secret2",type="kubernetes.io/service-account-token"} 1
 				kube_secret_created{namespace="ns2",secret="secret2"} 1.501569018e+09
-				kube_secret_labels{namespace="ns2",secret="secret2"} 1
 				`,
 			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},
 		},
@@ -110,7 +108,6 @@ func TestSecretStore(t *testing.T) {
 				kube_secret_type{namespace="ns3",secret="secret3",type="kubernetes.io/dockercfg"} 1
 				kube_secret_created{namespace="ns3",secret="secret3"} 1.501569018e+09
 				kube_secret_metadata_resource_version{namespace="ns3",secret="secret3"} 0
-				kube_secret_labels{namespace="ns3",secret="secret3"} 1
 `,
 			MetricNames: []string{"kube_secret_info", "kube_secret_metadata_resource_version", "kube_secret_created", "kube_secret_labels", "kube_secret_type"},
 		},

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -97,6 +97,9 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			basemetrics.ALPHA,
 			"",
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
 				m := metric.Metric{
 					LabelKeys:   annotationKeys,
@@ -113,6 +116,9 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			basemetrics.STABLE,
 			"",
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
 				m := metric.Metric{
 					LabelKeys:   labelKeys,

--- a/internal/store/service_test.go
+++ b/internal/store/service_test.go
@@ -73,10 +73,8 @@ func TestServiceStore(t *testing.T) {
 				# TYPE kube_service_info gauge
 				# TYPE kube_service_labels gauge
 				# TYPE kube_service_spec_type gauge
-				kube_service_annotations{namespace="default",service="test-service1",uid="uid1"} 1
 				kube_service_created{namespace="default",service="test-service1",uid="uid1"} 1.5e+09
 				kube_service_info{cluster_ip="1.2.3.4",external_name="",load_balancer_ip="",namespace="default",service="test-service1",uid="uid1"} 1
-				kube_service_labels{namespace="default",service="test-service1",uid="uid1"} 1
 				kube_service_spec_type{namespace="default",service="test-service1",type="ClusterIP",uid="uid1"} 1
 `,
 			MetricNames: []string{
@@ -105,10 +103,8 @@ func TestServiceStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_service_annotations{namespace="default",service="test-service2",uid="uid2"} 1
 				kube_service_created{namespace="default",service="test-service2",uid="uid2"} 1.5e+09
 				kube_service_info{cluster_ip="1.2.3.5",external_name="",load_balancer_ip="",namespace="default",service="test-service2",uid="uid2"} 1
-				kube_service_labels{namespace="default",service="test-service2",uid="uid2"} 1
 				kube_service_spec_type{namespace="default",service="test-service2",uid="uid2",type="NodePort"} 1
 `,
 		},
@@ -130,10 +126,8 @@ func TestServiceStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_service_annotations{namespace="default",service="test-service3",uid="uid3"} 1
 				kube_service_created{namespace="default",service="test-service3",uid="uid3"} 1.5e+09
 				kube_service_info{cluster_ip="1.2.3.6",external_name="",load_balancer_ip="1.2.3.7",namespace="default",service="test-service3",uid="uid3"} 1
-				kube_service_labels{namespace="default",service="test-service3",uid="uid3"} 1
 				kube_service_spec_type{namespace="default",service="test-service3",type="LoadBalancer",uid="uid3"} 1
 `,
 		},
@@ -154,10 +148,8 @@ func TestServiceStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_service_annotations{namespace="default",service="test-service4",uid="uid4"} 1
 				kube_service_created{namespace="default",service="test-service4",uid="uid4"} 1.5e+09
 				kube_service_info{cluster_ip="",external_name="www.example.com",load_balancer_ip="",namespace="default",service="test-service4",uid="uid4"} 1
-				kube_service_labels{namespace="default",service="test-service4",uid="uid4"} 1
 				kube_service_spec_type{namespace="default",service="test-service4",uid="uid4",type="ExternalName"} 1
 			`,
 		},
@@ -187,10 +179,8 @@ func TestServiceStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_service_annotations{namespace="default",service="test-service5",uid="uid5"} 1
 				kube_service_created{namespace="default",service="test-service5",uid="uid5"} 1.5e+09
 				kube_service_info{cluster_ip="",external_name="",load_balancer_ip="",namespace="default",service="test-service5",uid="uid5"} 1
-				kube_service_labels{namespace="default",service="test-service5",uid="uid5"} 1
 				kube_service_spec_type{namespace="default",service="test-service5",type="LoadBalancer",uid="uid5"} 1
 				kube_service_status_load_balancer_ingress{hostname="www.example.com",ip="1.2.3.8",namespace="default",service="test-service5",uid="uid5"} 1
 			`,
@@ -215,10 +205,8 @@ func TestServiceStore(t *testing.T) {
 				},
 			},
 			Want: metadata + `
-				kube_service_annotations{namespace="default",service="test-service6",uid="uid6"} 1
 				kube_service_created{namespace="default",service="test-service6",uid="uid6"} 1.5e+09
 				kube_service_info{cluster_ip="",external_name="",load_balancer_ip="",namespace="default",service="test-service6",uid="uid6"} 1
-				kube_service_labels{namespace="default",service="test-service6",uid="uid6"} 1
 				kube_service_spec_type{namespace="default",service="test-service6",uid="uid6",type="ClusterIP"} 1
 				kube_service_spec_external_ip{external_ip="1.2.3.9",namespace="default",service="test-service6",uid="uid6"} 1
 				kube_service_spec_external_ip{external_ip="1.2.3.10",namespace="default",service="test-service6",uid="uid6"} 1

--- a/internal/store/serviceaccount.go
+++ b/internal/store/serviceaccount.go
@@ -183,6 +183,9 @@ func createServiceAccountAnnotationsGenerator(allowAnnotations []string) generat
 		basemetrics.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
+			if len(allowAnnotations) == 0 {
+				return &metric.Family{}
+			}
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", sa.Annotations, allowAnnotations)
 			m := metric.Metric{
 				LabelKeys:   annotationKeys,
@@ -204,6 +207,9 @@ func createServiceAccountLabelsGenerator(allowLabelsList []string) generator.Fam
 		basemetrics.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
+			if len(allowLabelsList) == 0 {
+				return &metric.Family{}
+			}
 			labelKeys, labelValues := createPrometheusLabelKeysValues("label", sa.Labels, allowLabelsList)
 			m := metric.Metric{
 				LabelKeys:   labelKeys,

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -248,6 +248,9 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.ALPHA,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -267,6 +270,9 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/statefulset_test.go
+++ b/internal/store/statefulset_test.go
@@ -99,7 +99,6 @@ func TestStatefulSetStore(t *testing.T) {
  				kube_statefulset_status_observed_generation{namespace="ns1",statefulset="statefulset1"} 1
  				kube_statefulset_replicas{namespace="ns1",statefulset="statefulset1"} 3
  				kube_statefulset_metadata_generation{namespace="ns1",statefulset="statefulset1"} 3
-				kube_statefulset_labels{namespace="ns1",statefulset="statefulset1"} 1
 `,
 			MetricNames: []string{
 				"kube_statefulset_created",
@@ -177,7 +176,6 @@ func TestStatefulSetStore(t *testing.T) {
 				kube_statefulset_status_observed_generation{namespace="ns2",statefulset="statefulset2"} 2
 				kube_statefulset_replicas{namespace="ns2",statefulset="statefulset2"} 6
 				kube_statefulset_metadata_generation{namespace="ns2",statefulset="statefulset2"} 21
-				kube_statefulset_labels{namespace="ns2",statefulset="statefulset2"} 1
 				kube_statefulset_status_current_revision{namespace="ns2",revision="cr2",statefulset="statefulset2"} 1
 `,
 			MetricNames: []string{
@@ -247,7 +245,6 @@ func TestStatefulSetStore(t *testing.T) {
 				kube_statefulset_status_replicas_updated{namespace="ns3",statefulset="statefulset3"} 0
 				kube_statefulset_replicas{namespace="ns3",statefulset="statefulset3"} 9
 				kube_statefulset_metadata_generation{namespace="ns3",statefulset="statefulset3"} 36
-				kube_statefulset_labels{namespace="ns3",statefulset="statefulset3"} 1
 				kube_statefulset_status_current_revision{namespace="ns3",revision="cr3",statefulset="statefulset3"} 1
  			`,
 			MetricNames: []string{
@@ -321,7 +318,6 @@ func TestStatefulSetStore(t *testing.T) {
 				kube_statefulset_replicas{namespace="ns4",statefulset="statefulset4"} 3
  				kube_statefulset_metadata_generation{namespace="ns4",statefulset="statefulset4"} 1
  				kube_statefulset_persistentvolumeclaim_retention_policy{namespace="ns4",statefulset="statefulset4",when_deleted="Retain",when_scaled="Delete"} 1
-				kube_statefulset_labels{namespace="ns4",statefulset="statefulset4"} 1
 				kube_statefulset_status_current_revision{namespace="ns4",revision="cr3",statefulset="statefulset4"} 1
  			`,
 			MetricNames: []string{
@@ -397,7 +393,6 @@ func TestStatefulSetStore(t *testing.T) {
 				kube_statefulset_replicas{namespace="ns5",statefulset="statefulset5"} 3
 				kube_statefulset_ordinals_start{namespace="ns5",statefulset="statefulset5"} 2
  				kube_statefulset_metadata_generation{namespace="ns5",statefulset="statefulset5"} 1
-				kube_statefulset_labels{namespace="ns5",statefulset="statefulset5"} 1
 				kube_statefulset_status_current_revision{namespace="ns5",revision="cr5",statefulset="statefulset5"} 1
  			`,
 			MetricNames: []string{

--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -92,6 +92,9 @@ func storageClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			basemetrics.ALPHA,
 			"",
 			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
+				if len(allowAnnotationsList) == 0 {
+					return &metric.Family{}
+				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -111,6 +114,9 @@ func storageClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			basemetrics.STABLE,
 			"",
 			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
+				if len(allowLabelsList) == 0 {
+					return &metric.Family{}
+				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{

--- a/internal/store/storageclass_test.go
+++ b/internal/store/storageclass_test.go
@@ -100,7 +100,6 @@ func TestStorageClassStore(t *testing.T) {
 			Want: `
 					# HELP kube_storageclass_labels [STABLE] Kubernetes labels converted to Prometheus labels.
 					# TYPE kube_storageclass_labels gauge
-					kube_storageclass_labels{storageclass="test_storageclass-labels"} 1
 				`,
 			MetricNames: []string{
 				"kube_storageclass_labels",

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -301,7 +301,6 @@ func TestFullScrapeCycle(t *testing.T) {
 # TYPE kube_pod_status_scheduled_time gauge
 # TYPE kube_pod_status_unschedulable gauge
 # TYPE kube_pod_tolerations gauge
-kube_pod_annotations{namespace="default",pod="pod0",uid="abc-0"} 1
 kube_pod_container_info{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1",image_spec="k8s.gcr.io/hyperkube2_spec",image="k8s.gcr.io/hyperkube2",image_id="docker://sha256:bbb",container_id="docker://cd456"} 1
 kube_pod_container_info{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2",image_spec="k8s.gcr.io/hyperkube3_spec",image="k8s.gcr.io/hyperkube3",image_id="docker://sha256:ccc",container_id="docker://ef789"} 1
 kube_pod_container_resource_limits{namespace="default",pod="pod0",uid="abc-0",container="pod1_con1",node="node1",resource="cpu",unit="core"} 0.2
@@ -333,7 +332,6 @@ kube_pod_container_status_waiting{namespace="default",pod="pod0",uid="abc-0",con
 kube_pod_container_status_waiting{namespace="default",pod="pod0",uid="abc-0",container="pod1_con2"} 0
 kube_pod_created{namespace="default",pod="pod0",uid="abc-0"} 1.5e+09
 kube_pod_info{namespace="default",pod="pod0",uid="abc-0",host_ip="1.1.1.1",pod_ip="1.2.3.4",node="node1",created_by_kind="",created_by_name="",priority_class="",host_network="false"} 1
-kube_pod_labels{namespace="default",pod="pod0",uid="abc-0"} 1
 kube_pod_owner{namespace="default",pod="pod0",uid="abc-0",owner_kind="",owner_name="",owner_is_controller=""} 1
 kube_pod_restart_policy{namespace="default",pod="pod0",uid="abc-0",type="Always"} 1
 kube_pod_service_account{namespace="default",pod="pod0",uid="abc-0",service_account=""} 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

`kube-state-metrics` provides a lot of `kube_*_annotations` and `kube_*_labels` by default, and it consumes memory significantly.

```
kube_pod_annotations{instance="...:8080", job="monitoring/kube-state-metrics", namespace="namespace", pod="podname-bc94dfc78-fcf4j", uid="a482250c-6f6e-4533-a596-3eff484d8969"}
```

By disabling those metrics by default, `kube-state-metrics` can reduce memory usage.

Those metrics are provided when `kube_*_annotations` and `kube_*_labels` are configured.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

decrease

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1829
