### PR TITLE
fix(customresourcestate): typo in Error message

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -196,7 +196,7 @@ func newCompiledMetric(m Metric) (compiledMetric, error) {
 		}
 		valueFromPath, err := compilePath(m.StateSet.ValueFrom)
 		if err != nil {
-			return nil, fmt.Errorf("each.gauge.valueFrom: %w", err)
+			return nil, fmt.Errorf("each.stateSet.valueFrom: %w", err)
 		}
 		return &compiledStateSet{
 			compiledCommon: *cc,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing finding from https://github.com/kubernetes/kube-state-metrics/pull/2150

**How does this change affect the cardinality of KSM**: -

**Which issue(s) this PR fixes**:
Fixes #2150
