### PR TITLE
docs: Fix outdated RegistryFactory.MetricFamilyGenerators comments

### DIFF
--- a/pkg/customresource/registry_factory.go
+++ b/pkg/customresource/registry_factory.go
@@ -50,7 +50,7 @@ type RegistryFactory interface {
 	//
 	// Example:
 	//
-	// func (f *FooFactory) MetricFamilyGenerators(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	// func (f *FooFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
 	//	return []generator.FamilyGenerator{
 	//		*generator.NewFamilyGeneratorWithStability(
 	//			"kube_foo_spec_replicas",


### PR DESCRIPTION
**What this PR does / why we need it**:
Previous PR https://github.com/kubernetes/kube-state-metrics/commit/25a1d8da057cf761d614c59a52785335d34082d1 forgot to update the comments, so the current comment is outdated.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
No, this is only a comment change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
