### PR TITLE
fix: use --track-unscheduled-pods to select unscheduled pods in Daemonset sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ spec:
               fieldPath: spec.nodeName
 ```
 
-To track metrics for unassigned pods, you need to add an additional deployment and set `--enable-no-node-scrape`, as shown in the following example:
+To track metrics for unassigned pods, you need to add an additional deployment and set `--fetch-unscheduled-pods`, as shown in the following example:
 
 ```
 apiVersion: apps/v1
@@ -295,7 +295,7 @@ spec:
         name: kube-state-metrics
         args:
         - --resources=pods
-        - --enable-no-node-scrape
+        - --fetch-unscheduled-pods
 ```
 
 Other metrics can be sharded via [Horizontal sharding](#horizontal-sharding).

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ spec:
               fieldPath: spec.nodeName
 ```
 
-To track metrics for unassigned pods, you need to add an additional deployment and set `--enable-unscheduled-pods-fetching`, as shown in the following example:
+To track metrics for unassigned pods, you need to add an additional deployment and set `--track-unscheduled-pods`, as shown in the following example:
 
 ```
 apiVersion: apps/v1
@@ -295,7 +295,7 @@ spec:
         name: kube-state-metrics
         args:
         - --resources=pods
-        - --enable-unscheduled-pods-fetching
+        - --track-unscheduled-pods
 ```
 
 Other metrics can be sharded via [Horizontal sharding](#horizontal-sharding).

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ spec:
               fieldPath: spec.nodeName
 ```
 
-To track metrics for unassigned pods, you need to add an additional deployment and set `--node=""`, as shown in the following example:
+To track metrics for unassigned pods, you need to add an additional deployment and set `--node=`, as shown in the following example:
 
 ```
 apiVersion: apps/v1

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ spec:
               fieldPath: spec.nodeName
 ```
 
-To track metrics for unassigned pods, you need to add an additional deployment and set `--fetch-unscheduled-pods`, as shown in the following example:
+To track metrics for unassigned pods, you need to add an additional deployment and set `--enable-unscheduled-pods-fetching`, as shown in the following example:
 
 ```
 apiVersion: apps/v1
@@ -295,7 +295,7 @@ spec:
         name: kube-state-metrics
         args:
         - --resources=pods
-        - --fetch-unscheduled-pods
+        - --enable-unscheduled-pods-fetching
 ```
 
 Other metrics can be sharded via [Horizontal sharding](#horizontal-sharding).

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ spec:
               fieldPath: spec.nodeName
 ```
 
-To track metrics for unassigned pods, you need to add an additional deployment and set `--node=`, as shown in the following example:
+To track metrics for unassigned pods, you need to add an additional deployment and set `--enable-no-node-scrape`, as shown in the following example:
 
 ```
 apiVersion: apps/v1
@@ -295,7 +295,7 @@ spec:
         name: kube-state-metrics
         args:
         - --resources=pods
-        - --node=""
+        - --enable-no-node-scrape
 ```
 
 Other metrics can be sharded via [Horizontal sharding](#horizontal-sharding).

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -283,7 +283,7 @@ spec:
               fieldPath: spec.nodeName
 ```
 
-To track metrics for unassigned pods, you need to add an additional deployment and set `--enable-no-node-scrape`, as shown in the following example:
+To track metrics for unassigned pods, you need to add an additional deployment and set `--fetch-unscheduled-pods`, as shown in the following example:
 
 ```
 apiVersion: apps/v1
@@ -296,7 +296,7 @@ spec:
         name: kube-state-metrics
         args:
         - --resources=pods
-        - --enable-no-node-scrape
+        - --fetch-unscheduled-pods
 ```
 
 Other metrics can be sharded via [Horizontal sharding](#horizontal-sharding).

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -283,7 +283,7 @@ spec:
               fieldPath: spec.nodeName
 ```
 
-To track metrics for unassigned pods, you need to add an additional deployment and set `--node=""`, as shown in the following example:
+To track metrics for unassigned pods, you need to add an additional deployment and set `--node=`, as shown in the following example:
 
 ```
 apiVersion: apps/v1

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -283,7 +283,7 @@ spec:
               fieldPath: spec.nodeName
 ```
 
-To track metrics for unassigned pods, you need to add an additional deployment and set `--fetch-unscheduled-pods`, as shown in the following example:
+To track metrics for unassigned pods, you need to add an additional deployment and set `--enable-unscheduled-pods-fetching`, as shown in the following example:
 
 ```
 apiVersion: apps/v1
@@ -296,7 +296,7 @@ spec:
         name: kube-state-metrics
         args:
         - --resources=pods
-        - --fetch-unscheduled-pods
+        - --enable-unscheduled-pods-fetching
 ```
 
 Other metrics can be sharded via [Horizontal sharding](#horizontal-sharding).

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -283,7 +283,7 @@ spec:
               fieldPath: spec.nodeName
 ```
 
-To track metrics for unassigned pods, you need to add an additional deployment and set `--node=`, as shown in the following example:
+To track metrics for unassigned pods, you need to add an additional deployment and set `--enable-no-node-scrape`, as shown in the following example:
 
 ```
 apiVersion: apps/v1
@@ -296,7 +296,7 @@ spec:
         name: kube-state-metrics
         args:
         - --resources=pods
-        - --node=""
+        - --enable-no-node-scrape
 ```
 
 Other metrics can be sharded via [Horizontal sharding](#horizontal-sharding).

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -283,7 +283,7 @@ spec:
               fieldPath: spec.nodeName
 ```
 
-To track metrics for unassigned pods, you need to add an additional deployment and set `--enable-unscheduled-pods-fetching`, as shown in the following example:
+To track metrics for unassigned pods, you need to add an additional deployment and set `--track-unscheduled-pods`, as shown in the following example:
 
 ```
 apiVersion: apps/v1
@@ -296,7 +296,7 @@ spec:
         name: kube-state-metrics
         args:
         - --resources=pods
-        - --enable-unscheduled-pods-fetching
+        - --track-unscheduled-pods
 ```
 
 Other metrics can be sharded via [Horizontal sharding](#horizontal-sharding).

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -48,7 +48,7 @@ Flags:
       --custom-resource-state-config-file string   Path to a Custom Resource State Metrics config file (experimental)
       --custom-resource-state-only                 Only provide Custom Resource State metrics (experimental)
       --enable-gzip-encoding                       Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.
-      --enable-unscheduled-pods-fetching           This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.
+      --enable-unscheduled-pods-fetching           This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.
   -h, --help                                       Print Help text
       --host string                                Host to expose metrics on. (default "::")
       --kubeconfig string                          Absolute path to the kubeconfig file

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -48,7 +48,7 @@ Flags:
       --custom-resource-state-config-file string   Path to a Custom Resource State Metrics config file (experimental)
       --custom-resource-state-only                 Only provide Custom Resource State metrics (experimental)
       --enable-gzip-encoding                       Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.
-      --enable-unscheduled-pods-fetching           This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.
+      --track-unscheduled-pods           This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.
   -h, --help                                       Print Help text
       --host string                                Host to expose metrics on. (default "::")
       --kubeconfig string                          Absolute path to the kubeconfig file

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -48,6 +48,7 @@ Flags:
       --custom-resource-state-config-file string   Path to a Custom Resource State Metrics config file (experimental)
       --custom-resource-state-only                 Only provide Custom Resource State metrics (experimental)
       --enable-gzip-encoding                       Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.
+      --enable-no-node-scrape                      This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.
   -h, --help                                       Print Help text
       --host string                                Host to expose metrics on. (default "::")
       --kubeconfig string                          Absolute path to the kubeconfig file

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -48,7 +48,7 @@ Flags:
       --custom-resource-state-config-file string   Path to a Custom Resource State Metrics config file (experimental)
       --custom-resource-state-only                 Only provide Custom Resource State metrics (experimental)
       --enable-gzip-encoding                       Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.
-      --fetch-unscheduled-pods                     This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.
+      --enable-unscheduled-pods-fetching           This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.
   -h, --help                                       Print Help text
       --host string                                Host to expose metrics on. (default "::")
       --kubeconfig string                          Absolute path to the kubeconfig file

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -48,7 +48,7 @@ Flags:
       --custom-resource-state-config-file string   Path to a Custom Resource State Metrics config file (experimental)
       --custom-resource-state-only                 Only provide Custom Resource State metrics (experimental)
       --enable-gzip-encoding                       Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.
-      --enable-no-node-scrape                      This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.
+      --fetch-unscheduled-pods                     This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.
   -h, --help                                       Print Help text
       --host string                                Host to expose metrics on. (default "::")
       --kubeconfig string                          Absolute path to the kubeconfig file

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -48,7 +48,6 @@ Flags:
       --custom-resource-state-config-file string   Path to a Custom Resource State Metrics config file (experimental)
       --custom-resource-state-only                 Only provide Custom Resource State metrics (experimental)
       --enable-gzip-encoding                       Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.
-      --track-unscheduled-pods           This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.
   -h, --help                                       Print Help text
       --host string                                Host to expose metrics on. (default "::")
       --kubeconfig string                          Absolute path to the kubeconfig file
@@ -82,6 +81,7 @@ Flags:
       --telemetry-port int                         Port to expose kube-state-metrics self metrics on. (default 8081)
       --tls-config string                          Path to the TLS configuration file
       --total-shards int                           The total number of shards. Sharding is disabled when total shards is set to 1. (default 1)
+      --track-unscheduled-pods                     This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.
       --use-apiserver-cache                        Sets resourceVersion=0 for ListWatch requests, using cached resources from the apiserver instead of an etcd quorum read.
   -v, --v Level                                    number for the log level verbosity
       --vmodule moduleSpec                         comma-separated list of pattern=N settings for file-filtered logging

--- a/examples/daemonsetsharding/deployment-no-node-pods-service.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics-no-node-pods
+    app.kubernetes.io/version: 2.12.0
+  name: kube-state-metrics-no-node-pods
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+  selector:
+    app.kubernetes.io/name: kube-state-metrics-no-node-pods

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - args:
         - --resources=pods
-        - --enable-unscheduled-pods-fetching
+        - --track-unscheduled-pods
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
         livenessProbe:
           httpGet:

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -3,20 +3,20 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/name: kube-state-metrics-pods
+    app.kubernetes.io/name: kube-state-metrics-no-node-pods
     app.kubernetes.io/version: 2.13.0
-  name: kube-state-metrics-pods
+  name: kube-state-metrics-no-node-pods
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/name: kube-state-metrics-no-node-pods
   template:
     metadata:
       labels:
         app.kubernetes.io/component: exporter
-        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/name: kube-state-metrics-no-node-pods
         app.kubernetes.io/version: 2.13.0
     spec:
       automountServiceAccountToken: true
@@ -31,7 +31,7 @@ spec:
             port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
-        name: kube-state-metrics
+        name: kube-state-metrics-no-node-pods
         ports:
         - containerPort: 8080
           name: http-metrics

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - args:
         - --resources=pods
-        - --fetch-unscheduled-pods
+        - --enable-unscheduled-pods-fetching
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
         livenessProbe:
           httpGet:

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - args:
         - --resources=pods
-        - --node=""
+        - --enable-no-node-scrape
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
         livenessProbe:
           httpGet:

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - args:
         - --resources=pods
-        - --enable-no-node-scrape
+        - --fetch-unscheduled-pods
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
         livenessProbe:
           httpGet:

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -377,7 +377,7 @@
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
           '--resources=pods',
-          '--enable-no-node-scrape',
+          '--fetch-unscheduled-pods',
         ],
         name: shardksmname,
       };
@@ -410,7 +410,7 @@
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
           '--resources=pods',
-          '--enable-no-node-scrape',
+          '--fetch-unscheduled-pods',
         ],
       };
       local shardksmname = ksm.name + "-no-node-pods";

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -377,7 +377,7 @@
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
           '--resources=pods',
