### PR TITLE
fix: Fix CR cache for GVK all specified case

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -127,23 +127,20 @@ func (r *CRDiscoverer) ResolveGVKToGVKPs(gvk schema.GroupVersionKind) (resolvedG
 	hasKind := k != "" && k != "*"
 	// No need to resolve, return.
 	if hasVersion && hasKind {
-		var p string
 		for _, el := range r.Map[g][v] {
 			if el.Kind == k {
-				p = el.Plural
-				break
+				return []groupVersionKindPlural{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   g,
+							Version: v,
+							Kind:    k,
+						},
+						Plural: el.Plural,
+					},
+				}, nil
 			}
 		}
-		return []groupVersionKindPlural{
-			{
-				GroupVersionKind: schema.GroupVersionKind{
-					Group:   g,
-					Version: v,
-					Kind:    k,
-				},
-				Plural: p,
-			},
-		}, nil
 	}
 	if hasVersion && !hasKind {
 		kinds := r.Map[g][v]

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -163,6 +163,23 @@ func TestGVKMapsResolveGVK(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "fixed version and kind, no matching cache entry",
+			gvkmaps: &CRDiscoverer{
+				Map: map[string]map[string][]kindPlural{
+					"testgroup": {
+						"v1": {
+							kindPlural{
+								Kind:   "TestObject2",
+								Plural: "testobjects2",
+							},
+						},
+					},
+				},
+			},
+			gvk:  schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
+			want: nil,
+		},
 	}
 	for _, tc := range testcases {
 		got, err := tc.gvkmaps.ResolveGVKToGVKPs(tc.gvk)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Currently in CR discoverer, for the case where the GVK are all specified for a CR in CRS config (see below example) but CRD not registered, it will still have that CR enabled in CR factories.

```
kind: CustomResourceStateMetrics
spec:
  resources:
    - groupVersionKind:
        group: jobset.x-k8s.io
        kind: "JobSet"
        version: "v1alpha2"
```

The expected behaviour is that that resource shouldn't be enabled since the cache map doesn't contain that CRD.

This PR fixes this issue.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

No change for cardinality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2566
