### PR TITLE
fix: panic in `util.GVRFromType` for structured types

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -216,7 +216,16 @@ func (r *CRDiscoverer) PollForCacheUpdates(
 		// Update the list of enabled custom resources.
 		var enabledCustomResources []string
 		for _, factory := range customFactories {
-			gvrString := util.GVRFromType(factory.Name(), factory.ExpectedType()).String()
+			gvr, err := util.GVRFromType(factory.Name(), factory.ExpectedType())
+			if err != nil {
+				klog.ErrorS(err, "failed to update custom resource stores")
+			}
+			var gvrString string
+			if gvr != nil {
+				gvrString = gvr.String()
+			} else {
+				gvrString = factory.Name()
+			}
 			enabledCustomResources = append(enabledCustomResources, gvrString)
 		}
 		// Create clients for discovered factories.

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -197,7 +197,10 @@ func (b *Builder) DefaultGenerateCustomResourceStoresFunc() ksmtypes.BuildCustom
 func (b *Builder) WithCustomResourceStoreFactories(fs ...customresource.RegistryFactory) {
 	for i := range fs {
 		f := fs[i]
-		gvr := util.GVRFromType(f.Name(), f.ExpectedType())
+		gvr, err := util.GVRFromType(f.Name(), f.ExpectedType())
+		if err != nil {
+			klog.ErrorS(err, "Failed to get GVR from type", "resourceName", f.Name(), "expectedType", f.ExpectedType())
+		}
 		var gvrString string
 		if gvr != nil {
 			gvrString = gvr.String()
@@ -553,7 +556,10 @@ func (b *Builder) buildCustomResourceStores(resourceName string,
 
 	familyHeaders := generator.ExtractMetricFamilyHeaders(metricFamilies)
 
-	gvr := util.GVRFromType(resourceName, expectedType)
+	gvr, err := util.GVRFromType(resourceName, expectedType)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get GVR from type", "resourceName", resourceName, "expectedType", expectedType)
+	}
 	var gvrString string
 	if gvr != nil {
 		gvrString = gvr.String()

--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -204,7 +204,11 @@ func FromConfig(decoder ConfigDecoder, discovererInstance *discovery.CRDiscovere
 			if err != nil {
 				return nil, fmt.Errorf("failed to create metrics factory for %s: %w", resource.GroupVersionKind, err)
 			}
-			gvrString := util.GVRFromType(factory.Name(), factory.ExpectedType()).String()
+			gvr, err := util.GVRFromType(factory.Name(), factory.ExpectedType())
+			if err != nil {
+				return nil, fmt.Errorf("failed to create GVR for %s: %w", resource.GroupVersionKind, err)
+			}
+			gvrString := gvr.String()
 			if _, ok := factoriesIndex[gvrString]; ok {
 				klog.InfoS("reloaded factory", "GVR", gvrString)
 			}

--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -208,7 +208,12 @@ func FromConfig(decoder ConfigDecoder, discovererInstance *discovery.CRDiscovere
 			if err != nil {
 				return nil, fmt.Errorf("failed to create GVR for %s: %w", resource.GroupVersionKind, err)
 			}
-			gvrString := gvr.String()
+			var gvrString string
+			if gvr != nil {
+				gvrString = gvr.String()
+			} else {
+				gvrString = factory.Name()
+			}
 			if _, ok := factoriesIndex[gvrString]; ok {
 				klog.InfoS("reloaded factory", "GVR", gvrString)
 			}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -101,7 +101,13 @@ func CreateCustomResourceClients(apiserver string, kubeconfig string, factories 
 		if err != nil {
 			return nil, err
 		}
-		customResourceClients[gvr.String()] = customResourceClient
+		var gvrString string
+		if gvr != nil {
+			gvrString = gvr.String()
+		} else {
+			gvrString = f.Name()
+		}
+		customResourceClients[gvrString] = customResourceClient
 	}
 	return customResourceClients, nil
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -144,7 +144,8 @@ func GVRFromType(resourceName string, expectedType interface{}) *schema.GroupVer
 	}
 	t, err := meta.TypeAccessor(expectedType)
 	if err != nil {
-		panic(err)
+		klog.ErrorS(err, "Failed to get type accessor", "expectedType", expectedType)
+		return nil
 	}
 	apiVersion := t.GetAPIVersion()
 	g, v, found := strings.Cut(apiVersion, "/")

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -21,7 +21,7 @@ import (
 	"runtime"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -142,7 +142,11 @@ func GVRFromType(resourceName string, expectedType interface{}) *schema.GroupVer
 		// testUnstructuredMock.Foo is a mock type for testing
 		return nil
 	}
-	apiVersion := expectedType.(*unstructured.Unstructured).Object["apiVersion"].(string)
+	t, err := meta.TypeAccessor(expectedType)
+	if err != nil {
+		panic(err)
+	}
+	apiVersion := t.GetAPIVersion()
 	g, v, found := strings.Cut(apiVersion, "/")
 	if !found {
 		g = "core"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Make `util.GVRFromType` able to process structured types and not only unstructured ones.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

Does not change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
* Fixes #2202
