### PR TITLE
feat: include reason label to kube_deployment_status_condition

### DIFF
--- a/docs/deployment-metrics.md
+++ b/docs/deployment-metrics.md
@@ -9,7 +9,7 @@
 | kube_deployment_status_replicas_unavailable | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_status_replicas_updated | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_status_observed_generation | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
-| kube_deployment_status_condition | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; <br> `condition`=&lt;deployment-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
+| kube_deployment_status_condition | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; <br> `reason`=&lt;deployment-transition-reason&gt; <br> `condition`=&lt;deployment-condition&gt; <br> `status`=&lt;true\|false\|unknown&gt; | STABLE |
 | kube_deployment_spec_replicas | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_spec_paused | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |
 | kube_deployment_spec_strategy_rollingupdate_max_unavailable | Gauge | `deployment`=&lt;deployment-name&gt; <br> `namespace`=&lt;deployment-namespace&gt; | STABLE |

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -174,8 +174,8 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 					for j, m := range conditionMetrics {
 						metric := m
 
-						metric.LabelKeys = []string{"condition", "status"}
-						metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
+						metric.LabelKeys = []string{"reason", "condition", "status"}
+						metric.LabelValues = append([]string{c.Reason, string(c.Type)}, metric.LabelValues...)
 						ms[i*len(conditionStatuses)+j] = metric
 					}
 				}

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -98,8 +98,8 @@ func TestDeploymentStore(t *testing.T) {
 					UpdatedReplicas:     2,
 					ObservedGeneration:  111,
 					Conditions: []v1.DeploymentCondition{
-						{Type: v1.DeploymentAvailable, Status: corev1.ConditionTrue},
-						{Type: v1.DeploymentProgressing, Status: corev1.ConditionTrue},
+						{Type: v1.DeploymentAvailable, Status: corev1.ConditionTrue, Reason: "MinimumReplicasAvailable"},
+						{Type: v1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
 					},
 				},
 				Spec: v1.DeploymentSpec{
@@ -127,12 +127,12 @@ func TestDeploymentStore(t *testing.T) {
         kube_deployment_status_replicas_updated{deployment="depl1",namespace="ns1"} 2
         kube_deployment_status_replicas{deployment="depl1",namespace="ns1"} 15
         kube_deployment_status_replicas_ready{deployment="depl1",namespace="ns1"} 10
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="true"} 1
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="true"} 1
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="false"} 0
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="false"} 0
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="unknown"} 0
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="unknown"} 0
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",reason="MinimumReplicasAvailable",condition="Available",status="true"} 1
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",reason="NewReplicaSetAvailable",condition="Progressing",status="true"} 1
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",reason="MinimumReplicasAvailable",condition="Available",status="false"} 0
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",reason="NewReplicaSetAvailable",condition="Progressing",status="false"} 0
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",reason="MinimumReplicasAvailable",condition="Available",status="unknown"} 0
+        kube_deployment_status_condition{deployment="depl1",namespace="ns1",reason="NewReplicaSetAvailable",condition="Progressing",status="unknown"} 0
 `,
 		},
 		{
@@ -153,9 +153,9 @@ func TestDeploymentStore(t *testing.T) {
 					UpdatedReplicas:     1,
 					ObservedGeneration:  1111,
 					Conditions: []v1.DeploymentCondition{
-						{Type: v1.DeploymentAvailable, Status: corev1.ConditionFalse},
-						{Type: v1.DeploymentProgressing, Status: corev1.ConditionFalse},
-						{Type: v1.DeploymentReplicaFailure, Status: corev1.ConditionTrue},
+						{Type: v1.DeploymentAvailable, Status: corev1.ConditionFalse, Reason: "MinimumReplicasAvailable"},
+						{Type: v1.DeploymentProgressing, Status: corev1.ConditionFalse, Reason: "NewReplicaSetAvailable"},
+						{Type: v1.DeploymentReplicaFailure, Status: corev1.ConditionTrue, Reason: "FailedCreate"},
 					},
 				},
 				Spec: v1.DeploymentSpec{
@@ -183,15 +183,15 @@ func TestDeploymentStore(t *testing.T) {
         kube_deployment_status_replicas_updated{deployment="depl2",namespace="ns2"} 1
         kube_deployment_status_replicas{deployment="depl2",namespace="ns2"} 10
         kube_deployment_status_replicas_ready{deployment="depl2",namespace="ns2"} 5
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="true"} 0
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="true"} 0
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="true"} 1
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="false"} 1
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="false"} 1
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="false"} 0
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="unknown"} 0
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="unknown"} 0
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="unknown"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",reason="MinimumReplicasAvailable",condition="Available",status="true"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",reason="NewReplicaSetAvailable",condition="Progressing",status="true"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",reason="FailedCreate",condition="ReplicaFailure",status="true"} 1
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",reason="MinimumReplicasAvailable",condition="Available",status="false"} 1
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",reason="NewReplicaSetAvailable",condition="Progressing",status="false"} 1
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",reason="FailedCreate",condition="ReplicaFailure",status="false"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",reason="MinimumReplicasAvailable",condition="Available",status="unknown"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",reason="NewReplicaSetAvailable",condition="Progressing",status="unknown"} 0
+        kube_deployment_status_condition{deployment="depl2",namespace="ns2",reason="FailedCreate",condition="ReplicaFailure",status="unknown"} 0
 `,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Include `reason` label to `kube_deployment_status_condition` metrics.

It's necessary to distinguish between [Progressing Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progressing-deployment) and [Complete Deployment ](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment).

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

no change

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1991
