### PR TITLE
ci: least privileged GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/openvex.yml
+++ b/.github/workflows/openvex.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+
+permissions:
+  contents: read
+
 jobs:
   vexctl:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The `GITHUB_TOKEN` is an automatically generated secret to make authenticated calls to the GitHub API. GitHub recommends setting minimum token permissions for the `GITHUB_TOKEN`, otherwise attackers may use a compromised token with write access to, for example, push malicious code into the project.

Found in [CLOMonitor Checks](https://clomonitor.io/projects/cncf/kube-state-metrics#kube-state-metrics_security) and [OpenSSF Scorecard Report](https://securityscorecards.dev/viewer/?uri=github.com/kubernetes/kube-state-metrics).

**How does this change affect the cardinality of KSM**:

Does not change cardinality

**Which issue(s) this PR fixes**:

Part of #2274