### PR TITLE
fix: custommetrics: log no _info suffix in name only once per reading the configuration

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -72,6 +72,10 @@ func compileCommon(c MetricMeta) (*compiledCommon, error) {
 func compileFamily(f Generator, resource Resource) (*compiledFamily, error) {
 	labels := resource.Labels.Merge(f.Labels)
 
+	if f.Each.Type == MetricTypeInfo && !strings.HasSuffix(f.Name, "_info") {
+		klog.InfoS("Info metric does not have _info suffix", "gvk", resource.GroupVersionKind.String(), "name", f.Name)
+	}
+
 	metric, err := newCompiledMetric(f.Each)
 	if err != nil {
 		return nil, fmt.Errorf("compiling metric: %w", err)

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	basemetrics "k8s.io/component-base/metrics"
-	"k8s.io/klog/v2"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 )
@@ -74,10 +73,6 @@ func (g *FamilyGenerator) Generate(obj interface{}) *metric.Family {
 	family := g.GenerateFunc(obj)
 	family.Name = g.Name
 	family.Type = g.Type
-	// OpenMetrics spec requires that all Info metrics have a _info suffix.
-	if family.Type == metric.Info && !strings.HasSuffix(family.Name, "_info") {
-		klog.InfoS("Info metric %s does not have _info suffix", family.Name)
-	}
 	return family
 }
 


### PR DESCRIPTION
*What this PR does / why we need it**:

This PR moves the log statement `Info metric does not have _info suffix` from `pkg/metric_generator/generator.go` to `pkg/customresourcestate/registry_factory.go`.

By doing this it only gets logged once when the custom resource configuration gets initialised instead of on creation of every custom resource object.

Also properly uses `InfoS` to not output `%s`.

Before:

```
I0818 16:54:32.105070   71540 generator.go:79] "Info metric %s does not have _info suffix" capi_machine_owner="(MISSING)"
...
I0818 16:58:32.105070   71540 generator.go:79] "Info metric %s does not have _info suffix" capi_machine_owner="(MISSING)"
```

After:

```
I0818 17:54:21.954531    7984 registry_factory.go:76] "Info metric does not have _info suffix" gvk="cluster.x-k8s.io_v1beta1_Machine" name="info"
```

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

None

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2155
