### PR TITLE
fix: Support scraping pods metrics that is still in scheduling status and has no assigned node

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The downside of using an auto-sharded setup comes from the rollout strategy supp
 
 For pod metrics, they can be sharded per node with the following flag:
 
-* `--node`
+* `--node=$(NODE_NAME)`
 
 Each kube-state-metrics pod uses FieldSelector (spec.nodeName) to watch/list pod metrics only on the same node.
 
@@ -274,6 +274,21 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+```
+
+To track metrics for unassigned pods, you need to add an additional deployment and set `--node=""`, as shown in the following example:
+```
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:IMAGE_TAG
+        name: kube-state-metrics
+        args:
+        - --resources=pods
+        - --node=""
 ```
 
 Other metrics can be sharded via [Horizontal sharding](#horizontal-sharding).

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ spec:
 ```
 
 To track metrics for unassigned pods, you need to add an additional deployment and set `--node=""`, as shown in the following example:
+
 ```
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -3,9 +3,9 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/name: kube-state-metrics-global
+    app.kubernetes.io/name: kube-state-metrics-pods
     app.kubernetes.io/version: 2.10.0
-  name: kube-state-metrics-global
+  name: kube-state-metrics-pods
   namespace: kube-system
 spec:
   replicas: 1

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -3,9 +3,9 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics-global
     app.kubernetes.io/version: 2.10.0
-  name: kube-state-metrics-pods
+  name: kube-state-metrics-global
   namespace: kube-system
 spec:
   replicas: 1

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.10.0
+  name: kube-state-metrics-pods
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/version: 2.10.0
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --resources=pods
+        - --node=""
+        - --enable-no-node-scrape
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: kube-state-metrics

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -24,7 +24,6 @@ spec:
       - args:
         - --resources=pods
         - --node=""
-        - --enable-no-node-scrape
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0
         livenessProbe:
           httpGet:

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -380,7 +380,7 @@
           '--node=""',
         ],
       };
-      local shardksmname = ksm.name + "-global";
+      local shardksmname = ksm.name + "-pods";
       std.mergePatch(ksm.deployment,
         {
           metadata: {

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -373,6 +373,30 @@
         },
       ),
 
+    deploymentNoNodePods:
+      local c = ksm.deployment.spec.template.spec.containers[0] {
+        args: [
+          '--resources=pods',
+          '--node=""',
+        ],
+      };
+      local shardksmname = ksm.name + "-global";
+      std.mergePatch(ksm.deployment,
+        {
+          metadata: {
+            name: shardksmname,
+            labels: {'app.kubernetes.io/name': shardksmname}
+          },
+          spec: {
+            template: {
+              spec: {
+                containers: [c],
+              },
+            },
+          },
+        },
+      ),
+
     daemonset:
       // extending the default container from above
       local c0 = ksm.deployment.spec.template.spec.containers[0] {

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -204,7 +204,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	namespaces := opts.Namespaces.GetNamespaces()
 	nsFieldSelector := namespaces.GetExcludeNSFieldSelector(opts.NamespacesDenylist)
-	nodeFieldSelector := opts.Node.GetNodeFieldSelector()
+	nodeFieldSelector := opts.Node.GetNodeFieldSelector(opts.NoNodeScrape)
 	merged, err := storeBuilder.MergeFieldSelectors([]string{nsFieldSelector, nodeFieldSelector})
 	if err != nil {
 		return err

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -204,7 +204,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	namespaces := opts.Namespaces.GetNamespaces()
 	nsFieldSelector := namespaces.GetExcludeNSFieldSelector(opts.NamespacesDenylist)
-	nodeFieldSelector := opts.Node.GetNodeFieldSelector(opts.NoNodeScrape)
+	nodeFieldSelector := opts.Node.GetNodeFieldSelector()
 	merged, err := storeBuilder.MergeFieldSelectors([]string{nsFieldSelector, nodeFieldSelector})
 	if err != nil {
 		return err

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -46,7 +46,6 @@ type Options struct {
 	Namespaces               NamespaceList   `yaml:"namespaces"`
 	NamespacesDenylist       NamespaceList   `yaml:"namespaces_denylist"`
 	Node                     NodeType        `yaml:"node"`
-	NoNodeScrape             bool            `yaml:"no_node_scrape"`
 	Pod                      string          `yaml:"pod"`
 	Port                     int             `yaml:"port"`
 	Resources                ResourceSet     `yaml:"resources"`

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -46,6 +46,7 @@ type Options struct {
 	Namespaces               NamespaceList   `yaml:"namespaces"`
 	NamespacesDenylist       NamespaceList   `yaml:"namespaces_denylist"`
 	Node                     NodeType        `yaml:"node"`
+	NoNodeScrape             bool            `yaml:"no_node_scrape"`
 	Pod                      string          `yaml:"pod"`
 	Port                     int             `yaml:"port"`
 	Resources                ResourceSet     `yaml:"resources"`
@@ -120,6 +121,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 
 	o.cmd.Flags().BoolVar(&o.CustomResourcesOnly, "custom-resource-state-only", false, "Only provide Custom Resource State metrics (experimental)")
 	o.cmd.Flags().BoolVar(&o.EnableGZIPEncoding, "enable-gzip-encoding", false, "Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.")
+	o.cmd.Flags().BoolVar(&o.NoNodeScrape, "enable-no-node-scrape", false, "This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.")
 	o.cmd.Flags().BoolVarP(&o.Help, "help", "h", false, "Print Help text")
 	o.cmd.Flags().BoolVarP(&o.UseAPIServerCache, "use-apiserver-cache", "", false, "Sets resourceVersion=0 for ListWatch requests, using cached resources from the apiserver instead of an etcd quorum read.")
 	o.cmd.Flags().Int32Var(&o.Shard, "shard", int32(0), "The instances shard nominal (zero indexed) within the total number of shards. (default 0)")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -74,6 +74,7 @@ func NewOptions() *Options {
 		MetricAllowlist:      MetricSet{},
 		MetricDenylist:       MetricSet{},
 		MetricOptInList:      MetricSet{},
+		Node:                 NodeType{},
 		AnnotationsAllowList: LabelsAllowList{},
 		LabelsAllowList:      LabelsAllowList{},
 	}
@@ -121,7 +122,6 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 
 	o.cmd.Flags().BoolVar(&o.CustomResourcesOnly, "custom-resource-state-only", false, "Only provide Custom Resource State metrics (experimental)")
 	o.cmd.Flags().BoolVar(&o.EnableGZIPEncoding, "enable-gzip-encoding", false, "Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.")
-	o.cmd.Flags().BoolVar(&o.NoNodeScrape, "enable-no-node-scrape", false, "This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.")
 	o.cmd.Flags().BoolVarP(&o.Help, "help", "h", false, "Print Help text")
 	o.cmd.Flags().BoolVarP(&o.UseAPIServerCache, "use-apiserver-cache", "", false, "Sets resourceVersion=0 for ListWatch requests, using cached resources from the apiserver instead of an etcd quorum read.")
 	o.cmd.Flags().Int32Var(&o.Shard, "shard", int32(0), "The instances shard nominal (zero indexed) within the total number of shards. (default 0)")
@@ -138,7 +138,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	o.cmd.Flags().StringVar(&o.TLSConfig, "tls-config", "", "Path to the TLS configuration file")
 	o.cmd.Flags().StringVar(&o.TelemetryHost, "telemetry-host", "::", `Host to expose kube-state-metrics self metrics on.`)
 	o.cmd.Flags().StringVar(&o.Config, "config", "", "Path to the kube-state-metrics options config file")
-	o.cmd.Flags().StringVar((*string)(&o.Node), "node", "", "Name of the node that contains the kube-state-metrics pod. Most likely it should be passed via the downward API. This is used for daemonset sharding. Only available for resources (pod metrics) that support spec.nodeName fieldSelector. This is experimental.")
+	o.cmd.Flags().Var(&o.Node, "node", "Name of the node that contains the kube-state-metrics pod. Most likely it should be passed via the downward API. This is used for daemonset sharding. Only available for resources (pod metrics) that support spec.nodeName fieldSelector. This is experimental.")
 	o.cmd.Flags().Var(&o.AnnotationsAllowList, "metric-annotations-allowlist", "Comma-separated list of Kubernetes annotations keys that will be used in the resource' labels metric. By default the annotations metrics are not exposed. To include them, provide a list of resource names in their plural form and Kubernetes annotation keys you would like to allow for them (Example: '=namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...)'. A single '*' can be provided per resource instead to allow any annotations, but that has severe performance implications (Example: '=pods=[*]').")
 	o.cmd.Flags().Var(&o.LabelsAllowList, "metric-labels-allowlist", "Comma-separated list of additional Kubernetes label keys that will be used in the resource' labels metric. By default the labels metrics are not exposed. To include them, provide a list of resource names in their plural form and Kubernetes label keys you would like to allow for them (Example: '=namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...)'. A single '*' can be provided per resource instead to allow any labels, but that has severe performance implications (Example: '=pods=[*]'). Additionally, an asterisk (*) can be provided as a key, which will resolve to all resources, i.e., assuming '--resources=deployments,pods', '=*=[*]' will resolve to '=deployments=[*],pods=[*]'.")
 	o.cmd.Flags().Var(&o.MetricAllowlist, "metric-allowlist", "Comma-separated list of metrics to be exposed. This list comprises of exact metric names and/or regex patterns. The allowlist and denylist are mutually exclusive.")
@@ -163,7 +163,7 @@ func (o *Options) Usage() {
 // Validate validates arguments
 func (o *Options) Validate() error {
 	shardableResource := "pods"
-	if o.Node == "" {
+	if o.Node.String() == "" {
 		return nil
 	}
 	for _, x := range o.Resources.AsSlice() {

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -108,6 +108,7 @@ func (r *ResourceSet) Type() string {
 // NodeType represents a nodeName to query from.
 type NodeType map[string]struct{}
 
+// Set converts a comma-separated string of nodename into a slice and appends it to the NodeList
 func (n *NodeType) Set(value string) error {
 	s := *n
 	cols := strings.Split(value, ",")
@@ -120,6 +121,7 @@ func (n *NodeType) Set(value string) error {
 	return nil
 }
 
+// AsSlice returns the LabelsAllowList in the form of plain string slice.
 func (n NodeType) AsSlice() []string {
 	cols := make([]string, 0, len(n))
 	for col := range n {
@@ -132,6 +134,7 @@ func (n NodeType) String() string {
 	return strings.Join(n.AsSlice(), ",")
 }
 
+// Type returns a descriptive string about the NodeList type.
 func (n *NodeType) Type() string {
 	return "string"
 }
@@ -150,6 +153,7 @@ func (n *NodeType) GetNodeFieldSelector() string {
 
 }
 
+// NodeValue represents a nodeName to query from.
 type NodeValue interface {
 	GetNodeFieldSelector() string
 }

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -108,9 +108,12 @@ func (r *ResourceSet) Type() string {
 type NodeType string
 
 // GetNodeFieldSelector returns a nodename field selector.
-func (n *NodeType) GetNodeFieldSelector() string {
+func (n *NodeType) GetNodeFieldSelector(b bool) string {
 	if string(*n) != "" {
 		return fields.OneTermEqualSelector("spec.nodeName", string(*n)).String()
+	}
+	if b {
+		return fields.OneTermEqualSelector("spec.nodeName", "").String()
 	}
 	return EmptyFieldSelector()
 }

--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -175,7 +175,25 @@ func TestNodeFieldSelector(t *testing.T) {
 
 	for _, test := range tests {
 		node := test.Node
-		actual := node.GetNodeFieldSelector()
+		actual := node.GetNodeFieldSelector(false)
+		if !reflect.DeepEqual(actual, test.Wanted) {
+			t.Errorf("Test error for Desc: %s. Want: %+v. Got: %+v.", test.Desc, test.Wanted, actual)
+		}
+	}
+	tests1 := []struct {
+		Desc   string
+		Node   NodeType
+		Wanted string
+	}{
+		{
+			Desc:   "empty node name",
+			Node:   "",
+			Wanted: "spec.nodeName=",
+		},
+	}
+	for _, test := range tests1 {
+		node := test.Node
+		actual := node.GetNodeFieldSelector(true)
 		if !reflect.DeepEqual(actual, test.Wanted) {
 			t.Errorf("Test error for Desc: %s. Want: %+v. Got: %+v.", test.Desc, test.Wanted, actual)
 		}
@@ -238,7 +256,7 @@ func TestMergeFieldSelectors(t *testing.T) {
 		ns := test.Namespaces
 		deniedNS := test.DeniedNamespaces
 		selector1 := ns.GetExcludeNSFieldSelector(deniedNS)
-		selector2 := test.Node.GetNodeFieldSelector()
+		selector2 := test.Node.GetNodeFieldSelector(false)
 		actual, err := MergeFieldSelectors([]string{selector1, selector2})
 		if err != nil {
 			t.Errorf("Test error for Desc: %s. Can't merge field selector %v.", test.Desc, err)

--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -166,6 +166,11 @@ func TestNodeFieldSelector(t *testing.T) {
 			Wanted: "",
 		},
 		{
+			Desc:   "with node name",
+			Node:   nil,
+			Wanted: "",
+		},
+		{
 			Desc: "empty node name",
 			Node: NodeType(
 				map[string]struct{}{

--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -162,38 +162,32 @@ func TestNodeFieldSelector(t *testing.T) {
 		Wanted string
 	}{
 		{
-			Desc:   "empty node name",
-			Node:   "",
+			Desc:   "with node name",
 			Wanted: "",
 		},
 		{
-			Desc:   "with node name",
-			Node:   "k8s-node-1",
+			Desc: "empty node name",
+			Node: NodeType(
+				map[string]struct{}{
+					"": {},
+				},
+			),
+			Wanted: "spec.nodeName=",
+		},
+		{
+			Desc: "with node name",
+			Node: NodeType(
+				map[string]struct{}{
+					"k8s-node-1": {},
+				},
+			),
 			Wanted: "spec.nodeName=k8s-node-1",
 		},
 	}
 
 	for _, test := range tests {
 		node := test.Node
-		actual := node.GetNodeFieldSelector(false)
-		if !reflect.DeepEqual(actual, test.Wanted) {
-			t.Errorf("Test error for Desc: %s. Want: %+v. Got: %+v.", test.Desc, test.Wanted, actual)
-		}
-	}
-	tests1 := []struct {
-		Desc   string
-		Node   NodeType
-		Wanted string
-	}{
-		{
-			Desc:   "empty node name",
-			Node:   "",
-			Wanted: "spec.nodeName=",
-		},
-	}
-	for _, test := range tests1 {
-		node := test.Node
-		actual := node.GetNodeFieldSelector(true)
+		actual := node.GetNodeFieldSelector()
 		if !reflect.DeepEqual(actual, test.Wanted) {
 			t.Errorf("Test error for Desc: %s. Want: %+v. Got: %+v.", test.Desc, test.Wanted, actual)
 		}
@@ -212,43 +206,67 @@ func TestMergeFieldSelectors(t *testing.T) {
 			Desc:             "empty DeniedNamespaces",
 			Namespaces:       NamespaceList{"default", "kube-system"},
 			DeniedNamespaces: NamespaceList{},
-			Node:             "",
-			Wanted:           "",
+			Node: NodeType(
+				map[string]struct{}{
+					"": {},
+				},
+			),
+			Wanted: "spec.nodeName=",
 		},
 		{
 			Desc:             "all DeniedNamespaces",
 			Namespaces:       DefaultNamespaces,
 			DeniedNamespaces: NamespaceList{"some-system"},
-			Node:             "",
-			Wanted:           "metadata.namespace!=some-system",
+			Node: NodeType(
+				map[string]struct{}{
+					"": {},
+				},
+			),
+			Wanted: "metadata.namespace!=some-system,spec.nodeName=",
 		},
 		{
 			Desc:             "general case",
 			Namespaces:       DefaultNamespaces,
 			DeniedNamespaces: NamespaceList{"case1-system", "case2-system"},
-			Node:             "",
-			Wanted:           "metadata.namespace!=case1-system,metadata.namespace!=case2-system",
+			Node: NodeType(
+				map[string]struct{}{
+					"": {},
+				},
+			),
+			Wanted: "metadata.namespace!=case1-system,metadata.namespace!=case2-system,spec.nodeName=",
 		},
 		{
 			Desc:             "empty DeniedNamespaces",
 			Namespaces:       NamespaceList{"default", "kube-system"},
 			DeniedNamespaces: NamespaceList{},
-			Node:             "k8s-node-1",
-			Wanted:           "spec.nodeName=k8s-node-1",
+			Node: NodeType(
+				map[string]struct{}{
+					"k8s-node-1": {},
+				},
+			),
+			Wanted: "spec.nodeName=k8s-node-1",
 		},
 		{
 			Desc:             "all DeniedNamespaces",
 			Namespaces:       DefaultNamespaces,
 			DeniedNamespaces: NamespaceList{"some-system"},
-			Node:             "k8s-node-1",
-			Wanted:           "metadata.namespace!=some-system,spec.nodeName=k8s-node-1",
+			Node: NodeType(
+				map[string]struct{}{
+					"k8s-node-1": {},
+				},
+			),
+			Wanted: "metadata.namespace!=some-system,spec.nodeName=k8s-node-1",
 		},
 		{
 			Desc:             "general case",
 			Namespaces:       DefaultNamespaces,
 			DeniedNamespaces: NamespaceList{"case1-system", "case2-system"},
-			Node:             "k8s-node-1",
-			Wanted:           "metadata.namespace!=case1-system,metadata.namespace!=case2-system,spec.nodeName=k8s-node-1",
+			Node: NodeType(
+				map[string]struct{}{
+					"k8s-node-1": {},
+				},
+			),
+			Wanted: "metadata.namespace!=case1-system,metadata.namespace!=case2-system,spec.nodeName=k8s-node-1",
 		},
 	}
 
@@ -256,7 +274,7 @@ func TestMergeFieldSelectors(t *testing.T) {
 		ns := test.Namespaces
 		deniedNS := test.DeniedNamespaces
 		selector1 := ns.GetExcludeNSFieldSelector(deniedNS)
-		selector2 := test.Node.GetNodeFieldSelector(false)
+		selector2 := test.Node.GetNodeFieldSelector()
 		actual, err := MergeFieldSelectors([]string{selector1, selector2})
 		if err != nil {
 			t.Errorf("Test error for Desc: %s. Can't merge field selector %v.", test.Desc, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When daemonset is used to scrape the metrics of pods, it can only scrape the metrics of pods assigned to nodes, but in scheduling, for example, pods in pending state cannot be scraped. 
This results in pending pods with no indicators to observe and alert. 
This pr adds a configuration parameter that, when enabled, captures pending pods from apiservice.

