### PR TITLE
feat: Add namespace label to endpoinslice metrics

### DIFF
--- a/internal/store/endpointslice.go
+++ b/internal/store/endpointslice.go
@@ -35,7 +35,7 @@ var (
 	descEndpointSliceAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descEndpointSliceLabelsName          = "kube_endpointslice_labels"
 	descEndpointSliceLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descEndpointSliceLabelsDefaultLabels = []string{"endpointslice"}
+	descEndpointSliceLabelsDefaultLabels = []string{"endpointslice", "namespace"}
 )
 
 func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -261,7 +261,7 @@ func wrapEndpointSliceFunc(f func(*discoveryv1.EndpointSlice) *metric.Family) fu
 		metricFamily := f(endpointSlice)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descEndpointSliceLabelsDefaultLabels, []string{endpointSlice.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys, m.LabelValues = mergeKeyValues(descEndpointSliceLabelsDefaultLabels, []string{endpointSlice.Name, endpointSlice.Namespace}, m.LabelKeys, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/endpointslice_test.go
+++ b/internal/store/endpointslice_test.go
@@ -40,14 +40,15 @@ func TestEndpointSliceStore(t *testing.T) {
 		{
 			Obj: &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test_endpointslice-info",
+					Name:      "test_endpointslice-info",
+					Namespace: "test",
 				},
 				AddressType: "IPv4",
 			},
 			Want: `
 					# HELP kube_endpointslice_info Information about endpointslice.
 					# TYPE kube_endpointslice_info gauge
-					kube_endpointslice_info{endpointslice="test_endpointslice-info",addresstype="IPv4"} 1
+					kube_endpointslice_info{endpointslice="test_endpointslice-info",addresstype="IPv4",namespace="test"} 1
 				`,
 			MetricNames: []string{
 				"kube_endpointslice_info",
@@ -57,6 +58,7 @@ func TestEndpointSliceStore(t *testing.T) {
 			Obj: &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test_kube_endpointslice-created",
+					Namespace:         "test",
 					CreationTimestamp: metav1StartTime,
 				},
 				AddressType: "IPv4",
@@ -64,7 +66,7 @@ func TestEndpointSliceStore(t *testing.T) {
 			Want: `
 					# HELP kube_endpointslice_created Unix creation timestamp
 					# TYPE kube_endpointslice_created gauge
-					kube_endpointslice_created{endpointslice="test_kube_endpointslice-created"} 1.501569018e+09
+					kube_endpointslice_created{endpointslice="test_kube_endpointslice-created",namespace="test"} 1.501569018e+09
 				`,
 			MetricNames: []string{
 				"kube_endpointslice_created",
@@ -73,7 +75,8 @@ func TestEndpointSliceStore(t *testing.T) {
 		{
 			Obj: &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test_endpointslice-ports",
+					Name:      "test_endpointslice-ports",
+					Namespace: "test",
 				},
 				AddressType: "IPv4",
 				Ports: []discoveryv1.EndpointPort{
@@ -86,7 +89,7 @@ func TestEndpointSliceStore(t *testing.T) {
 			Want: `
 					# HELP kube_endpointslice_ports Ports attached to the endpointslice.
 					# TYPE kube_endpointslice_ports gauge
-					kube_endpointslice_ports{endpointslice="test_endpointslice-ports",port_name="http",port_protocol="TCP",port_number="80"} 1
+					kube_endpointslice_ports{endpointslice="test_endpointslice-ports",port_name="http",port_protocol="TCP",port_number="80",namespace="test"} 1
 				`,
 			MetricNames: []string{
 				"kube_endpointslice_ports",
@@ -95,7 +98,8 @@ func TestEndpointSliceStore(t *testing.T) {
 		{
 			Obj: &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test_endpointslice-endpoints",
+					Name:      "test_endpointslice-endpoints",
+					Namespace: "test",
 				},
 				AddressType: "IPv4",
 				Endpoints: []discoveryv1.Endpoint{
@@ -116,8 +120,8 @@ func TestEndpointSliceStore(t *testing.T) {
 					# HELP kube_endpointslice_endpoints_hints Topology routing hints attached to endpoints
 					# TYPE kube_endpointslice_endpoints gauge
 					# TYPE kube_endpointslice_endpoints_hints gauge
-					kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false"} 1
-					kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false"} 1
+					kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false",namespace="test"} 1
+					kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false",namespace="test"} 1
 				  `,
 
 			MetricNames: []string{
@@ -127,7 +131,8 @@ func TestEndpointSliceStore(t *testing.T) {
 		{
 			Obj: &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test_endpointslice-endpoints",
+					Name:      "test_endpointslice-endpoints",
+					Namespace: "test",
 				},
 				AddressType: "IPv4",
 				Endpoints: []discoveryv1.Endpoint{
@@ -152,10 +157,10 @@ func TestEndpointSliceStore(t *testing.T) {
 					# HELP kube_endpointslice_endpoints Endpoints attached to the endpointslice.
 					# HELP kube_endpointslice_endpoints_hints Topology routing hints attached to endpoints
 					# TYPE kube_endpointslice_endpoints gauge
-        			# TYPE kube_endpointslice_endpoints_hints gauge
-         			kube_endpointslice_endpoints_hints{address="10.0.0.1",endpointslice="test_endpointslice-endpoints",for_zone="zone1"} 1
-        			kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false"} 1
-        			kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false"} 1
+        			        # TYPE kube_endpointslice_endpoints_hints gauge
+         			kube_endpointslice_endpoints_hints{address="10.0.0.1",endpointslice="test_endpointslice-endpoints",for_zone="zone1",namespace="test"} 1
+        			kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false",namespace="test"} 1
+        			kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false",namespace="test"} 1
 				  `,
 
 			MetricNames: []string{
@@ -168,7 +173,8 @@ func TestEndpointSliceStore(t *testing.T) {
 			},
 			Obj: &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test_endpointslice-labels",
+					Name:      "test_endpointslice-labels",
+					Namespace: "test",
 					Annotations: map[string]string{
 						"foo": "baz",
 					},
@@ -183,7 +189,7 @@ func TestEndpointSliceStore(t *testing.T) {
 					# HELP kube_endpointslice_labels Kubernetes labels converted to Prometheus labels.
 					# TYPE kube_endpointslice_annotations gauge
 					# TYPE kube_endpointslice_labels gauge
-					kube_endpointslice_annotations{endpointslice="test_endpointslice-labels",annotation_foo="baz"} 1
+					kube_endpointslice_annotations{endpointslice="test_endpointslice-labels",annotation_foo="baz",namespace="test"} 1
 				`,
 			MetricNames: []string{
 				"kube_endpointslice_annotations", "kube_endpointslice_labels",


### PR DESCRIPTION
**What this PR does / why we need it**:
endpointslices are namespaced resources and we didn't expose the namespace before.
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fix #2255 
Supersedes #2256 
