### PR TITLE
feat: Add ResourceMetricsConfig for configurable core resource metrics

### DIFF
--- a/pkg/customresourcestate/custom_resource_metrics.go
+++ b/pkg/customresourcestate/custom_resource_metrics.go
@@ -33,6 +33,9 @@ import (
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
 )
 
+// CompiledFamily is an exported alias of the internal compiled family.
+type CompiledFamily = compiledFamily
+
 // customResourceMetrics is an implementation of the customresource.RegistryFactory
 // interface which provides metrics for custom resources defined in a configuration file.
 type customResourceMetrics struct {
@@ -43,6 +46,16 @@ type customResourceMetrics struct {
 }
 
 var _ customresource.RegistryFactory = &customResourceMetrics{}
+
+// Compile exposes the internal compile(resource) to other packages.
+func Compile(r Resource) ([]CompiledFamily, error) {
+	return compile(r)
+}
+
+// FamGen exposes the internal famGen to other packages.
+func FamGen(f CompiledFamily) generator.FamilyGenerator {
+	return famGen(f)
+}
 
 // NewCustomResourceMetrics creates a customresource.RegistryFactory from a configuration object.
 func NewCustomResourceMetrics(resource Resource) (customresource.RegistryFactory, error) {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -83,6 +83,9 @@ type Options struct {
 	UseAPIServerCache    bool  `yaml:"use_api_server_cache"`
 	ObjectLimit          int64 `yaml:"object_limit"`
 	AuthFilter           bool  `yaml:"auth_filter"`
+
+	ResourceMetricsConfigFile string
+	DisableDefaultCoreMetrics bool
 }
 
 // GetConfigFile is the getter for --config value.
@@ -159,6 +162,8 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	o.cmd.Flags().StringVar(&o.CustomResourceConfig, "custom-resource-state-config", "", "Inline Custom Resource State Metrics config YAML (experimental)")
 	o.cmd.Flags().StringVar(&o.CustomResourceConfigFile, "custom-resource-state-config-file", "", "Path to a Custom Resource State Metrics config file (experimental)")
 	o.cmd.Flags().BoolVar(&o.ContinueWithoutCustomResourceConfigFile, "continue-without-custom-resource-state-config-file", false, "If true, Kube-state-metrics continues to run even if the config file specified by --custom-resource-state-config-file is not present. This is useful for scenarios where config file is not provided at startup but is provided later, for e.g., via configmap. Kube-state-metrics will not exit with an error if the custom-resource-state-config file is not found, instead watches and reloads when it is created.")
+	o.cmd.Flags().StringVar(&o.ResourceMetricsConfigFile, "resource-metrics-config-file", "", "Path to ResourceMetricsConfig YAML for core resources")
+	o.cmd.Flags().BoolVar(&o.DisableDefaultCoreMetrics, "disable-default-core-metrics", false, "Disable built-in core metric families; only config-defined ones will be used")
 	o.cmd.Flags().StringVar(&o.Host, "host", "::", `Host to expose metrics on.`)
 	o.cmd.Flags().StringVar(&o.Kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file")
 	o.cmd.Flags().StringVar(&o.Namespace, "pod-namespace", "", "Name of the namespace of the pod specified by --pod. "+autoshardingNotice)

--- a/pkg/resourcestate/factory.go
+++ b/pkg/resourcestate/factory.go
@@ -1,0 +1,144 @@
+package resourcestate
+
+import (
+	"context"
+	"fmt"
+	klog "k8s.io/klog/v2"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	cr "k8s.io/kube-state-metrics/v2/pkg/customresource"
+	crs "k8s.io/kube-state-metrics/v2/pkg/customresourcestate"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+)
+
+type coreFactory struct {
+	name string
+	kind string
+	gvk  metav1.GroupVersionKind // Add this field
+	fams []crs.CompiledFamily
+}
+
+var _ cr.RegistryFactory = (*coreFactory)(nil)
+
+func (f *coreFactory) Name() string { return f.name }
+
+func (f *coreFactory) CreateClient(cfg *rest.Config) (interface{}, error) {
+	return kubernetes.NewForConfig(cfg)
+}
+
+func (f *coreFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
+	out := make([]generator.FamilyGenerator, 0, len(f.fams))
+	for _, fam := range f.fams {
+		// Wrap the CRS generator to handle typed-to-unstructured conversion
+		crsGen := crs.FamGen(fam)
+		wrappedGen := generator.FamilyGenerator{
+			Name:              crsGen.Name,
+			Help:              crsGen.Help,
+			Type:              crsGen.Type,
+			DeprecatedVersion: crsGen.DeprecatedVersion,
+			StabilityLevel:    crsGen.StabilityLevel,
+			OptIn:             crsGen.OptIn,
+			GenerateFunc: func(obj interface{}) *metric.Family {
+				// Convert typed object to unstructured
+				unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				if err != nil {
+					klog.ErrorS(err, "Failed to convert to unstructured", "objType", fmt.Sprintf("%T", obj))
+					return &metric.Family{}
+				}
+
+				u := &unstructured.Unstructured{Object: unstructuredObj}
+				return crsGen.GenerateFunc(u)
+			},
+		}
+		out = append(out, wrappedGen)
+	}
+	return out
+}
+
+func (f *coreFactory) ExpectedType() interface{} {
+	switch f.kind {
+	case "Pod":
+		return &corev1.Pod{}
+	case "Deployment":
+		return &appsv1.Deployment{}
+	default:
+		return &corev1.Pod{}
+	}
+}
+
+func (f *coreFactory) ListWatch(client interface{}, ns, fieldSelector string) cache.ListerWatcher {
+	cs := client.(kubernetes.Interface)
+	ctx := context.Background()
+	switch f.kind {
+	case "Pod":
+		return &cache.ListWatch{
+			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+				opts.FieldSelector = fieldSelector
+				return cs.CoreV1().Pods(ns).List(ctx, opts)
+			},
+			WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+				opts.FieldSelector = fieldSelector
+				return cs.CoreV1().Pods(ns).Watch(ctx, opts)
+			},
+		}
+	case "Deployment":
+		return &cache.ListWatch{
+			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+				opts.FieldSelector = fieldSelector
+				return cs.AppsV1().Deployments(ns).List(ctx, opts)
+			},
+			WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+				opts.FieldSelector = fieldSelector
+				return cs.AppsV1().Deployments(ns).Watch(ctx, opts)
+			},
+		}
+	default:
+		// Return a valid but empty ListWatch instead of nil
+		return &cache.ListWatch{
+			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+				return &corev1.PodList{}, nil
+			},
+			WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+				return watch.NewEmptyWatch(), nil
+			},
+		}
+	}
+}
+
+func (f *coreFactory) GVRString() string {
+	return fmt.Sprintf("%s/%s, Resource=%s", f.gvk.Group, f.gvk.Version, strings.ToLower(f.name))
+}
+
+// BuildFactoriesFromConfig compiles the config into RegistryFactories.
+func BuildFactoriesFromConfig(c *Config) ([]cr.RegistryFactory, error) {
+	var out []cr.RegistryFactory
+	for _, r := range c.Spec.Resources {
+		fams, err := crs.Compile(r)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, &coreFactory{
+			name: r.GetResourceName(),
+			kind: r.GroupVersionKind.Kind,
+			gvk: metav1.GroupVersionKind{
+				Group:   r.GroupVersionKind.Group,
+				Version: r.GroupVersionKind.Version,
+				Kind:    r.GroupVersionKind.Kind,
+			}, // Store the GVK
+			fams: fams,
+		})
+	}
+	return out, nil
+}