-          '--enable-unscheduled-pods-fetching',
+          '--track-unscheduled-pods',
         ],
         name: shardksmname,
       };
@@ -410,7 +410,7 @@
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
           '--resources=pods',
-          '--enable-unscheduled-pods-fetching',
+          '--track-unscheduled-pods',
         ],
       };
       local shardksmname = ksm.name + "-no-node-pods";

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -379,8 +379,9 @@
           '--resources=pods',
           '--node=""',
         ],
+        name: shardksmname,
       };
-      local shardksmname = ksm.name + "-pods";
+      local shardksmname = ksm.name + "-no-node-pods";
       std.mergePatch(ksm.deployment,
         {
           metadata: {
@@ -388,7 +389,15 @@
             labels: {'app.kubernetes.io/name': shardksmname}
           },
           spec: {
+            selector{
+              matchLabels: {app.kubernetes.io/name': shardksmname}
+            }
             template: {
+              metadata: {
+                labels: {
+                  app.kubernetes.io/name': shardksmname
+                }
+              }
               spec: {
                 containers: [c],
               },
@@ -397,6 +406,27 @@
         },
       ),
 
+    deploymentNoNodePodsService:
+      local c = ksm.deployment.spec.template.spec.containers[0] {
+        args: [
+          '--resources=pods',
+          '--node=""',
+        ],
+      };
+      local shardksmname = ksm.name + "-no-node-pods";
+      std.mergePatch(ksm.service,
+        {
+          metadata: {
+            name: shardksmname,
+            labels: {'app.kubernetes.io/name': shardksmname}
+          },
+          spec: {
+            selector: {
+              'app.kubernetes.io/name': shardksmname
+            }
+          }
+        }
+      ),
     daemonset:
       // extending the default container from above
       local c0 = ksm.deployment.spec.template.spec.containers[0] {

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -381,7 +381,7 @@
         ],
         name: shardksmname,
       };
-      local shardksmname = ksm.name + "-no-node-pods";
+      local shardksmname = ksm.name + "-unscheduled-pods-fetching";
       std.mergePatch(ksm.deployment,
         {
           metadata: {

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -377,7 +377,7 @@
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
           '--resources=pods',
-          '--fetch-unscheduled-pods',
+          '--enable-unscheduled-pods-fetching',
         ],
         name: shardksmname,
       };
@@ -410,7 +410,7 @@
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
           '--resources=pods',
-          '--fetch-unscheduled-pods',
+          '--enable-unscheduled-pods-fetching',
         ],
       };
       local shardksmname = ksm.name + "-no-node-pods";

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -377,7 +377,7 @@
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
           '--resources=pods',
-          '--node=""',
+          '--enable-no-node-scrape',
         ],
         name: shardksmname,
       };
