### PR TITLE
fix: add `readyz` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,11 +346,11 @@ After running the above, if you see `Clusterrolebinding "cluster-admin-binding" 
 
 #### Healthcheck Endpoints
 
-The following healthcheck endpoints are available, some of which are used to determine the result of the aforementioned probes:
+The following healthcheck endpoints are available (`self` refers to the telemetry port, while `main` refers to the exposition port):
 
-* `/healthz`: Returns a 200 status code if the application is running. We recommend to use this for the startup probe.
-* `/livez`: Returns a 200 status code if the application is not affected by an outage of the Kubernetes API Server. We recommend to using this for the liveness probe.
-* `/readyz`: Returns a 200 status code if the application is ready to accept traffic. We recommend using this for the readiness probe.
+* `/healthz` (exposed on `main`): Returns a 200 status code if the application is running. We recommend to use this for the startup probe.
+* `/livez` (exposed on `main`): Returns a 200 status code if the application is not affected by an outage of the Kubernetes API Server. We recommend to using this for the liveness probe.
+* `/readyz` (exposed on `self`): Returns a 200 status code if the application is ready to accept traffic. We recommend using this for the readiness probe.
 
 Note that it is discouraged to use the telemetry metrics endpoint for any probe when proxying the exposition data.
 

--- a/README.md
+++ b/README.md
@@ -348,9 +348,11 @@ After running the above, if you see `Clusterrolebinding "cluster-admin-binding" 
 
 The following healthcheck endpoints are available, some of which are used to determine the result of the aforementioned probes:
 
