### PR TITLE
fix: syntax errors in kube-state-metrics.libsonnet

### DIFF
--- a/examples/daemonsetsharding/deployment-no-node-pods-service.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods-service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics-no-node-pods
-    app.kubernetes.io/version: 2.12.0
+    app.kubernetes.io/version: 2.13.0
   name: kube-state-metrics-no-node-pods
   namespace: kube-system
 spec:

--- a/examples/daemonsetsharding/deployment-no-node-pods.yaml
+++ b/examples/daemonsetsharding/deployment-no-node-pods.yaml
@@ -3,20 +3,20 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/name: kube-state-metrics-no-node-pods
+    app.kubernetes.io/name: kube-state-metrics-unscheduled-pods-fetching
     app.kubernetes.io/version: 2.13.0
-  name: kube-state-metrics-no-node-pods
+  name: kube-state-metrics-unscheduled-pods-fetching
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: kube-state-metrics-no-node-pods
+      app.kubernetes.io/name: kube-state-metrics-unscheduled-pods-fetching
   template:
     metadata:
       labels:
         app.kubernetes.io/component: exporter
-        app.kubernetes.io/name: kube-state-metrics-no-node-pods
+        app.kubernetes.io/name: kube-state-metrics-unscheduled-pods-fetching
         app.kubernetes.io/version: 2.13.0
     spec:
       automountServiceAccountToken: true
@@ -31,7 +31,7 @@ spec:
             port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
-        name: kube-state-metrics-no-node-pods
+        name: kube-state-metrics-unscheduled-pods-fetching
         ports:
         - containerPort: 8080
           name: http-metrics

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -1,4 +1,3 @@
-
 {
   local ksm = self,
   name:: error 'must set namespace',
@@ -164,7 +163,7 @@
         ],
         verbs: ['list', 'watch'],
       },
-     ];
+    ];
 
     {
       apiVersion: 'rbac.authorization.k8s.io/v1',
@@ -192,11 +191,11 @@
         seccompProfile: { type: 'RuntimeDefault' },
       },
       livenessProbe: { timeoutSeconds: 5, initialDelaySeconds: 5, httpGet: {
-        port: "http-metrics",
+        port: 'http-metrics',
         path: '/livez',
       } },
       readinessProbe: { timeoutSeconds: 5, initialDelaySeconds: 5, httpGet: {
-        port: "telemetry",
+        port: 'telemetry',
         path: '/readyz',
       } },
     };
@@ -344,16 +343,17 @@
     clusterRoleBinding: ksm.clusterRoleBinding,
   },
   daemonsetsharding:: {
-    local shardksmname = ksm.name + "-shard",
-		daemonsetService: std.mergePatch(ksm.service,
-       {
-				 metadata: {
-					 name: shardksmname,
-					 labels: {'app.kubernetes.io/name': shardksmname}
-				 },
-			   spec: {selector: {'app.kubernetes.io/name': shardksmname}},
-			 }
-		),
+    local shardksmname = ksm.name + '-shard',
+    daemonsetService: std.mergePatch(
+      ksm.service,
+      {
+        metadata: {
+          name: shardksmname,
+          labels: { 'app.kubernetes.io/name': shardksmname },
+        },
+        spec: { selector: { 'app.kubernetes.io/name': shardksmname } },
+      }
+    ),
     deployment:
       // extending the default container from above
       local c = ksm.deployment.spec.template.spec.containers[0] {
@@ -361,7 +361,8 @@
           '--resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments',
         ],
       };
