### PR TITLE
refactor: prepare for stable metrics static analysis by defining metric labels with same format

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -474,7 +474,7 @@ func (b *Builder) buildValidatingWebhookConfigurationStores() []cache.Store {
 }
 
 func (b *Builder) buildVolumeAttachmentStores() []cache.Store {
-	return b.buildStoresFunc(volumeAttachmentMetricFamilies, &storagev1.VolumeAttachment{}, createVolumeAttachmentListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(volumeAttachmentMetricFamilies(), &storagev1.VolumeAttachment{}, createVolumeAttachmentListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildLeasesStores() []cache.Store {

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -470,7 +470,7 @@ func (b *Builder) buildCsrStores() []cache.Store {
 }
 
 func (b *Builder) buildValidatingWebhookConfigurationStores() []cache.Store {
-	return b.buildStoresFunc(validatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.ValidatingWebhookConfiguration{}, createValidatingWebhookConfigurationListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(validatingWebhookConfigurationMetricFamilies(), &admissionregistrationv1.ValidatingWebhookConfiguration{}, createValidatingWebhookConfigurationListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildVolumeAttachmentStores() []cache.Store {

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -434,7 +434,7 @@ func (b *Builder) buildReplicaSetStores() []cache.Store {
 }
 
 func (b *Builder) buildReplicationControllerStores() []cache.Store {
-	return b.buildStoresFunc(replicationControllerMetricFamilies, &v1.ReplicationController{}, createReplicationControllerListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(replicationControllerMetricFamilies(), &v1.ReplicationController{}, createReplicationControllerListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildResourceQuotaStores() []cache.Store {

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -478,7 +478,7 @@ func (b *Builder) buildVolumeAttachmentStores() []cache.Store {
 }
 
 func (b *Builder) buildLeasesStores() []cache.Store {
-	return b.buildStoresFunc(leaseMetricFamilies, &coordinationv1.Lease{}, createLeaseListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(leaseMetricFamilies(), &coordinationv1.Lease{}, createLeaseListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildClusterRoleStores() []cache.Store {

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -402,7 +402,7 @@ func (b *Builder) buildLimitRangeStores() []cache.Store {
 }
 
 func (b *Builder) buildMutatingWebhookConfigurationStores() []cache.Store {
-	return b.buildStoresFunc(mutatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.MutatingWebhookConfiguration{}, createMutatingWebhookConfigurationListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(mutatingWebhookConfigurationMetricFamilies(), &admissionregistrationv1.MutatingWebhookConfiguration{}, createMutatingWebhookConfigurationListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildNamespaceStores() []cache.Store {

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -398,7 +398,7 @@ func (b *Builder) buildJobStores() []cache.Store {
 }
 
 func (b *Builder) buildLimitRangeStores() []cache.Store {
-	return b.buildStoresFunc(limitRangeMetricFamilies, &v1.LimitRange{}, createLimitRangeListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(limitRangeMetricFamilies(), &v1.LimitRange{}, createLimitRangeListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildMutatingWebhookConfigurationStores() []cache.Store {

--- a/internal/store/clusterrole.go
+++ b/internal/store/clusterrole.go
@@ -36,7 +36,7 @@ var (
 	descClusterRoleAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descClusterRoleLabelsName          = "kube_clusterrole_labels"
 	descClusterRoleLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descClusterRoleLabelsDefaultLabels = []string{"clusterrole"}
+	descClusterRoleLabelsDefaultLabels = SharedLabelKeys{"clusterrole"}
 )
 
 func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -52,14 +52,15 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -74,14 +75,15 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -92,12 +94,15 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.ALPHA,
 			"",
 			wrapClusterRoleFunc(func(r *rbacv1.ClusterRole) *metric.Family {
+				ms := []*metric.Metric{{
+					LabelValues: []string{},
+					Value:       1,
+				}}
+
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
-					Metrics: []*metric.Metric{{
-						LabelKeys:   []string{},
-						LabelValues: []string{},
-						Value:       1,
-					}},
+					Metrics: ms,
 				}
 			}),
 		),
@@ -112,11 +117,12 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 
 				if !r.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{},
 						LabelValues: []string{},
 						Value:       float64(r.CreationTimestamp.Unix()),
 					})
 				}
+
+				metric.SetLabelKeys(ms, []string{})
 
 				return &metric.Family{
 					Metrics: ms,

--- a/internal/store/clusterrolebinding.go
+++ b/internal/store/clusterrolebinding.go
@@ -36,7 +36,7 @@ var (
 	descClusterRoleBindingAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descClusterRoleBindingLabelsName          = "kube_clusterrolebinding_labels"
 	descClusterRoleBindingLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descClusterRoleBindingLabelsDefaultLabels = []string{"clusterrolebinding"}
+	descClusterRoleBindingLabelsDefaultLabels = SharedLabelKeys{"clusterrolebinding"}
 )
 
 func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -52,14 +52,15 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -74,14 +75,15 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -94,12 +96,15 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 			wrapClusterRoleBindingFunc(func(r *rbacv1.ClusterRoleBinding) *metric.Family {
 				labelKeys := []string{"roleref_kind", "roleref_name"}
 				labelValues := []string{r.RoleRef.Kind, r.RoleRef.Name}
+				ms := []*metric.Metric{{
+					LabelValues: labelValues,
+					Value:       1,
+				}}
+
+				metric.SetLabelKeys(ms, labelKeys)
+
 				return &metric.Family{
-					Metrics: []*metric.Metric{{
-						LabelKeys:   labelKeys,
-						LabelValues: labelValues,
-						Value:       1,
-					}},
+					Metrics: ms,
 				}
 			}),
 		),
@@ -114,11 +119,11 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 
 				if !r.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{},
 						LabelValues: []string{},
 						Value:       float64(r.CreationTimestamp.Unix()),
 					})
 				}
+				metric.SetLabelKeys(ms, []string{})
 
 				return &metric.Family{
 					Metrics: ms,

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	descConfigMapLabelsDefaultLabels = []string{"namespace", "configmap"}
+	descConfigMapLabelsDefaultLabels = SharedLabelKeys{"namespace", "configmap"}
 )
 
 func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -48,14 +48,15 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", c.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -70,14 +71,15 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", c.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -88,12 +90,15 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
+				ms := []*metric.Metric{{
+					LabelValues: []string{},
+					Value:       1,
+				}}
+
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
-					Metrics: []*metric.Metric{{
-						LabelKeys:   []string{},
-						LabelValues: []string{},
-						Value:       1,
-					}},
+					Metrics: ms,
 				}
 			}),
 		),
@@ -108,11 +113,12 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 
 				if !c.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{},
 						LabelValues: []string{},
 						Value:       float64(c.CreationTimestamp.Unix()),
 					})
 				}
+
+				metric.SetLabelKeys(ms, []string{})
 
 				return &metric.Family{
 					Metrics: ms,

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -36,7 +36,7 @@ var (
 	descDaemonSetAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descDaemonSetLabelsName          = "kube_daemonset_labels"
 	descDaemonSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descDaemonSetLabelsDefaultLabels = []string{"namespace", "daemonset"}
+	descDaemonSetLabelsDefaultLabels = SharedLabelKeys{"namespace", "daemonset"}
 )
 
 func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -52,11 +52,12 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 
 				if !d.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{},
 						LabelValues: []string{},
 						Value:       float64(d.CreationTimestamp.Unix()),
 					})
 				}
+
+				metric.SetLabelKeys(ms, []string{})
 
 				return &metric.Family{
 					Metrics: ms,
@@ -70,14 +71,17 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(d.Status.CurrentNumberScheduled),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(d.Status.CurrentNumberScheduled),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -88,14 +92,17 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(d.Status.DesiredNumberScheduled),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(d.Status.DesiredNumberScheduled),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -106,14 +113,17 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(d.Status.NumberAvailable),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(d.Status.NumberAvailable),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -124,14 +134,17 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(d.Status.NumberMisscheduled),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(d.Status.NumberMisscheduled),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -142,14 +155,17 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(d.Status.NumberReady),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(d.Status.NumberReady),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -160,14 +176,17 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(d.Status.NumberUnavailable),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(d.Status.NumberUnavailable),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -178,14 +197,17 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(d.Status.ObservedGeneration),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(d.Status.ObservedGeneration),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -196,12 +218,16 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.UpdatedNumberScheduled),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(d.Status.UpdatedNumberScheduled),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -212,14 +238,17 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 			basemetrics.STABLE,
 			"",
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(d.ObjectMeta.Generation),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(d.ObjectMeta.Generation),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -234,14 +263,15 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -256,14 +286,15 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", d.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -38,7 +38,7 @@ var (
 	descDeploymentAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descDeploymentLabelsName          = "kube_deployment_labels"
 	descDeploymentLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
+	descDeploymentLabelsDefaultLabels = SharedLabelKeys{"namespace", "deployment"}
 )
 
 func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -58,6 +58,8 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -70,12 +72,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.Replicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(d.Status.Replicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -86,12 +92,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.ReadyReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(d.Status.ReadyReplicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -102,12 +112,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.AvailableReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(d.Status.AvailableReplicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -118,12 +132,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.UnavailableReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(d.Status.UnavailableReplicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -134,12 +152,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.UpdatedReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(d.Status.UpdatedReplicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -150,12 +172,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.ObservedGeneration),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(d.Status.ObservedGeneration),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -192,12 +218,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(*d.Spec.Replicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(*d.Spec.Replicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -208,12 +238,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: boolFloat64(d.Spec.Paused),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: boolFloat64(d.Spec.Paused),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -233,12 +267,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 					panic(err)
 				}
 
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(maxUnavailable),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(maxUnavailable),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -258,12 +296,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 					panic(err)
 				}
 
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(maxSurge),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(maxSurge),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -274,12 +316,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.ObjectMeta.Generation),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(d.ObjectMeta.Generation),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -294,14 +340,18 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelKeys:   annotationKeys,
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+
+				metric.SetLabelKeys(ms, annotationKeys)
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -316,14 +366,18 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", d.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+
+						Value: 1,
 					},
+				}
+
+				metric.SetLabelKeys(ms, labelKeys)
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -110,14 +110,15 @@ func createHPAInfo() generator.FamilyGenerator {
 				labelKeys = append([]string{"scaletargetref_api_version"}, labelKeys...)
 				labelValues = append([]string{a.Spec.ScaleTargetRef.APIVersion}, labelValues...)
 			}
-			return &metric.Family{
-				Metrics: []*metric.Metric{
-					{
-						LabelKeys:   labelKeys,
-						LabelValues: labelValues,
-						Value:       1,
-					},
+			ms := []*metric.Metric{
+				{
+					LabelValues: labelValues,
+					Value:       1,
 				},
+			}
+			metric.SetLabelKeys(ms, labelKeys)
+			return &metric.Family{
+				Metrics: ms,
 			}
 		}),
 	)
@@ -131,12 +132,16 @@ func createHPAMetaDataGeneration() generator.FamilyGenerator {
 		basemetrics.STABLE,
 		"",
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-			return &metric.Family{
-				Metrics: []*metric.Metric{
-					{
-						Value: float64(a.ObjectMeta.Generation),
-					},
+			ms := []*metric.Metric{
+				{
+					Value: float64(a.ObjectMeta.Generation),
 				},
+			}
+
+			metric.SetLabelKeys(ms, []string{})
+
+			return &metric.Family{
+				Metrics: ms,
 			}
 		}),
 	)
@@ -150,12 +155,16 @@ func createHPASpecMaxReplicas() generator.FamilyGenerator {
 		basemetrics.STABLE,
 		"",
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-			return &metric.Family{
-				Metrics: []*metric.Metric{
-					{
-						Value: float64(a.Spec.MaxReplicas),
-					},
+			ms := []*metric.Metric{
+				{
+					Value: float64(a.Spec.MaxReplicas),
 				},
+			}
+
+			metric.SetLabelKeys(ms, []string{})
+
+			return &metric.Family{
+				Metrics: ms,
 			}
 		}),
 	)
@@ -169,12 +178,16 @@ func createHPASpecMinReplicas() generator.FamilyGenerator {
 		basemetrics.STABLE,
 		"",
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-			return &metric.Family{
-				Metrics: []*metric.Metric{
-					{
-						Value: float64(*a.Spec.MinReplicas),
-					},
+			ms := []*metric.Metric{
+				{
+					Value: float64(*a.Spec.MinReplicas),
 				},
+			}
+
+			metric.SetLabelKeys(ms, []string{})
+
+			return &metric.Family{
+				Metrics: ms,
 			}
 		}),
 	)
@@ -228,12 +241,14 @@ func createHPASpecTargetMetric() generator.FamilyGenerator {
 
 				for metricTypeIndex, metricValue := range metricMap {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   targetMetricLabels,
 						LabelValues: []string{metricName, metricTypeIndex.String()},
 						Value:       metricValue,
 					})
 				}
 			}
+
+			metric.SetLabelKeys(ms, targetMetricLabels)
+
 			return &metric.Family{Metrics: ms}
 		}),
 	)
@@ -287,12 +302,14 @@ func createHPAStatusTargetMetric() generator.FamilyGenerator {
 
 				for metricTypeIndex, metricValue := range metricMap {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   targetMetricLabels,
 						LabelValues: []string{metricName, metricTypeIndex.String()},
 						Value:       metricValue,
 					})
 				}
 			}
