### PR TITLE
chore: Memory align structs

### DIFF
--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -37,18 +37,18 @@ type kindPlural struct {
 
 // CRDiscoverer provides a cache of the collected GVKs, along with helper utilities.
 type CRDiscoverer struct {
-	// m is a mutex to protect the cache.
-	m sync.RWMutex
-	// Map is a cache of the collected GVKs.
-	Map map[string]map[string][]kindPlural
-	// ShouldUpdate is a flag that indicates whether the cache was updated.
-	WasUpdated bool
 	// CRDsAddEventsCounter tracks the number of times that the CRD informer triggered the "add" event.
 	CRDsAddEventsCounter prometheus.Counter
 	// CRDsDeleteEventsCounter tracks the number of times that the CRD informer triggered the "remove" event.
 	CRDsDeleteEventsCounter prometheus.Counter
 	// CRDsCacheCountGauge tracks the net amount of CRDs affecting the cache at this point.
 	CRDsCacheCountGauge prometheus.Gauge
+	// Map is a cache of the collected GVKs.
+	Map map[string]map[string][]kindPlural
+	// m is a mutex to protect the cache.
+	m sync.RWMutex
+	// ShouldUpdate is a flag that indicates whether the cache was updated.
+	WasUpdated bool
 }
 
 // SafeRead executes the given function while holding a read lock.

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -65,24 +65,24 @@ var _ ksmtypes.BuilderInterface = &Builder{}
 // Builder helps to build store. It follows the builder pattern
 // (https://en.wikipedia.org/wiki/Builder_pattern).
 type Builder struct {
-	kubeClient            clientset.Interface
-	customResourceClients map[string]interface{}
-	namespaces            options.NamespaceList
-	// namespaceFilter is inside fieldSelectorFilter
-	fieldSelectorFilter           string
+	kubeClient                    clientset.Interface
 	ctx                           context.Context
-	enabledResources              []string
 	familyGeneratorFilter         generator.FamilyGeneratorFilter
+	customResourceClients         map[string]interface{}
 	listWatchMetrics              *watch.ListWatchMetrics
 	shardingMetrics               *sharding.Metrics
-	shard                         int32
-	totalShards                   int
 	buildStoresFunc               ksmtypes.BuildStoresFunc
 	buildCustomResourceStoresFunc ksmtypes.BuildCustomResourceStoresFunc
 	allowAnnotationsList          map[string][]string
 	allowLabelsList               map[string][]string
-	useAPIServerCache             bool
 	utilOptions                   *options.Options
+	// namespaceFilter is inside fieldSelectorFilter
+	fieldSelectorFilter string
+	namespaces          options.NamespaceList
+	enabledResources    []string
+	totalShards         int
+	shard               int32
+	useAPIServerCache   bool
 }
 
 // NewBuilder returns a new builder.

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -1349,14 +1349,14 @@ func createPodStatusPhaseFamilyGenerator() generator.FamilyGenerator {
 			}
 
 			phases := []struct {
-				v bool
 				n string
+				v bool
 			}{
-				{phase == v1.PodPending, string(v1.PodPending)},
-				{phase == v1.PodSucceeded, string(v1.PodSucceeded)},
-				{phase == v1.PodFailed, string(v1.PodFailed)},
-				{phase == v1.PodUnknown, string(v1.PodUnknown)},
-				{phase == v1.PodRunning, string(v1.PodRunning)},
+				{string(v1.PodPending), phase == v1.PodPending},
+				{string(v1.PodSucceeded), phase == v1.PodSucceeded},
+				{string(v1.PodFailed), phase == v1.PodFailed},
+				{string(v1.PodUnknown), phase == v1.PodUnknown},
+				{string(v1.PodRunning), phase == v1.PodRunning},
 			}
 
 			ms := make([]*metric.Metric, len(phases))
@@ -1475,12 +1475,12 @@ func createPodStatusQosClassFamilyGenerator() generator.FamilyGenerator {
 			}
 
 			qosClasses := []struct {
-				v bool
 				n string
+				v bool
 			}{
-				{class == v1.PodQOSBestEffort, string(v1.PodQOSBestEffort)},
-				{class == v1.PodQOSBurstable, string(v1.PodQOSBurstable)},
-				{class == v1.PodQOSGuaranteed, string(v1.PodQOSGuaranteed)},
+				{string(v1.PodQOSBestEffort), class == v1.PodQOSBestEffort},
+				{string(v1.PodQOSBurstable), class == v1.PodQOSBurstable},
+				{string(v1.PodQOSGuaranteed), class == v1.PodQOSGuaranteed},
 			}
 
 			ms := make([]*metric.Metric, len(qosClasses))

--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -31,12 +31,12 @@ import (
 
 type generateMetricsTestCase struct {
 	Obj                  interface{}
+	Func                 func(interface{}) []metric.FamilyInterface
+	Want                 string
 	MetricNames          []string
 	AllowAnnotationsList []string
 	AllowLabelsList      []string
-	Want                 string
 	Headers              []string
-	Func                 func(interface{}) []metric.FamilyInterface
 }
 
 func (testCase *generateMetricsTestCase) run() error {

--- a/pkg/customresourcestate/config_metrics_types.go
+++ b/pkg/customresourcestate/config_metrics_types.go
@@ -27,12 +27,12 @@ type MetricMeta struct {
 // MetricGauge targets a Path that may be a single value, array, or object. Arrays and objects will generate a metric per element.
 // Ref: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#gauge
 type MetricGauge struct {
-	MetricMeta `yaml:",inline" json:",inline"`
+	// LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
+	LabelFromKey string `yaml:"labelFromKey" json:"labelFromKey"`
+	MetricMeta   `yaml:",inline" json:",inline"`
 
 	// ValueFrom is the path to a numeric field under Path that will be the metric value.
 	ValueFrom []string `yaml:"valueFrom" json:"valueFrom"`
-	// LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
-	LabelFromKey string `yaml:"labelFromKey" json:"labelFromKey"`
 	// NilIsZero indicates that if a value is nil it will be treated as zero value.
 	NilIsZero bool `yaml:"nilIsZero" json:"nilIsZero"`
 }
@@ -40,9 +40,9 @@ type MetricGauge struct {
 // MetricInfo is a metric which is used to expose textual information.
 // Ref: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#info
 type MetricInfo struct {
-	MetricMeta `yaml:",inline" json:",inline"`
 	// LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
 	LabelFromKey string `yaml:"labelFromKey" json:"labelFromKey"`
+	MetricMeta   `yaml:",inline" json:",inline"`
 }
 
 // MetricStateSet is a metric which represent a series of related boolean values, also called a bitset.

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -124,8 +124,8 @@ type compiledEach compiledMetric
 
 type compiledCommon struct {
 	labelFromPath map[string]valuePath
-	path          valuePath
 	t             metric.Type
+	path          valuePath
 }
 
 func (c compiledCommon) Path() valuePath {
@@ -211,9 +211,9 @@ func newCompiledMetric(m Metric) (compiledMetric, error) {
 
 type compiledGauge struct {
 	compiledCommon
+	labelFromKey string
 	ValueFrom    valuePath
 	NilIsZero    bool
-	labelFromKey string
 }
 
 func (c *compiledGauge) Values(v interface{}) (result []eachValue, errs []error) {
@@ -376,9 +376,9 @@ func (c *compiledInfo) values(v interface{}) (result []eachValue, err []error) {
 
 type compiledStateSet struct {
 	compiledCommon
+	LabelName string
 	ValueFrom valuePath
 	List      []string
-	LabelName string
 }
 
 func (c *compiledStateSet) Values(v interface{}) (result []eachValue, errs []error) {
@@ -495,11 +495,11 @@ func (e eachValue) ToMetric() *metric.Metric {
 }
 
 type compiledFamily struct {
-	Name          string
-	Help          string
 	Each          compiledEach
 	Labels        map[string]string
 	LabelFromPath map[string]valuePath
+	Name          string
+	Help          string
 	ErrorLogV     klog.Level
 }
 
@@ -547,8 +547,8 @@ func addPathLabels(obj interface{}, labels map[string]valuePath, result map[stri
 }
 
 type pathOp struct {
-	part string
 	op   func(interface{}) interface{}
+	part string
 }
 
 type valuePath []pathOp

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -30,13 +30,13 @@ import (
 // DeprecatedVersion is defined only if the metric for which this options applies is,
 // in fact, deprecated.
 type FamilyGenerator struct {
+	GenerateFunc      func(obj interface{}) *metric.Family
 	Name              string
 	Help              string
 	Type              metric.Type
-	OptIn             bool
 	DeprecatedVersion string
 	StabilityLevel    basemetrics.StabilityLevel
-	GenerateFunc      func(obj interface{}) *metric.Family
+	OptIn             bool
 }
 
 // NewFamilyGeneratorWithStability creates new FamilyGenerator instances with metric

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -29,21 +29,22 @@ import (
 // interface. Instead of storing entire Kubernetes objects, it stores metrics
 // generated based on those objects.
 type MetricsStore struct {
-	// Protects metrics
-	mutex sync.RWMutex
 	// metrics is a map indexed by Kubernetes object id, containing a slice of
 	// metric families, containing a slice of metrics. We need to keep metrics
 	// grouped by metric families in order to zip families with their help text in
 	// MetricsStore.WriteAll().
 	metrics map[types.UID][][]byte
+
+	// generateMetricsFunc generates metrics based on a given Kubernetes object
+	// and returns them grouped by metric family.
+	generateMetricsFunc func(interface{}) []metric.FamilyInterface
 	// headers contains the header (TYPE and HELP) of each metric family. It is
 	// later on zipped with with their corresponding metric families in
 	// MetricStore.WriteAll().
 	headers []string
 
-	// generateMetricsFunc generates metrics based on a given Kubernetes object
-	// and returns them grouped by metric family.
-	generateMetricsFunc func(interface{}) []metric.FamilyInterface
+	// Protects metrics
+	mutex sync.RWMutex
 }
 
 // NewMetricsStore returns a new MetricsStore

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -44,18 +44,18 @@ import (
 // MetricsHandler is a http.Handler that exposes the main kube-state-metrics
 // /metrics endpoint. It allows concurrent reconfiguration at runtime.
 type MetricsHandler struct {
-	opts               *options.Options
-	kubeClient         kubernetes.Interface
-	storeBuilder       ksmtypes.BuilderInterface
-	enableGZIPEncoding bool
+	kubeClient   kubernetes.Interface
+	storeBuilder ksmtypes.BuilderInterface
+	opts         *options.Options
 
 	cancel func()
 
 	// mtx protects metricsWriters, curShard, and curTotalShards
-	mtx            *sync.RWMutex
-	metricsWriters metricsstore.MetricsWriterList
-	curShard       int32
-	curTotalShards int
+	mtx                *sync.RWMutex
+	metricsWriters     metricsstore.MetricsWriterList
+	curTotalShards     int
+	curShard           int32
+	enableGZIPEncoding bool
 }
 
 // New creates and returns a new MetricsHandler with the given options.

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -40,43 +40,45 @@ var (
 
 // Options are the configurable parameters for kube-state-metrics.
 type Options struct {
-	AnnotationsAllowList     LabelsAllowList `yaml:"annotations_allow_list"`
-	Apiserver                string          `yaml:"apiserver"`
-	AutoGoMemlimit           bool            `yaml:"auto-gomemlimit"`
-	AutoGoMemlimitRatio      float64         `yaml:"auto-gomemlimit-ratio"`
-	CustomResourceConfig     string          `yaml:"custom_resource_config"`
-	CustomResourceConfigFile string          `yaml:"custom_resource_config_file"`
-	CustomResourcesOnly      bool            `yaml:"custom_resources_only"`
-	EnableGZIPEncoding       bool            `yaml:"enable_gzip_encoding"`
-	Help                     bool            `yaml:"help"`
-	Host                     string          `yaml:"host"`
-	Kubeconfig               string          `yaml:"kubeconfig"`
-	LabelsAllowList          LabelsAllowList `yaml:"labels_allow_list"`
-	MetricAllowlist          MetricSet       `yaml:"metric_allowlist"`
-	MetricDenylist           MetricSet       `yaml:"metric_denylist"`
-	MetricOptInList          MetricSet       `yaml:"metric_opt_in_list"`
-	Namespace                string          `yaml:"namespace"`
-	Namespaces               NamespaceList   `yaml:"namespaces"`
-	NamespacesDenylist       NamespaceList   `yaml:"namespaces_denylist"`
-	Node                     NodeType        `yaml:"node"`
-	TrackUnscheduledPods     bool            `yaml:"track_unscheduled_pods"`
-	Pod                      string          `yaml:"pod"`
-	Port                     int             `yaml:"port"`
-	Resources                ResourceSet     `yaml:"resources"`
-	Shard                    int32           `yaml:"shard"`
-	TLSConfig                string          `yaml:"tls_config"`
-	TelemetryHost            string          `yaml:"telemetry_host"`
-	TelemetryPort            int             `yaml:"telemetry_port"`
-	TotalShards              int             `yaml:"total_shards"`
-	UseAPIServerCache        bool            `yaml:"use_api_server_cache"`
-	ServerReadTimeout        time.Duration   `yaml:"server_read_timeout"`
-	ServerWriteTimeout       time.Duration   `yaml:"server_write_timeout"`
-	ServerIdleTimeout        time.Duration   `yaml:"server_idle_timeout"`
-	ServerReadHeaderTimeout  time.Duration   `yaml:"server_read_header_timeout"`
+	AnnotationsAllowList LabelsAllowList `yaml:"annotations_allow_list"`
+	LabelsAllowList      LabelsAllowList `yaml:"labels_allow_list"`
+	MetricAllowlist      MetricSet       `yaml:"metric_allowlist"`
+	MetricDenylist       MetricSet       `yaml:"metric_denylist"`
+	MetricOptInList      MetricSet       `yaml:"metric_opt_in_list"`
+	Resources            ResourceSet     `yaml:"resources"`
+
+	cmd                      *cobra.Command
+	Apiserver                string   `yaml:"apiserver"`
+	CustomResourceConfig     string   `yaml:"custom_resource_config"`
+	CustomResourceConfigFile string   `yaml:"custom_resource_config_file"`
+	Host                     string   `yaml:"host"`
+	Kubeconfig               string   `yaml:"kubeconfig"`
+	Namespace                string   `yaml:"namespace"`
+	Node                     NodeType `yaml:"node"`
+	Pod                      string   `yaml:"pod"`
+	TLSConfig                string   `yaml:"tls_config"`
+	TelemetryHost            string   `yaml:"telemetry_host"`
 
 	Config string
 
-	cmd *cobra.Command
+	Namespaces              NamespaceList `yaml:"namespaces"`
+	NamespacesDenylist      NamespaceList `yaml:"namespaces_denylist"`
+	AutoGoMemlimitRatio     float64       `yaml:"auto-gomemlimit-ratio"`
+	Port                    int           `yaml:"port"`
+	TelemetryPort           int           `yaml:"telemetry_port"`
+	TotalShards             int           `yaml:"total_shards"`
+	ServerReadTimeout       time.Duration `yaml:"server_read_timeout"`
+	ServerWriteTimeout      time.Duration `yaml:"server_write_timeout"`
+	ServerIdleTimeout       time.Duration `yaml:"server_idle_timeout"`
+	ServerReadHeaderTimeout time.Duration `yaml:"server_read_header_timeout"`
+
+	Shard                int32 `yaml:"shard"`
+	AutoGoMemlimit       bool  `yaml:"auto-gomemlimit"`
+	CustomResourcesOnly  bool  `yaml:"custom_resources_only"`
+	EnableGZIPEncoding   bool  `yaml:"enable_gzip_encoding"`
+	Help                 bool  `yaml:"help"`
+	TrackUnscheduledPods bool  `yaml:"track_unscheduled_pods"`
+	UseAPIServerCache    bool  `yaml:"use_api_server_cache"`
 }
 
 // GetConfigFile is the getter for --config value.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This might shave off some bytes here and there using https://github.com/dkorunic/betteralign
```
pkg/metric_generator/generator.go:32:22: 16 bytes saved: struct with 96 pointer bytes could be 80
pkg/metrics_store/metrics_store.go:31:19: 40 bytes saved: struct with 64 pointer bytes could be 24
pkg/options/options.go:42:14: 24 bytes saved: struct of size 384 could be 360
internal/store/builder.go:67:14: 8 bytes saved: struct of size 200 could be 192
internal/store/pod.go:1351:16: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/store/pod.go:1477:20: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/store/testutils.go:32:30: 16 bytes saved: struct with 136 pointer bytes could be 120
pkg/metricshandler/metrics_handler.go:46:21: 8 bytes saved: struct of size 104 could be 96
internal/discovery/types.go:39:19: 32 bytes saved: struct with 88 pointer bytes could be 56
pkg/customresourcestate/config.go:51:15: 16 bytes saved: struct with 112 pointer bytes could be 96
pkg/customresourcestate/config.go:134:16: 8 bytes saved: struct with 88 pointer bytes could be 80
pkg/customresourcestate/config.go:150:13: 8 bytes saved: struct with 40 pointer bytes could be 32
pkg/customresourcestate/config_metrics_types.go:29:18: 8 bytes saved: struct with 64 pointer bytes could be 56
pkg/customresourcestate/config_metrics_types.go:42:17: 8 bytes saved: struct with 40 pointer bytes could be 32
pkg/customresourcestate/registry_factory.go:125:21: 8 bytes saved: struct with 40 pointer bytes could be 32
pkg/customresourcestate/registry_factory.go:212:20: 16 bytes saved: struct with 88 pointer bytes could be 72
pkg/customresourcestate/registry_factory.go:377:23: 8 bytes saved: struct with 104 pointer bytes could be 96
pkg/customresourcestate/registry_factory.go:497:21: 8 bytes saved: struct with 64 pointer bytes could be 56
pkg/customresourcestate/registry_factory.go:549:13: 8 bytes saved: struct with 24 pointer bytes could be 16
```

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
