### PR TITLE
fix: de-duplication of custom resource metrics

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -113,12 +113,10 @@ func (b *Builder) WithEnabledResources(r []string) error {
 		}
 	}
 
-	var sortedResources []string
-	sortedResources = append(sortedResources, r...)
+	b.enabledResources = append(b.enabledResources, r...)
+	slices.Sort(b.enabledResources)
+	b.enabledResources = slices.Compact(b.enabledResources)
 
-	sort.Strings(sortedResources)
-
-	b.enabledResources = append(b.enabledResources, sortedResources...)
 	return nil
 }
 

--- a/internal/store/builder_test.go
+++ b/internal/store/builder_test.go
@@ -238,13 +238,21 @@ func TestWithEnabledResources(t *testing.T) {
 
 		// Set the enabled resources.
 		err := b.WithEnabledResources(test.EnabledResources)
-		if err != nil && !test.err.expectedResourceError {
-			t.Log("Did not expect error while setting resources (--resources).")
-			t.Errorf("Test error for Desc: %s. Got Error: %v", test.Desc, err)
+		if test.err.expectedResourceError {
+			if err == nil {
+				t.Log("Did not expect error while setting resources (--resources).")
+				t.Fatal("Test error for Desc: %s. Got Error: %v", test.Desc, err)
+			} else {
+				return
+			}
+		}
+		if err != nil {
+			t.Log("...")
+			t.Fatal("...", test.Desc, err)
 		}
 
 		// Evaluate.
-		if !slices.Equal(b.enabledResources, test.Wanted) && err == nil {
+		if !slices.Equal(b.enabledResources, test.Wanted) {
 			t.Log("Expected enabled resources to be equal.")
 			t.Errorf("Test error for Desc: %s\n Want: \n%+v\n Got: \n%#+v", test.Desc, test.Wanted, b.enabledResources)
 		}

--- a/internal/store/builder_test.go
+++ b/internal/store/builder_test.go
@@ -241,7 +241,7 @@ func TestWithEnabledResources(t *testing.T) {
 		if test.err.expectedResourceError {
 			if err == nil {
 				t.Log("Did not expect error while setting resources (--resources).")
-				t.Fatal("Test error for Desc: %s. Got Error: %v", test.Desc, err)
+				t.Fatalf("Test error for Desc: %s. Got Error: %v", test.Desc, err)
 			} else {
 				return
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes an issue that causes custom resource metrics to duplicate every time a CR resource that KSM is watching changed.  The duplication was happening because the informer events (add/delete) triggered a subsequent call to `WithEnabledResources` in `store.Builder`.  This would append, but not de-duplicate the CR resources to the `enabledResources` list. This, in turn, would cause the custom resources to be be added multiple times when the store was built.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Does not change cardinality

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2446
