### PR TITLE
Add kube_deployment_spec_topology_spread_constraints metric for issue #2701

### DIFF
--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -1,358 +1,697 @@
 /*
+
 Copyright 2016 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
+
 you may not use this file except in compliance with the License.
+
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
+
 distributed under the License is distributed on an "AS IS" BASIS,
+
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
 See the License for the specific language governing permissions and
+
 limitations under the License.
+
 */
 
 package store
 
 import (
-	"context"
 
-	basemetrics "k8s.io/component-base/metrics"
+"context"
 
-	"k8s.io/kube-state-metrics/v2/pkg/metric"
-	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+basemetrics "k8s.io/component-base/metrics"
 
-	v1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/watch"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
+"k8s.io/kube-state-metrics/v2/pkg/metric"
+
+generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+
+v1 "k8s.io/api/apps/v1"
+
+metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+"k8s.io/apimachinery/pkg/runtime"
+
+"k8s.io/apimachinery/pkg/util/intstr"
+
+"k8s.io/apimachinery/pkg/watch"
+
+clientset "k8s.io/client-go/kubernetes"
+
+"k8s.io/client-go/tools/cache"
+
 )
 
 var (
-	descDeploymentAnnotationsName     = "kube_deployment_annotations"
-	descDeploymentAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
-	descDeploymentLabelsName          = "kube_deployment_labels"
-	descDeploymentLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
+
+descDeploymentAnnotationsName = "kube_deployment_annotations"
+
+descDeploymentAnnotationsHelp = "Kubernetes annotations converted to Prometheus labels."
+
+descDeploymentLabelsName = "kube_deployment_labels"
+
+descDeploymentLabelsHelp = "Kubernetes labels converted to Prometheus labels."
+
+descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
+
 )
 
 func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
-	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_created",
-			"Unix creation timestamp",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				ms := []*metric.Metric{}
 
