### PR TITLE
fix(jsonnet): Fix NoNodePod naming

### DIFF
--- a/examples/daemonsetsharding/deployment-unscheduled-pods-fetching-service.yaml
+++ b/examples/daemonsetsharding/deployment-unscheduled-pods-fetching-service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics-unscheduled-pods-fetching
-    app.kubernetes.io/version: 2.13.0
+    app.kubernetes.io/version: 2.14.0
   name: kube-state-metrics-unscheduled-pods-fetching
   namespace: kube-system
 spec:

--- a/examples/daemonsetsharding/deployment-unscheduled-pods-fetching.yaml
+++ b/examples/daemonsetsharding/deployment-unscheduled-pods-fetching.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics-unscheduled-pods-fetching
-    app.kubernetes.io/version: 2.13.0
+    app.kubernetes.io/version: 2.14.0
   name: kube-state-metrics-unscheduled-pods-fetching
   namespace: kube-system
 spec:
@@ -17,14 +17,14 @@ spec:
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics-unscheduled-pods-fetching
-        app.kubernetes.io/version: 2.13.0
+        app.kubernetes.io/version: 2.14.0
     spec:
       automountServiceAccountToken: true
       containers:
       - args:
         - --resources=pods
         - --track-unscheduled-pods
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         livenessProbe:
           httpGet:
             path: /livez

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -374,7 +374,7 @@
         },
       ),
 
-    deploymentNoNodePods:
+    deploymentUnscheduledPodsFetching:
       local shardksmname = ksm.name + '-unscheduled-pods-fetching';
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
@@ -408,7 +408,7 @@
         },
       ),
 
-    deploymentNoNodePodsService:
+    deploymentUnscheduledPodsFetchingService:
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
           '--resources=pods',


### PR DESCRIPTION
**What this PR does / why we need it**:
This has an effect on the file name, and otherwise we would render the wrong file name in the examples file. This lead to the fact that we didn't upgrade the existing files in the last release (v2.14.0)
CC: @CatherineF-dev
**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
