### PR TITLE
customresourcestate: fix panic

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -652,7 +652,7 @@ func compilePath(path []string) (out valuePath, _ error) {
 							// negative index
 							i += len(s)
 						}
-						if i < 0 || i > len(s) {
+						if i < 0 || i >= len(s) {
 							return fmt.Errorf("list index out of range: %s", part)
 						}
 						return s[i]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes following panic:

```go
E0804 12:57:09.762257       1 panic.go:115] "Observed a panic" panic="runtime error: index out of range [1] with length 1" panicGoValue="runtime.boundsError{x:1, y:1, signed:true, code:0x0}" stacktrace=<
        goroutine 233 [running]:
        k8s.io/apimachinery/pkg/util/runtime.logPanic({0x27e71d0, 0x3c38b80}, {0x22cf3a0, 0xc00272ea08})
                /go/pkg/mod/k8s.io/apimachinery@v0.32.6/pkg/util/runtime/runtime.go:107 +0xbc
        k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x27e71d0, 0x3c38b80}, {0x22cf3a0, 0xc00272ea08}, {0x3c38b80, 0x0, 0x10000c002706f60?})
                /go/pkg/mod/k8s.io/apimachinery@v0.32.6/pkg/util/runtime/runtime.go:82 +0x5a
        k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x2540be400?})
                /go/pkg/mod/k8s.io/apimachinery@v0.32.6/pkg/util/runtime/runtime.go:59 +0x105
        panic({0x22cf3a0?, 0xc00272ea08?})
                /usr/local/go/src/runtime/panic.go:792 +0x132
        k8s.io/kube-state-metrics/v2/pkg/customresourcestate.compilePath.func2({0x1f22ea0?, 0xc002706ea0?})
                /go/src/k8s.io/kube-state-metrics/pkg/customresourcestate/registry_factory.go:658 +0x24a
        k8s.io/kube-state-metrics/v2/pkg/customresourcestate.valuePath.Get(...)
                /go/src/k8s.io/kube-state-metrics/pkg/customresourcestate/registry_factory.go:564
        k8s.io/kube-state-metrics/v2/pkg/customresourcestate.addPathLabels({0x21177a0, 0xc002705d70}, 0xc0011d9080, 0xc002778ea0)
                /go/src/k8s.io/kube-state-metrics/pkg/customresourcestate/registry_factory.go:543 +0x552
        k8s.io/kube-state-metrics/v2/pkg/customresourcestate.compiledFamily.BaseLabels({{0x7f25fd19f198, 0xc000d4bd40}, 0xc0011d8f90, 0xc0011d9080, {0xc003d0a740, 0x39}, {0xc000058e10, 0x44}, 0x0}, 0xc002705d70)
                /go/src/k8s.io/kube-state-metrics/pkg/customresourcestate/registry_factory.go:514 +0x13c
        k8s.io/kube-state-metrics/v2/pkg/customresourcestate.generate(0xc00019a7f8, {{0x7f25fd19f198, 0xc000d4bd40}, 0xc0011d8f90, 0xc0011d9080, {0xc003d0a740, 0x39}, {0xc000058e10, 0x44}, 0x0}, ...)
                /go/src/k8s.io/kube-state-metrics/pkg/customresourcestate/registry_factory.go:684 +0x248
        k8s.io/kube-state-metrics/v2/pkg/customresourcestate.famGen.func1({0x2452f00?, 0xc00019a7f8?})
                /go/src/k8s.io/kube-state-metrics/pkg/customresourcestate/registry_factory.go:675 +0x65
        k8s.io/kube-state-metrics/v2/pkg/metric_generator.(*FamilyGenerator).Generate(0xc000993a08, {0x2452f00?, 0xc00019a7f8?})
                /go/src/k8s.io/kube-state-metrics/pkg/metric_generator/generator.go:73 +0x2f
        k8s.io/kube-state-metrics/v2/internal/store.(*Builder).buildCustomResourceStores.ComposeMetricGenFuncs.func1({0x2452f00, 0xc00019a7f8})
                /go/src/k8s.io/kube-state-metrics/pkg/metric_generator/generator.go:117 +0xf0
        k8s.io/kube-state-metrics/v2/pkg/metrics_store.(*MetricsStore).Add(0xc00042bea0, {0x2452f00, 0xc00019a7f8})
                /go/src/k8s.io/kube-state-metrics/pkg/metrics_store/metrics_store.go:65 +0x65
        k8s.io/kube-state-metrics/v2/pkg/metrics_store.(*MetricsStore).Replace(0xc00042bea0, {0xc00270f1e0, 0x2, 0x3c159e0?}, {0x247d328?, 0x11?})
                /go/src/k8s.io/kube-state-metrics/pkg/metrics_store/metrics_store.go:122 +0x68
        k8s.io/client-go/tools/cache.(*Reflector).syncWith(0xc0005b1590, {0xc00270f1c0, 0x2, 0x0?}, {0xc00270ac78, 0x8})
                /go/pkg/mod/k8s.io/client-go@v0.32.6/tools/cache/reflector.go:726 +0x123
        k8s.io/client-go/tools/cache.(*Reflector).list(0xc0005b1590, 0xc003cf0f50)
                /go/pkg/mod/k8s.io/client-go@v0.32.6/tools/cache/reflector.go:599 +0x7a5
        k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0xc0005b1590, 0xc003cf0f50)
                /go/pkg/mod/k8s.io/client-go@v0.32.6/tools/cache/reflector.go:370 +0x285
        k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
                /go/pkg/mod/k8s.io/client-go@v0.32.6/tools/cache/reflector.go:315 +0x25
        k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000180008?)
                /go/pkg/mod/k8s.io/apimachinery@v0.32.6/pkg/util/wait/backoff.go:226 +0x33
        k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000993f98, {0x27c1dc0, 0xc0001f4730}, 0x1, 0xc003cf0f50)
                /go/pkg/mod/k8s.io/apimachinery@v0.32.6/pkg/util/wait/backoff.go:227 +0xaf
        k8s.io/client-go/tools/cache.(*Reflector).Run(0xc0005b1590, 0xc003cf0f50)
                /go/pkg/mod/k8s.io/client-go@v0.32.6/tools/cache/reflector.go:314 +0x1af
        created by k8s.io/kube-state-metrics/v2/internal/store.(*Builder).startReflector in goroutine 118
                /go/src/k8s.io/kube-state-metrics/internal/store/builder.go:624 +0x3f3
```

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*
Doesn't affect cardinality

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes N/A