-				if !d.CreationTimestamp.IsZero() {
-					ms = append(ms, &metric.Metric{
-						Value: float64(d.CreationTimestamp.Unix()),
-					})
-				}
+return []generator.FamilyGenerator{
 
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_status_replicas",
-			"The number of replicas per deployment.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.Replicas),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_status_replicas_ready",
-			"The number of ready replicas per deployment.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.ReadyReplicas),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_status_replicas_available",
-			"The number of available replicas per deployment.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.AvailableReplicas),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_status_replicas_unavailable",
-			"The number of unavailable replicas per deployment.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.UnavailableReplicas),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_status_replicas_updated",
-			"The number of updated replicas per deployment.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.UpdatedReplicas),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_status_observed_generation",
-			"The generation observed by the deployment controller.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Status.ObservedGeneration),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_status_condition",
-			"The current status conditions of a deployment.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				ms := make([]*metric.Metric, len(d.Status.Conditions)*len(conditionStatuses))
+*generator.NewFamilyGeneratorWithStability(
 
-				for i, c := range d.Status.Conditions {
-					conditionMetrics := addConditionMetrics(c.Status)
+"kube_deployment_created",
 
-					for j, m := range conditionMetrics {
-						metric := m
+"Unix creation timestamp",
 
-						metric.LabelKeys = []string{"condition", "status"}
-						metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
-						ms[i*len(conditionStatuses)+j] = metric
-					}
-				}
+metric.Gauge,
 
-				return &metric.Family{
-					Metrics: ms,
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_spec_replicas",
-			"Number of desired pods for a deployment.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(*d.Spec.Replicas),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_spec_paused",
-			"Whether the deployment is paused and will not be processed by the deployment controller.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: boolFloat64(d.Spec.Paused),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
-			"Maximum number of unavailable replicas during a rolling update of a deployment.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				if d.Spec.Strategy.RollingUpdate == nil {
-					return &metric.Family{}
-				}
+basemetrics.STABLE,
 
-				maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*d.Spec.Replicas), false)
-				if err != nil {
-					panic(err)
-				}
+"",
 
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(maxUnavailable),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_spec_strategy_rollingupdate_max_surge",
-			"Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				if d.Spec.Strategy.RollingUpdate == nil {
-					return &metric.Family{}
-				}
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 
-				maxSurge, err := intstr.GetScaledValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxSurge, int(*d.Spec.Replicas), true)
-				if err != nil {
-					panic(err)
-				}
+ms := []*metric.Metric{}
 
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(maxSurge),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			"kube_deployment_metadata_generation",
-			"Sequence number representing a specific generation of the desired state.",
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(d.Generation),
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			descDeploymentAnnotationsName,
-			descDeploymentAnnotationsHelp,
-			metric.Gauge,
-			basemetrics.ALPHA,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				if len(allowAnnotationsList) == 0 {
-					return &metric.Family{}
-				}
-				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   annotationKeys,
-							LabelValues: annotationValues,
-							Value:       1,
-						},
-					},
-				}
-			}),
-		),
-		*generator.NewFamilyGeneratorWithStability(
-			descDeploymentLabelsName,
-			descDeploymentLabelsHelp,
-			metric.Gauge,
-			basemetrics.STABLE,
-			"",
-			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				if len(allowLabelsList) == 0 {
-					return &metric.Family{}
-				}
-				labelKeys, labelValues := createPrometheusLabelKeysValues("label", d.Labels, allowLabelsList)
-				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							LabelKeys:   labelKeys,
-							LabelValues: labelValues,
-							Value:       1,
-						},
-					},
-				}
-			}),
-		),
-	}
+if !d.CreationTimestamp.IsZero() {
+
+ms = append(ms, &metric.Metric{
+
+Value: float64(d.CreationTimestamp.Unix()),
+
+})
+
+}
+
+return &metric.Family{
+
+Metrics: ms,
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_status_replicas",
+
+"The number of replicas per deployment.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(d.Status.Replicas),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_status_replicas_ready",
+
+"The number of ready replicas per deployment.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(d.Status.ReadyReplicas),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_status_replicas_available",
+
+"The number of available replicas per deployment.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(d.Status.AvailableReplicas),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_status_replicas_unavailable",
+
+"The number of unavailable replicas per deployment.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(d.Status.UnavailableReplicas),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_status_replicas_updated",
+
+"The number of updated replicas per deployment.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(d.Status.UpdatedReplicas),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_status_observed_generation",
+
+"The generation observed by the deployment controller.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(d.Status.ObservedGeneration),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_status_condition",
+
+"The current status conditions of a deployment.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+ms := make([]*metric.Metric, len(d.Status.Conditions)*len(conditionStatuses))
+
+for i, c := range d.Status.Conditions {
+
+conditionMetrics := addConditionMetrics(c.Status)
+
+for j, m := range conditionMetrics {
+
+metric := m
+
+metric.LabelKeys = []string{"condition", "status"}
+
+metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
+
+ms[i*len(conditionStatuses)+j] = metric
+
+}
+
+}
+
+return &metric.Family{
+
+Metrics: ms,
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_spec_replicas",
+
+"Number of desired pods for a deployment.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(*d.Spec.Replicas),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_spec_paused",
+
+"Whether the deployment is paused and will not be processed by the deployment controller.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: boolFloat64(d.Spec.Paused),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
+
+"Maximum number of unavailable replicas during a rolling update of a deployment.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+if d.Spec.Strategy.RollingUpdate == nil {
+
+return &metric.Family{}
+
+}
+
+maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*d.Spec.Replicas), false)
+
+if err != nil {
+
+panic(err)
+
+}
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(maxUnavailable),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_spec_strategy_rollingupdate_max_surge",
+
+"Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+if d.Spec.Strategy.RollingUpdate == nil {
+
+return &metric.Family{}
+
+}
+
+maxSurge, err := intstr.GetScaledValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxSurge, int(*d.Spec.Replicas), true)
+
+if err != nil {
+
+panic(err)
+
+}
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(maxSurge),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_spec_topology_spread_constraints",
+
+"Number of topology spread constraints in the deployment's pod template.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(len(d.Spec.Template.Spec.TopologySpreadConstraints)),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+"kube_deployment_metadata_generation",
+
+"Sequence number representing a specific generation of the desired state.",
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+Value: float64(d.Generation),
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+descDeploymentAnnotationsName,
+
+descDeploymentAnnotationsHelp,
+
+metric.Gauge,
+
+basemetrics.ALPHA,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+if len(allowAnnotationsList) == 0 {
+
+return &metric.Family{}
+
+}
+
+annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", d.Annotations, allowAnnotationsList)
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+LabelKeys: annotationKeys,
+
+LabelValues: annotationValues,
+
+Value: 1,
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+*generator.NewFamilyGeneratorWithStability(
+
+descDeploymentLabelsName,
+
+descDeploymentLabelsHelp,
+
+metric.Gauge,
+
+basemetrics.STABLE,
+
+"",
+
+wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+
+if len(allowLabelsList) == 0 {
+
+return &metric.Family{}
+
+}
+
+labelKeys, labelValues := createPrometheusLabelKeysValues("label", d.Labels, allowLabelsList)
+
+return &metric.Family{
+
+Metrics: []*metric.Metric{
+
+{
+
+LabelKeys: labelKeys,
+
+LabelValues: labelValues,
+
+Value: 1,
+
+},
+
+},
+
+}
+
+}),
+
+),
+
+}
+
 }
 
 func wrapDeploymentFunc(f func(*v1.Deployment) *metric.Family) func(interface{}) *metric.Family {
-	return func(obj interface{}) *metric.Family {
-		deployment := obj.(*v1.Deployment)
 
-		metricFamily := f(deployment)
+return func(obj interface{}) *metric.Family {
 
-		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descDeploymentLabelsDefaultLabels, []string{deployment.Namespace, deployment.Name}, m.LabelKeys, m.LabelValues)
-		}
+deployment := obj.(*v1.Deployment)
 
-		return metricFamily
-	}
+metricFamily := f(deployment)
+
+for _, m := range metricFamily.Metrics {
+
+m.LabelKeys, m.LabelValues = mergeKeyValues(descDeploymentLabelsDefaultLabels, []string{deployment.Namespace, deployment.Name}, m.LabelKeys, m.LabelValues)
+
+}
+
+return metricFamily
+
+}
+
 }
 
 func createDeploymentListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {
-	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			opts.FieldSelector = fieldSelector
-			return kubeClient.AppsV1().Deployments(ns).List(context.TODO(), opts)
-		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			opts.FieldSelector = fieldSelector
-			return kubeClient.AppsV1().Deployments(ns).Watch(context.TODO(), opts)
-		},
-	}
+
+return &cache.ListWatch{
+
+ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+
+opts.FieldSelector = fieldSelector
+
+return kubeClient.AppsV1().Deployments(ns).List(context.TODO(), opts)
+
+},
+
+WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+
+opts.FieldSelector = fieldSelector
+
+return kubeClient.AppsV1().Deployments(ns).Watch(context.TODO(), opts)
+
+},
+
+}
+
 }

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -1,203 +1,431 @@
 /*
+
 Copyright 2016 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
+
 you may not use this file except in compliance with the License.
+
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
+
 distributed under the License is distributed on an "AS IS" BASIS,
+
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
 See the License for the specific language governing permissions and
+
 limitations under the License.
+
 */
 
 package store
 
 import (
-	"testing"
-	"time"
 
-	v1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+"testing"
 
-	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+"time"
+
+v1 "k8s.io/api/apps/v1"
+
+corev1 "k8s.io/api/core/v1"
+
+metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+"k8s.io/apimachinery/pkg/util/intstr"
+
+generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+
 )
 
 var (
-	depl1Replicas int32 = 200
-	depl2Replicas int32 = 5
 
-	depl1MaxUnavailable = intstr.FromInt(10)
-	depl2MaxUnavailable = intstr.FromString("25%")
+depl1Replicas int32 = 200
 
-	depl1MaxSurge = intstr.FromInt(10)
-	depl2MaxSurge = intstr.FromString("20%")
+depl2Replicas int32 = 5
+
+depl1MaxUnavailable = intstr.FromInt(10)
+
+depl2MaxUnavailable = intstr.FromString("25%")
+
+depl1MaxSurge = intstr.FromInt(10)
+
+depl2MaxSurge = intstr.FromString("20%")
+
 )
 
 func TestDeploymentStore(t *testing.T) {
-	// Fixed metadata on type and help text. We prepend this to every expected
-	// output so we only have to modify a single place when doing adjustments.
-	const metadata = `
-		# HELP kube_deployment_annotations Kubernetes annotations converted to Prometheus labels.
-		# TYPE kube_deployment_annotations gauge
-		# HELP kube_deployment_created [STABLE] Unix creation timestamp
-		# TYPE kube_deployment_created gauge
-		# HELP kube_deployment_metadata_generation [STABLE] Sequence number representing a specific generation of the desired state.
-		# TYPE kube_deployment_metadata_generation gauge
-		# HELP kube_deployment_spec_paused [STABLE] Whether the deployment is paused and will not be processed by the deployment controller.
-		# TYPE kube_deployment_spec_paused gauge
-		# HELP kube_deployment_spec_replicas [STABLE] Number of desired pods for a deployment.
-		# TYPE kube_deployment_spec_replicas gauge
-		# HELP kube_deployment_status_replicas [STABLE] The number of replicas per deployment.
-		# TYPE kube_deployment_status_replicas gauge
-		# HELP kube_deployment_status_replicas_ready [STABLE] The number of ready replicas per deployment.
-		# TYPE kube_deployment_status_replicas_ready gauge
-		# HELP kube_deployment_status_replicas_available [STABLE] The number of available replicas per deployment.
-		# TYPE kube_deployment_status_replicas_available gauge
-		# HELP kube_deployment_status_replicas_unavailable [STABLE] The number of unavailable replicas per deployment.
-		# TYPE kube_deployment_status_replicas_unavailable gauge
-		# HELP kube_deployment_status_replicas_updated [STABLE] The number of updated replicas per deployment.
-		# TYPE kube_deployment_status_replicas_updated gauge
-		# HELP kube_deployment_status_observed_generation [STABLE] The generation observed by the deployment controller.
-		# TYPE kube_deployment_status_observed_generation gauge
-		# HELP kube_deployment_status_condition [STABLE] The current status conditions of a deployment.
-		# TYPE kube_deployment_status_condition gauge
-		# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable [STABLE] Maximum number of unavailable replicas during a rolling update of a deployment.
-		# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
-		# HELP kube_deployment_spec_strategy_rollingupdate_max_surge [STABLE] Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
-		# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
-		# HELP kube_deployment_labels [STABLE] Kubernetes labels converted to Prometheus labels.
-		# TYPE kube_deployment_labels gauge
-	`
-	cases := []generateMetricsTestCase{
-		{
-			AllowAnnotationsList: []string{"company.io/team"},
-			Obj: &v1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "depl1",
-					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
-					Namespace:         "ns1",
-					Annotations: map[string]string{
-						"company.io/team": "my-brilliant-team",
-					},
-					Labels: map[string]string{
-						"app": "example1",
-					},
-					Generation: 21,
-				},
-				Status: v1.DeploymentStatus{
-					Replicas:            15,
-					ReadyReplicas:       10,
-					AvailableReplicas:   10,
-					UnavailableReplicas: 5,
-					UpdatedReplicas:     2,
-					ObservedGeneration:  111,
-					Conditions: []v1.DeploymentCondition{
-						{Type: v1.DeploymentAvailable, Status: corev1.ConditionTrue},
-						{Type: v1.DeploymentProgressing, Status: corev1.ConditionTrue},
-					},
-				},
-				Spec: v1.DeploymentSpec{
-					Replicas: &depl1Replicas,
-					Strategy: v1.DeploymentStrategy{
-						RollingUpdate: &v1.RollingUpdateDeployment{
-							MaxUnavailable: &depl1MaxUnavailable,
-							MaxSurge:       &depl1MaxSurge,
-						},
-					},
-				},
-			},
-			Want: metadata + `
-        kube_deployment_annotations{annotation_company_io_team="my-brilliant-team",deployment="depl1",namespace="ns1"} 1
-        kube_deployment_created{deployment="depl1",namespace="ns1"} 1.5e+09
-        kube_deployment_metadata_generation{deployment="depl1",namespace="ns1"} 21
-        kube_deployment_spec_paused{deployment="depl1",namespace="ns1"} 0
-        kube_deployment_spec_replicas{deployment="depl1",namespace="ns1"} 200
-        kube_deployment_spec_strategy_rollingupdate_max_surge{deployment="depl1",namespace="ns1"} 10
-        kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="depl1",namespace="ns1"} 10
-        kube_deployment_status_observed_generation{deployment="depl1",namespace="ns1"} 111
-        kube_deployment_status_replicas_available{deployment="depl1",namespace="ns1"} 10
-        kube_deployment_status_replicas_unavailable{deployment="depl1",namespace="ns1"} 5
-        kube_deployment_status_replicas_updated{deployment="depl1",namespace="ns1"} 2
-        kube_deployment_status_replicas{deployment="depl1",namespace="ns1"} 15
-        kube_deployment_status_replicas_ready{deployment="depl1",namespace="ns1"} 10
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="true"} 1
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="true"} 1
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="false"} 0
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="false"} 0
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="unknown"} 0
-        kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="unknown"} 0
-`,
-		},
-		{
-			Obj: &v1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "depl2",
-					Namespace: "ns2",
-					Labels: map[string]string{
-						"app": "example2",
-					},
-					Generation: 14,
-				},
-				Status: v1.DeploymentStatus{
-					Replicas:            10,
-					ReadyReplicas:       5,
-					AvailableReplicas:   5,
-					UnavailableReplicas: 0,
-					UpdatedReplicas:     1,
-					ObservedGeneration:  1111,
-					Conditions: []v1.DeploymentCondition{
-						{Type: v1.DeploymentAvailable, Status: corev1.ConditionFalse},
-						{Type: v1.DeploymentProgressing, Status: corev1.ConditionFalse},
-						{Type: v1.DeploymentReplicaFailure, Status: corev1.ConditionTrue},
-					},
-				},
-				Spec: v1.DeploymentSpec{
-					Paused:   true,
-					Replicas: &depl2Replicas,
-					Strategy: v1.DeploymentStrategy{
-						RollingUpdate: &v1.RollingUpdateDeployment{
-							MaxUnavailable: &depl2MaxUnavailable,
-							MaxSurge:       &depl2MaxSurge,
-						},
-					},
-				},
-			},
-			Want: metadata + `
-        kube_deployment_metadata_generation{deployment="depl2",namespace="ns2"} 14
-        kube_deployment_spec_paused{deployment="depl2",namespace="ns2"} 1
-        kube_deployment_spec_replicas{deployment="depl2",namespace="ns2"} 5
-        kube_deployment_spec_strategy_rollingupdate_max_surge{deployment="depl2",namespace="ns2"} 1
-        kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="depl2",namespace="ns2"} 1
-        kube_deployment_status_observed_generation{deployment="depl2",namespace="ns2"} 1111
-        kube_deployment_status_replicas_available{deployment="depl2",namespace="ns2"} 5
-        kube_deployment_status_replicas_unavailable{deployment="depl2",namespace="ns2"} 0
-        kube_deployment_status_replicas_updated{deployment="depl2",namespace="ns2"} 1
-        kube_deployment_status_replicas{deployment="depl2",namespace="ns2"} 10
-        kube_deployment_status_replicas_ready{deployment="depl2",namespace="ns2"} 5
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="true"} 0
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="true"} 0
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="true"} 1
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="false"} 1
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="false"} 1
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="false"} 0
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="unknown"} 0
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="unknown"} 0
-        kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="unknown"} 0
-`,
-		},
-	}
 