+
+			metric.SetLabelKeys(ms, targetMetricLabels)
+
 			return &metric.Family{Metrics: ms}
 		}),
 	)
@@ -306,12 +323,16 @@ func createHPAStatusCurrentReplicas() generator.FamilyGenerator {
 		basemetrics.STABLE,
 		"",
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-			return &metric.Family{
-				Metrics: []*metric.Metric{
-					{
-						Value: float64(a.Status.CurrentReplicas),
-					},
+			ms := []*metric.Metric{
+				{
+					Value: float64(a.Status.CurrentReplicas),
 				},
+			}
+
+			metric.SetLabelKeys(ms, []string{})
+
+			return &metric.Family{
+				Metrics: ms,
 			}
 		}),
 	)
@@ -325,12 +346,16 @@ func createHPAStatusDesiredReplicas() generator.FamilyGenerator {
 		basemetrics.STABLE,
 		"",
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
-			return &metric.Family{
-				Metrics: []*metric.Metric{
-					{
-						Value: float64(a.Status.DesiredReplicas),
-					},
+			ms := []*metric.Metric{
+				{
+					Value: float64(a.Status.DesiredReplicas),
 				},
+			}
+
+			metric.SetLabelKeys(ms, []string{})
+
+			return &metric.Family{
+				Metrics: ms,
 			}
 		}),
 	)
