### PR TITLE
ci: publish openvex on release

### DIFF
--- a/.github/workflows/openvex.yml
+++ b/.github/workflows/openvex.yml
@@ -3,7 +3,8 @@ name: openvex
 on:
   workflow_dispatch:
   release:
-    types: [published]
+    types:
+      - released
 
 permissions:
   contents: read

--- a/.github/workflows/openvex.yml
+++ b/.github/workflows/openvex.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - name: Set environment variables
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
@@ -33,4 +34,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ env.RELEASE_VERSION }} kube-state-metrics.openvex.json
+          gh release upload ${{ env.RELEASE_VERSION }} kube-state-metrics.openvex.json

--- a/.github/workflows/openvex.yml
+++ b/.github/workflows/openvex.yml
@@ -16,8 +16,16 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set environment variables
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - uses: openvex/generate-vex@c59881b41451d7ccba5c3b74cd195382b8971fcd
         # Refer: https://github.com/openvex/vexctl#operational-model
         name: Run vexctl
         with:
             product: pkg:golang/k8s.io/kube-state-metrics/v2@${{ env.RELEASE_VERSION }}
+            file: kube-state-metrics.openvex.json
+
+      - name: Upload OpenVEX document to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ env.RELEASE_VERSION }} kube-state-metrics.openvex.json

--- a/.github/workflows/openvex.yml
+++ b/.github/workflows/openvex.yml
@@ -12,6 +12,10 @@ permissions:
 jobs:
   vexctl:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Append OpenVEX data to release, not just to stdout

**How does this change affect the cardinality of KSM**:

Does not change cardinality

**Which issue(s) this PR fixes**:

Part of https://github.com/kubernetes/kube-state-metrics/issues/2274
