### PR TITLE
perf: use concurrent map when storing metrics

### DIFF
--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 )
 

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -20,8 +20,6 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/types"
-
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 )
 
@@ -33,7 +31,7 @@ type MetricsStore struct {
 	// metric families, containing a slice of metrics. We need to keep metrics
 	// grouped by metric families in order to zip families with their help text in
 	// MetricsStore.WriteAll().
-	metrics map[types.UID][][]byte
+	metrics sync.Map
 
 	// generateMetricsFunc generates metrics based on a given Kubernetes object
 	// and returns them grouped by metric family.
@@ -42,9 +40,6 @@ type MetricsStore struct {
 	// later on zipped with with their corresponding metric families in
 	// MetricStore.WriteAll().
 	headers []string
-
-	// Protects metrics
-	mutex sync.RWMutex
 }
 
 // NewMetricsStore returns a new MetricsStore
@@ -52,7 +47,7 @@ func NewMetricsStore(headers []string, generateFunc func(interface{}) []metric.F
 	return &MetricsStore{
 		generateMetricsFunc: generateFunc,
 		headers:             headers,
-		metrics:             map[types.UID][][]byte{},
+		metrics:             sync.Map{},
 	}
 }
 
@@ -66,9 +61,6 @@ func (s *MetricsStore) Add(obj interface{}) error {
 		return err
 	}
 
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
 	families := s.generateMetricsFunc(obj)
 	familyStrings := make([][]byte, len(families))
 
@@ -76,7 +68,7 @@ func (s *MetricsStore) Add(obj interface{}) error {
 		familyStrings[i] = f.ByteSlice()
 	}
 
-	s.metrics[o.GetUID()] = familyStrings
+	s.metrics.Store(o.GetUID(), familyStrings)
 
 	return nil
 }
@@ -95,10 +87,7 @@ func (s *MetricsStore) Delete(obj interface{}) error {
 		return err
 	}
 
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	delete(s.metrics, o.GetUID())
+	s.metrics.Delete(o.GetUID())
 
 	return nil
 }
@@ -126,9 +115,7 @@ func (s *MetricsStore) GetByKey(_ string) (item interface{}, exists bool, err er
 // Replace will delete the contents of the store, using instead the
 // given list.
 func (s *MetricsStore) Replace(list []interface{}, _ string) error {
-	s.mutex.Lock()
-	s.metrics = map[types.UID][][]byte{}
-	s.mutex.Unlock()
+	s.metrics.Clear()
 
 	for _, o := range list {
 		err := s.Add(o)

--- a/pkg/metrics_store/metrics_writer.go
+++ b/pkg/metrics_store/metrics_writer.go
@@ -56,31 +56,35 @@ func (m MetricsWriter) WriteAll(w io.Writer) error {
 		return nil
 	}
 
-	for _, s := range m.stores {
-		s.mutex.RLock()
-		defer func(s *MetricsStore) {
-			s.mutex.RUnlock()
-		}(s)
-	}
-
 	for i, help := range m.stores[0].headers {
 		if help != "" && help != "\n" {
 			help += "\n"
 		}
 
-		if len(m.stores[0].metrics) > 0 {
-			_, err := w.Write([]byte(help))
+		var err error
+		m.stores[0].metrics.Range(func(key interface{}, value interface{}) bool {
+			_, err = w.Write([]byte(help))
 			if err != nil {
-				return fmt.Errorf("failed to write help text: %v", err)
+				err = fmt.Errorf("failed to write help text: %v", err)
 			}
+			return false
+		})
+		if err != nil {
+			return err
 		}
 
 		for _, s := range m.stores {
-			for _, metricFamilies := range s.metrics {
-				_, err := w.Write(metricFamilies[i])
+			s.metrics.Range(func(key interface{}, value interface{}) bool {
+				metricFamilies := value.([][]byte)
+				_, err = w.Write(metricFamilies[i])
 				if err != nil {
-					return fmt.Errorf("failed to write metrics family: %v", err)
+					err = fmt.Errorf("failed to write metrics family: %v", err)
+					return false
 				}
+				return true
+			})
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/metrics_store/metrics_writer.go
+++ b/pkg/metrics_store/metrics_writer.go
@@ -62,7 +62,7 @@ func (m MetricsWriter) WriteAll(w io.Writer) error {
 		}
 
 		var err error
-		m.stores[0].metrics.Range(func(key interface{}, value interface{}) bool {
+		m.stores[0].metrics.Range(func(_ interface{}, _ interface{}) bool {
 			_, err = w.Write([]byte(help))
 			if err != nil {
 				err = fmt.Errorf("failed to write help text: %v", err)
@@ -74,7 +74,7 @@ func (m MetricsWriter) WriteAll(w io.Writer) error {
 		}
 
 		for _, s := range m.stores {
-			s.metrics.Range(func(key interface{}, value interface{}) bool {
+			s.metrics.Range(func(_ interface{}, value interface{}) bool {
 				metricFamilies := value.([][]byte)
 				_, err = w.Write(metricFamilies[i])
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**: In busy/large clusters, will prevent timeouts from long living locks/concurrency issues, as the writing to the map takes overly long, blocking the metrics-reading thread and as the lock doesn't get released in a timely manner, timing out the request.

In these graphs you see:
1. VMagent scrape duration (yellow: with this patch applied, green: no patch)
2.  VMagent samples scraped: (yellow: with this patch applied, green: no patch)
3. Heatmap from selfMetrics with patch applied
4. Heatmap from selfMetrics no patch
5. Number of pods in LOG scale, max is close to 16k
6. Number of nodes in cluster
![Screenshot from 2024-09-26 12-48-47](https://github.com/user-attachments/assets/2ee1a953-8d19-4556-a025-0686a6abac03)

You can see that with this patch we reduce latency significantly under all scenarios in our cluster.

Inspired by previous PR at https://github.com/kubernetes/kube-state-metrics/pull/1028

**How does this change affect the cardinality of KSM**: *does not change cardinality*

**Which issue(s) this PR fixes**:
Fixes #995