@@ -348,14 +373,15 @@ func createHPAAnnotations(allowAnnotationsList []string) generator.FamilyGenerat
 				return &metric.Family{}
 			}
 			annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", a.Annotations, allowAnnotationsList)
-			return &metric.Family{
-				Metrics: []*metric.Metric{
-					{
-						LabelKeys:   annotationKeys,
-						LabelValues: annotationValues,
-						Value:       1,
-					},
+			ms := []*metric.Metric{
+				{
+					LabelValues: annotationValues,
+					Value:       1,
 				},
+			}
+			metric.SetLabelKeys(ms, annotationKeys)
+			return &metric.Family{
+				Metrics: ms,
 			}
 		}),
 	)
@@ -373,14 +399,15 @@ func createHPALabels(allowLabelsList []string) generator.FamilyGenerator {
 				return &metric.Family{}
 			}
 			labelKeys, labelValues := createPrometheusLabelKeysValues("label", a.Labels, allowLabelsList)
-			return &metric.Family{
-				Metrics: []*metric.Metric{
-					{
-						LabelKeys:   labelKeys,
-						LabelValues: labelValues,
-						Value:       1,
-					},
+			ms := []*metric.Metric{
+				{
+					LabelValues: labelValues,
+					Value:       1,
 				},
+			}
+			metric.SetLabelKeys(ms, labelKeys)
+			return &metric.Family{
+				Metrics: ms,
 			}
 		}),
 	)
