### PR TITLE
chore: Uplift go version as a fix to 3 CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kube-state-metrics/v2
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/KimMachineGun/automemlimit v0.6.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kube-state-metrics/v2/tools
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/brancz/gojsontoyaml v0.1.0


### PR DESCRIPTION
An update of the go version to 1.23.1 is carried out here, in order to fix 3 CVEs, as raised in https://github.com/kubernetes/kube-state-metrics/issues/2512. 
