### PR TITLE
refactor: Replace ListerWatcher with ListerWatcherWithContext 

### DIFF
--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -153,12 +153,12 @@ func wrapCSRFunc(f func(*certv1.CertificateSigningRequest) *metric.Family) func(
 	}
 }
 
-func createCSRListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createCSRListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CertificatesV1().CertificateSigningRequests().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.CertificatesV1().CertificateSigningRequests().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -156,10 +156,10 @@ func wrapCSRFunc(f func(*certv1.CertificateSigningRequest) *metric.Family) func(
 func createCSRListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.CertificatesV1().CertificateSigningRequests().List(context.TODO(), opts)
+			return kubeClient.CertificatesV1().CertificateSigningRequests().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.CertificatesV1().CertificateSigningRequests().Watch(context.TODO(), opts)
+			return kubeClient.CertificatesV1().CertificateSigningRequests().Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/clusterrole.go
+++ b/internal/store/clusterrole.go
@@ -141,10 +141,10 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 func createClusterRoleListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.RbacV1().ClusterRoles().List(context.TODO(), opts)
+			return kubeClient.RbacV1().ClusterRoles().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.RbacV1().ClusterRoles().Watch(context.TODO(), opts)
+			return kubeClient.RbacV1().ClusterRoles().Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/clusterrole.go
+++ b/internal/store/clusterrole.go
@@ -138,12 +138,12 @@ func clusterRoleMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 	}
 }
 
-func createClusterRoleListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createClusterRoleListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.RbacV1().ClusterRoles().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.RbacV1().ClusterRoles().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/clusterrolebinding.go
+++ b/internal/store/clusterrolebinding.go
@@ -140,12 +140,12 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 	}
 }
 
-func createClusterRoleBindingListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createClusterRoleBindingListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.RbacV1().ClusterRoleBindings().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.RbacV1().ClusterRoleBindings().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/clusterrolebinding.go
+++ b/internal/store/clusterrolebinding.go
@@ -143,10 +143,10 @@ func clusterRoleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []st
 func createClusterRoleBindingListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.RbacV1().ClusterRoleBindings().List(context.TODO(), opts)
+			return kubeClient.RbacV1().ClusterRoleBindings().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.RbacV1().ClusterRoleBindings().Watch(context.TODO(), opts)
+			return kubeClient.RbacV1().ClusterRoleBindings().Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -134,13 +134,13 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 	}
 }
 
