### PR TITLE
customresourcestate: don't error on missing status stateSet

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -397,10 +397,16 @@ func (c *compiledStateSet) Values(v interface{}) (result []eachValue, errs []err
 	return c.values(v)
 }
 
+const statusPart = "status"
+
 func (c *compiledStateSet) values(v interface{}) (result []eachValue, errs []error) {
 	comparable := c.ValueFrom.Get(v)
 	value, ok := comparable.(string)
 	if !ok {
+		if len(c.path) > 0 && c.path[0].part == statusPart {
+			klog.V(2).InfoS("Skipping unavailable resource status", "path", c.path)
+			return []eachValue{}, []error{}
+		}
 		return []eachValue{}, []error{fmt.Errorf("%s: expected value for path to be string, got %T", c.path, comparable)}
 	}
 


### PR DESCRIPTION
It's legitimate for new objects to not have status fields. Especially if controller is unavailable. Such errors are printed for every resource and can mask actual problems. Instead, log in verbose mode to allow troubleshooting.

Fixes #2482

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
