### PR TITLE
fix: Remove redundant factories array since it is not written after

### DIFF
--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -52,7 +52,6 @@ import (
 	"k8s.io/kube-state-metrics/v2/internal/discovery"
 	"k8s.io/kube-state-metrics/v2/internal/store"
 	"k8s.io/kube-state-metrics/v2/pkg/allowdenylist"
-	"k8s.io/kube-state-metrics/v2/pkg/customresource"
 	"k8s.io/kube-state-metrics/v2/pkg/customresourcestate"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
 	"k8s.io/kube-state-metrics/v2/pkg/metricshandler"
@@ -175,8 +174,6 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		return err
 	}
 
-	var factories []customresource.RegistryFactory
-
 	if opts.CustomResourceConfigFile != "" {
 		crcFile, err := os.ReadFile(filepath.Clean(opts.CustomResourceConfigFile))
 		if err != nil {
@@ -189,11 +186,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	}
 
-	resources := make([]string, len(factories))
-
-	for i, factory := range factories {
-		resources[i] = factory.Name()
-	}
+	resources := []string{}
 
 	switch {
 	case len(opts.Resources) == 0 && !opts.CustomResourcesOnly:


### PR DESCRIPTION
construction.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Cleanup by remove unnecessary factories.
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
 does not change cardinality
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This[ git commit](https://github.com/kubernetes/kube-state-metrics/commit/25a1d8da057cf761d614c59a52785335d34082d1#diff-dc8fe36bd1edf1b4cd03bacbd94b02cd4226717fe7e1a6474c534f5b5db30227L156-L164) remove the write to the factories variable, which makes factories always be an empty array. 
