### PR TITLE
docs: add policy for consuming and upgrading dependencies

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -32,6 +32,8 @@ dependencies:
   dependencies-lists:
     - https://github.com/kubernetes/kube-state-metrics/blob/main/go.mod
     - https://github.com/kubernetes/kube-state-metrics/blob/main/Dockerfile
+  env-dependencies-policy:
+    policy-url: https://github.com/kubernetes/kube-state-metrics/blob/main/docs/dependencies-policy.md
 documentation:
     - https://github.com/kubernetes/kube-state-metrics/tree/main/docs
 security-testing:

--- a/docs/dependencies-policy.md
+++ b/docs/dependencies-policy.md
@@ -1,0 +1,43 @@
+# Dependencies Policy
+
+## Purpose
+
+This policy describes how kube-state-metrics maintainers consume third-party packages.
+
+## Scope
+
+This policy applies to all kube-state-metrics maintainers and all third-party packages used in the kube-state-metrics project.
+
+## Policy
+
+kube-state-metrics maintainers must follow these guidelines when consuming third-party packages:
+
+- Only use third-party packages that are necessary for the functionality of kube-state-metrics.
+- Use the latest version of all third-party packages whenever possible.
+- Avoid using third-party packages that are known to have security vulnerabilities.
+- Pin all third-party packages to specific versions in the kube-state-metrics codebase.
+- Use a dependency management tool, such as Go modules, to manage third-party dependencies.
+
+## Procedure
+
+When adding a new third-party package to kube-state-metrics, maintainers must follow these steps:
+
+1. Evaluate the need for the package. Is it necessary for the functionality of kube-state-metrics? 
+2. Research the package. Is it actively maintained? Does it have a good reputation? 
+3. Choose a version of the package. Use the latest version whenever possible. 
+4. Pin the package to the specific version in the kube-state-metrics codebase. 
+5. Update the kube-state-metrics documentation to reflect the new dependency.
+
+## Enforcement
+
+This policy is enforced by the kube-state-metrics maintainers.
+
+Maintainers are expected to review each other's code changes to ensure that they comply with this policy.
+
+## Exceptions
+
+Exceptions to this policy may be granted by the kube-state-metrics project owners on a case-by-case basis.
+
+## Credits
+
+This policy was adapted from Kubescape's [Environment Dependencies Policy](https://github.com/kubescape/kubescape/blob/master/docs/environment-dependencies-policy.md).

--- a/docs/dependencies-policy.md
+++ b/docs/dependencies-policy.md
@@ -12,20 +12,20 @@ This policy applies to all kube-state-metrics maintainers and all third-party pa
 
 kube-state-metrics maintainers must follow these guidelines when consuming third-party packages:
 
-- Only use third-party packages that are necessary for the functionality of kube-state-metrics.
-- Use the latest version of all third-party packages whenever possible.
-- Avoid using third-party packages that are known to have security vulnerabilities.
-- Pin all third-party packages to specific versions in the kube-state-metrics codebase.
-- Use a dependency management tool, such as Go modules, to manage third-party dependencies.
+* Only use third-party packages that are necessary for the functionality of kube-state-metrics.
+* Use the latest version of all third-party packages whenever possible.
+* Avoid using third-party packages that are known to have security vulnerabilities.
+* Pin all third-party packages to specific versions in the kube-state-metrics codebase.
+* Use a dependency management tool, such as Go modules, to manage third-party dependencies.
 
 ## Procedure
 
 When adding a new third-party package to kube-state-metrics, maintainers must follow these steps:
 
-1. Evaluate the need for the package. Is it necessary for the functionality of kube-state-metrics? 
-2. Research the package. Is it actively maintained? Does it have a good reputation? 
-3. Choose a version of the package. Use the latest version whenever possible. 
-4. Pin the package to the specific version in the kube-state-metrics codebase. 
+1. Evaluate the need for the package. Is it necessary for the functionality of kube-state-metrics?
+2. Research the package. Is it actively maintained? Does it have a good reputation?
+3. Choose a version of the package. Use the latest version whenever possible.
+4. Pin the package to the specific version in the kube-state-metrics codebase.
 5. Update the kube-state-metrics documentation to reflect the new dependency.
 
 ## Enforcement


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Improve documentation by communicating the project’s policy for consuming and upgrading dependencies

Adapted from Kubescape

Should pass https://clomonitor.io/docs/topics/checks/#dependencies-policy after merge

**How does this change affect the cardinality of KSM**:

Does not change cardinality

**Which issue(s) this PR fixes**:

Part of https://github.com/kubernetes/kube-state-metrics/issues/2274
