### PR TITLE
fix:  `.` is removed in nodeName

### DIFF
--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -18,7 +18,6 @@ package options
 
 import (
 	"errors"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -145,9 +144,7 @@ func (n *NodeType) GetNodeFieldSelector() string {
 		klog.InfoS("Using node type is nil")
 		return EmptyFieldSelector()
 	}
-	pattern := "[^a-zA-Z0-9_,-\\.]+"
-	re := regexp.MustCompile(pattern)
-	result := re.ReplaceAllString(n.String(), "")
+	result := n.String()
 	klog.InfoS("Using node type", "node", result)
 	return fields.OneTermEqualSelector("spec.nodeName", result).String()
 

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -18,7 +18,6 @@ package options
 
 import (
 	"errors"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -145,9 +144,7 @@ func (n *NodeType) GetNodeFieldSelector() string {
 		klog.InfoS("Using node type is nil")
 		return EmptyFieldSelector()
 	}
-	pattern := "[^a-zA-Z0-9_,-]+"
-	re := regexp.MustCompile(pattern)
-	result := re.ReplaceAllString(n.String(), "")
+	result := n.String()
 	klog.InfoS("Using node type", "node", result)
 	return fields.OneTermEqualSelector("spec.nodeName", result).String()
 

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"errors"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -144,7 +145,9 @@ func (n *NodeType) GetNodeFieldSelector() string {
 		klog.InfoS("Using node type is nil")
 		return EmptyFieldSelector()
 	}
-	result := n.String()
+	pattern := "[^a-zA-Z0-9_,-\\.]+"
+	re := regexp.MustCompile(pattern)
+	result := re.ReplaceAllString(n.String(), "")
 	klog.InfoS("Using node type", "node", result)
 	return fields.OneTermEqualSelector("spec.nodeName", result).String()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)* No

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # an issue raised in slack chat `We see the fieldSelector  get created with the node-name … but it’s missing the .`
