### PR TITLE
docs(customresourestate): add example to expose same metrics with different label

### DIFF
--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -32,6 +32,7 @@ spec:
           # in YAML files, | allows a multi-line string to be passed as a flag value
           # see https://yaml-multiline.info
           -  |
+              kind: CustomResourceStateMetrics
               spec:
                 resources:
                   - groupVersionKind:
@@ -65,6 +66,7 @@ spec:
           # in YAML files, | allows a multi-line string to be passed as a flag value
           # see https://yaml-multiline.info
           -  |
+              kind: CustomResourceStateMetrics
               spec:
                 resources:
                   - groupVersionKind:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Give an example on how to expose a same metrics with different label (VPA recommendation for example)

**How does this change affect the cardinality of KSM**: does not change cardinality directly since this is an optional / custom resource state metrics

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