@@ -395,17 +422,19 @@ func createHPAStatusCondition() generator.FamilyGenerator {
 		"",
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(a.Status.Conditions)*len(conditionStatuses))
+			labelKeys := []string{"condition", "status"}
 
 			for _, c := range a.Status.Conditions {
 				metrics := addConditionMetrics(c.Status)
 
 				for _, m := range metrics {
 					metric := m
-					metric.LabelKeys = []string{"condition", "status"}
 					metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
 					ms = append(ms, metric)
 				}
 			}
+
+			metric.SetLabelKeys(ms, labelKeys)
 
 			return &metric.Family{
 				Metrics: ms,

--- a/internal/store/ingressclass.go
+++ b/internal/store/ingressclass.go
@@ -34,7 +34,7 @@ var (
 	descIngressClassAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descIngressClassLabelsName          = "kube_ingressclass_labels" //nolint:gosec
 	descIngressClassLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descIngressClassLabelsDefaultLabels = []string{"ingressclass"}
+	descIngressClassLabelsDefaultLabels = SharedLabelKeys{"ingressclass"}
 )
 
 func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -47,12 +47,15 @@ func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 			"",
 			wrapIngressClassFunc(func(s *networkingv1.IngressClass) *metric.Family {
 
-				m := metric.Metric{
-					LabelKeys:   []string{"controller"},
-					LabelValues: []string{s.Spec.Controller},
-					Value:       1,
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{s.Spec.Controller},
+						Value:       1,
+					},
 				}
-				return &metric.Family{Metrics: []*metric.Metric{&m}}
+
+				metric.SetLabelKeys(ms, []string{"controller"})
+				return &metric.Family{Metrics: ms}
 			}),
 		),
 		*generator.NewFamilyGeneratorWithStability(
@@ -68,6 +71,7 @@ func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 						Value: float64(s.CreationTimestamp.Unix()),
 					})
 				}
+				metric.SetLabelKeys(ms, []string{})
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -84,14 +88,15 @@ func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -106,14 +111,15 @@ func ingressClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -38,7 +38,7 @@ var (
 	descJobAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descJobLabelsName          = "kube_job_labels"
 	descJobLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descJobLabelsDefaultLabels = []string{"namespace", "job_name"}
+	descJobLabelsDefaultLabels = SharedLabelKeys{"namespace", "job_name"}
 	jobFailureReasons          = []string{"BackoffLimitExceeded", "DeadlineExceeded", "Evicted"}
 )
 
@@ -55,14 +55,15 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -77,14 +78,15 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", j.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -95,12 +97,16 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			basemetrics.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: 1,
-						},
+				ms := []*metric.Metric{
+					{
+						Value: 1,
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -118,6 +124,8 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 						Value: float64(j.CreationTimestamp.Unix()),
 					})
 				}
+
+				metric.SetLabelKeys(ms, []string{})
 
 				return &metric.Family{
 					Metrics: ms,
@@ -139,6 +147,8 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -158,6 +168,8 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 						Value: float64(*j.Spec.Completions),
 					})
 				}
+
+				metric.SetLabelKeys(ms, []string{})
 
 				return &metric.Family{
 					Metrics: ms,
@@ -179,6 +191,8 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -191,12 +205,16 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			basemetrics.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(j.Status.Succeeded),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(j.Status.Succeeded),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -256,12 +274,16 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			basemetrics.STABLE,
 			"",
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(j.Status.Active),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(j.Status.Active),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -278,11 +300,11 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 						metrics := addConditionMetrics(c.Status)
 						for _, m := range metrics {
 							metric := m
-							metric.LabelKeys = []string{"condition"}
 							ms = append(ms, metric)
 						}
 					}
 				}
+				metric.SetLabelKeys(ms, []string{"condition"})
 
 				return &metric.Family{
 					Metrics: ms,
@@ -303,11 +325,12 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 						metrics := addConditionMetrics(c.Status)
 						for _, m := range metrics {
 							metric := m
-							metric.LabelKeys = []string{"condition"}
 							ms = append(ms, metric)
 						}
 					}
 				}
