### PR TITLE
fix(custom resource state metrics): correctly convert status condition `Unknown` to a valid value

### DIFF
--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -337,7 +337,7 @@ Supported types are:
 * `nil` is generally mapped to `0.0` if NilIsZero is `true`, otherwise it will throw an error
 * for bool `true` is mapped to `1.0` and `false` is mapped to `0.0`
 * for string the following logic applies
-  * `"true"` and `"yes"` are mapped to `1.0` and `"false"` and `"no"` are mapped to `0.0` (all case-insensitive)
+  * `"true"` and `"yes"` are mapped to `1.0`, `"false"`, `"no"` and `"unknown"` are mapped to `0.0` (all case-insensitive)
   * RFC3339 times are parsed to float timestamp  
   * Quantities like "250m" or "512Gi" are parsed to float using <https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go>
   * Percentages ending with a "%" are parsed to float

--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -337,7 +337,8 @@ Supported types are:
 * `nil` is generally mapped to `0.0` if NilIsZero is `true`, otherwise it will throw an error
 * for bool `true` is mapped to `1.0` and `false` is mapped to `0.0`
 * for string the following logic applies
-  * `"true"` and `"yes"` are mapped to `1.0`, `"false"`, `"no"` and `"unknown"` are mapped to `0.0` (all case-insensitive)
+  * `"true"` and `"yes"` are mapped to `1.0`, `"false"` and `"no"` are mapped to `0.0` (all case-insensitive)
+  * `"unknown"` is mapped to `-1.0` (all case-insensitive)
   * RFC3339 times are parsed to float timestamp  
   * Quantities like "250m" or "512Gi" are parsed to float using <https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go>
   * Percentages ending with a "%" are parsed to float

--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -337,8 +337,7 @@ Supported types are:
 * `nil` is generally mapped to `0.0` if NilIsZero is `true`, otherwise it will throw an error
 * for bool `true` is mapped to `1.0` and `false` is mapped to `0.0`
 * for string the following logic applies
-  * `"true"` and `"yes"` are mapped to `1.0`, `"false"` and `"no"` are mapped to `0.0` (all case-insensitive)
-  * `"unknown"` is mapped to `-1.0` (all case-insensitive)
+  * `"true"` and `"yes"` are mapped to `1.0`, `"false"`, `"no"` and `"unknown"` are mapped to `0.0` (all case-insensitive)
   * RFC3339 times are parsed to float timestamp  
   * Quantities like "250m" or "512Gi" are parsed to float using <https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go>
   * Percentages ending with a "%" are parsed to float

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -131,9 +131,11 @@ type compiledCommon struct {
 func (c compiledCommon) Path() valuePath {
 	return c.path
 }
+
 func (c compiledCommon) LabelFromPath() map[string]valuePath {
 	return c.labelFromPath
 }
+
 func (c compiledCommon) Type() metric.Type {
 	return c.t
 }
@@ -477,6 +479,7 @@ func (e eachValue) DefaultLabels(defaults map[string]string) {
 		}
 	}
 }
+
 func (e eachValue) ToMetric() *metric.Metric {
 	var keys, values []string
 	for k := range e.Labels {
@@ -730,6 +733,9 @@ func toFloat64(value interface{}, nilIsZero bool) (float64, error) {
 			return 1, nil
 		}
 		if normalized == "false" || normalized == "no" {
+			return 0, nil
+		}
+		if normalized == "unknown" {
 			return 0, nil
 		}
 		// The string contains a RFC3339 timestamp

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -732,11 +732,8 @@ func toFloat64(value interface{}, nilIsZero bool) (float64, error) {
 		if normalized == "true" || normalized == "yes" {
 			return 1, nil
 		}
-		if normalized == "false" || normalized == "no" {
+		if normalized == "false" || normalized == "no" || normalized == "unknown" {
 			return 0, nil
-		}
-		if normalized == "unknown" {
-			return -1, nil
 		}
 		// The string contains a RFC3339 timestamp
 		if t, e := time.Parse(time.RFC3339, value.(string)); e == nil {

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -727,7 +727,7 @@ func toFloat64(value interface{}, nilIsZero bool) (float64, error) {
 		}
 		return 0, nil
 	case string:
-		// The string contains a boolean as a string
+		// The string is a boolean or `"unknown"` according to https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition
 		normalized := strings.ToLower(value.(string))
 		if normalized == "true" || normalized == "yes" {
 			return 1, nil
@@ -736,7 +736,7 @@ func toFloat64(value interface{}, nilIsZero bool) (float64, error) {
 			return 0, nil
 		}
 		if normalized == "unknown" {
-			return 0, nil
+			return -1, nil
 		}
 		// The string contains a RFC3339 timestamp
 		if t, e := time.Parse(time.RFC3339, value.(string)); e == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

According to https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md#gauge
>This will work for kubernetes controller CRs which expose status conditions according to the kubernetes api (https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition):

`ConditionUnknown = "Unknown"` should be converted corrctly to a valid value, and more like `0.0` instead of `1.0`.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

Does not change cardinality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2439 
