### PR TITLE
fix: expose empty labels

### DIFF
--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -131,35 +131,25 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 			"",
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				ms := []*metric.Metric{}
+				labelKeys := []string{"port_protocol", "port_number", "port_name", "ip", "ready"}
+
 				for _, s := range e.Subsets {
 					for _, port := range s.Ports {
 						for _, available := range s.Addresses {
-							labelValues := []string{string(port.Protocol), strconv.FormatInt(int64(port.Port), 10)}
-							labelKeys := []string{"port_protocol", "port_number"}
-
-							if port.Name != "" {
-								labelKeys = append(labelKeys, "port_name")
-								labelValues = append(labelValues, port.Name)
-							}
+							labelValues := []string{string(port.Protocol), strconv.FormatInt(int64(port.Port), 10), port.Name}
 
 							ms = append(ms, &metric.Metric{
 								LabelValues: append(labelValues, available.IP, "true"),
-								LabelKeys:   append(labelKeys, "ip", "ready"),
+								LabelKeys:   labelKeys,
 								Value:       1,
 							})
 						}
 						for _, notReadyAddresses := range s.NotReadyAddresses {
-							labelValues := []string{string(port.Protocol), strconv.FormatInt(int64(port.Port), 10)}
-							labelKeys := []string{"port_protocol", "port_number"}
-
-							if port.Name != "" {
-								labelKeys = append(labelKeys, "port_name")
-								labelValues = append(labelValues, port.Name)
-							}
+							labelValues := []string{string(port.Protocol), strconv.FormatInt(int64(port.Port), 10), port.Name}
 
 							ms = append(ms, &metric.Metric{
 								LabelValues: append(labelValues, notReadyAddresses.IP, "false"),
-								LabelKeys:   append(labelKeys, "ip", "ready"),
+								LabelKeys:   labelKeys,
 								Value:       1,
 							})
 						}

--- a/internal/store/endpoint_test.go
+++ b/internal/store/endpoint_test.go
@@ -135,9 +135,9 @@ func TestEndpointStore(t *testing.T) {
 				kube_endpoint_created{endpoint="single-port-endpoint",namespace="default"} 1.5e+09
 				kube_endpoint_info{endpoint="single-port-endpoint",namespace="default"} 1
 				kube_endpoint_ports{endpoint="single-port-endpoint",namespace="default",port_name="",port_number="8080",port_protocol="TCP"} 1
-                                kube_endpoint_address{endpoint="single-port-endpoint",ip="10.0.0.1",namespace="default",port_number="8080",port_protocol="TCP",ready="true"} 1
-                                kube_endpoint_address{endpoint="single-port-endpoint",ip="10.0.0.10",namespace="default",port_number="8080",port_protocol="TCP",ready="false"} 1
-                                kube_endpoint_address{endpoint="single-port-endpoint",ip="127.0.0.1",namespace="default",port_number="8080",port_protocol="TCP",ready="true"} 1
+                                kube_endpoint_address{endpoint="single-port-endpoint",ip="10.0.0.1",namespace="default",port_name="",port_number="8080",port_protocol="TCP",ready="true"} 1
+                                kube_endpoint_address{endpoint="single-port-endpoint",ip="10.0.0.10",namespace="default",port_name="",port_number="8080",port_protocol="TCP",ready="false"} 1
+                                kube_endpoint_address{endpoint="single-port-endpoint",ip="127.0.0.1",namespace="default",port_name="",port_number="8080",port_protocol="TCP",ready="true"} 1
 			`,
 		},
 	}
@@ -269,9 +269,9 @@ func TestEndpointStoreWithLabels(t *testing.T) {
 				kube_endpoint_info{endpoint="single-port-endpoint",namespace="default"} 1
 				kube_endpoint_labels{endpoint="single-port-endpoint",label_app="single-foobar",namespace="default"} 1
 				kube_endpoint_ports{endpoint="single-port-endpoint",namespace="default",port_name="",port_number="8080",port_protocol="TCP"} 1
-				kube_endpoint_address{endpoint="single-port-endpoint",ip="10.0.0.1",namespace="default",port_number="8080",port_protocol="TCP",ready="true"} 1
-				kube_endpoint_address{endpoint="single-port-endpoint",ip="10.0.0.10",namespace="default",port_number="8080",port_protocol="TCP",ready="false"} 1
-				kube_endpoint_address{endpoint="single-port-endpoint",ip="127.0.0.1",namespace="default",port_number="8080",port_protocol="TCP",ready="true"} 1
+				kube_endpoint_address{endpoint="single-port-endpoint",ip="10.0.0.1",namespace="default",port_name="",port_number="8080",port_protocol="TCP",ready="true"} 1
+				kube_endpoint_address{endpoint="single-port-endpoint",ip="10.0.0.10",namespace="default",port_name="",port_number="8080",port_protocol="TCP",ready="false"} 1
+				kube_endpoint_address{endpoint="single-port-endpoint",ip="127.0.0.1",namespace="default",port_name="",port_number="8080",port_protocol="TCP",ready="true"} 1
 			`,
 		},
 	}

--- a/internal/store/endpointslice.go
+++ b/internal/store/endpointslice.go
@@ -121,54 +121,41 @@ func endpointSliceMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 			wrapEndpointSliceFunc(func(e *discoveryv1.EndpointSlice) *metric.Family {
 				m := []*metric.Metric{}
 				for _, ep := range e.Endpoints {
-					var (
-						labelKeys,
-						labelValues []string
-					)
+
+					var ready, serving, terminating, hostname, targetrefKind, targetrefName, targetrefNamespace, endpointNodename, endpointZone string
 
 					if ep.Conditions.Ready != nil {
-						labelKeys = append(labelKeys, "ready")
-						labelValues = append(labelValues, strconv.FormatBool(*ep.Conditions.Ready))
-					}
-					if ep.Conditions.Serving != nil {
-						labelKeys = append(labelKeys, "serving")
-						labelValues = append(labelValues, strconv.FormatBool(*ep.Conditions.Serving))
-					}
-					if ep.Conditions.Terminating != nil {
-						labelKeys = append(labelKeys, "terminating")
-						labelValues = append(labelValues, strconv.FormatBool(*ep.Conditions.Terminating))
+						ready = strconv.FormatBool(*ep.Conditions.Ready)
 					}
 
+					if ep.Conditions.Serving != nil {
+						serving = strconv.FormatBool(*ep.Conditions.Serving)
+					}
+
+					if ep.Conditions.Terminating != nil {
+						serving = strconv.FormatBool(*ep.Conditions.Terminating)
+					}
 					if ep.Hostname != nil {
-						labelKeys = append(labelKeys, "hostname")
-						labelValues = append(labelValues, *ep.Hostname)
+						hostname = *ep.Hostname
 					}
 
 					if ep.TargetRef != nil {
-						if ep.TargetRef.Kind != "" {
-							labelKeys = append(labelKeys, "targetref_kind")
-							labelValues = append(labelValues, ep.TargetRef.Kind)
-						}
-						if ep.TargetRef.Name != "" {
-							labelKeys = append(labelKeys, "targetref_name")
-							labelValues = append(labelValues, ep.TargetRef.Name)
-						}
-						if ep.TargetRef.Namespace != "" {
-							labelKeys = append(labelKeys, "targetref_namespace")
-							labelValues = append(labelValues, ep.TargetRef.Namespace)
-						}
+						targetrefKind = ep.TargetRef.Kind
+						targetrefName = ep.TargetRef.Name
+						targetrefNamespace = ep.TargetRef.Namespace
 					}
 
 					if ep.NodeName != nil {
-						labelKeys = append(labelKeys, "endpoint_nodename")
-						labelValues = append(labelValues, *ep.NodeName)
+						endpointNodename = *ep.NodeName
 					}
 
 					if ep.Zone != nil {
-						labelKeys = append(labelKeys, "endpoint_zone")
-						labelValues = append(labelValues, *ep.Zone)
+						endpointZone = *ep.Zone
 					}
-					labelKeys = append(labelKeys, "address")
+
+					labelKeys := []string{"ready", "serving", "hostname", "terminating", "targetref_kind", "targetref_name", "targetref_namespace", "endpoint_nodename", "endpoint_zone", "address"}
+					labelValues := []string{ready, serving, terminating, hostname, targetrefKind, targetrefName, targetrefNamespace, endpointNodename, endpointZone}
+
 					for _, address := range ep.Addresses {
 						newlabelValues := make([]string, len(labelValues))
 						copy(newlabelValues, labelValues)

--- a/internal/store/endpointslice_test.go
+++ b/internal/store/endpointslice_test.go
@@ -120,8 +120,8 @@ func TestEndpointSliceStore(t *testing.T) {
 					# HELP kube_endpointslice_endpoints_hints Topology routing hints attached to endpoints
 					# TYPE kube_endpointslice_endpoints gauge
 					# TYPE kube_endpointslice_endpoints_hints gauge
-					kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false",namespace="test"} 1
-					kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false",namespace="test"} 1
+					kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="",namespace="test",ready="true",serving="false",targetref_kind="",targetref_name="",targetref_namespace="",terminating="host"} 1
+					kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="",namespace="test",ready="true",serving="false",targetref_kind="",targetref_name="",targetref_namespace="",terminating="host"} 1
 				  `,
 
 			MetricNames: []string{
@@ -159,9 +159,9 @@ func TestEndpointSliceStore(t *testing.T) {
 					# TYPE kube_endpointslice_endpoints gauge
         			        # TYPE kube_endpointslice_endpoints_hints gauge
          			kube_endpointslice_endpoints_hints{address="10.0.0.1",endpointslice="test_endpointslice-endpoints",for_zone="zone1",namespace="test"} 1
-        			kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false",namespace="test"} 1
-        			kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",ready="true",terminating="false",namespace="test"} 1
-				  `,
+        			kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="",namespace="test",ready="true",serving="false",targetref_kind="",targetref_name="",targetref_namespace="",terminating="host"} 1
+				kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="",namespace="test",ready="true",serving="false",targetref_kind="",targetref_name="",targetref_namespace="",terminating="host"} 1  
+				`,
 
 			MetricNames: []string{
 				"kube_endpointslice_endpoints",

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -1653,41 +1653,26 @@ func createPodTolerationsFamilyGenerator() generator.FamilyGenerator {
 			var ms []*metric.Metric
 
 			for _, t := range p.Spec.Tolerations {
-				var labelKeys []string
-				var labelValues []string
+				var key, operator, value, effect, tolerationSeconds string
 
-				if t.Key != "" {
-					labelKeys = append(labelKeys, "key")
-					labelValues = append(labelValues, t.Key)
-				}
-
+				key = t.Key
 				if t.Operator != "" {
-					labelKeys = append(labelKeys, "operator")
-					labelValues = append(labelValues, string(t.Operator))
+					operator = string(t.Operator)
 				}
 
-				if t.Value != "" {
-					labelKeys = append(labelKeys, "value")
-					labelValues = append(labelValues, t.Value)
-				}
+				value = t.Value
 
 				if t.Effect != "" {
-					labelKeys = append(labelKeys, "effect")
-					labelValues = append(labelValues, string(t.Effect))
+					effect = string(t.Effect)
 				}
 
 				if t.TolerationSeconds != nil {
-					labelKeys = append(labelKeys, "toleration_seconds")
-					labelValues = append(labelValues, strconv.FormatInt(*t.TolerationSeconds, 10))
-				}
-
-				if len(labelKeys) == 0 {
-					continue
+					tolerationSeconds = strconv.FormatInt(*t.TolerationSeconds, 10)
 				}
 
 				ms = append(ms, &metric.Metric{
-					LabelKeys:   labelKeys,
-					LabelValues: labelValues,
+					LabelKeys:   []string{"key", "operator", "value", "effect", "toleration_seconds"},
+					LabelValues: []string{key, operator, value, effect, tolerationSeconds},
 					Value:       1,
 				})
 			}

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -2123,9 +2123,10 @@ func TestPodStore(t *testing.T) {
 			Want: `
 				# HELP kube_pod_tolerations Information about the pod tolerations
 				# TYPE kube_pod_tolerations gauge
-				kube_pod_tolerations{namespace="ns1",pod="pod1",uid="uid1",key="key1",operator="Equal",value="value1",effect="NoSchedule"} 1
-				kube_pod_tolerations{namespace="ns1",pod="pod1",uid="uid1",key="key2",operator="Exists"} 1
-				kube_pod_tolerations{namespace="ns1",pod="pod1",uid="uid1",key="key3",operator="Equal",value="value3"} 1
+				kube_pod_tolerations{effect="",key="",namespace="ns1",operator="",pod="pod1",toleration_seconds="",uid="uid1",value=""} 1
+				kube_pod_tolerations{effect="",key="key2",namespace="ns1",operator="Exists",pod="pod1",toleration_seconds="",uid="uid1",value=""} 1
+				kube_pod_tolerations{effect="",key="key3",namespace="ns1",operator="Equal",pod="pod1",toleration_seconds="",uid="uid1",value="value3"} 1
+				kube_pod_tolerations{effect="NoSchedule",key="key1",namespace="ns1",operator="Equal",pod="pod1",toleration_seconds="",uid="uid1",value="value1"} 1
 			`,
 			MetricNames: []string{
 				"kube_pod_tolerations",

--- a/internal/store/serviceaccount.go
+++ b/internal/store/serviceaccount.go
@@ -56,18 +56,16 @@ func createServiceAccountInfoFamilyGenerator() generator.FamilyGenerator {
 		basemetrics.ALPHA,
 		"",
 		wrapServiceAccountFunc(func(sa *v1.ServiceAccount) *metric.Family {
-			var labelKeys []string
-			var labelValues []string
+			var automountToken string
 
 			if sa.AutomountServiceAccountToken != nil {
-				labelKeys = append(labelKeys, "automount_token")
-				labelValues = append(labelValues, strconv.FormatBool(*sa.AutomountServiceAccountToken))
+				automountToken = strconv.FormatBool(*sa.AutomountServiceAccountToken)
 			}
 
 			return &metric.Family{
 				Metrics: []*metric.Metric{{
-					LabelKeys:   labelKeys,
-					LabelValues: labelValues,
+					LabelKeys:   []string{"automount_token"},
+					LabelValues: []string{automountToken},
 					Value:       1,
 				}},
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
To align with https://github.com/kubernetes/kube-state-metrics/pull/2528
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Adds labels if they are empty.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
