### PR TITLE
fix: panic in `util.GVRFromType` for core objects

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -143,11 +143,10 @@ func GVRFromType(resourceName string, expectedType interface{}) *schema.GroupVer
 		return nil
 	}
 	apiVersion := expectedType.(*unstructured.Unstructured).Object["apiVersion"].(string)
-	expectedTypeSlice := strings.Split(apiVersion, "/")
-	g := expectedTypeSlice[0]
-	v := expectedTypeSlice[1]
-	if v == "" /* "" group (core) objects */ {
-		v = expectedTypeSlice[0]
+	g, v, found := strings.Cut(apiVersion, "/")
+	if !found {
+		g = "core"
+		v = apiVersion
 	}
 	r := resourceName
 	return &schema.GroupVersionResource{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes a panic in the `util.GVRFromType` function when called for a `core` object.

For a pod object, for example, the `apiVersion` would be `v1`,
```go
expectedTypeSlice := strings.Split(apiVersion, "/")
```
would return a slice of a single element because `apiVersion` has no `/`.
And
```go
v := expectedTypeSlice[1]
```
would panic because of an array out-of-bound access.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

Does not change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
