### PR TITLE
docs: update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -294,13 +294,13 @@ The above configuration was tested on [this](https://github.com/kubernetes/autos
 
 ### Metric types
 
-The configuration supports three kind of metrics from the [OpenMetrics specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md).
+The configuration supports three kind of metrics from the [OpenMetrics specification](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md).
 
 The metric type is specified by the `type` field and its specific configuration at the types specific struct.
 
 #### Gauge
 
-> Gauges are current measurements, such as bytes of memory currently used or the number of items in a queue. For gauges the absolute value is what is of interest to a user. [[0]](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#gauge)
+> Gauges are current measurements, such as bytes of memory currently used or the number of items in a queue. For gauges the absolute value is what is of interest to a user. [[0]](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#gauge)
 
 Example:
 
@@ -386,7 +386,7 @@ kube_customresource_foo_status{customresource_group="myteam.io", customresource_
 
 #### StateSet
 
-> StateSets represent a series of related boolean values, also called a bitset. If ENUMs need to be encoded this MAY be done via StateSet. [[1]](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#stateset)
+> StateSets represent a series of related boolean values, also called a bitset. If ENUMs need to be encoded this MAY be done via StateSet. [[1]](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#stateset)
 
 ```yaml
 kind: CustomResourceStateMetrics
@@ -420,7 +420,7 @@ kube_customresource_status_phase{customresource_group="myteam.io", customresourc
 
 #### Info
 
-> Info metrics are used to expose textual information which SHOULD NOT change during process lifetime. Common examples are an application's version, revision control commit, and the version of a compiler. [[2]](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#info)
+> Info metrics are used to expose textual information which SHOULD NOT change during process lifetime. Common examples are an application's version, revision control commit, and the version of a compiler. [[2]](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#info)
 
 Metrics of type `Info` will always have a value of 1.
 

--- a/pkg/customresourcestate/config_metrics_types.go
+++ b/pkg/customresourcestate/config_metrics_types.go
@@ -25,7 +25,7 @@ type MetricMeta struct {
 }
 
 // MetricGauge targets a Path that may be a single value, array, or object. Arrays and objects will generate a metric per element.
-// Ref: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#gauge
+// Ref: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#gauge
 type MetricGauge struct {
 	// LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
 	LabelFromKey string `yaml:"labelFromKey" json:"labelFromKey"`
@@ -38,7 +38,7 @@ type MetricGauge struct {
 }
 
 // MetricInfo is a metric which is used to expose textual information.
-// Ref: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#info
+// Ref: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#info
 type MetricInfo struct {
 	// LabelFromKey adds a label with the given name if Path is an object. The label value will be the object key.
 	LabelFromKey string `yaml:"labelFromKey" json:"labelFromKey"`
@@ -46,7 +46,7 @@ type MetricInfo struct {
 }
 
 // MetricStateSet is a metric which represent a series of related boolean values, also called a bitset.
-// Ref: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#stateset
+// Ref: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#stateset
 type MetricStateSet struct {
 	MetricMeta `yaml:",inline" json:",inline"`
 

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -37,7 +37,7 @@ var (
 	}
 )
 
-// Type represents the type of the metric. See https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-types.
+// Type represents the type of the metric. See https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#metric-types.
 type Type string
 
 // Supported metric types.


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.