### PR TITLE
fix: Index out of range in metrics_store.SanitizeHeaders

### DIFF
--- a/pkg/metrics_store/metrics_writer.go
+++ b/pkg/metrics_store/metrics_writer.go
@@ -91,11 +91,13 @@ func (m MetricsWriter) WriteAll(w io.Writer) error {
 func SanitizeHeaders(writers MetricsWriterList) MetricsWriterList {
 	var lastHeader string
 	for _, writer := range writers {
-		for i, header := range writer.stores[0].headers {
-			if header == lastHeader {
-				writer.stores[0].headers[i] = ""
-			} else {
-				lastHeader = header
+		if len(writer.stores) > 0 {
+			for i, header := range writer.stores[0].headers {
+				if header == lastHeader {
+					writer.stores[0].headers[i] = ""
+				} else {
+					lastHeader = header
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We observed a panic that did not crash ksm but could have been avoided.

```
2023-08-24T18:08:21.796778057Z 2023/08/24 18:08:21 http: panic serving ip:port: runtime error: index out of range [0] with length 0 
2023-08-24T18:08:21.796814387Z goroutine 589687 [running]: 
2023-08-24T18:08:21.796823334Z net/http.(*conn).serve.func1() 
2023-08-24T18:08:21.796830520Z  /usr/local/go/src/net/http/server.go:1854 +0xbf 
2023-08-24T18:08:21.796838117Z panic({0x19c2060, 0xc0043060a8}) 
2023-08-24T18:08:21.796844764Z  /usr/local/go/src/runtime/panic.go:890 +0x263 
2023-08-24T18:08:21.796852064Z k8s.io/kube-state-metrics/v2/pkg/metrics_store.SanitizeHeaders(...) 2023-08-24T18:08:21.796858974Z  /root/go/src/k8s.io/kube-state-metrics/pkg/metrics_store/metrics_writer.go:94 2023-08-24T18:08:21.796866007Z k8s.io/kube-state-metrics/v2/pkg/metricshandler.(*MetricsHandler).ServeHTTP(0xc000221490, {0x1d425a0, 0xc005872700}, 0xc003f9d300) 2023-08-24T18:08:21.796873054Z  /root/go/src/k8s.io/kube-state-metrics/pkg/metricshandler/metrics_handler.go:211 +0x8fe ...
```

I'm not sure if this is the correct fix, it should resolve the symptom but the question is why or if any writer should have an empty store in the first place. @rexagod @dgrisonnet if you have any ideas, please let me know.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