+
+				metric.SetLabelKeys(ms, []string{"condition"})
 
 				return &metric.Family{
 					Metrics: ms,
@@ -330,6 +353,8 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -350,6 +375,8 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -367,14 +394,18 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				owners := j.GetOwnerReferences()
 
 				if len(owners) == 0 {
-					return &metric.Family{
-						Metrics: []*metric.Metric{
-							{
-								LabelKeys:   labelKeys,
-								LabelValues: []string{"", "", ""},
-								Value:       1,
-							},
+					ms := []*metric.Metric{
+						{
+							LabelKeys:   labelKeys,
+							LabelValues: []string{"", "", ""},
+							Value:       1,
 						},
+					}
+
+					metric.SetLabelKeys(ms, labelKeys)
+
+					return &metric.Family{
+						Metrics: ms,
 					}
 				}
 
@@ -383,18 +414,18 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				for i, owner := range owners {
 					if owner.Controller != nil {
 						ms[i] = &metric.Metric{
-							LabelKeys:   labelKeys,
 							LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
 							Value:       1,
 						}
 					} else {
 						ms[i] = &metric.Metric{
-							LabelKeys:   labelKeys,
 							LabelValues: []string{owner.Kind, owner.Name, "false"},
 							Value:       1,
 						}
 					}
 				}
+
+				metric.SetLabelKeys(ms, labelKeys)
 
 				return &metric.Family{
 					Metrics: ms,

--- a/internal/store/lease_test.go
+++ b/internal/store/lease_test.go
@@ -94,8 +94,8 @@ func TestLeaseStore(t *testing.T) {
 		}
 	)
 	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(leaseMetricFamilies)
-		c.Headers = generator.ExtractMetricFamilyHeaders(leaseMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(leaseMetricFamilies())
+		c.Headers = generator.ExtractMetricFamilyHeaders(leaseMetricFamilies())
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %dth run:\n%v", i, err)
 		}

--- a/internal/store/limitrange.go
+++ b/internal/store/limitrange.go
@@ -32,9 +32,11 @@ import (
 )
 
 var (
-	descLimitRangeLabelsDefaultLabels = []string{"namespace", "limitrange"}
+	descLimitRangeLabelsDefaultLabels = SharedLabelKeys{"namespace", "limitrange"}
+)
 
-	limitRangeMetricFamilies = []generator.FamilyGenerator{
+func limitRangeMetricFamilies() []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
 			"kube_limitrange",
 			"Information about limit range.",
@@ -106,14 +108,14 @@ var (
 						Value: float64(r.CreationTimestamp.Unix()),
 					})
 				}
-
+				metric.SetLabelKeys(ms, []string{})
 				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
 		),
 	}
-)
+}
 
 func wrapLimitRangeFunc(f func(*v1.LimitRange) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {

--- a/internal/store/limitrange_test.go
+++ b/internal/store/limitrange_test.go
@@ -81,8 +81,8 @@ func TestLimitRangeStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(limitRangeMetricFamilies)
-		c.Headers = generator.ExtractMetricFamilyHeaders(limitRangeMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(limitRangeMetricFamilies())
+		c.Headers = generator.ExtractMetricFamilyHeaders(limitRangeMetricFamilies())
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -32,9 +32,11 @@ import (
 )
 
 var (
-	descMutatingWebhookConfigurationDefaultLabels = []string{"namespace", "mutatingwebhookconfiguration"}
+	descMutatingWebhookConfigurationDefaultLabels = SharedLabelKeys{"namespace", "mutatingwebhookconfiguration"}
+)
 
-	mutatingWebhookConfigurationMetricFamilies = []generator.FamilyGenerator{
+func mutatingWebhookConfigurationMetricFamilies() []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
 			"kube_mutatingwebhookconfiguration_info",
 			"Information about the MutatingWebhookConfiguration.",
@@ -42,12 +44,14 @@ var (
 			basemetrics.ALPHA,
 			"",
 			wrapMutatingWebhookConfigurationFunc(func(mwc *admissionregistrationv1.MutatingWebhookConfiguration) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: 1,
-						},
+				ms := []*metric.Metric{
+					{
+						Value: 1,
 					},
+				}
+				metric.SetLabelKeys(ms, []string{})
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -65,6 +69,8 @@ var (
 						Value: float64(mwc.CreationTimestamp.Unix()),
 					})
 				}
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -98,18 +104,19 @@ var (
 					}
 
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"webhook_name", "service_name", "service_namespace"},
 						LabelValues: []string{webhook.Name, serviceName, serviceNamespace},
 						Value:       1,
 					})
 				}
+				metric.SetLabelKeys(ms, []string{"webhook_name", "service_name", "service_namespace"})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
 		),
 	}
-)
+}
 
 func createMutatingWebhookConfigurationListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
 	return &cache.ListWatch{

--- a/internal/store/mutatingwebhookconfiguration_test.go
+++ b/internal/store/mutatingwebhookconfiguration_test.go
@@ -103,8 +103,8 @@ func TestMutatingWebhookConfigurationStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(mutatingWebhookConfigurationMetricFamilies)
-		c.Headers = generator.ExtractMetricFamilyHeaders(mutatingWebhookConfigurationMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(mutatingWebhookConfigurationMetricFamilies())
+		c.Headers = generator.ExtractMetricFamilyHeaders(mutatingWebhookConfigurationMetricFamilies())
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -37,7 +37,7 @@ var (
 	descNamespaceAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descNamespaceLabelsName          = "kube_namespace_labels"
 	descNamespaceLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descNamespaceLabelsDefaultLabels = []string{"namespace"}
+	descNamespaceLabelsDefaultLabels = SharedLabelKeys{"namespace"}
 )
 
 func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -56,6 +56,8 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -73,14 +75,15 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -95,14 +98,15 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", n.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -124,9 +128,7 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 					},
 				}
 
-				for _, metric := range ms {
-					metric.LabelKeys = []string{"phase"}
-				}
+				metric.SetLabelKeys(ms, []string{"phase"})
 
 				return &metric.Family{
 					Metrics: ms,
@@ -147,13 +149,13 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 					for j, m := range conditionMetrics {
 						metric := m
 
-						metric.LabelKeys = []string{"condition", "status"}
 						metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
 
 						ms[i*len(conditionStatuses)+j] = metric
 					}
 				}
 
+				metric.SetLabelKeys(ms, []string{"condition", "status"})
 				return &metric.Family{
 					Metrics: ms,
 				}

--- a/internal/store/networkpolicy.go
+++ b/internal/store/networkpolicy.go
@@ -36,7 +36,7 @@ var (
 	descNetworkPolicyAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descNetworkPolicyLabelsName          = "kube_networkpolicy_labels"
 	descNetworkPolicyLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descNetworkPolicyLabelsDefaultLabels = []string{"namespace", "networkpolicy"}
+	descNetworkPolicyLabelsDefaultLabels = SharedLabelKeys{"namespace", "networkpolicy"}
 )
 
 func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -48,14 +48,15 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			basemetrics.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(n.CreationTimestamp.Unix()),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(n.CreationTimestamp.Unix()),
 					},