@@ -410,7 +410,7 @@
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
           '--resources=pods',
-          '--node=""',
+          '--enable-no-node-scrape',
         ],
       };
       local shardksmname = ksm.name + "-no-node-pods";

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -224,7 +224,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	namespaces := opts.Namespaces.GetNamespaces()
 	nsFieldSelector := namespaces.GetExcludeNSFieldSelector(opts.NamespacesDenylist)
-	nodeFieldSelector := opts.Node.GetNodeFieldSelector(opts.EnableUnscheduledPodsFetching)
+	nodeFieldSelector := opts.Node.GetNodeFieldSelector(opts.TrackUnscheduledPods)
 	merged, err := storeBuilder.MergeFieldSelectors([]string{nsFieldSelector, nodeFieldSelector})
 	if err != nil {
 		return err

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -224,7 +224,13 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	namespaces := opts.Namespaces.GetNamespaces()
 	nsFieldSelector := namespaces.GetExcludeNSFieldSelector(opts.NamespacesDenylist)
-	nodeFieldSelector := opts.Node.GetNodeFieldSelector(opts.TrackUnscheduledPods)
+	var nodeFieldSelector string
+	if opts.TrackUnscheduledPods {
+		nodeFieldSelector = "spec.nodeName="
+		klog.InfoS("Using spec.nodeName= to select unscheduable pods without node")
+	} else {
+		nodeFieldSelector = opts.Node.GetNodeFieldSelector()
+	}
 	merged, err := storeBuilder.MergeFieldSelectors([]string{nsFieldSelector, nodeFieldSelector})
 	if err != nil {
 		return err

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -224,7 +224,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	namespaces := opts.Namespaces.GetNamespaces()
 	nsFieldSelector := namespaces.GetExcludeNSFieldSelector(opts.NamespacesDenylist)
-	nodeFieldSelector := opts.Node.GetNodeFieldSelector(opts.EnableNoNodeScrape)
+	nodeFieldSelector := opts.Node.GetNodeFieldSelector(opts.FetchUnscheduledPods)
 	merged, err := storeBuilder.MergeFieldSelectors([]string{nsFieldSelector, nodeFieldSelector})
 	if err != nil {
 		return err

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -224,7 +224,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	namespaces := opts.Namespaces.GetNamespaces()
 	nsFieldSelector := namespaces.GetExcludeNSFieldSelector(opts.NamespacesDenylist)
-	nodeFieldSelector := opts.Node.GetNodeFieldSelector(opts.FetchUnscheduledPods)
+	nodeFieldSelector := opts.Node.GetNodeFieldSelector(opts.EnableUnscheduledPodsFetching)
 	merged, err := storeBuilder.MergeFieldSelectors([]string{nsFieldSelector, nodeFieldSelector})
 	if err != nil {
 		return err

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -224,7 +224,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	namespaces := opts.Namespaces.GetNamespaces()
 	nsFieldSelector := namespaces.GetExcludeNSFieldSelector(opts.NamespacesDenylist)
-	nodeFieldSelector := opts.Node.GetNodeFieldSelector()
+	nodeFieldSelector := opts.Node.GetNodeFieldSelector(opts.EnableNoNodeScrape)
 	merged, err := storeBuilder.MergeFieldSelectors([]string{nsFieldSelector, nodeFieldSelector})
 	if err != nil {
 		return err

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -60,19 +60,19 @@ type Options struct {
 	NamespacesDenylist       NamespaceList   `yaml:"namespaces_denylist"`
 	Node                     NodeType        `yaml:"node"`
 	EnableUnscheduledPodsFetching bool            `yaml:"enable_unscheduled_pods_fetching"`
-	Pod                      string          `yaml:"pod"`
-	Port                     int             `yaml:"port"`
-	Resources                ResourceSet     `yaml:"resources"`
-	Shard                    int32           `yaml:"shard"`
-	TLSConfig                string          `yaml:"tls_config"`
-	TelemetryHost            string          `yaml:"telemetry_host"`
-	TelemetryPort            int             `yaml:"telemetry_port"`
-	TotalShards              int             `yaml:"total_shards"`
-	UseAPIServerCache        bool            `yaml:"use_api_server_cache"`
-	ServerReadTimeout        time.Duration   `yaml:"server_read_timeout"`
-	ServerWriteTimeout       time.Duration   `yaml:"server_write_timeout"`
-	ServerIdleTimeout        time.Duration   `yaml:"server_idle_timeout"`
-	ServerReadHeaderTimeout  time.Duration   `yaml:"server_read_header_timeout"`
+	Pod                           string          `yaml:"pod"`
+	Port                          int             `yaml:"port"`
+	Resources                     ResourceSet     `yaml:"resources"`
+	Shard                         int32           `yaml:"shard"`
+	TLSConfig                     string          `yaml:"tls_config"`
+	TelemetryHost                 string          `yaml:"telemetry_host"`
+	TelemetryPort                 int             `yaml:"telemetry_port"`
+	TotalShards                   int             `yaml:"total_shards"`
+	UseAPIServerCache             bool            `yaml:"use_api_server_cache"`
+	ServerReadTimeout             time.Duration   `yaml:"server_read_timeout"`
+	ServerWriteTimeout            time.Duration   `yaml:"server_write_timeout"`
+	ServerIdleTimeout             time.Duration   `yaml:"server_idle_timeout"`
+	ServerReadHeaderTimeout       time.Duration   `yaml:"server_read_header_timeout"`
 
 	Config string
 
@@ -138,7 +138,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 
 	o.cmd.Flags().BoolVar(&o.CustomResourcesOnly, "custom-resource-state-only", false, "Only provide Custom Resource State metrics (experimental)")
 	o.cmd.Flags().BoolVar(&o.EnableGZIPEncoding, "enable-gzip-encoding", false, "Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.")
-	o.cmd.Flags().BoolVar(&o.EnableUnscheduledPodsFetching, "enable-unscheduled-pods-fetching", false, "This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.")
+	o.cmd.Flags().BoolVar(&o.EnableUnscheduledPodsFetching, "enable-unscheduled-pods-fetching", false, "This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.")
 	o.cmd.Flags().BoolVarP(&o.Help, "help", "h", false, "Print Help text")
 	o.cmd.Flags().BoolVarP(&o.UseAPIServerCache, "use-apiserver-cache", "", false, "Sets resourceVersion=0 for ListWatch requests, using cached resources from the apiserver instead of an etcd quorum read.")
 	o.cmd.Flags().Int32Var(&o.Shard, "shard", int32(0), "The instances shard nominal (zero indexed) within the total number of shards. (default 0)")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -59,7 +59,7 @@ type Options struct {
 	Namespaces               NamespaceList   `yaml:"namespaces"`
 	NamespacesDenylist       NamespaceList   `yaml:"namespaces_denylist"`
 	Node                     NodeType        `yaml:"node"`
-	EnableUnscheduledPodsFetching bool            `yaml:"enable_unscheduled_pods_fetching"`
+	TrackUnscheduledPods     bool            `yaml:"track_unscheduled_pods"`
 	Pod                           string          `yaml:"pod"`
 	Port                          int             `yaml:"port"`
 	Resources                     ResourceSet     `yaml:"resources"`
@@ -138,7 +138,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 
 	o.cmd.Flags().BoolVar(&o.CustomResourcesOnly, "custom-resource-state-only", false, "Only provide Custom Resource State metrics (experimental)")
 	o.cmd.Flags().BoolVar(&o.EnableGZIPEncoding, "enable-gzip-encoding", false, "Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.")
-	o.cmd.Flags().BoolVar(&o.EnableUnscheduledPodsFetching, "enable-unscheduled-pods-fetching", false, "This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.")
+	o.cmd.Flags().BoolVar(&o.TrackUnscheduledPods, "track-unscheduled-pods", false, "This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.")
 	o.cmd.Flags().BoolVarP(&o.Help, "help", "h", false, "Print Help text")
 	o.cmd.Flags().BoolVarP(&o.UseAPIServerCache, "use-apiserver-cache", "", false, "Sets resourceVersion=0 for ListWatch requests, using cached resources from the apiserver instead of an etcd quorum read.")
 	o.cmd.Flags().Int32Var(&o.Shard, "shard", int32(0), "The instances shard nominal (zero indexed) within the total number of shards. (default 0)")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -60,19 +60,19 @@ type Options struct {
 	NamespacesDenylist       NamespaceList   `yaml:"namespaces_denylist"`
 	Node                     NodeType        `yaml:"node"`
 	TrackUnscheduledPods     bool            `yaml:"track_unscheduled_pods"`
-	Pod                           string          `yaml:"pod"`
-	Port                          int             `yaml:"port"`
-	Resources                     ResourceSet     `yaml:"resources"`
-	Shard                         int32           `yaml:"shard"`
-	TLSConfig                     string          `yaml:"tls_config"`
-	TelemetryHost                 string          `yaml:"telemetry_host"`
-	TelemetryPort                 int             `yaml:"telemetry_port"`
-	TotalShards                   int             `yaml:"total_shards"`
-	UseAPIServerCache             bool            `yaml:"use_api_server_cache"`
-	ServerReadTimeout             time.Duration   `yaml:"server_read_timeout"`
-	ServerWriteTimeout            time.Duration   `yaml:"server_write_timeout"`
-	ServerIdleTimeout             time.Duration   `yaml:"server_idle_timeout"`
-	ServerReadHeaderTimeout       time.Duration   `yaml:"server_read_header_timeout"`
+	Pod                      string          `yaml:"pod"`
+	Port                     int             `yaml:"port"`
+	Resources                ResourceSet     `yaml:"resources"`
+	Shard                    int32           `yaml:"shard"`
+	TLSConfig                string          `yaml:"tls_config"`
+	TelemetryHost            string          `yaml:"telemetry_host"`
+	TelemetryPort            int             `yaml:"telemetry_port"`
+	TotalShards              int             `yaml:"total_shards"`
+	UseAPIServerCache        bool            `yaml:"use_api_server_cache"`
+	ServerReadTimeout        time.Duration   `yaml:"server_read_timeout"`
+	ServerWriteTimeout       time.Duration   `yaml:"server_write_timeout"`
+	ServerIdleTimeout        time.Duration   `yaml:"server_idle_timeout"`
+	ServerReadHeaderTimeout  time.Duration   `yaml:"server_read_header_timeout"`
 
 	Config string
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -59,7 +59,7 @@ type Options struct {
 	Namespaces               NamespaceList   `yaml:"namespaces"`
 	NamespacesDenylist       NamespaceList   `yaml:"namespaces_denylist"`
 	Node                     NodeType        `yaml:"node"`
-	EnableNoNodeScrape       bool            `yaml:"enable_no_node_scrape"`
+	FetchUnscheduledPods     bool            `yaml:"fetch_unscheduled_pods"`
 	Pod                      string          `yaml:"pod"`
 	Port                     int             `yaml:"port"`
 	Resources                ResourceSet     `yaml:"resources"`
@@ -138,7 +138,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 
 	o.cmd.Flags().BoolVar(&o.CustomResourcesOnly, "custom-resource-state-only", false, "Only provide Custom Resource State metrics (experimental)")
 	o.cmd.Flags().BoolVar(&o.EnableGZIPEncoding, "enable-gzip-encoding", false, "Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.")
-	o.cmd.Flags().BoolVar(&o.EnableNoNodeScrape, "enable-no-node-scrape", false, "This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.")
+	o.cmd.Flags().BoolVar(&o.FetchUnscheduledPods, "fetch-unscheduled-pods", false, "This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.")
 	o.cmd.Flags().BoolVarP(&o.Help, "help", "h", false, "Print Help text")
 	o.cmd.Flags().BoolVarP(&o.UseAPIServerCache, "use-apiserver-cache", "", false, "Sets resourceVersion=0 for ListWatch requests, using cached resources from the apiserver instead of an etcd quorum read.")
 	o.cmd.Flags().Int32Var(&o.Shard, "shard", int32(0), "The instances shard nominal (zero indexed) within the total number of shards. (default 0)")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -59,7 +59,7 @@ type Options struct {
 	Namespaces               NamespaceList   `yaml:"namespaces"`
 	NamespacesDenylist       NamespaceList   `yaml:"namespaces_denylist"`
 	Node                     NodeType        `yaml:"node"`
-	FetchUnscheduledPods     bool            `yaml:"fetch_unscheduled_pods"`
+	EnableUnscheduledPodsFetching bool            `yaml:"enable_unscheduled_pods_fetching"`
 	Pod                      string          `yaml:"pod"`
 	Port                     int             `yaml:"port"`
 	Resources                ResourceSet     `yaml:"resources"`
@@ -138,7 +138,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 
 	o.cmd.Flags().BoolVar(&o.CustomResourcesOnly, "custom-resource-state-only", false, "Only provide Custom Resource State metrics (experimental)")
 	o.cmd.Flags().BoolVar(&o.EnableGZIPEncoding, "enable-gzip-encoding", false, "Gzip responses when requested by clients via 'Accept-Encoding: gzip' header.")
-	o.cmd.Flags().BoolVar(&o.FetchUnscheduledPods, "fetch-unscheduled-pods", false, "This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.")
+	o.cmd.Flags().BoolVar(&o.EnableUnscheduledPodsFetching, "enable-unscheduled-pods-fetching", false, "This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of no scheduled pods is scraped. This is experimental.")
 	o.cmd.Flags().BoolVarP(&o.Help, "help", "h", false, "Print Help text")
 	o.cmd.Flags().BoolVarP(&o.UseAPIServerCache, "use-apiserver-cache", "", false, "Sets resourceVersion=0 for ListWatch requests, using cached resources from the apiserver instead of an etcd quorum read.")
 	o.cmd.Flags().Int32Var(&o.Shard, "shard", int32(0), "The instances shard nominal (zero indexed) within the total number of shards. (default 0)")

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -107,15 +107,19 @@ func (r *ResourceSet) Type() string {
 // NodeType represents a nodeName to query from.
 type NodeType string
 
+// Set sets the node name to NodeType.
+func (n *NodeType) Set(value string) error {
+	*n = NodeType(value)
+	return nil
+}
+
+// String gets node name.
+func (n NodeType) String() string {
+	return string(n)
+}
+
 // GetNodeFieldSelector returns a nodename field selector.
-func (n *NodeType) GetNodeFieldSelector(fetchUnscheduledPods bool) string {
-	if fetchUnscheduledPods {
-		if string(*n) != "" {
-			klog.Warningf("spec.nodeName=%s will not be used, because --track-unscheduled-pods is set", string(*n))
-		}
-		klog.InfoS("Using spec.nodeName= to select unscheduable pods without node")
-		return "spec.nodeName="
-	}
+func (n *NodeType) GetNodeFieldSelector() string {
 	if string(*n) != "" {
 		return fields.OneTermEqualSelector("spec.nodeName", string(*n)).String()
 	}

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -111,7 +111,7 @@ type NodeType string
 func (n *NodeType) GetNodeFieldSelector(fetchUnscheduledPods bool) string {
 	if fetchUnscheduledPods {
 		if string(*n) != "" {
-			klog.Warningf("spec.nodeName=%s will not be used, because --enable-unscheduled-pods-fetching is set", string(*n))
+			klog.Warningf("spec.nodeName=%s will not be used, because --track-unscheduled-pods is set", string(*n))
 		}
 		klog.InfoS("Using spec.nodeName= to select unscheduable pods without node")
 		return "spec.nodeName="

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -110,6 +110,9 @@ type NodeType string
 // GetNodeFieldSelector returns a nodename field selector.
 func (n *NodeType) GetNodeFieldSelector(noNodeAssigned bool) string {
 	if noNodeAssigned {
+		if string(*n) != "" {
+			klog.Warningf("spec.nodeName=%s will not be used, because --enable-unscheduled-pods-fetching is set", string(*n))
+		}
 		klog.InfoS("Using spec.nodeName= to select unscheduable pods without node")
 		return "spec.nodeName="
 	}

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -108,8 +108,8 @@ func (r *ResourceSet) Type() string {
 type NodeType string
 
 // GetNodeFieldSelector returns a nodename field selector.
-func (n *NodeType) GetNodeFieldSelector(noNodeAssigned bool) string {
-	if noNodeAssigned {
+func (n *NodeType) GetNodeFieldSelector(fetchUnscheduledPods bool) string {
+	if fetchUnscheduledPods {
 		if string(*n) != "" {
 			klog.Warningf("spec.nodeName=%s will not be used, because --enable-unscheduled-pods-fetching is set", string(*n))
 		}

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -130,6 +130,7 @@ func (n NodeType) AsSlice() []string {
 }
 
 func (n NodeType) String() string {
+	klog.InfoS("n.AsSlice()", n.AsSlice())
 	return strings.Join(n.AsSlice(), ",")
 }
 
@@ -151,6 +152,7 @@ func (n *NodeType) GetNodeFieldSelector() string {
 		klog.InfoS("Using spec.nodeName= to select unscheduable pods without node")
 		return "spec.nodeName="
 	}
+	klog.InfoS("Using spec.nodeName=", nodeName)
 	return fields.OneTermEqualSelector("spec.nodeName", nodeName).String()
 
 }

--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -190,6 +190,11 @@ func TestNodeFieldSelector(t *testing.T) {
 			Node:   "",
 			Wanted: "spec.nodeName=",
 		},
+		{
+			Desc:   "have node name when --enable-unscheduled-pods-fetching is set",
+			Node:   "",
+			Wanted: "spec.nodeName=",
+		},
 	}
 	for _, test := range tests1 {
 		node := test.Node

--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -175,30 +175,7 @@ func TestNodeFieldSelector(t *testing.T) {
 
 	for _, test := range tests {
 		node := test.Node
-		actual := node.GetNodeFieldSelector(false)
-		if !reflect.DeepEqual(actual, test.Wanted) {
-			t.Errorf("Test error for Desc: %s. Want: %+v. Got: %+v.", test.Desc, test.Wanted, actual)
-		}
-	}
-	tests1 := []struct {
-		Desc   string
-		Node   NodeType
-		Wanted string
-	}{
-		{
-			Desc:   "empty node name",
-			Node:   "",
-			Wanted: "spec.nodeName=",
-		},
-		{
-			Desc:   "have node name when --track-unscheduled-pods is set",
-			Node:   "",
-			Wanted: "spec.nodeName=",
-		},
-	}
-	for _, test := range tests1 {
-		node := test.Node
-		actual := node.GetNodeFieldSelector(true)
+		actual := node.GetNodeFieldSelector()
 		if !reflect.DeepEqual(actual, test.Wanted) {
 			t.Errorf("Test error for Desc: %s. Want: %+v. Got: %+v.", test.Desc, test.Wanted, actual)
 		}
@@ -261,7 +238,7 @@ func TestMergeFieldSelectors(t *testing.T) {
 		ns := test.Namespaces
 		deniedNS := test.DeniedNamespaces
 		selector1 := ns.GetExcludeNSFieldSelector(deniedNS)
-		selector2 := test.Node.GetNodeFieldSelector(false)
+		selector2 := test.Node.GetNodeFieldSelector()
 		actual, err := MergeFieldSelectors([]string{selector1, selector2})
 		if err != nil {
 			t.Errorf("Test error for Desc: %s. Can't merge field selector %v.", test.Desc, err)

--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -191,7 +191,7 @@ func TestNodeFieldSelector(t *testing.T) {
 			Wanted: "spec.nodeName=",
 		},
 		{
-			Desc:   "have node name when --enable-unscheduled-pods-fetching is set",
+			Desc:   "have node name when --track-unscheduled-pods is set",
 			Node:   "",
 			Wanted: "spec.nodeName=",
 		},

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -187,9 +187,6 @@ set -e
 kubectl version
 
 # query kube-state-metrics image tag
-cat pkg/options/types.go
-sleep 3
-
 REGISTRY="registry.k8s.io/kube-state-metrics" make container
 docker images -a
 KUBE_STATE_METRICS_IMAGE_TAG=$(docker images -a|grep "${KUBE_STATE_METRICS_IMAGE_NAME}" |grep -v 'latest'|awk '{print $2}'|sort -u)
@@ -234,7 +231,6 @@ echo "start e2e test for kube-state-metrics"
 KSM_HTTP_METRICS_URL='http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy'
 KSM_TELEMETRY_URL='http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:telemetry/proxy'
 
-kubectl --namespace=kube-system logs deployment/kube-state-metrics kube-state-metrics
 go test -v ./tests/e2e/main_test.go --ksm-http-metrics-url=${KSM_HTTP_METRICS_URL} --ksm-telemetry-url=${KSM_TELEMETRY_URL}
 
 # TODO: re-implement the following test cases in Go with the goal of removing this file.

--- a/tests/e2e/testdata/pods.yaml
+++ b/tests/e2e/testdata/pods.yaml
@@ -26,7 +26,7 @@ spec:
       - command:
         - /agnhost
         - netexec
-        - --http-port=8080q
+        - --http-port=8080
         image: registry.k8s.io/e2e-test-images/agnhost:2.39
         imagePullPolicy: IfNotPresent
         name: agnhost

--- a/tests/e2e/testdata/pods.yaml
+++ b/tests/e2e/testdata/pods.yaml
@@ -27,7 +27,7 @@ spec:
         - /agnhost
         - netexec
         - --http-port=8080
-        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        image: registry.k8s.io/e2e-test-images/agnhost@sha256:7e8bdd271312fd25fc5ff5a8f04727be84044eb3d7d8d03611972a6752e2e11e # 2.39
         imagePullPolicy: IfNotPresent
         name: agnhost
         terminationMessagePath: /dev/termination-log
@@ -64,7 +64,7 @@ spec:
         - /agnhost
         - netexec
         - --http-port=8080
-        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        image: registry.k8s.io/e2e-test-images/agnhost@sha256:7e8bdd271312fd25fc5ff5a8f04727be84044eb3d7d8d03611972a6752e2e11e # 2.39
         imagePullPolicy: IfNotPresent
         name: agnhost
         terminationMessagePath: /dev/termination-log

--- a/tests/e2e/testdata/pods.yaml
+++ b/tests/e2e/testdata/pods.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: pendingpod2
+  name: pendingpod2
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pendingpod2
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: pendingpod2
+    spec:
+      nodeSelector:
+        debug-node: "non"
+      containers:
+      - command:
+        - /agnhost
+        - netexec
+        - --http-port=8080q
+        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        imagePullPolicy: IfNotPresent
+        name: agnhost
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: runningpod1
+  name: runningpod1
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: runningpod1
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: runningpod1
+    spec:
+      containers:
+      - command:
+        - /agnhost
+        - netexec
+        - --http-port=8080
+        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        imagePullPolicy: IfNotPresent
+        name: agnhost
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kube-state-metrics/issues/2353

Tested using minikube
