### PR TITLE
chore: Port away from gopkg.in/yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.3
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
@@ -27,6 +26,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/sample-controller v0.32.3
 	k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -236,11 +236,11 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 tool (

--- a/internal/wrapper.go
+++ b/internal/wrapper.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	"k8s.io/kube-state-metrics/v2/pkg/app"
 	"k8s.io/kube-state-metrics/v2/pkg/options"

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -33,11 +33,11 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"gopkg.in/yaml.v3"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Initialize common client auth plugins.
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/oklog/run"

--- a/pkg/customresourcestate/config_test.go
+++ b/pkg/customresourcestate/config_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
 //go:embed example_config.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
gopkg.in/yaml.v3 is deprecated by upstream and we can use sigs.k8s.io/yaml now.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