+				}
+				metric.SetLabelKeys(ms, []string{})
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -70,14 +71,15 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", n.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -92,14 +94,15 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", n.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -110,14 +113,15 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			basemetrics.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(len(n.Spec.Ingress)),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(len(n.Spec.Ingress)),
 					},
+				}
+				metric.SetLabelKeys(ms, []string{})
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -128,14 +132,15 @@ func networkPolicyMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			basemetrics.ALPHA,
 			"",
 			wrapNetworkPolicyFunc(func(n *networkingv1.NetworkPolicy) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{},
-							LabelValues: []string{},
-							Value:       float64(len(n.Spec.Egress)),
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{},
+						Value:       float64(len(n.Spec.Egress)),
 					},
+				}
+				metric.SetLabelKeys(ms, []string{})
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	descPodDisruptionBudgetLabelsDefaultLabels = []string{"namespace", "poddisruptionbudget"}
+	descPodDisruptionBudgetLabelsDefaultLabels = SharedLabelKeys{"namespace", "poddisruptionbudget"}
 	descPodDisruptionBudgetAnnotationsName     = "kube_poddisruptionbudget_annotations"
 	descPodDisruptionBudgetAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descPodDisruptionBudgetLabelsName          = "kube_poddisruptionbudget_labels"
@@ -52,14 +52,15 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -74,14 +75,15 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -100,6 +102,8 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -112,12 +116,16 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			basemetrics.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(p.Status.CurrentHealthy),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(p.Status.CurrentHealthy),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -128,12 +136,16 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			basemetrics.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(p.Status.DesiredHealthy),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(p.Status.DesiredHealthy),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -144,12 +156,16 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			basemetrics.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(p.Status.DisruptionsAllowed),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(p.Status.DisruptionsAllowed),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -160,12 +176,16 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			basemetrics.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(p.Status.ExpectedPods),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(p.Status.ExpectedPods),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -176,12 +196,16 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			basemetrics.STABLE,
 			"",
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(p.Status.ObservedGeneration),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(p.Status.ObservedGeneration),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -33,9 +33,11 @@ import (
 )
 
 var (
-	descReplicationControllerLabelsDefaultLabels = []string{"namespace", "replicationcontroller"}
+	descReplicationControllerLabelsDefaultLabels = SharedLabelKeys{"namespace", "replicationcontroller"}
+)
 
-	replicationControllerMetricFamilies = []generator.FamilyGenerator{
+func replicationControllerMetricFamilies() []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
 			"kube_replicationcontroller_created",
 			"Unix creation timestamp",
@@ -51,6 +53,8 @@ var (
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -63,12 +67,16 @@ var (
 			basemetrics.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(r.Status.Replicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(r.Status.Replicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -79,12 +87,15 @@ var (
 			basemetrics.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(r.Status.FullyLabeledReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(r.Status.FullyLabeledReplicas),
 					},
+				}
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -95,12 +106,15 @@ var (
 			basemetrics.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(r.Status.ReadyReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(r.Status.ReadyReplicas),
 					},
+				}
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -111,12 +125,14 @@ var (
 			basemetrics.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(r.Status.AvailableReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(r.Status.AvailableReplicas),
 					},
+				}
+				metric.SetLabelKeys(ms, []string{})
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -127,12 +143,15 @@ var (
 			basemetrics.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(r.Status.ObservedGeneration),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(r.Status.ObservedGeneration),
 					},
+				}
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -151,6 +170,8 @@ var (
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -163,12 +184,15 @@ var (
 			basemetrics.STABLE,
 			"",
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(r.ObjectMeta.Generation),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(r.ObjectMeta.Generation),
 					},
+				}
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -185,7 +209,6 @@ var (
 				owners := r.GetOwnerReferences()
 				if len(owners) == 0 {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   labelKeys,
 						LabelValues: []string{"", "", ""},
 						Value:       1,
 					})
@@ -197,12 +220,13 @@ var (
 						}
 
 						ms = append(ms, &metric.Metric{
-							LabelKeys:   labelKeys,
 							LabelValues: []string{owner.Kind, owner.Name, ownerIsController},
 							Value:       1,
 						})
 					}
 				}
+
+				metric.SetLabelKeys(ms, labelKeys)
 
 				return &metric.Family{
 					Metrics: ms,
@@ -210,7 +234,7 @@ var (
 			}),
 		),
 	}
