### PR TITLE
feat(customresourcestate): allow string Array for labelFromPath

### DIFF
--- a/docs/customresourcestate-metrics.md
+++ b/docs/customresourcestate-metrics.md
@@ -477,6 +477,9 @@ Examples:
 # indexing an array
 [spec, order, "0", value]                # spec.order[0].value = true
 
+# indexing a string array
+["."]
+
 # finding an element in a list by key=value  
 [status, conditions, "[name=a]", value]  # status.conditions[0].value = 45
 

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -192,7 +192,7 @@ func newCompiledMetric(m Metric) (compiledMetric, error) {
 		}
 		valueFromPath, err := compilePath(m.StateSet.ValueFrom)
 		if err != nil {
-			return nil, fmt.Errorf("each.gauge.valueFrom: %w", err)
+			return nil, fmt.Errorf("each.stateSet.valueFrom: %w", err)
 		}
 		return &compiledStateSet{
 			compiledCommon: *cc,
@@ -630,6 +630,10 @@ func compilePath(path []string) (out valuePath, _ error) {
 							return fmt.Errorf("list index out of range: %s", part)
 						}
 						return s[i]
+					} else if s, ok := m.(string); ok {
+						if strings.Contains(path[len(path)-1], ".") {
+							return s
+						}
 					}
 					return nil
 				},

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -88,6 +88,10 @@ func init() {
 					"status": "False",
 				},
 			},
+			"namespaces": Array{
+				"foo",
+				"bar",
+			},
 		},
 		"metadata": Obj{
 			"name": "foo",
@@ -161,6 +165,17 @@ func Test_values(t *testing.T) {
 	}
 
 	tests := []tc{
+		{name: "info labels from namespaces", each: &compiledInfo{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "status", "namespaces"),
+				labelFromPath: map[string]valuePath{
+					"namespace": mustCompilePath(t, "."),
+				},
+			},
+		}, wantResult: []eachValue{
+			newEachValue(t, 1, "namespace", "bar"),
+			newEachValue(t, 1, "namespace", "foo"),
+		}},
 		{name: "single", each: &compiledGauge{
 			compiledCommon: compiledCommon{
 				path: mustCompilePath(t, "spec", "replicas"),


### PR DESCRIPTION
**What this PR does / why we need it**:

Some CRs expose information as Arrays of type String and not Array of type Maps (e.g. namespaces in https://capsule.clastix.io/docs/general/crds-apis/#tenantstatus).
AFAIK it's currently not possible to add these as labels to a metric, this PR should fix this.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

If I understand this correctly, the cardinality should not increase.

**Which issue(s) this PR fixes**

https://github.com/kubernetes/kube-state-metrics/discussions/2149