-      std.mergePatch(ksm.deployment,
+      std.mergePatch(
+        ksm.deployment,
         {
           spec: {
             template: {
@@ -374,6 +375,7 @@
       ),
 
     deploymentNoNodePods:
+      local shardksmname = ksm.name + '-unscheduled-pods-fetching';
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
           '--resources=pods',
@@ -381,23 +383,23 @@
         ],
         name: shardksmname,
       };
-      local shardksmname = ksm.name + "-unscheduled-pods-fetching";
-      std.mergePatch(ksm.deployment,
+      std.mergePatch(
+        ksm.deployment,
         {
           metadata: {
             name: shardksmname,
-            labels: {'app.kubernetes.io/name': shardksmname}
+            labels: { 'app.kubernetes.io/name': shardksmname },
           },
           spec: {
-            selector{
-              matchLabels: {app.kubernetes.io/name': shardksmname}
-            }
+            selector: {
+              matchLabels: { 'app.kubernetes.io/name': shardksmname },
+            },
             template: {
               metadata: {
                 labels: {
-                  app.kubernetes.io/name': shardksmname
-                }
-              }
+                  'app.kubernetes.io/name': shardksmname,
+                },
+              },
               spec: {
                 containers: [c],
               },
@@ -413,18 +415,19 @@
           '--track-unscheduled-pods',
         ],
       };
-      local shardksmname = ksm.name + "-no-node-pods";
-      std.mergePatch(ksm.service,
+      local shardksmname = ksm.name + '-no-node-pods';
+      std.mergePatch(
+        ksm.service,
         {
           metadata: {
             name: shardksmname,
-            labels: {'app.kubernetes.io/name': shardksmname}
+            labels: { 'app.kubernetes.io/name': shardksmname },
           },
           spec: {
             selector: {
-              'app.kubernetes.io/name': shardksmname
-            }
-          }
+              'app.kubernetes.io/name': shardksmname,
+            },
+          },
         }
       ),
     daemonset:
@@ -439,10 +442,10 @@
         ],
       };
 
-      local c = std.mergePatch(c0, {name: shardksmname});
+      local c = std.mergePatch(c0, { name: shardksmname });
 
-      local ksmLabels =  std.mergePatch(ksm.commonLabels + ksm.extraRecommendedLabels, {'app.kubernetes.io/name': shardksmname});
-      local ksmPodLabels =  std.mergePatch(ksm.podLabels, {'app.kubernetes.io/name': shardksmname});
+      local ksmLabels = std.mergePatch(ksm.commonLabels + ksm.extraRecommendedLabels, { 'app.kubernetes.io/name': shardksmname });
+      local ksmPodLabels = std.mergePatch(ksm.podLabels, { 'app.kubernetes.io/name': shardksmname });
 
       {
         apiVersion: 'apps/v1',
@@ -450,7 +453,7 @@
         metadata: {
           namespace: ksm.namespace,
           labels: ksmLabels,
-					name: shardksmname,
+          name: shardksmname,
         },
         spec: {
           selector: { matchLabels: ksmPodLabels },
@@ -475,5 +478,3 @@
     clusterRoleBinding: ksm.clusterRoleBinding,
   },
 }
-
-


### PR DESCRIPTION
Previously customizing kube-prometheus [1] failed with the following
error.

    ❯ ./build.sh example.jsonnet
    + set -o pipefail
    + rm -rf manifests
    + mkdir -p manifests/setup
    + jsonnet -J vendor -m manifests example.jsonnet
    + xargs '-I{}' sh -c 'cat {} | gojsontoyaml > {}.yaml' -- '{}'
    RUNTIME ERROR: vendor/github.com/kubernetes/kube-state-metrics/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet:392:21-22 Expected token OPERATOR but got "{"
            vendor/kube-prometheus/components/kube-state-metrics.libsonnet:51:19-124        function <anonymous>
            vendor/kube-prometheus/main.libsonnet:136:21-64 object <anonymous>
            vendor/kube-prometheus/platforms/platforms.libsonnet:37:22-40   +:
            example.jsonnet:33:90-109       thunk from <$>
            <std>:1539:24-25        thunk from <function <anonymous>>
            <std>:1539:5-33 function <anonymous>
            example.jsonnet:33:73-110       $
            example.jsonnet:33:1-112
            example.jsonnet:33:1-112
            During evaluation

With this patch, the build succeeds:

    ❯ bash build.sh example.jsonnet ; echo $?
    + set -o pipefail
    + rm -rf manifests
    + mkdir -p manifests/setup
    + jsonnet -J vendor -m manifests example.jsonnet
    + xargs '-I{}' sh -c 'cat {} | gojsontoyaml > {}.yaml' -- '{}'
    + find manifests -type f '!' -name '*.yaml' -delete
    + rm -f kustomization
    0

[1]: https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/customizing.md

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Quick follow up fix to syntax errors introduced in #2388 affecting kube-prometheus customization.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

Does not change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Unknown, see #2388
