### PR TITLE
docs(options): Slightly improve comments for the `NodeType` set type

### DIFF
--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -105,10 +105,10 @@ func (r *ResourceSet) Type() string {
 	return "string"
 }
 
-// NodeType represents a nodeName to query from.
+// NodeType represents a set of nodeNames to query from.
 type NodeType map[string]struct{}
 
-// Set converts a comma-separated string of nodename into a slice and appends it to the NodeList
+// Set splits a comma-separated string of nodeNames and appends them to the NodeType set
 func (n *NodeType) Set(value string) error {
 	s := *n
 	cols := strings.Split(value, ",")
@@ -121,7 +121,7 @@ func (n *NodeType) Set(value string) error {
 	return nil
 }
 
-// AsSlice returns the LabelsAllowList in the form of plain string slice.
+// AsSlice returns the NodeType set in the form of a plain string slice.
 func (n NodeType) AsSlice() []string {
 	cols := make([]string, 0, len(n))
 	for col := range n {
@@ -130,16 +130,17 @@ func (n NodeType) AsSlice() []string {
 	return cols
 }
 
+// String returns the NodeType set in the form of a comma-separated string.
 func (n NodeType) String() string {
 	return strings.Join(n.AsSlice(), ",")
 }
 
-// Type returns a descriptive string about the NodeList type.
+// Type returns a descriptive string about the NodeType set type.
 func (n *NodeType) Type() string {
 	return "string"
 }
 
-// GetNodeFieldSelector returns a nodename field selector.
+// GetNodeFieldSelector returns a nodeName field selector.
 func (n *NodeType) GetNodeFieldSelector() string {
 	if nil == n || len(*n) == 0 {
 		klog.InfoS("Using node type is nil")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Improves docs to help developers.

**How does this change affect the cardinality of KSM**: does not change cardinality

**Which issue(s) this PR fixes**: n/a

Updates: https://github.com/kubernetes/kube-state-metrics/commit/d1f04c2479c792d15e420255d5c6829fdd95766c