### PR TITLE
style: fix warning during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GOVERSION=1.23
 ARG GOARCH
-FROM golang:${GOVERSION} as builder
+FROM golang:${GOVERSION} AS builder
 ARG GOARCH
 ENV GOARCH=${GOARCH}
 WORKDIR /go/src/k8s.io/kube-state-metrics/


### PR DESCRIPTION
by addressing the warning below.

```
make container
...

 2 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
```


**How does this change affect the cardinality of KSM**: does not change cardinality