-* `/livez`: Returns a 200 status code if the application is not affected by an outage of the Kubernetes API Server. We recommend to use this as a liveness probe.
-* `/metrics`: Returns a 200 status code if the application is able to serve metrics. While this is available for both ports, we recommend to use the telemetry metrics endpoint as a readiness probe.
-* `/healthz`: Returns a 200 status code if the application is running. We recommend to use this as a startup probe.
+* `/healthz`: Returns a 200 status code if the application is running. We recommend to use this for the startup probe.
+* `/livez`: Returns a 200 status code if the application is not affected by an outage of the Kubernetes API Server. We recommend to using this for the liveness probe.
+* `/readyz`: Returns a 200 status code if the application is ready to accept traffic. We recommend using this for the readiness probe.
+
+Note that it is discouraged to use the telemetry metrics endpoint for any probe when proxying the exposition data.
 
 #### Limited privileges environment
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ The following healthcheck endpoints are available (`self` refers to the telemetr
 
 * `/healthz` (exposed on `main`): Returns a 200 status code if the application is running. We recommend to use this for the startup probe.
 * `/livez` (exposed on `main`): Returns a 200 status code if the application is not affected by an outage of the Kubernetes API Server. We recommend to using this for the liveness probe.
-* `/readyz` (exposed on `self`): Returns a 200 status code if the application is ready to accept traffic. We recommend using this for the readiness probe.
+* `/readyz` (exposed on `self`): Returns a 200 status code if the application is ready to accept requests and expose metrics. We recommend using this for the readiness probe.
 
 Note that it is discouraged to use the telemetry metrics endpoint for any probe when proxying the exposition data.
 

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -347,11 +347,11 @@ After running the above, if you see `Clusterrolebinding "cluster-admin-binding" 
 
 #### Healthcheck Endpoints
 
-The following healthcheck endpoints are available, some of which are used to determine the result of the aforementioned probes:
+The following healthcheck endpoints are available (`self` refers to the telemetry port, while `main` refers to the exposition port):
 
-* `/healthz`: Returns a 200 status code if the application is running. We recommend to use this for the startup probe.
-* `/livez`: Returns a 200 status code if the application is not affected by an outage of the Kubernetes API Server. We recommend to using this for the liveness probe.
-* `/readyz`: Returns a 200 status code if the application is ready to accept traffic. We recommend using this for the readiness probe.
+* `/healthz` (exposed on `main`): Returns a 200 status code if the application is running. We recommend to use this for the startup probe.
+* `/livez` (exposed on `main`): Returns a 200 status code if the application is not affected by an outage of the Kubernetes API Server. We recommend to using this for the liveness probe.
+* `/readyz` (exposed on `self`): Returns a 200 status code if the application is ready to accept traffic. We recommend using this for the readiness probe.
 
 Note that it is discouraged to use the telemetry metrics endpoint for any probe when proxying the exposition data.
 

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -349,9 +349,11 @@ After running the above, if you see `Clusterrolebinding "cluster-admin-binding" 
 
 The following healthcheck endpoints are available, some of which are used to determine the result of the aforementioned probes:
 
-* `/livez`: Returns a 200 status code if the application is not affected by an outage of the Kubernetes API Server. We recommend to use this as a liveness probe.
-* `/metrics`: Returns a 200 status code if the application is able to serve metrics. While this is available for both ports, we recommend to use the telemetry metrics endpoint as a readiness probe.
-* `/healthz`: Returns a 200 status code if the application is running. We recommend to use this as a startup probe.
+* `/healthz`: Returns a 200 status code if the application is running. We recommend to use this for the startup probe.
+* `/livez`: Returns a 200 status code if the application is not affected by an outage of the Kubernetes API Server. We recommend to using this for the liveness probe.
+* `/readyz`: Returns a 200 status code if the application is ready to accept traffic. We recommend using this for the readiness probe.
+
+Note that it is discouraged to use the telemetry metrics endpoint for any probe when proxying the exposition data.
 
 #### Limited privileges environment
 

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -351,7 +351,7 @@ The following healthcheck endpoints are available (`self` refers to the telemetr
 
 * `/healthz` (exposed on `main`): Returns a 200 status code if the application is running. We recommend to use this for the startup probe.
 * `/livez` (exposed on `main`): Returns a 200 status code if the application is not affected by an outage of the Kubernetes API Server. We recommend to using this for the liveness probe.
-* `/readyz` (exposed on `self`): Returns a 200 status code if the application is ready to accept traffic. We recommend using this for the readiness probe.
+* `/readyz` (exposed on `self`): Returns a 200 status code if the application is ready to accept requests and expose metrics. We recommend using this for the readiness probe.
 
 Note that it is discouraged to use the telemetry metrics endpoint for any probe when proxying the exposition data.
 

--- a/examples/autosharding/statefulset.yaml
+++ b/examples/autosharding/statefulset.yaml
@@ -38,7 +38,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         name: kube-state-metrics
@@ -49,8 +49,8 @@ spec:
           name: telemetry
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: 8081
+            path: /readyz
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:

--- a/examples/autosharding/statefulset.yaml
+++ b/examples/autosharding/statefulset.yaml
@@ -50,7 +50,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: http-metrics
+            port: telemetry
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:

--- a/examples/daemonsetsharding/daemonset.yaml
+++ b/examples/daemonsetsharding/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: http-metrics
+            port: telemetry
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:

--- a/examples/daemonsetsharding/daemonset.yaml
+++ b/examples/daemonsetsharding/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         name: kube-state-metrics-shard
@@ -44,8 +44,8 @@ spec:
           name: telemetry
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: 8081
+            path: /readyz
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -40,7 +40,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: http-metrics
+            port: telemetry
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -28,7 +28,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         name: kube-state-metrics
@@ -39,8 +39,8 @@ spec:
           name: telemetry
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: 8081
+            path: /readyz
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:

--- a/examples/daemonsetsharding/deployment.yaml
+++ b/examples/daemonsetsharding/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: http-metrics
+            port: telemetry
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:

--- a/examples/daemonsetsharding/deployment.yaml
+++ b/examples/daemonsetsharding/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         name: kube-state-metrics
@@ -38,8 +38,8 @@ spec:
           name: telemetry
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: 8081
+            path: /readyz
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:

--- a/examples/standard/deployment.yaml
+++ b/examples/standard/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: http-metrics
+            port: telemetry
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:

--- a/examples/standard/deployment.yaml
+++ b/examples/standard/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         name: kube-state-metrics
@@ -36,8 +36,8 @@ spec:
           name: telemetry
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: 8081
+            path: /readyz
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -192,12 +192,12 @@
         seccompProfile: { type: 'RuntimeDefault' },
       },
       livenessProbe: { timeoutSeconds: 5, initialDelaySeconds: 5, httpGet: {
-        port: 8080,
+        port: "http-metrics",
         path: '/livez',
       } },
       readinessProbe: { timeoutSeconds: 5, initialDelaySeconds: 5, httpGet: {
-        port: 8081,
-        path: '/metrics',
+        port: "http-metrics",
+        path: '/readyz',
       } },
     };
 

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -196,7 +196,7 @@
         path: '/livez',
       } },
       readinessProbe: { timeoutSeconds: 5, initialDelaySeconds: 5, httpGet: {
-        port: "http-metrics",
+        port: "telemetry",
         path: '/readyz',
       } },
     };

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -42,7 +42,6 @@ import (
 	versionCollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
 
@@ -380,7 +379,7 @@ func buildTelemetryServer(registry prometheus.Gatherer) *http.ServeMux {
 
 	// Add readyzPath
 	mux.Handle(readyzPath, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		count, err := testutil.GatherAndCount(registry)
+		count, err := util.GatherAndCount(registry)
 		if err != nil || count == 0 {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Write([]byte(http.StatusText(http.StatusServiceUnavailable)))
@@ -440,7 +439,10 @@ func buildMetricsServer(m *metricshandler.MetricsHandler, durationObserver prome
 	mux.Handle(livezPath, handleClusterDelegationForProber(client, livezPath))
 
 	// Add healthzPath
-	mux.Handle(healthzPath, handleClusterDelegationForProber(client, healthzPath))
+	mux.HandleFunc(healthzPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(http.StatusText(http.StatusOK)))
+	})
 
 	// Add index
 	landingConfig := web.LandingConfig{


### PR DESCRIPTION
Discourage the usage of `/metrics` for any probe, and use `/readyz` in place of the earlier telemetry metrics endpoint to secure the exposition data.

/cc @mrueg 