-)
+}
 
 func wrapReplicationControllerFunc(f func(*v1.ReplicationController) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {

--- a/internal/store/replicationcontroller_test.go
+++ b/internal/store/replicationcontroller_test.go
@@ -163,8 +163,8 @@ func TestReplicationControllerStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(replicationControllerMetricFamilies)
-		c.Headers = generator.ExtractMetricFamilyHeaders(replicationControllerMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(replicationControllerMetricFamilies())
+		c.Headers = generator.ExtractMetricFamilyHeaders(replicationControllerMetricFamilies())
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/resourcequota.go
+++ b/internal/store/resourcequota.go
@@ -57,6 +57,8 @@ func resourceQuotaMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -84,9 +86,7 @@ func resourceQuotaMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 					})
 				}
 
-				for _, m := range ms {
-					m.LabelKeys = []string{"resource", "type"}
-				}
+				metric.SetLabelKeys(ms, []string{"resource", "type"})
 
 				return &metric.Family{
 					Metrics: ms,
@@ -104,14 +104,15 @@ func resourceQuotaMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -126,14 +127,15 @@ func resourceQuotaMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", d.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -36,7 +36,7 @@ var (
 	descRoleAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descRoleLabelsName          = "kube_role_labels"
 	descRoleLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descRoleLabelsDefaultLabels = []string{"namespace", "role"}
+	descRoleLabelsDefaultLabels = SharedLabelKeys{"namespace", "role"}
 )
 
 func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -52,14 +52,15 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -74,14 +75,15 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -92,12 +94,15 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 			basemetrics.ALPHA,
 			"",
 			wrapRoleFunc(func(r *rbacv1.Role) *metric.Family {
+				ms := []*metric.Metric{{
+					LabelValues: []string{},
+					Value:       1,
+				}}
+
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
-					Metrics: []*metric.Metric{{
-						LabelKeys:   []string{},
-						LabelValues: []string{},
-						Value:       1,
-					}},
+					Metrics: ms,
 				}
 			}),
 		),
@@ -112,11 +117,12 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 
 				if !r.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{},
 						LabelValues: []string{},
 						Value:       float64(r.CreationTimestamp.Unix()),
 					})
 				}
+
+				metric.SetLabelKeys(ms, []string{})
 
 				return &metric.Family{
 					Metrics: ms,

--- a/internal/store/rolebinding.go
+++ b/internal/store/rolebinding.go
@@ -52,14 +52,15 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", r.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -74,14 +75,15 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", r.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -94,12 +96,13 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			wrapRoleBindingFunc(func(r *rbacv1.RoleBinding) *metric.Family {
 				labelKeys := []string{"roleref_kind", "roleref_name"}
 				labelValues := []string{r.RoleRef.Kind, r.RoleRef.Name}
+				ms := []*metric.Metric{{
+					LabelValues: labelValues,
+					Value:       1,
+				}}
+				metric.SetLabelKeys(ms, labelKeys)
 				return &metric.Family{
-					Metrics: []*metric.Metric{{
-						LabelKeys:   labelKeys,
-						LabelValues: labelValues,
-						Value:       1,
-					}},
+					Metrics: ms,
 				}
 			}),
 		),
@@ -114,11 +117,12 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 
 				if !r.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{},
 						LabelValues: []string{},
 						Value:       float64(r.CreationTimestamp.Unix()),
 					})
 				}
+
+				metric.SetLabelKeys(ms, []string{})
 
 				return &metric.Family{
 					Metrics: ms,

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -37,7 +37,7 @@ var (
 	descStatefulSetAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descStatefulSetLabelsName          = "kube_statefulset_labels"
 	descStatefulSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descStatefulSetLabelsDefaultLabels = []string{"namespace", "statefulset"}
+	descStatefulSetLabelsDefaultLabels = SharedLabelKeys{"namespace", "statefulset"}
 )
 
 func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -57,6 +57,8 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -69,12 +71,16 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(s.Status.Replicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(s.Status.Replicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -85,12 +91,16 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.ALPHA,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(s.Status.AvailableReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(s.Status.AvailableReplicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -101,12 +111,16 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(s.Status.CurrentReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(s.Status.CurrentReplicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -117,12 +131,16 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(s.Status.ReadyReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(s.Status.ReadyReplicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -133,12 +151,16 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(s.Status.UpdatedReplicas),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(s.Status.UpdatedReplicas),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -149,12 +171,16 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(s.Status.ObservedGeneration),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(s.Status.ObservedGeneration),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -172,6 +198,8 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 						Value: float64(*s.Spec.Replicas),
 					})
 				}
+
+				metric.SetLabelKeys(ms, []string{})
 
 				return &metric.Family{
 					Metrics: ms,
@@ -193,6 +221,8 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 					})
 				}
 
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -205,12 +235,16 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(s.ObjectMeta.Generation),
-						},
+				ms := []*metric.Metric{
+					{
+						Value: float64(s.ObjectMeta.Generation),
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -231,11 +265,12 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				ms := []*metric.Metric{}
 				if deletedPolicyLabel != "" || scaledPolicyLabel != "" {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"when_deleted", "when_scaled"},
 						LabelValues: []string{deletedPolicyLabel, scaledPolicyLabel},
 						Value:       1,
 					})
 				}
+				metric.SetLabelKeys(ms, []string{"when_deleted", "when_scaled"})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -252,14 +287,15 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 					return &metric.Family{}
 				}
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", s.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: annotationValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, annotationKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -274,14 +310,15 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 					return &metric.Family{}
 				}
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", s.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: labelValues,
+						Value:       1,
 					},