-func createConfigMapListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createConfigMapListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().ConfigMaps(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().ConfigMaps(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -138,11 +138,11 @@ func createConfigMapListWatch(kubeClient clientset.Interface, ns string, fieldSe
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().ConfigMaps(ns).List(context.TODO(), opts)
+			return kubeClient.CoreV1().ConfigMaps(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().ConfigMaps(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().ConfigMaps(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -338,13 +338,13 @@ func wrapCronJobFunc(f func(*batchv1.CronJob) *metric.Family) func(interface{}) 
 	}
 }
 
-func createCronJobListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createCronJobListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.BatchV1().CronJobs(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.BatchV1().CronJobs(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -342,11 +342,11 @@ func createCronJobListWatch(kubeClient clientset.Interface, ns string, fieldSele
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.BatchV1().CronJobs(ns).List(context.TODO(), opts)
+			return kubeClient.BatchV1().CronJobs(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.BatchV1().CronJobs(ns).Watch(context.TODO(), opts)
+			return kubeClient.BatchV1().CronJobs(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -288,11 +288,11 @@ func createDaemonSetListWatch(kubeClient clientset.Interface, ns string, fieldSe
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.AppsV1().DaemonSets(ns).List(context.TODO(), opts)
+			return kubeClient.AppsV1().DaemonSets(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.AppsV1().DaemonSets(ns).Watch(context.TODO(), opts)
+			return kubeClient.AppsV1().DaemonSets(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -284,13 +284,13 @@ func wrapDaemonSetFunc(f func(*v1.DaemonSet) *metric.Family) func(interface{}) *
 	}
 }
 
-func createDaemonSetListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createDaemonSetListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.AppsV1().DaemonSets(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.AppsV1().DaemonSets(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -348,11 +348,11 @@ func createDeploymentListWatch(kubeClient clientset.Interface, ns string, fieldS
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.AppsV1().Deployments(ns).List(context.TODO(), opts)
+			return kubeClient.AppsV1().Deployments(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.AppsV1().Deployments(ns).Watch(context.TODO(), opts)
+			return kubeClient.AppsV1().Deployments(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -344,13 +344,13 @@ func wrapDeploymentFunc(f func(*v1.Deployment) *metric.Family) func(interface{})
 	}
 }
 
-func createDeploymentListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createDeploymentListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.AppsV1().Deployments(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.AppsV1().Deployments(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -203,11 +203,11 @@ func createEndpointsListWatch(kubeClient clientset.Interface, ns string, fieldSe
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().Endpoints(ns).List(context.TODO(), opts)
+			return kubeClient.CoreV1().Endpoints(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().Endpoints(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().Endpoints(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -199,13 +199,13 @@ func wrapEndpointFunc(f func(*v1.Endpoints) *metric.Family) func(interface{}) *m
 	}
 }
 
-func createEndpointsListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createEndpointsListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().Endpoints(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().Endpoints(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/endpointslice.go
+++ b/internal/store/endpointslice.go
@@ -255,13 +255,13 @@ func wrapEndpointSliceFunc(f func(*discoveryv1.EndpointSlice) *metric.Family) fu
 	}
 }
 
-func createEndpointSliceListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createEndpointSliceListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.DiscoveryV1().EndpointSlices(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.DiscoveryV1().EndpointSlices(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/endpointslice.go
+++ b/internal/store/endpointslice.go
@@ -259,11 +259,11 @@ func createEndpointSliceListWatch(kubeClient clientset.Interface, ns string, fie
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.DiscoveryV1().EndpointSlices(ns).List(context.TODO(), opts)
+			return kubeClient.DiscoveryV1().EndpointSlices(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.DiscoveryV1().EndpointSlices(ns).Watch(context.TODO(), opts)
+			return kubeClient.DiscoveryV1().EndpointSlices(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -87,11 +87,11 @@ func createHPAListWatch(kubeClient clientset.Interface, ns string, fieldSelector
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.AutoscalingV2().HorizontalPodAutoscalers(ns).List(context.TODO(), opts)
+			return kubeClient.AutoscalingV2().HorizontalPodAutoscalers(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.AutoscalingV2().HorizontalPodAutoscalers(ns).Watch(context.TODO(), opts)
+			return kubeClient.AutoscalingV2().HorizontalPodAutoscalers(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -83,13 +83,13 @@ func wrapHPAFunc(f func(*autoscaling.HorizontalPodAutoscaler) *metric.Family) fu
 	}
 }
 
-func createHPAListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createHPAListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.AutoscalingV2().HorizontalPodAutoscalers(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.AutoscalingV2().HorizontalPodAutoscalers(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -223,13 +223,13 @@ func wrapIngressFunc(f func(*networkingv1.Ingress) *metric.Family) func(interfac
 	}
 }
 
-func createIngressListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createIngressListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.NetworkingV1().Ingresses(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.NetworkingV1().Ingresses(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -227,11 +227,11 @@ func createIngressListWatch(kubeClient clientset.Interface, ns string, fieldSele
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.NetworkingV1().Ingresses(ns).List(context.TODO(), opts)
+			return kubeClient.NetworkingV1().Ingresses(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.NetworkingV1().Ingresses(ns).Watch(context.TODO(), opts)
+			return kubeClient.NetworkingV1().Ingresses(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/ingressclass.go
+++ b/internal/store/ingressclass.go
@@ -137,10 +137,10 @@ func wrapIngressClassFunc(f func(*networkingv1.IngressClass) *metric.Family) fun
 func createIngressClassListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.NetworkingV1().IngressClasses().List(context.TODO(), opts)
+			return kubeClient.NetworkingV1().IngressClasses().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.NetworkingV1().IngressClasses().Watch(context.TODO(), opts)
+			return kubeClient.NetworkingV1().IngressClasses().Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/ingressclass.go
+++ b/internal/store/ingressclass.go
@@ -134,12 +134,12 @@ func wrapIngressClassFunc(f func(*networkingv1.IngressClass) *metric.Family) fun
 	}
 }
 
-func createIngressClassListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createIngressClassListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.NetworkingV1().IngressClasses().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.NetworkingV1().IngressClasses().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -444,11 +444,11 @@ func createJobListWatch(kubeClient clientset.Interface, ns string, fieldSelector
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.BatchV1().Jobs(ns).List(context.TODO(), opts)
+			return kubeClient.BatchV1().Jobs(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.BatchV1().Jobs(ns).Watch(context.TODO(), opts)
+			return kubeClient.BatchV1().Jobs(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -440,13 +440,13 @@ func wrapJobFunc(f func(*v1batch.Job) *metric.Family) func(interface{}) *metric.
 	}
 }
 
-func createJobListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createJobListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.BatchV1().Jobs(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.BatchV1().Jobs(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -120,11 +120,11 @@ func createLeaseListWatch(kubeClient clientset.Interface, ns string, fieldSelect
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoordinationV1().Leases(ns).List(context.TODO(), opts)
+			return kubeClient.CoordinationV1().Leases(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoordinationV1().Leases(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoordinationV1().Leases(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -116,13 +116,13 @@ func wrapLeaseFunc(f func(*coordinationv1.Lease) *metric.Family) func(interface{
 	}
 }
 
-func createLeaseListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createLeaseListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoordinationV1().Leases(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoordinationV1().Leases(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/limitrange.go
+++ b/internal/store/limitrange.go
@@ -129,13 +129,13 @@ func wrapLimitRangeFunc(f func(*v1.LimitRange) *metric.Family) func(interface{})
 	}
 }
 
-func createLimitRangeListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createLimitRangeListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().LimitRanges(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().LimitRanges(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/limitrange.go
+++ b/internal/store/limitrange.go
@@ -133,11 +133,11 @@ func createLimitRangeListWatch(kubeClient clientset.Interface, ns string, fieldS
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().LimitRanges(ns).List(context.TODO(), opts)
+			return kubeClient.CoreV1().LimitRanges(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().LimitRanges(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().LimitRanges(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -111,12 +111,12 @@ var (
 	}
 )
 
-func createMutatingWebhookConfigurationListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createMutatingWebhookConfigurationListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/mutatingwebhookconfiguration.go
+++ b/internal/store/mutatingwebhookconfiguration.go
@@ -114,10 +114,10 @@ var (
 func createMutatingWebhookConfigurationListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), opts)
+			return kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Watch(context.TODO(), opts)
+			return kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -179,10 +179,10 @@ func wrapNamespaceFunc(f func(*v1.Namespace) *metric.Family) func(interface{}) *
 func createNamespaceListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.CoreV1().Namespaces().List(context.TODO(), opts)
+			return kubeClient.CoreV1().Namespaces().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.CoreV1().Namespaces().Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().Namespaces().Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -176,12 +176,12 @@ func wrapNamespaceFunc(f func(*v1.Namespace) *metric.Family) func(interface{}) *
 	}
 }
 
-func createNamespaceListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createNamespaceListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().Namespaces().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.CoreV1().Namespaces().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/networkpolicy.go
+++ b/internal/store/networkpolicy.go
@@ -160,11 +160,11 @@ func createNetworkPolicyListWatch(kubeClient clientset.Interface, ns string, fie
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.NetworkingV1().NetworkPolicies(ns).List(context.TODO(), opts)
+			return kubeClient.NetworkingV1().NetworkPolicies(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.NetworkingV1().NetworkPolicies(ns).Watch(context.TODO(), opts)
+			return kubeClient.NetworkingV1().NetworkPolicies(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/networkpolicy.go
+++ b/internal/store/networkpolicy.go
@@ -156,13 +156,13 @@ func wrapNetworkPolicyFunc(f func(*networkingv1.NetworkPolicy) *metric.Family) f
 	}
 }
 
-func createNetworkPolicyListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createNetworkPolicyListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.NetworkingV1().NetworkPolicies(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.NetworkingV1().NetworkPolicies(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -523,10 +523,10 @@ func wrapNodeFunc(f func(*v1.Node) *metric.Family) func(interface{}) *metric.Fam
 func createNodeListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.CoreV1().Nodes().List(context.TODO(), opts)
+			return kubeClient.CoreV1().Nodes().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.CoreV1().Nodes().Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().Nodes().Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -520,12 +520,12 @@ func wrapNodeFunc(f func(*v1.Node) *metric.Family) func(interface{}) *metric.Fam
 	}
 }
 
-func createNodeListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createNodeListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().Nodes().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.CoreV1().Nodes().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -79,10 +79,10 @@ func wrapPersistentVolumeFunc(f func(*v1.PersistentVolume) *metric.Family) func(
 func createPersistentVolumeListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.CoreV1().PersistentVolumes().List(context.TODO(), opts)
+			return kubeClient.CoreV1().PersistentVolumes().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.CoreV1().PersistentVolumes().Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().PersistentVolumes().Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -76,12 +76,12 @@ func wrapPersistentVolumeFunc(f func(*v1.PersistentVolume) *metric.Family) func(
 	}
 }
 
-func createPersistentVolumeListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createPersistentVolumeListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.CoreV1().PersistentVolumes().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.CoreV1().PersistentVolumes().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -282,13 +282,13 @@ func wrapPersistentVolumeClaimFunc(f func(*v1.PersistentVolumeClaim) *metric.Fam
 	}
 }
 
-func createPersistentVolumeClaimListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createPersistentVolumeClaimListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().PersistentVolumeClaims(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -286,11 +286,11 @@ func createPersistentVolumeClaimListWatch(kubeClient clientset.Interface, ns str
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), opts)
+			return kubeClient.CoreV1().PersistentVolumeClaims(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().PersistentVolumeClaims(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().PersistentVolumeClaims(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -1819,13 +1819,13 @@ func wrapPodFunc(f func(*v1.Pod) *metric.Family) func(interface{}) *metric.Famil
 	}
 }
 
-func createPodListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createPodListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().Pods(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().Pods(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -1823,11 +1823,11 @@ func createPodListWatch(kubeClient clientset.Interface, ns string, fieldSelector
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().Pods(ns).List(context.TODO(), opts)
+			return kubeClient.CoreV1().Pods(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().Pods(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().Pods(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -202,13 +202,13 @@ func wrapPodDisruptionBudgetFunc(f func(*policyv1.PodDisruptionBudget) *metric.F
 	}
 }
 
-func createPodDisruptionBudgetListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createPodDisruptionBudgetListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.PolicyV1().PodDisruptionBudgets(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.PolicyV1().PodDisruptionBudgets(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -206,11 +206,11 @@ func createPodDisruptionBudgetListWatch(kubeClient clientset.Interface, ns strin
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.PolicyV1().PodDisruptionBudgets(ns).List(context.TODO(), opts)
+			return kubeClient.PolicyV1().PodDisruptionBudgets(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.PolicyV1().PodDisruptionBudgets(ns).Watch(context.TODO(), opts)
+			return kubeClient.PolicyV1().PodDisruptionBudgets(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -274,11 +274,11 @@ func createReplicaSetListWatch(kubeClient clientset.Interface, ns string, fieldS
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.AppsV1().ReplicaSets(ns).List(context.TODO(), opts)
+			return kubeClient.AppsV1().ReplicaSets(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.AppsV1().ReplicaSets(ns).Watch(context.TODO(), opts)
+			return kubeClient.AppsV1().ReplicaSets(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -270,13 +270,13 @@ func wrapReplicaSetFunc(f func(*v1.ReplicaSet) *metric.Family) func(interface{})
 	}
 }
 
-func createReplicaSetListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createReplicaSetListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.AppsV1().ReplicaSets(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.AppsV1().ReplicaSets(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -230,11 +230,11 @@ func createReplicationControllerListWatch(kubeClient clientset.Interface, ns str
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().ReplicationControllers(ns).List(context.TODO(), opts)
+			return kubeClient.CoreV1().ReplicationControllers(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().ReplicationControllers(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().ReplicationControllers(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -226,13 +226,13 @@ func wrapReplicationControllerFunc(f func(*v1.ReplicationController) *metric.Fam
 	}
 }
 
-func createReplicationControllerListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createReplicationControllerListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().ReplicationControllers(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().ReplicationControllers(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/resourcequota.go
+++ b/internal/store/resourcequota.go
@@ -158,11 +158,11 @@ func createResourceQuotaListWatch(kubeClient clientset.Interface, ns string, fie
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().ResourceQuotas(ns).List(context.TODO(), opts)
+			return kubeClient.CoreV1().ResourceQuotas(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().ResourceQuotas(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().ResourceQuotas(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/resourcequota.go
+++ b/internal/store/resourcequota.go
@@ -154,13 +154,13 @@ func wrapResourceQuotaFunc(f func(*v1.ResourceQuota) *metric.Family) func(interf
 	}
 }
 
-func createResourceQuotaListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createResourceQuotaListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().ResourceQuotas(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().ResourceQuotas(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -142,11 +142,11 @@ func createRoleListWatch(kubeClient clientset.Interface, ns string, fieldSelecto
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.RbacV1().Roles(ns).List(context.TODO(), opts)
+			return kubeClient.RbacV1().Roles(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.RbacV1().Roles(ns).Watch(context.TODO(), opts)
+			return kubeClient.RbacV1().Roles(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -138,13 +138,13 @@ func roleMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 	}
 }
 
-func createRoleListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createRoleListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.RbacV1().Roles(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.RbacV1().Roles(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/rolebinding.go
+++ b/internal/store/rolebinding.go
@@ -144,11 +144,11 @@ func createRoleBindingListWatch(kubeClient clientset.Interface, ns string, field
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.RbacV1().RoleBindings(ns).List(context.TODO(), opts)
+			return kubeClient.RbacV1().RoleBindings(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.RbacV1().RoleBindings(ns).Watch(context.TODO(), opts)
+			return kubeClient.RbacV1().RoleBindings(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/rolebinding.go
+++ b/internal/store/rolebinding.go
@@ -140,13 +140,13 @@ func roleBindingMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 	}
 }
 
-func createRoleBindingListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createRoleBindingListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.RbacV1().RoleBindings(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.RbacV1().RoleBindings(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -222,11 +222,11 @@ func createSecretListWatch(kubeClient clientset.Interface, ns string, fieldSelec
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().Secrets(ns).List(context.TODO(), opts)
+			return kubeClient.CoreV1().Secrets(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().Secrets(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().Secrets(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -218,13 +218,13 @@ func wrapSecretFunc(f func(*v1.Secret) *metric.Family) func(interface{}) *metric
 	}
 }
 
-func createSecretListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createSecretListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().Secrets(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().Secrets(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -205,11 +205,11 @@ func createServiceListWatch(kubeClient clientset.Interface, ns string, fieldSele
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().Services(ns).List(context.TODO(), opts)
+			return kubeClient.CoreV1().Services(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().Services(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().Services(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -201,13 +201,13 @@ func wrapSvcFunc(f func(*v1.Service) *metric.Family) func(interface{}) *metric.F
 	}
 }
 
-func createServiceListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createServiceListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().Services(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().Services(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/serviceaccount.go
+++ b/internal/store/serviceaccount.go
@@ -239,11 +239,11 @@ func createServiceAccountListWatch(kubeClient clientset.Interface, ns string, fi
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().ServiceAccounts(ns).List(context.TODO(), opts)
+			return kubeClient.CoreV1().ServiceAccounts(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.CoreV1().ServiceAccounts(ns).Watch(context.TODO(), opts)
+			return kubeClient.CoreV1().ServiceAccounts(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/serviceaccount.go
+++ b/internal/store/serviceaccount.go
@@ -235,13 +235,13 @@ func wrapServiceAccountFunc(f func(*v1.ServiceAccount) *metric.Family) func(inte
 	}
 }
 
-func createServiceAccountListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createServiceAccountListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().ServiceAccounts(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.CoreV1().ServiceAccounts(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -342,11 +342,11 @@ func createStatefulSetListWatch(kubeClient clientset.Interface, ns string, field
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.AppsV1().StatefulSets(ns).List(context.TODO(), opts)
+			return kubeClient.AppsV1().StatefulSets(ns).List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.AppsV1().StatefulSets(ns).Watch(context.TODO(), opts)
+			return kubeClient.AppsV1().StatefulSets(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -338,13 +338,13 @@ func wrapStatefulSetFunc(f func(*v1.StatefulSet) *metric.Family) func(interface{
 	}
 }
 
-func createStatefulSetListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
+func createStatefulSetListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.AppsV1().StatefulSets(ns).List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return kubeClient.AppsV1().StatefulSets(ns).Watch(context.TODO(), opts)
 		},

--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -146,12 +146,12 @@ func wrapStorageClassFunc(f func(*storagev1.StorageClass) *metric.Family) func(i
 	}
 }
 
-func createStorageClassListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createStorageClassListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.StorageV1().StorageClasses().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.StorageV1().StorageClasses().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -149,10 +149,10 @@ func wrapStorageClassFunc(f func(*storagev1.StorageClass) *metric.Family) func(i
 func createStorageClassListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.StorageV1().StorageClasses().List(context.TODO(), opts)
+			return kubeClient.StorageV1().StorageClasses().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.StorageV1().StorageClasses().Watch(context.TODO(), opts)
+			return kubeClient.StorageV1().StorageClasses().Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -111,12 +111,12 @@ var (
 	}
 )
 
-func createValidatingWebhookConfigurationListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createValidatingWebhookConfigurationListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/validatingwebhookconfiguration.go
+++ b/internal/store/validatingwebhookconfiguration.go
@@ -114,10 +114,10 @@ var (
 func createValidatingWebhookConfigurationListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), opts)
+			return kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Watch(context.TODO(), opts)
+			return kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Watch(ctx, opts)
 		},
 	}
 }

--- a/internal/store/volumeattachment.go
+++ b/internal/store/volumeattachment.go
@@ -167,12 +167,12 @@ func wrapVolumeAttachmentFunc(f func(*storagev1.VolumeAttachment) *metric.Family
 	}
 }
 
-func createVolumeAttachmentListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcher {
+func createVolumeAttachmentListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			return kubeClient.StorageV1().VolumeAttachments().List(context.TODO(), opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			return kubeClient.StorageV1().VolumeAttachments().Watch(context.TODO(), opts)
 		},
 	}

--- a/internal/store/volumeattachment.go
+++ b/internal/store/volumeattachment.go
@@ -170,10 +170,10 @@ func wrapVolumeAttachmentFunc(f func(*storagev1.VolumeAttachment) *metric.Family
 func createVolumeAttachmentListWatch(kubeClient clientset.Interface, _ string, _ string) cache.ListerWatcherWithContext {
 	return &cache.ListWatch{
 		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return kubeClient.StorageV1().VolumeAttachments().List(context.TODO(), opts)
+			return kubeClient.StorageV1().VolumeAttachments().List(ctx, opts)
 		},
 		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kubeClient.StorageV1().VolumeAttachments().Watch(context.TODO(), opts)
+			return kubeClient.StorageV1().VolumeAttachments().Watch(ctx, opts)
 		},
 	}
 }

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -65,7 +65,7 @@ func TestBuilderWithCustomStore(t *testing.T) {
 
 func customStore(_ []generator.FamilyGenerator,
 	_ interface{},
-	_ func(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher,
+	_ func(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext,
 	_ bool,
 	_ int64,
 ) []cache.Store {

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -56,7 +56,7 @@ type BuilderInterface interface {
 // BuildStoresFunc function signature that is used to return a list of cache.Store
 type BuildStoresFunc func(metricFamilies []generator.FamilyGenerator,
 	expectedType interface{},
-	listWatchFunc func(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher,
+	listWatchWithContextFunc func(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcherWithContext,
 	useAPIServerCache bool, limit int64,
 ) []cache.Store
 

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -64,7 +64,7 @@ type BuildStoresFunc func(metricFamilies []generator.FamilyGenerator,
 type BuildCustomResourceStoresFunc func(resourceName string,
 	metricFamilies []generator.FamilyGenerator,
 	expectedType interface{},
-	listWatchFunc func(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher,
+	listWatchFunc func(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcherWithContext,
 	useAPIServerCache bool, limit int64,
 ) []cache.Store
 

--- a/pkg/customresource/registry_factory.go
+++ b/pkg/customresource/registry_factory.go
@@ -114,5 +114,5 @@ type RegistryFactory interface {
 	//		},
 	//	}
 	// }
-	ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher
+	ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcherWithContext
 }

--- a/pkg/customresourcestate/custom_resource_metrics.go
+++ b/pkg/customresourcestate/custom_resource_metrics.go
@@ -90,15 +90,14 @@ func (s customResourceMetrics) ExpectedType() interface{} {
 	return &u
 }
 
-func (s customResourceMetrics) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
+func (s customResourceMetrics) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcherWithContext {
 	api := customResourceClient.(dynamic.NamespaceableResourceInterface).Namespace(ns)
-	ctx := context.Background()
 	return &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
 			return api.List(ctx, options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = fieldSelector
 			return api.Watch(ctx, options)
 		},


### PR DESCRIPTION
**What this PR does / why we need it:**
`ListerWatcher` is deprecated and we need to move KSM code to use instead `ListerWatcherWithContext`
**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*
N/A
**Which issue(s) this PR fixes:
Fixes #2721 
