### PR TITLE
fix:  modify kube-state-metrics.libsonnet  spelling mistake

### DIFF
--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -389,15 +389,15 @@
             labels: {'app.kubernetes.io/name': shardksmname}
           },
           spec: {
-            selector{
-              matchLabels: {app.kubernetes.io/name': shardksmname}
+            selector: {
+              matchLabels: {'app.kubernetes.io/name': shardksmname}
             }
             template: {
               metadata: {
                 labels: {
-                  app.kubernetes.io/name': shardksmname
+                  'app.kubernetes.io/name': shardksmname
                 }
-              }
+              },
               spec: {
                 containers: [c],
               },


### PR DESCRIPTION
I found kube-state-metris jsonnet format error when I build monitoring yaml  relating to kube-prometheus project.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-procesDiscuss and review the changes in this comparison with others. Learn about pull requests
￼Create pull request
s and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


**Which issue(s) this PR fixes**:  https://github.com/kubernetes/kube-state-metrics/issues/2460