+				}
+				metric.SetLabelKeys(ms, labelKeys)
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -292,14 +329,17 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{"revision"},
-							LabelValues: []string{s.Status.CurrentRevision},
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{s.Status.CurrentRevision},
+						Value:       1,
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{"revision"})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -310,14 +350,17 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			basemetrics.STABLE,
 			"",
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   []string{"revision"},
-							LabelValues: []string{s.Status.UpdateRevision},
-							Value:       1,
-						},
+				ms := []*metric.Metric{
+					{
+						LabelValues: []string{s.Status.UpdateRevision},
+						Value:       1,
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{"revision"})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -30,6 +30,9 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/options"
 )
 
+// SharedLabelKeys is the type for labelKeys which are shared in all metrics under one resource type
+type SharedLabelKeys []string
+
 var (
 	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 	matchAllCap        = regexp.MustCompile("([a-z0-9])([A-Z])")

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -33,8 +33,10 @@ import (
 
 var (
 	descValidatingWebhookConfigurationDefaultLabels = []string{"namespace", "validatingwebhookconfiguration"}
+)
 
-	validatingWebhookConfigurationMetricFamilies = []generator.FamilyGenerator{
+func validatingWebhookConfigurationMetricFamilies() []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
 			"kube_validatingwebhookconfiguration_info",
 			"Information about the ValidatingWebhookConfiguration.",
@@ -42,12 +44,16 @@ var (
 			basemetrics.ALPHA,
 			"",
 			wrapValidatingWebhookConfigurationFunc(func(vwc *admissionregistrationv1.ValidatingWebhookConfiguration) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: 1,
-						},
+				ms := []*metric.Metric{
+					{
+						Value: 1,
 					},
+				}
+
+				metric.SetLabelKeys(ms, []string{})
+
+				return &metric.Family{
+					Metrics: ms,
 				}
 			}),
 		),
@@ -65,6 +71,9 @@ var (
 						Value: float64(vwc.CreationTimestamp.Unix()),
 					})
 				}
+
+				metric.SetLabelKeys(ms, []string{})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
@@ -98,18 +107,20 @@ var (
 					}
 
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"webhook_name", "service_name", "service_namespace"},
 						LabelValues: []string{webhook.Name, serviceName, serviceNamespace},
 						Value:       1,
 					})
 				}
+
+				metric.SetLabelKeys(ms, []string{"webhook_name", "service_name", "service_namespace"})
+
 				return &metric.Family{
 					Metrics: ms,
 				}
 			}),
 		),
 	}
-)
+}
 
 func createValidatingWebhookConfigurationListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
 	return &cache.ListWatch{

--- a/internal/store/validatingwebhookconfiguration_test.go
+++ b/internal/store/validatingwebhookconfiguration_test.go
@@ -103,8 +103,8 @@ func TestValidatingWebhookConfigurationStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(validatingWebhookConfigurationMetricFamilies)
-		c.Headers = generator.ExtractMetricFamilyHeaders(validatingWebhookConfigurationMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(validatingWebhookConfigurationMetricFamilies())
+		c.Headers = generator.ExtractMetricFamilyHeaders(validatingWebhookConfigurationMetricFamilies())
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/volumeattachment_test.go
+++ b/internal/store/volumeattachment_test.go
@@ -87,8 +87,8 @@ func TestVolumeAttachmentStore(t *testing.T) {
 		}
 	)
 	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(volumeAttachmentMetricFamilies)
-		c.Headers = generator.ExtractMetricFamilyHeaders(volumeAttachmentMetricFamilies)
+		c.Func = generator.ComposeMetricGenFuncs(volumeAttachmentMetricFamilies())
+		c.Headers = generator.ExtractMetricFamilyHeaders(volumeAttachmentMetricFamilies())
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/pkg/metric/family.go
+++ b/pkg/metric/family.go
@@ -48,3 +48,10 @@ func (f Family) ByteSlice() []byte {
 
 	return []byte(b.String())
 }
+
+// SetLabelKeys set same label name to all metrics
+func SetLabelKeys(metrics []*Metric, labelKeys []string) {
+	for _, metric := range metrics {
+		metric.LabelKeys = labelKeys
+	}
+}


### PR DESCRIPTION
…ls with same format

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: 

KSM metrics are defined freely, which increases the difficulties of static analysis.

Will add a static analysis to make sure each metric defines label in this way:

1. SetLabelKeys appears once
2. The values is []string{*}
```
labelKeys := []string{"container"}

metric.SetLabelKeys(ms, labelKeys)
```


**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)* N/A

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1833

[x] certificatesigningrequest.go
[x] clusterrolebinding.go
[x] clusterrole.go
[x] configmap.go
[x] cronjob.go
[x] daemonset.go
[x] deployment.go
[x] endpoint.go
[x] endpointslice.go
[x] horizontalpodautoscaler.go
[x] ingressclass.go
[x] ingress.go
[x] job.go
[x] lease.go
[x] limitrange.go
[x] mutatingwebhookconfiguration.go
[x] namespace.go
[x] networkpolicy.go
[x] node.go
[x] persistentvolumeclaim.go
[x] persistentvolume.go
[x] poddisruptionbudget.go
[x] pod.go
[x] replicaset.go
[x] replicationcontroller.go
[x] resourcequota.go
[x] rolebinding.go
[x] role.go
[x] secret.go
[x] serviceaccount.go
[x] service.go
[x] statefulset.go
[x] storageclass.go
[x] validatingwebhookconfiguration.go
[x] volumeattachment.go
