### PR TITLE
Continue running kube-state-metrics when config file doesnt exist at startup

### DIFF
--- a/internal/wrapper.go
+++ b/internal/wrapper.go
@@ -52,6 +52,10 @@ func RunKubeStateMetricsWrapper(opts *options.Options) {
 		if err = cfgViper.ReadInConfig(); err != nil {
 			if errors.Is(err, viper.ConfigFileNotFoundError{}) {
 				klog.InfoS("Options configuration file not found at startup", "file", file)
+			} else if _, err = os.Stat(filepath.Clean(file)); os.IsNotExist(err) {
+				// Adding this check in addition to the above since viper.ConfigFileNotFoundError is not working as expected due to this issue -
+				// https://github.com/spf13/viper/issues/1783
+				klog.InfoS("Options configuration file not found at startup", "file", file)
 			} else {
 				klog.ErrorS(err, "Error reading options configuration file", "file", file)
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR enables k-s-m should to run when config file doesnt exist.
Currently, [k-s-m expects the file provided in the config parameter to exist at startup](https://github.com/kubernetes/kube-state-metrics/blob/56d3b561e6954e0055ea0d6f2d7034f6d898b6c6/internal/wrapper.go#L50C1-L56C47) and if not, errors out. We are planning to take dependency on the config file by mounting it as an optional configmap which users can use to optionally override k-s-m configuration.

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Does not change cardinality

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2700 