-	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(deploymentMetricFamilies(c.AllowAnnotationsList, nil))
-		c.Headers = generator.ExtractMetricFamilyHeaders(deploymentMetricFamilies(c.AllowAnnotationsList, nil))
-		if err := c.run(); err != nil {
-			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
-		}
-	}
+// Fixed metadata on type and help text. We prepend this to every expected
+
+// output so we only have to modify a single place when doing adjustments.
+
+const metadata = `
+
+# HELP kube_deployment_annotations Kubernetes annotations converted to Prometheus labels.
+
+# TYPE kube_deployment_annotations gauge
+
+# HELP kube_deployment_created [STABLE] Unix creation timestamp
+
+# TYPE kube_deployment_created gauge
+
+# HELP kube_deployment_metadata_generation [STABLE] Sequence number representing a specific generation of the desired state.
+
+# TYPE kube_deployment_metadata_generation gauge
+
+# HELP kube_deployment_spec_paused [STABLE] Whether the deployment is paused and will not be processed by the deployment controller.
+
+# TYPE kube_deployment_spec_paused gauge
+
+# HELP kube_deployment_spec_replicas [STABLE] Number of desired pods for a deployment.
+
+# TYPE kube_deployment_spec_replicas gauge
+
+# HELP kube_deployment_status_replicas [STABLE] The number of replicas per deployment.
+
+# TYPE kube_deployment_status_replicas gauge
+
+# HELP kube_deployment_status_replicas_ready [STABLE] The number of ready replicas per deployment.
+
+# TYPE kube_deployment_status_replicas_ready gauge
+
+# HELP kube_deployment_status_replicas_available [STABLE] The number of available replicas per deployment.
+
+# TYPE kube_deployment_status_replicas_available gauge
+
+# HELP kube_deployment_status_replicas_unavailable [STABLE] The number of unavailable replicas per deployment.
+
+# TYPE kube_deployment_status_replicas_unavailable gauge
+
+# HELP kube_deployment_status_replicas_updated [STABLE] The number of updated replicas per deployment.
+
+# TYPE kube_deployment_status_replicas_updated gauge
+
+# HELP kube_deployment_status_observed_generation [STABLE] The generation observed by the deployment controller.
+
+# TYPE kube_deployment_status_observed_generation gauge
+
+# HELP kube_deployment_status_condition [STABLE] The current status conditions of a deployment.
+
+# TYPE kube_deployment_status_condition gauge
+
+# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable [STABLE] Maximum number of unavailable replicas during a rolling update of a deployment.
+
+# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
+
+# HELP kube_deployment_spec_strategy_rollingupdate_max_surge [STABLE] Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
+
+# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
+
+# HELP kube_deployment_spec_topology_spread_constraints [STABLE] Number of topology spread constraints in the deployment's pod template.
+
+# TYPE kube_deployment_spec_topology_spread_constraints gauge
+
+# HELP kube_deployment_labels [STABLE] Kubernetes labels converted to Prometheus labels.
+
+# TYPE kube_deployment_labels gauge
+
+`
+
+cases := []generateMetricsTestCase{
+
+{
+
+AllowAnnotationsList: []string{"company.io/team"},
+
+Obj: &v1.Deployment{
+
+ObjectMeta: metav1.ObjectMeta{
+
+Name: "depl1",
+
+CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+
+Namespace: "ns1",
+
+Annotations: map[string]string{
+
+"company.io/team": "my-brilliant-team",
+
+},
+
+Labels: map[string]string{
+
+"app": "example1",
+
+},
+
+Generation: 21,
+
+},
+
+Status: v1.DeploymentStatus{
+
+Replicas: 15,
+
+ReadyReplicas: 10,
+
+AvailableReplicas: 10,
+
+UnavailableReplicas: 5,
+
+UpdatedReplicas: 2,
+
+ObservedGeneration: 111,
+
+Conditions: []v1.DeploymentCondition{
+
+{Type: v1.DeploymentAvailable, Status: corev1.ConditionTrue},
+
+{Type: v1.DeploymentProgressing, Status: corev1.ConditionTrue},
+
+},
+
+},
+
+Spec: v1.DeploymentSpec{
+
+Replicas: &depl1Replicas,
+
+Strategy: v1.DeploymentStrategy{
+
+RollingUpdate: &v1.RollingUpdateDeployment{
+
+MaxUnavailable: &depl1MaxUnavailable,
+
+MaxSurge: &depl1MaxSurge,
+
+},
+
+},
+
+Template: corev1.PodTemplateSpec{
+
+Spec: corev1.PodSpec{
+
+TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+
+{
+
+MaxSkew: 1,
+
+TopologyKey: "kubernetes.io/zone",
+
+WhenUnsatisfiable: corev1.DoNotSchedule,
+
+},
+
+{
+
+MaxSkew: 1,
+
+TopologyKey: "kubernetes.io/hostname",
+
+WhenUnsatisfiable: corev1.ScheduleAnyway,
+
+},
+
+},
+
+},
+
+},
+
+},
+
+},
+
+Want: metadata + `
+
+kube_deployment_annotations{annotation_company_io_team="my-brilliant-team",deployment="depl1",namespace="ns1"} 1
+
+kube_deployment_created{deployment="depl1",namespace="ns1"} 1.5e+09
+
+kube_deployment_metadata_generation{deployment="depl1",namespace="ns1"} 21
+
+kube_deployment_spec_paused{deployment="depl1",namespace="ns1"} 0
+
+kube_deployment_spec_replicas{deployment="depl1",namespace="ns1"} 200
+
+kube_deployment_spec_strategy_rollingupdate_max_surge{deployment="depl1",namespace="ns1"} 10
+
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="depl1",namespace="ns1"} 10
+
+kube_deployment_spec_topology_spread_constraints{deployment="depl1",namespace="ns1"} 2
+
+kube_deployment_status_observed_generation{deployment="depl1",namespace="ns1"} 111
+
+kube_deployment_status_replicas_available{deployment="depl1",namespace="ns1"} 10
+
+kube_deployment_status_replicas_unavailable{deployment="depl1",namespace="ns1"} 5
+
+kube_deployment_status_replicas_updated{deployment="depl1",namespace="ns1"} 2
+
+kube_deployment_status_replicas{deployment="depl1",namespace="ns1"} 15
+
+kube_deployment_status_replicas_ready{deployment="depl1",namespace="ns1"} 10
+
+kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="true"} 1
+
+kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="true"} 1
+
+kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="false"} 0
+
+kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="false"} 0
+
+kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Available",status="unknown"} 0
+
+kube_deployment_status_condition{deployment="depl1",namespace="ns1",condition="Progressing",status="unknown"} 0
+
+`,
+
+},
+
+{
+
+Obj: &v1.Deployment{
+
+ObjectMeta: metav1.ObjectMeta{
+
+Name: "depl2",
+
+Namespace: "ns2",
+
+Labels: map[string]string{
+
+"app": "example2",
+
+},
+
+Generation: 14,
+
+},
+
+Status: v1.DeploymentStatus{
+
+Replicas: 10,
+
+ReadyReplicas: 5,
+
+AvailableReplicas: 5,
+
+UnavailableReplicas: 0,
+
+UpdatedReplicas: 1,
+
+ObservedGeneration: 1111,
+
+Conditions: []v1.DeploymentCondition{
+
+{Type: v1.DeploymentAvailable, Status: corev1.ConditionFalse},
+
+{Type: v1.DeploymentProgressing, Status: corev1.ConditionFalse},
+
+{Type: v1.DeploymentReplicaFailure, Status: corev1.ConditionTrue},
+
+},
+
+},
+
+Spec: v1.DeploymentSpec{
+
+Paused: true,
+
+Replicas: &depl2Replicas,
+
+Strategy: v1.DeploymentStrategy{
+
+RollingUpdate: &v1.RollingUpdateDeployment{
+
+MaxUnavailable: &depl2MaxUnavailable,
+
+MaxSurge: &depl2MaxSurge,
+
+},
+
+},
+
+Template: corev1.PodTemplateSpec{
+
+Spec: corev1.PodSpec{
+
+TopologySpreadConstraints: []corev1.TopologySpreadConstraint{},
+
+},
+
+},
+
+},
+
+},
+
+Want: metadata + `
+
+kube_deployment_metadata_generation{deployment="depl2",namespace="ns2"} 14
+
+kube_deployment_spec_paused{deployment="depl2",namespace="ns2"} 1
+
+kube_deployment_spec_replicas{deployment="depl2",namespace="ns2"} 5
+
+kube_deployment_spec_strategy_rollingupdate_max_surge{deployment="depl2",namespace="ns2"} 1
+
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="depl2",namespace="ns2"} 1
+
+kube_deployment_spec_topology_spread_constraints{deployment="depl2",namespace="ns2"} 0
+
+kube_deployment_status_observed_generation{deployment="depl2",namespace="ns2"} 1111
+
+kube_deployment_status_replicas_available{deployment="depl2",namespace="ns2"} 5
+
+kube_deployment_status_replicas_unavailable{deployment="depl2",namespace="ns2"} 0
+
+kube_deployment_status_replicas_updated{deployment="depl2",namespace="ns2"} 1
+
+kube_deployment_status_replicas{deployment="depl2",namespace="ns2"} 10
+
+kube_deployment_status_replicas_ready{deployment="depl2",namespace="ns2"} 5
+
+kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="true"} 0
+
+kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="true"} 0
+
+kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="true"} 1
+
+kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="false"} 1
+
+kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="false"} 1
+
+kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="false"} 0
+
+kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Available",status="unknown"} 0
+
+kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="Progressing",status="unknown"} 0
+
+kube_deployment_status_condition{deployment="depl2",namespace="ns2",condition="ReplicaFailure",status="unknown"} 0
+
+`,
+
+},
+
+}
+
+for i, c := range cases {
+
+c.Func = generator.ComposeMetricGenFuncs(deploymentMetricFamilies(c.AllowAnnotationsList, nil))
+
+c.Headers = generator.ExtractMetricFamilyHeaders(deploymentMetricFamilies(c.AllowAnnotationsList, nil))
+
+if err := c.run(); err != nil {
+
+t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+
+}
+
+}
+
 }


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds the `kube_deployment_spec_topology_spread_constraints` metric that counts the number of topology spread constraints defined in a deployment's pod template specification.

**This PR solves the topology spread constraints monitoring requirement from issue #2701**, which specifically requested visibility into scheduling primitives including "pod topology spread constraints" for workload pod distribution monitoring.

## Which issue(s) this PR fixes

**Solves topology spread constraints monitoring from** #2701 - Add schedule spec and status for workload

## Problem Solved

Issue #2701 identified that operators need to monitor various scheduling primitives to detect when "break variation may happen because pod priority preemption or node pressure eviction." 