### PR TITLE
feat: enable metric-annotations-allowlist and metric-labels-allowlist for ResourceQuota

### DIFF
--- a/docs/resourcequota-metrics.md
+++ b/docs/resourcequota-metrics.md
@@ -4,3 +4,5 @@
 | ---------- | ----------- | ----------- | ----------- |
 | kube_resourcequota | Gauge | `resourcequota`=&lt;quota-name&gt; <br> `namespace`=&lt;namespace&gt; <br> `resource`=&lt;ResourceName&gt; <br> `type`=&lt;quota-type&gt; | STABLE |
 | kube_resourcequota_created | Gauge | `resourcequota`=&lt;quota-name&gt; <br> `namespace`=&lt;namespace&gt; | STABLE |
+| kube_resourcequota_annotations | Gauge | `resourcequota`=&lt;quota-name&gt; <br> `namespace`=&lt;namespace&gt; <br> `annotation_RESOURCE_QUOTA_ANNOTATION`=&lt;RESOURCE_QUOTA_ANNOTATION&gt; | EXPERIMENTAL |
+| kube_resourcequota_labels | Gauge | `resourcequota`=&lt;quota-name&gt; <br> `namespace`=&lt;namespace&gt; <br> `label_RESOURCE_QUOTA_LABEL`=&lt;RESOURCE_QUOTA_LABEL&gt; | EXPERIMENTAL |

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -431,7 +431,7 @@ func (b *Builder) buildReplicationControllerStores() []cache.Store {
 }
 
 func (b *Builder) buildResourceQuotaStores() []cache.Store {
-	return b.buildStoresFunc(resourceQuotaMetricFamilies, &v1.ResourceQuota{}, createResourceQuotaListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(resourceQuotaMetricFamilies(b.allowAnnotationsList["resourcequotas"], b.allowLabelsList["resourcequotas"]), &v1.ResourceQuota{}, createResourceQuotaListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildSecretStores() []cache.Store {

--- a/internal/store/resourcequota_test.go
+++ b/internal/store/resourcequota_test.go
@@ -32,9 +32,13 @@ func TestResourceQuotaStore(t *testing.T) {
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
 	# HELP kube_resourcequota [STABLE] Information about resource quota.
+	# HELP kube_resourcequota_annotations Kubernetes annotations converted to Prometheus labels.
 	# TYPE kube_resourcequota gauge
 	# HELP kube_resourcequota_created [STABLE] Unix creation timestamp
+	# HELP kube_resourcequota_labels [STABLE] Kubernetes labels converted to Prometheus labels.
+	# TYPE kube_resourcequota_annotations gauge
 	# TYPE kube_resourcequota_created gauge
+	# TYPE kube_resourcequota_labels gauge
 	`
 	cases := []generateMetricsTestCase{
 		// Verify populating base metric and that metric for unset fields are skipped.
@@ -132,10 +136,38 @@ func TestResourceQuotaStore(t *testing.T) {
 			kube_resourcequota{namespace="testNS",resource="storage",resourcequota="quotaTest",type="used"} 9e+09
 			`,
 		},
+		// Verify kube_resourcequota_annotations and kube_resourcequota_labels are shown.
+		{
+			AllowAnnotationsList: []string{
+				"foo",
+			},
+			AllowLabelsList: []string{
+				"hello",
+			},
+			Obj: &v1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "quotaTest",
+					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+					Namespace:         "testNS",
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+					Labels: map[string]string{
+						"hello": "world",
+					},
+				},
+				Status: v1.ResourceQuotaStatus{},
+			},
+			Want: metadata + `
+			kube_resourcequota_annotations{annotation_foo="bar",namespace="testNS",resourcequota="quotaTest"} 1
+			kube_resourcequota_created{namespace="testNS",resourcequota="quotaTest"} 1.5e+09
+			kube_resourcequota_labels{label_hello="world",namespace="testNS",resourcequota="quotaTest"} 1
+			`,
+		},
 	}
 	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(resourceQuotaMetricFamilies)
-		c.Headers = generator.ExtractMetricFamilyHeaders(resourceQuotaMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(resourceQuotaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.Headers = generator.ExtractMetricFamilyHeaders(resourceQuotaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Enable metric-annotations-allowlist and metric-labels-allowlist for ResourceQuota like other resources (e.g. Deployment)

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
increases

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1951
