### PR TITLE
WIP: feat: Add SELinux metrics

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -316,6 +316,7 @@ var availableStores = map[string]func(f *Builder) []cache.Store{
 	"configmaps":                      func(b *Builder) []cache.Store { return b.buildConfigMapStores() },
 	"clusterrolebindings":             func(b *Builder) []cache.Store { return b.buildClusterRoleBindingStores() },
 	"cronjobs":                        func(b *Builder) []cache.Store { return b.buildCronJobStores() },
+	"csidrivers":                      func(b *Builder) []cache.Store { return b.buildCSIDriverStores() },
 	"daemonsets":                      func(b *Builder) []cache.Store { return b.buildDaemonSetStores() },
 	"deployments":                     func(b *Builder) []cache.Store { return b.buildDeploymentStores() },
 	"endpoints":                       func(b *Builder) []cache.Store { return b.buildEndpointsStores() },
@@ -459,6 +460,10 @@ func (b *Builder) buildStatefulSetStores() []cache.Store {
 
 func (b *Builder) buildStorageClassStores() []cache.Store {
 	return b.buildStoresFunc(storageClassMetricFamilies(b.allowAnnotationsList["storageclasses"], b.allowLabelsList["storageclasses"]), &storagev1.StorageClass{}, createStorageClassListWatch, b.useAPIServerCache)
+}
+
+func (b *Builder) buildCSIDriverStores() []cache.Store {
+	return b.buildStoresFunc(csiDriverMetricFamilies(b.allowAnnotationsList["csidrivers"], b.allowLabelsList["csidrivers"]), &storagev1.CSIDriver{}, createCSIDriverListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildPodStores() []cache.Store {

--- a/internal/store/csidriver.go
+++ b/internal/store/csidriver.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"context"
+	"strconv"
+
+	basemetrics "k8s.io/component-base/metrics"
+
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	defaultSELinuxMount              = false
+	descCSIDriverLabelsDefaultLabels = []string{"csi_driver"}
+)
+
+func csiDriverMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	return []generator.FamilyGenerator{
+		*generator.NewFamilyGeneratorWithStability(
+			"kube_csidriver_info",
+			"Information about CSI drivers.",
+			metric.Gauge,
+			basemetrics.ALPHA,
+			"",
+			wrapCSIDriverFunc(func(c *storagev1.CSIDriver) *metric.Family {
+				if c.Spec.SELinuxMount == nil {
+					c.Spec.SELinuxMount = &defaultSELinuxMount
+				}
+				m := metric.Metric{
+					LabelKeys:   []string{"selinux_mount"},
+					LabelValues: []string{strconv.FormatBool(*c.Spec.SELinuxMount)},
+					Value:       1,
+				}
+				return &metric.Family{Metrics: []*metric.Metric{&m}}
+			}),
+		),
+	}
+}
+
+func wrapCSIDriverFunc(f func(*storagev1.CSIDriver) *metric.Family) func(interface{}) *metric.Family {
+	return func(obj interface{}) *metric.Family {
+		csiDriver := obj.(*storagev1.CSIDriver)
+
+		metricFamily := f(csiDriver)
+
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys, m.LabelValues = mergeKeyValues(descCSIDriverLabelsDefaultLabels, []string{csiDriver.Name}, m.LabelKeys, m.LabelValues)
+		}
+
+		return metricFamily
+	}
+}
+
+func createCSIDriverListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return kubeClient.StorageV1().CSIDrivers().List(context.TODO(), opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return kubeClient.StorageV1().CSIDrivers().Watch(context.TODO(), opts)
+		},
+	}
+}

--- a/pkg/options/resource.go
+++ b/pkg/options/resource.go
@@ -29,6 +29,7 @@ var (
 		"certificatesigningrequests":      struct{}{},
 		"configmaps":                      struct{}{},
 		"cronjobs":                        struct{}{},
+		"csidrivers":                      struct{}{},
 		"daemonsets":                      struct{}{},
 		"deployments":                     struct{}{},
 		"endpoints":                       struct{}{},


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a proof of concept for metrics suggested by [SELinuxMount feature](https://github.com/kubernetes/enhancements/pull/4843).

Using these metrics I think with lot of joins and label replaces I can detect if two containers use the same volume in parallel, and the containers have the same SELinux label (good) or a different one (bad, those Pods will not run when SELinuxMount gets enabled). 

New metrics:

* `kube_pod_security_context`: pod's `spec.securityContext` fields. The only values I need are `seLinuxOptions`.
* `kube_pod_container_security_context`: pod's `spec.containers[*].securityContext` fields. I need `privileged` flag + `seLinuxOptions`.
* `kube_pod_container_volume_mount`:  report volumes used by *containers*. The existing `kube_pod_spec_volumes_persistentvolumeclaims_info` tracks volumes used in *pods*.
* `kube_csidriver_info`: report CSIDriver object fields. I need just `seLinuxMount` flag.

WIP. TODO when the KEP is approved:
* Add RBACs for reading CSIDriver objects.
* Add unit tests + docs.
* Add more labels to the metrics. What other `SecurityContext`, `PodSecrutyContext` and `CSIDriver` fields are useful?
* Add proposed pod `spec.securityContext.seLinuxChangePolicy` to `kube_pod_security_context`.
* Consider adding `kube_persistentvolume_unique_volume_id`. `kube_persistentvolume_info` does misses some volume types (e.g. in-tree vSphere or Cinder) and is declared STABLE. And it's clumsy to work with.

**How does this change affect the cardinality of KSM**: increases
(no change to any existing metric, new metrics do have nozero cardinality)

KEP update proposal: https://github.com/kubernetes/enhancements/pull/4843