### PR TITLE
fix: Clean up CR reflectors after parent CRD deletion

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -64,8 +64,8 @@ func (r *CRDiscoverer) StartDiscovery(ctx context.Context, config *rest.Config) 
 					},
 					Plural: p,
 				}
-				r.AppendToMap(gotGVKP)
 				r.SafeWrite(func() {
+					r.AppendToMap(gotGVKP)
 					r.WasUpdated = true
 				})
 			}
@@ -89,8 +89,8 @@ func (r *CRDiscoverer) StartDiscovery(ctx context.Context, config *rest.Config) 
 					},
 					Plural: p,
 				}
-				r.RemoveFromMap(gotGVKP)
 				r.SafeWrite(func() {
+					r.RemoveFromMap(gotGVKP)
 					r.WasUpdated = true
 				})
 			}

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -296,6 +296,8 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 			CRDsDeleteEventsCounter: crdsDeleteEventsCounter,
 			CRDsCacheCountGauge:     crdsCacheCountGauge,
 		}
+		// storeBuilder starts reflectors for the discovered GVKs, and as such, should close them too.
+		storeBuilder.GVKToReflectorStopChanMap = &discovererInstance.GVKToReflectorStopChanMap
 		// This starts a goroutine that will watch for any new GVKs to extract from CRDs.
 		err = discovererInstance.StartDiscovery(ctx, kubeConfig)
 		if err != nil {


### PR DESCRIPTION
With this patch, CRD deletions don't make CRS throw LW errors from the respective CRD's reflector anymore.

I noticed this way back, but never got around to actually patching it. That is, until a certain request downstream made me ponder it again, for which we currently have a workaround in the parent operator, which we would be better off without. Also, this workaround would more-or-less be what anyone would have to do to prevent CRS from false alerting where there's a cache race.

This reduces our urgent need for [1] to go in, as it addresses the "failed to list/watch resource" errors from client-go's `tools/cache/reflector.go` owing to which, in addition to error logs, we also saw `kube_state_metrics_{list,watch}{result="error"}` increment, leading to false alerts in the metrics backend.

Note that we still need control over client-go's error machinery, so I'll keep that issue open. See [2] for more details about this change.

[1]: https://github.com/kubernetes/kubernetes/issues/127329
[2]: https://github.com/openshift/cluster-monitoring-operator/pull/2595

***

To reproduce this, run KSM with the CRS configuration pointing to a CRD, deploy the CRD and CR, then delete them. Usually (not 100% of the time, as this is a race, but pretty frequently) this will log a "failed to watch" error, and `watch_total{result="error"}` will be incremented as well.

***

Update: The patch now consists of a single commit that cleans up reflectors for CRs for which the CRDs have been deleted, thus avoiding a memory leak. This additionally fixes the aforementioned problem statement as well.