### PR TITLE
ci: generate sbom on release

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -3,7 +3,7 @@ name: Generate SBOM with Kubernetes BOM
 on:
   release:
     types:
-      - published
+      - released
 
 permissions:
   contents: read

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: write
 
     env:
-      OUTPUT: kube-state-metrics-${{ github.event.release.tag_name }}.spdx
+      OUTPUT: sbom.spdx
       TAG: ${{ github.event.release.tag_name }}
 
     steps:

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -16,8 +16,8 @@ jobs:
       contents: write
 
     env:
-      OUTPUT: kube-state-metrics-${{ github.ref_name }}.spdx
-      TAG: ${{ github.ref_name }}
+      OUTPUT: kube-state-metrics-${{ github.event.release.tag_name }}.spdx
+      TAG: ${{ github.event.release.tag_name }}
 
     steps:
       - name: Fetch source code into GITHUB_WORKSPACE

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -1,0 +1,41 @@
+name: Generate SBOM with Kubernetes BOM
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    env:
+      OUTPUT: kube-state-metrics-${{ github.ref_name }}.spdx
+      TAG: ${{ github.ref_name }}
+
+    steps:
+      - name: Fetch source code into GITHUB_WORKSPACE
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+
+      - name: Install Kubernetes BOM
+        uses: kubernetes-sigs/release-actions/setup-bom@841d76a188a7c121231a863572e27012805715a2 # v0.1.4
+
+      - name: Generate SBOM
+        run: |
+          bom generate \
+            --dirs=. \
+            --image=registry.k8s.io/kube-state-metrics/kube-state-metrics:$TAG \
+            --namespace=https://github.com/kubernetes/kube-state-metrics/releases/download/$TAG/$OUTPUT
+            --output=$OUTPUT
+
+      - name: Upload SBOM to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload $TAG $OUTPUT


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Generate an SBOM for each new release of kube-state-metrics

**How does this change affect the cardinality of KSM**:

Does not change cardinality

**Which issue(s) this PR fixes**:

Part of https://github.com/kubernetes/kube-state-metrics/issues/2274
