### PR TITLE
fix(customresourcestate): generate unique HELP message for each family

### DIFF
--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -177,13 +177,13 @@ func FromConfig(decoder ConfigDecoder, discovererInstance *discovery.CRDiscovere
 		// resolvedGVKPs will have the final list of GVKs, in addition to the resolved G** resources.
 		var resolvedGVKPs []Resource
 		for _, resource := range resources /* G** */ {
-			resolvedSet /* GVKPs */, err := discovererInstance.ResolveGVKToGVKPs(schema.GroupVersionKind(resource.GroupVersionKind))
+			resolvedSet /* GVKPs */, err := discovererInstance.ResolveGVKToGVKPs(resource.GroupVersionKind)
 			if err != nil {
 				klog.ErrorS(err, "failed to resolve GVK", "gvk", resource.GroupVersionKind)
 			}
 			for _, resolved /* GVKP */ := range resolvedSet {
 				// Set their G** attributes to various resolutions of the GVK.
-				resource.GroupVersionKind = schema.GroupVersionKind(resolved.GroupVersionKind)
+				resource.GroupVersionKind = resolved.GroupVersionKind
 				// Set the plural name of the resource based on the extracted value from the same field in the CRD schema.
 				resource.ResourcePlural = resolved.Plural
 				resolvedGVKPs = append(resolvedGVKPs, resource)

--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -59,7 +59,7 @@ type Resource struct {
 	MetricNamePrefix *string `yaml:"metricNamePrefix" json:"metricNamePrefix"`
 
 	// GroupVersionKind of the custom resource to be monitored.
-	GroupVersionKind GroupVersionKind `yaml:"groupVersionKind" json:"groupVersionKind"`
+	GroupVersionKind schema.GroupVersionKind `yaml:"groupVersionKind" json:"groupVersionKind"`
 
 	// ResourcePlural sets the plural name of the resource. Defaults to the plural version of the Kind according to flect.Pluralize.
 	ResourcePlural string `yaml:"resourcePlural" json:"resourcePlural"`
@@ -87,17 +87,6 @@ func (r Resource) GetResourceName() string {
 	}
 	// kubebuilder default:
 	return strings.ToLower(flect.Pluralize(r.GroupVersionKind.Kind))
-}
-
-// GroupVersionKind is the Kubernetes group, version, and kind of a resource.
-type GroupVersionKind struct {
-	Group   string `yaml:"group" json:"group"`
-	Version string `yaml:"version" json:"version"`
-	Kind    string `yaml:"kind" json:"kind"`
-}
-
-func (gvk GroupVersionKind) String() string {
-	return fmt.Sprintf("%s_%s_%s", gvk.Group, gvk.Version, gvk.Kind)
 }
 
 // Labels is common configuration of labels to add to metrics.
@@ -194,7 +183,7 @@ func FromConfig(decoder ConfigDecoder, discovererInstance *discovery.CRDiscovere
 			}
 			for _, resolved /* GVKP */ := range resolvedSet {
 				// Set their G** attributes to various resolutions of the GVK.
-				resource.GroupVersionKind = GroupVersionKind(resolved.GroupVersionKind)
+				resource.GroupVersionKind = schema.GroupVersionKind(resolved.GroupVersionKind)
 				// Set the plural name of the resource based on the extracted value from the same field in the CRD schema.
 				resource.ResourcePlural = resolved.Plural
 				resolvedGVKPs = append(resolvedGVKPs, resource)

--- a/pkg/customresourcestate/custom_resource_metrics.go
+++ b/pkg/customresourcestate/custom_resource_metrics.go
@@ -50,10 +50,9 @@ func NewCustomResourceMetrics(resource Resource) (customresource.RegistryFactory
 	if err != nil {
 		return nil, err
 	}
-	gvk := schema.GroupVersionKind(resource.GroupVersionKind)
 	return &customResourceMetrics{
 		MetricNamePrefix: resource.GetMetricNamePrefix(),
-		GroupVersionKind: gvk,
+		GroupVersionKind: resource.GroupVersionKind,
 		Families:         compiled,
 		ResourceName:     resource.GetResourceName(),
 	}, nil

--- a/pkg/customresourcestate/custom_resource_metrics_test.go
+++ b/pkg/customresourcestate/custom_resource_metrics_test.go
@@ -83,7 +83,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 				Families: []compiledFamily{
 					{
 						Name: "kube_customresource_test_metrics",
-						Help: "metrics for testing",
+						Help: "metrics for testing for apps/v1/Deployment",
 						Each: &compiledInfo{},
 						Labels: map[string]string{
 							"customresource_group":   "apps",
@@ -146,7 +146,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 				Families: []compiledFamily{
 					{
 						Name: "apps_deployment_test_metrics",
-						Help: "metrics for testing",
+						Help: "metrics for testing for apps/v1/Deployment",
 						Each: &compiledInfo{},
 						Labels: map[string]string{
 							"customresource_group":   "apps",
@@ -208,7 +208,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 				Families: []compiledFamily{
 					{
 						Name: "apps_deployment_test_metrics",
-						Help: "metrics for testing",
+						Help: "metrics for testing for apps/v1/Deployment",
 						Each: &compiledInfo{},
 						Labels: map[string]string{
 							"customresource_group":   "apps",

--- a/pkg/customresourcestate/custom_resource_metrics_test.go
+++ b/pkg/customresourcestate/custom_resource_metrics_test.go
@@ -39,7 +39,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 			// https://github.com/kubernetes/kube-state-metrics/issues/1886
 			name: "cr metric with dynamic metric type",
 			r: Resource{
-				GroupVersionKind: GroupVersionKind{
+				GroupVersionKind: schema.GroupVersionKind{
 					Group:   "apps",
 					Version: "v1",
 					Kind:    "Deployment",
@@ -83,7 +83,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 				Families: []compiledFamily{
 					{
 						Name: "kube_customresource_test_metrics",
-						Help: "metrics for testing for apps_v1_Deployment",
+						Help: "metrics for testing for apps/v1, Kind=Deployment",
 						Each: &compiledInfo{},
 						Labels: map[string]string{
 							"customresource_group":   "apps",
@@ -101,7 +101,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 		{
 			name: "cr metric with custom prefix",
 			r: Resource{
-				GroupVersionKind: GroupVersionKind{
+				GroupVersionKind: schema.GroupVersionKind{
 					Group:   "apps",
 					Version: "v1",
 					Kind:    "Deployment",
@@ -146,7 +146,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 				Families: []compiledFamily{
 					{
 						Name: "apps_deployment_test_metrics",
-						Help: "metrics for testing for apps_v1_Deployment",
+						Help: "metrics for testing for apps/v1, Kind=Deployment",
 						Each: &compiledInfo{},
 						Labels: map[string]string{
 							"customresource_group":   "apps",
@@ -164,7 +164,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 		{
 			name: "cr metric with custom prefix - expect error",
 			r: Resource{
-				GroupVersionKind: GroupVersionKind{
+				GroupVersionKind: schema.GroupVersionKind{
 					Group:   "apps",
 					Version: "v1",
 					Kind:    "Deployment",
@@ -208,7 +208,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 				Families: []compiledFamily{
 					{
 						Name: "apps_deployment_test_metrics",
-						Help: "metrics for testing for apps_v1_Deployment",
+						Help: "metrics for testing for apps/v1, Kind=Deployment",
 						Each: &compiledInfo{},
 						Labels: map[string]string{
 							"customresource_group":   "apps",

--- a/pkg/customresourcestate/custom_resource_metrics_test.go
+++ b/pkg/customresourcestate/custom_resource_metrics_test.go
@@ -83,7 +83,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 				Families: []compiledFamily{
 					{
 						Name: "kube_customresource_test_metrics",
-						Help: "metrics for testing for apps/v1/Deployment",
+						Help: "metrics for testing for apps_v1_Deployment",
 						Each: &compiledInfo{},
 						Labels: map[string]string{
 							"customresource_group":   "apps",
@@ -146,7 +146,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 				Families: []compiledFamily{
 					{
 						Name: "apps_deployment_test_metrics",
-						Help: "metrics for testing for apps/v1/Deployment",
+						Help: "metrics for testing for apps_v1_Deployment",
 						Each: &compiledInfo{},
 						Labels: map[string]string{
 							"customresource_group":   "apps",
@@ -208,7 +208,7 @@ func TestNewCustomResourceMetrics(t *testing.T) {
 				Families: []compiledFamily{
 					{
 						Name: "apps_deployment_test_metrics",
-						Help: "metrics for testing for apps/v1/Deployment",
+						Help: "metrics for testing for apps_v1_Deployment",
 						Each: &compiledInfo{},
 						Labels: map[string]string{
 							"customresource_group":   "apps",

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -90,10 +90,13 @@ func compileFamily(f Generator, resource Resource) (*compiledFamily, error) {
 	if errorLogV == 0 {
 		errorLogV = resource.ErrorLogV
 	}
+
+	help := fmt.Sprintf("%s for %s/%s/%s", f.Help, resource.GroupVersionKind.Group, resource.GroupVersionKind.Version, resource.GroupVersionKind.Kind)
+
 	return &compiledFamily{
 		Name:          fullName(resource, f),
 		ErrorLogV:     errorLogV,
-		Help:          f.Help,
+		Help:          help,
 		Each:          metric,
 		Labels:        labels.CommonLabels,
 		LabelFromPath: labelsFromPath,

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -91,7 +91,7 @@ func compileFamily(f Generator, resource Resource) (*compiledFamily, error) {
 		errorLogV = resource.ErrorLogV
 	}
 
-	help := fmt.Sprintf("%s for %s/%s/%s", f.Help, resource.GroupVersionKind.Group, resource.GroupVersionKind.Version, resource.GroupVersionKind.Kind)
+	help := fmt.Sprintf("%s for %s", f.Help, resource.GroupVersionKind)
 
 	return &compiledFamily{
 		Name:          fullName(resource, f),

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -23,9 +23,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 )
 

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 )
 
@@ -493,8 +494,8 @@ func r(metricNamePrefix *string) Resource {
 	return Resource{MetricNamePrefix: metricNamePrefix, GroupVersionKind: gkv("apps", "v1", "Deployment")}
 }
 
-func gkv(group, version, kind string) GroupVersionKind {
-	return GroupVersionKind{
+func gkv(group, version, kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{
 		Group:   group,
 		Version: version,
 		Kind:    kind,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The family generator creates a family per GVK, this requires that the
configuration has a unique HELP text per custom metric. This is not
feasible when using wildcards as the generate will reuse the same HELP
text for each GVK it finds.


**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

It does not change cardinality but does change the HELP text on metrics generated by CustomResourceState.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2384, fixes #2453
