### PR TITLE
fix: report correct reason in kube_pod_status_reason metric

### DIFF
--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -2290,3 +2290,85 @@ func BenchmarkPodStore(b *testing.B) {
 		}
 	}
 }
+
+func TestGetPodStatusReasonValue(t *testing.T) {
+	reason := "TestReason"
+
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want float64
+	}{
+		{
+			name: "matches Status.Reason",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					Reason: "TestReason",
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "matches condition Reason",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Reason: "TestReason",
+						},
+					},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "matches container terminated Reason",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									Reason: "TestReason",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "no match returns 0",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					Reason: "OtherReason",
+					Conditions: []v1.PodCondition{
+						{
+							Reason: "NotTestReason",
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									Reason: "AnotherReason",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getPodStatusReasonValue(tt.pod, reason)
+			if got != tt.want {
+				t.Errorf("getPodStatusReasonValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR updates the logic for generating the kube_pod_status_reason metric. Instead of only checking p.Status.Reason, the new implementation also verifies the pod conditions and the termination reasons of container statuses. This change fixes an issue where the metric always returned 0, even when a pod had a valid status reason (such as "Evicted", "NodeLost", etc.), leading to inaccurate monitoring data. Accurately reporting these values is crucial for diagnosing pod behavior and overall cluster health.

**How does this change affect the cardinality of KSM:**
It does not change the cardinality. The update only adjusts the value calculation for an existing metric family, so no new labels or metric series are introduced.

**Which issue(s) this PR fixes:**
Fixes #2612
