### PR TITLE
fix: set kube_job_status_failed metric even when there are no job.Status.Conditions present

### DIFF
--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -219,10 +219,10 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 					}
 				}
 
+				reasonKnown := false
 				for _, c := range j.Status.Conditions {
 					condition := c
 					if condition.Type == v1batch.JobFailed {
-						reasonKnown := false
 						for _, reason := range jobFailureReasons {
 							reasonKnown = reasonKnown || failureReason(&condition, reason)
 
@@ -233,15 +233,15 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 								Value:       boolFloat64(failureReason(&condition, reason)),
 							})
 						}
-						// for unknown reasons
-						if !reasonKnown {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"reason"},
-								LabelValues: []string{""},
-								Value:       float64(j.Status.Failed),
-							})
-						}
 					}
+				}
+				// for unknown reasons
+				if !reasonKnown {
+					ms = append(ms, &metric.Metric{
+						LabelKeys:   []string{"reason"},
+						LabelValues: []string{""},
+						Value:       float64(j.Status.Failed),
+					})
 				}
 
 				return &metric.Family{

--- a/internal/store/job_test.go
+++ b/internal/store/job_test.go
@@ -213,6 +213,28 @@ func TestJobStore(t *testing.T) {
 		{
 			Obj: &v1batch.Job{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "FailedJobWithNoConditions",
+					Namespace: "ns1",
+				},
+				Status: v1batch.JobStatus{
+					Failed: 1,
+				},
+				Spec: v1batch.JobSpec{
+					ActiveDeadlineSeconds: &ActiveDeadlineSeconds900,
+				},
+			},
+			Want: metadata + `
+				kube_job_owner{job_name="FailedJobWithNoConditions",namespace="ns1",owner_is_controller="",owner_kind="",owner_name=""} 1
+				kube_job_info{job_name="FailedJobWithNoConditions",namespace="ns1"} 1
+				kube_job_spec_active_deadline_seconds{job_name="FailedJobWithNoConditions",namespace="ns1"} 900
+				kube_job_status_active{job_name="FailedJobWithNoConditions",namespace="ns1"} 0
+				kube_job_status_failed{job_name="FailedJobWithNoConditions",namespace="ns1",reason=""} 1
+				kube_job_status_succeeded{job_name="FailedJobWithNoConditions",namespace="ns1"} 0
+`,
+		},
+		{
+			Obj: &v1batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:       "SuccessfulJob2NoActiveDeadlineSeconds",
 					Namespace:  "ns1",
 					Generation: 1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Sets the `kube_job_status_failed` metric when a job's conditions are empty. Previously, the metric was only being set while iterating through a job's conditions, thus ignoring the case when no conditions were found but the job still failed.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
does not change 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2443 
