### PR TITLE
fix: Bump golang/x/net version for CVE-2025-22870

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ require (
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.21.0 // indirect
-	golang.org/x/net v0.35.0 // indirect
+	golang.org/x/net v0.36.0 // indirect
 	golang.org/x/oauth2 v0.26.0 // indirect
 	golang.org/x/perf v0.0.0-20250214215153-c95ad7d5b636 // indirect
 	golang.org/x/sync v0.11.0 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:

Increment version of golang/x/net to fix [CVE-2025-22870](https://github.com/advisories/GHSA-qxp5-gwg8-xv66) 

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

No change