### PR TITLE
chore: use string verb to format logging messages in tests 

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -188,7 +188,7 @@ func getLabelsDocumentation() (map[string][]string, error) {
 		return nil
 	})
 	if err != nil {
-		log.Fatalf("cannot walk the documentation directory: %w", err)
+		log.Fatalf("cannot walk the documentation directory: %s", err)
 	}
 
 	return documentedMetrics, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
The %w makes the CI to fail, replacing it back to %s.
After the https://github.com/kubernetes/kube-state-metrics/pull/2358 was merged, looks like the CI is failing on the main branch.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
no impact

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
