### PR TITLE
fix(kube_pod_tolerations): deduplicate tolerations before creating metric

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -1642,6 +1642,21 @@ func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
 	)
 }
 
+// getUniqueTolerations takes an array
+func getUniqueTolerations(tolerations []v1.Toleration) []v1.Toleration {
+	uniqueTolerationsMap := make(map[v1.Toleration]struct{})
+	var uniqueTolerations []v1.Toleration
+
+	for _, toleration := range tolerations {
+		_, exists := uniqueTolerationsMap[toleration]
+		if !exists {
+			uniqueTolerationsMap[toleration] = struct{}{}
+			uniqueTolerations = append(uniqueTolerations, toleration)
+		}
+	}
+	return uniqueTolerations
+}
+
 func createPodTolerationsFamilyGenerator() generator.FamilyGenerator {
 	return *generator.NewFamilyGeneratorWithStability(
 		"kube_pod_tolerations",
@@ -1651,8 +1666,9 @@ func createPodTolerationsFamilyGenerator() generator.FamilyGenerator {
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			var ms []*metric.Metric
+			uniqueTolerations := getUniqueTolerations(p.Spec.Tolerations)
 
-			for _, t := range p.Spec.Tolerations {
+			for _, t := range uniqueTolerations {
 				var key, operator, value, effect, tolerationSeconds string
 
 				key = t.Key

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -2115,6 +2115,12 @@ func TestPodStore(t *testing.T) {
 							Value:    "value3",
 						},
 						{
+							// Duplicate toleration, to ensure that doesn't result in a duplicate metric
+							Key:      "key3",
+							Operator: v1.TolerationOpEqual,
+							Value:    "value3",
+						},
+						{
 							// an empty toleration to ensure that an empty toleration does not result in a metric
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
duplicate metrics currently create warnings in the logs of prometheus. Tolerations can be duplicated and kube-api doesn't want to change that behavior, hence we have to deduplicate here

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
does not change cardinality

**Which issue(s) this PR fixes** 
Fixes #2390
