### PR TITLE
feat: Added goreleaser config for generating release notes and pre release creation

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,46 @@
+name: Pre-release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  discussions: write
+
+jobs:
+  build-and-create-prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Extract versions
+        id: versions
+        run: |
+          # Extract Go version from Dockerfile
+          GO_VERSION=$(grep '^ARG GOVERSION=' Dockerfile | cut -d'=' -f2)
+          echo "go-version=${GO_VERSION}" >> $GITHUB_OUTPUT
+          
+          # Extract k8s.io/client-go version from go.mod
+          CLIENT_GO_VERSION=$(go list -m -f '{{.Version}}' k8s.io/client-go)
+          echo "client-go-version=${CLIENT_GO_VERSION}" >> $GITHUB_OUTPUT
+          
+          echo "📦 Go version: ${GO_VERSION}"
+          echo "📦 k8s.io/client-go version: ${CLIENT_GO_VERSION}"  
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.versions.outputs.go-version }}
+        id: go
+      - name: Make pre-release
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GO_VERSION: ${{ steps.versions.outputs.go-version }}
+          K8S_CLIENT_VERSION: ${{ steps.versions.outputs.client-go-version }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,77 @@
+version: 2
+
+archives:
+  - formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: "Features"
+      regexp: "(?i)(feat|feature|\\[feature\\]|\\[feat\\]|\\bFEATURE\\b)"
+      order: 1
+    - title: "Bug Fixes"  
+      regexp: "(?i)(fix|bugfix|\\[bugfix\\]|\\[BUGFIX\\]|\\bBUGFIX\\b)"
+      order: 2
+    - title: "Documentation"
+      regexp: "(?i)(docs?|documentation|\\[docs?\\])"
+      order: 3
+    - title: "Dependencies"
+      regexp: "(?i)(build\\(deps\\)|bump|dependencies)"
+      order: 4
+    - title: "Maintenance"
+      regexp: "(?i)(chore|refactor|\\[chore\\])"
+      order: 5
+    - title: "Other Changes"
+      regexp: ".*"
+      order: 99
+
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - 'merge conflict'
+      - 'Merge branch'
+      - 'Merge pull request'
+
+release:
+  github:
+    owner: kubernetes     
+    name: kube-state-metrics      
+
+  prerelease: "true"
+
+  header: |
+    ## {{ .Tag }} / {{ .Now.Format "2006-01-02" }}
+    
+    {{- if index .Env "GO_VERSION" }}
+    ## Note
+    - This release builds with Go `{{ index .Env "GO_VERSION" }}`
+    {{- end }}
+
+    {{- if index .Env "K8S_CLIENT_VERSION" }}
+    - This release builds with `k8s.io/client-go`: `{{ index .Env "K8S_CLIENT_VERSION" }}`
+    {{- end }}
+
+    {{- if index .Env "GITHUB_ACTOR" }}
+    - Release coordinator: @{{ index .Env "GITHUB_ACTOR" }}
+    {{- end }}
+
+  footer: |
+    **Full Changelog**: {{ .GitURL }}/compare/{{ .PreviousTag }}...{{ .Tag }}
+
+  mode: replace
+  
+  # If set, will create a release discussion in the category specified.
+  # Warning: do not use categories in the 'Announcement' format.
+  # Check https://github.com/goreleaser/goreleaser/issues/2304 for more info.
+  # Default: ''.
+  discussion_category_name: Releases


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**
In this PR I've added goreleaser config and a workflow which on tag push helps to generate release notes and create a pre release on github.

Test release: https://github.com/Rishab87/kube-state-metrics/releases/tag/v2.18.0 

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*
does not changes

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Related to #2756 
