### PR TITLE
chore: Bump e2e kind node to 1.30

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -25,7 +25,7 @@ case $(uname -m) in
 esac
 
 NODE_IMAGE_NAME="docker.io/kindest/node"
-KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.29.0"}
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.30.0"}
 KUBE_STATE_METRICS_LOG_DIR=./log
 KUBE_STATE_METRICS_CURRENT_IMAGE_NAME="registry.k8s.io/kube-state-metrics/kube-state-metrics"
 KUBE_STATE_METRICS_IMAGE_NAME="registry.k8s.io/kube-state-metrics/kube-state-metrics-${ARCH}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This was missed when I bumped k8s libs to 1.30.0

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
