### PR TITLE
feat: Adds category label for unschedulable pod as part of `kube_pod_status_unschedulable` metric

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -1628,8 +1628,8 @@ func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
 			for _, c := range p.Status.Conditions {
 				if c.Type == v1.PodScheduled && c.Status == v1.ConditionFalse {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{},
-						LabelValues: []string{},
+						LabelKeys:   []string{"reason"},
+						LabelValues: []string{c.Message},
 						Value:       1,
 					})
 				}

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -1628,7 +1628,7 @@ func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
 			for _, c := range p.Status.Conditions {
 				if c.Type == v1.PodScheduled && c.Status == v1.ConditionFalse {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"reason"},
+						LabelKeys:   []string{"message"},
 						LabelValues: []string{c.Message},
 						Value:       1,
 					})

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1691,7 +1691,7 @@ func TestPodStore(t *testing.T) {
 			Want: `
 				# HELP kube_pod_status_unschedulable [STABLE] Describes the unschedulable status for the pod.
 				# TYPE kube_pod_status_unschedulable gauge
-				kube_pod_status_unschedulable{namespace="ns2",pod="pod2",uid="uid2",reason="0/3 nodes are available: 3 Insufficient cpu."} 1
+				kube_pod_status_unschedulable{namespace="ns2",pod="pod2",uid="uid2",message="0/3 nodes are available: 3 Insufficient cpu."} 1
 			`,
 			MetricNames: []string{"kube_pod_status_unschedulable"},
 		},

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1691,7 +1691,32 @@ func TestPodStore(t *testing.T) {
 			Want: `
 				# HELP kube_pod_status_unschedulable [STABLE] Describes the unschedulable status for the pod.
 				# TYPE kube_pod_status_unschedulable gauge
-				kube_pod_status_unschedulable{namespace="ns2",pod="pod2",uid="uid2",message="0/3 nodes are available: 3 Insufficient cpu."} 1
+				kube_pod_status_unschedulable{namespace="ns2",pod="pod2",uid="uid2",category="RESOURCE"} 1
+			`,
+			MetricNames: []string{"kube_pod_status_unschedulable"},
+		},
+		{
+			Obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "ns2",
+					UID:       "uid2",
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Type:    v1.PodScheduled,
+							Status:  v1.ConditionFalse,
+							Reason:  "Unschedulable",
+							Message: "failed due to pod affinity.",
+						},
+					},
+				},
+			},
+			Want: `
+				# HELP kube_pod_status_unschedulable [STABLE] Describes the unschedulable status for the pod.
+				# TYPE kube_pod_status_unschedulable gauge
+				kube_pod_status_unschedulable{namespace="ns2",pod="pod2",uid="uid2",category="AFFINITY"} 1
 			`,
 			MetricNames: []string{"kube_pod_status_unschedulable"},
 		},

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1691,7 +1691,7 @@ func TestPodStore(t *testing.T) {
 			Want: `
 				# HELP kube_pod_status_unschedulable [STABLE] Describes the unschedulable status for the pod.
 				# TYPE kube_pod_status_unschedulable gauge
-				kube_pod_status_unschedulable{namespace="ns2",pod="pod2",uid="uid2"} 1
+				kube_pod_status_unschedulable{namespace="ns2",pod="pod2",uid="uid2",reason="0/3 nodes are available: 3 Insufficient cpu."} 1
 			`,
 			MetricNames: []string{"kube_pod_status_unschedulable"},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR allows us to determine if a pod's reason for being unschedulable by introducing a custom `category` label:
- `RESOURCE` - Pod is unschedulable due to insufficient resources.
- `AFFINITY` - Pod is unschedulable due to pod affinity.
- `UNKNOWN` - Pod is unschedulable due to unknown reasons.

The `category` is derived from making assumptions on the the `PodCondition.Message` value (see below).

```go
// PodCondition contains details for the current condition of this pod.
type PodCondition struct {
	...
	// Human-readable message indicating details about last transition.
	// +optional
	Message string `json:"message,omitempty" protobuf:"bytes,6,opt,name=message"`
        ...
}
```

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

Increases cardinality mildly due to the addition of a label with 3 dimensions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
(No ongoing issue)
