### PR TITLE
ci: missing line break escape on sbom workflow

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -31,7 +31,7 @@ jobs:
           bom generate \
             --dirs=. \
             --image=registry.k8s.io/kube-state-metrics/kube-state-metrics:$TAG \
-            --namespace=https://github.com/kubernetes/kube-state-metrics/releases/download/$TAG/$OUTPUT
+            --namespace=https://github.com/kubernetes/kube-state-metrics/releases/download/$TAG/$OUTPUT \
             --output=$OUTPUT
 
       - name: Upload SBOM to GitHub Release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Generate SBOM with Kubernetes BOM workflow fails because of missing line break escape

https://github.com/kubernetes/kube-state-metrics/actions/runs/10009598032/job/27669716084#step:4:13122

**How does this change affect the cardinality of KSM**:

Does not change cardinality

**Which issue(s) this PR fixes**:

None