### PR TITLE
feat: Added a post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,92 @@
+name: Post Release
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  promote-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          
+      - name: Install kpromo
+        run: go install sigs.k8s.io/promo-tools/v4/cmd/kpromo@latest
+        
+      - name: Get latest pre-release tag
+        id: extract_tag
+        run: |
+          TAG=$(gh release list --limit 1 --json tagName,isPrerelease --jq '.[] | select(.isPrerelease == true) | .tagName')
+          if [ -z "$TAG" ]; then
+            echo "Error: No pre-release found"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "Found pre-release tag: ${TAG}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Create image promotion PR
+        run: |
+          kpromo pr --fork=${{ github.actor }} -i \
+            --project=kube-state-metrics \
+            --tag=${{ steps.extract_tag.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  merge-back-to-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Get latest pre-release tag
+        id: extract_tag
+        run: |
+          TAG=$(gh release list --limit 1 --json tagName,isPrerelease --jq '.[] | select(.isPrerelease == true) | .tagName')
+          if [ -z "$TAG" ]; then
+            echo "Error: No pre-release found"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "Found pre-release tag: ${TAG}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Create PR to merge release changes back to main
+        run: |
+          # Extract major.minor for branch name
+          MAJOR_MINOR=$(echo "${{ steps.extract_tag.outputs.tag }}" | sed 's/v//' | cut -d. -f1,2)
+          RELEASE_BRANCH="release-${MAJOR_MINOR}"
+          
+          # Check if branches exist and have differences
+          if ! git rev-parse --verify "origin/${RELEASE_BRANCH}" >/dev/null 2>&1; then
+            echo "Error: Branch ${RELEASE_BRANCH} does not exist"
+            exit 1
+          fi
+          
+          # Check if there are commits to merge
+          if git merge-base --is-ancestor "origin/${RELEASE_BRANCH}" origin/main; then
+            echo "No commits to merge - ${RELEASE_BRANCH} is already merged into main"
+            exit 0
+          fi
+          
+          gh pr create \
+            --title "chore: Merge ${{ steps.extract_tag.outputs.tag }} back to main" \
+            --body "Merge release changes from ${{ steps.extract_tag.outputs.tag }} back to main branch." \
+            --base main \
+            --head $RELEASE_BRANCH \
+            --reviewer @sig-instrumentation-approvers \
+            --assignee @sig-instrumentation-leads
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**
This PR adds a post release workflow, which helps in creating a PR for merging back to main & promoting images with `kpromo`. This needs to be run manually after pre release is created and images have been built on prow. (For making this workflow run automatically, one approach we can take is create a PR in test-infra repo which curls a github API when image build is completed after which this workflow is triggered triggered, open to suggestions and other possible approaches).

Test PR: https://github.com/Rishab87/kube-state-metrics/pull/16

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*
does not changes

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Related to #2756 