--- a/pkg/resourcestate/resource_metrics_config.go
+++ b/pkg/resourcestate/resource_metrics_config.go
@@ -1,0 +1,32 @@
+package resourcestate
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	crs "k8s.io/kube-state-metrics/v2/pkg/customresourcestate"
+)
+
+// Config wraps a list of customresourcestate.Resource entries for core resources.
+type Config struct {
+	Kind string `yaml:"kind"` // expect "ResourceMetricsConfig"
+	Spec struct {
+		Resources []crs.Resource `yaml:"resources"`
+	} `yaml:"spec"`
+}
+
+func LoadConfig(path string) (*Config, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var c Config
+	if err := yaml.Unmarshal(b, &c); err != nil {
+		return nil, err
+	}
+	if c.Kind == "" {
+		c.Kind = "ResourceMetricsConfig"
+	}
+	return &c, nil
+}

--- a/tests/manifests/resouce-metrics-config.yaml
+++ b/tests/manifests/resouce-metrics-config.yaml
@@ -1,0 +1,31 @@
+kind: ResourceMetricsConfig
+spec:
+  resources:
+    - groupVersionKind:
+        group: ""
+        version: "v1"
+        kind: "Pod"
+      resourceName: "pods"
+      metricNamePrefix: "kube_pod"
+      metrics:
+        - name: "phase"
+          help: "Pod phase"
+          each:
+            type: stateset  
+            stateSet:
+              labelName: "phase"
+              path: ["status","phase"]
+              list: ["Pending","Running","Succeeded","Failed","Unknown"]
+    - groupVersionKind:
+        group: "apps"
+        version: "v1"
+        kind: "Deployment"
+      resourceName: "deployments"
+      metricNamePrefix: "kube_deployment"
+      metrics:
+        - name: "spec_replicas"
+          help: "Desired replicas"
+          each:
+            type: gauge
+            gauge:
+              path: ["spec","replicas"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**
Implements ResourceMetricsConfig to allow users to define custom metrics for core Kubernetes resources (Pods, Deployments, etc.) via YAML configuration. This enables users to create only the metrics they need, reducing cardinality and eliminating the complexity of allowlists/denylists. The feature reuses the proven CustomResourceState metric generation system for familiar configuration syntax.


**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*
Decreases cardinality by allowing users to define only specific metrics they need instead of all default metrics for a resource type.

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Fixes #2165 
