### PR TITLE
fix: fix the issue that duplicated CR metrics are generated when CRD is deleted/applied multiple times

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -121,6 +121,7 @@ func (b *Builder) WithEnabledResources(r []string) error {
 	b.enabledResources = append(b.enabledResources, sortedResources...)
 	// It's an mitigation for #2223. unique should be removed after #2223 is fixed.
 	b.enabledResources = unique(b.enabledResources)
+	sort.Strings(b.enabledResources)
 	return nil
 }
 

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -119,7 +119,20 @@ func (b *Builder) WithEnabledResources(r []string) error {
 	sort.Strings(sortedResources)
 
 	b.enabledResources = append(b.enabledResources, sortedResources...)
+	b.enabledResources = unique(b.enabledResources)
 	return nil
+}
+
+func unique(arr []string) []string {
+	mp := make(map[string]bool)
+	for _, s := range arr {
+		mp[s] = true
+	}
+	result := []string{}
+	for key, _ := range mp {
+		result = append(result, key)
+	}
+	return result
 }
 
 // WithFieldSelectorFilter sets the fieldSelector property of a Builder.

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -119,6 +119,7 @@ func (b *Builder) WithEnabledResources(r []string) error {
 	sort.Strings(sortedResources)
 
 	b.enabledResources = append(b.enabledResources, sortedResources...)
+	// It's an mitigation for #2223. unique should be removed after #2223 is fixed.
 	b.enabledResources = unique(b.enabledResources)
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: https://github.com/kubernetes/kube-state-metrics/issues/2223

```
# It returns same metrics data many times when CRD is deleted/applied multiple times
 curl localhost:8089/metrics
# HELP cr_creationtimestamp
# TYPE cr_creationtimestamp gauge
cr_creationtimestamp{customresource_group="example.com",customresource_kind="Bar",customresource_version="v1",name="mybar"} 1.701828773e+09
# HELP cr_resourceversion
# TYPE cr_resourceversion gauge
cr_resourceversion{customresource_group="example.com",customresource_kind="Bar",customresource_version="v1",name="mybar"} 909919
# HELP cr_creationtimestamp
# TYPE cr_creationtimestamp gauge
cr_creationtimestamp{customresource_group="example.com",customresource_kind="Bar",customresource_version="v1",name="mybar"} 1.701828773e+09
# HELP cr_resourceversion
# TYPE cr_resourceversion gauge
cr_resourceversion{customresource_group="example.com",customresource_kind="Bar",customresource_version="v1",name="mybar"} 909919
```

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Mitigation for https://github.com/kubernetes/kube-state-metrics/issues/2223
