### PR TITLE
feat: add valueType field for explicit duration parsing in custom resources

### DIFF
--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -639,7 +639,7 @@ The `valueType` field in gauge configuration accepts the following values:
 
 The `duration` value type is particularly useful for custom resources that store time values as Go duration strings, such as cert-manager Certificates.
 
-**Example: cert-manager Certificate Duration**
+###### Example: cert-manager Certificate Duration
 
 ```yaml
 kind: CustomResourceStateMetrics
@@ -670,7 +670,7 @@ spec:
               valueType: duration  # Explicitly parse as duration
 ```
 
-**Supported Duration Formats**
+###### Supported Duration Formats
 
 The `duration` value type uses Go's `time.ParseDuration` format and supports:
 
@@ -684,7 +684,7 @@ The `duration` value type uses Go's `time.ParseDuration` format and supports:
 
 All durations are converted to **seconds as float64** for Prometheus compatibility.
 
-**Example Metrics Output**
+###### Example Metrics Output
 
 For a cert-manager Certificate with `spec.duration: "2160h"` and `spec.renewBefore: "720h"`:
 
@@ -693,14 +693,16 @@ kube_customresource_certificate_duration_seconds{customresource_group="cert-mana
 kube_customresource_certificate_renew_before_seconds{customresource_group="cert-manager.io", customresource_kind="Certificate", customresource_version="v1", name="example-cert", namespace="default"} 2592000
 ```
 
-**When to Use valueType**
+###### When to Use valueType
 
 Use `valueType: duration` when:
+
 * The resource field contains Go duration strings (e.g., "72h", "30m")
 * Auto-detection fails because the string isn't recognized as a number
 * You want explicit, predictable parsing behavior
 
 Use `valueType: quantity` when:
+
 * You want to ensure Kubernetes quantity parsing (even if auto-detection would work)
 * You want to make the parsing behavior explicit in configuration
 

--- a/pkg/customresourcestate/config_metrics_types.go
+++ b/pkg/customresourcestate/config_metrics_types.go
@@ -16,6 +16,20 @@ limitations under the License.
 
 package customresourcestate
 
+// ValueType specifies how to parse the value from the resource field.
+type ValueType string
+
+const (
+	// ValueTypeDefault uses automatic type detection (current behavior).
+	// This is the default when ValueType is not specified.
+	ValueTypeDefault ValueType = ""
+	// ValueTypeDuration parses duration strings (e.g., "1h", "30m", "1h30m45s") using time.ParseDuration.
+	// The parsed duration is converted to seconds as a float64 for Prometheus compatibility.
+	ValueTypeDuration ValueType = "duration"
+	// ValueTypeQuantity parses Kubernetes resource quantities (e.g., "250m" for millicores, "1Gi" for memory).
+	ValueTypeQuantity ValueType = "quantity"
+)
+
 // MetricMeta are variables which may used for any metric type.
 type MetricMeta struct {
 	// LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
@@ -32,7 +46,9 @@ type MetricGauge struct {
 	MetricMeta   `yaml:",inline" json:",inline"`
 
 	// ValueFrom is the path to a numeric field under Path that will be the metric value.
-	ValueFrom []string `yaml:"valueFrom" json:"valueFrom"`
+	ValueFrom []string  `yaml:"valueFrom" json:"valueFrom"`
+	ValueType ValueType `yaml:"valueType,omitempty" json:"valueType,omitempty"`
+
 	// NilIsZero indicates that if a value is nil it will be treated as zero value.
 	NilIsZero bool `yaml:"nilIsZero" json:"nilIsZero"`
 }


### PR DESCRIPTION
## What this PR does 

This PR adds a `valueType` field to custom resource state metrics gauge configuration, enabling explicit parsing of Go duration strings to seconds. This is particularly useful for resources like cert-manager Certificates that store durations as strings (e.g., "2160h", "720h").

Currently, kube-state-metrics automatically detects value types but fails to parse Go duration strings, resulting in errors like:
```
strconv.ParseFloat: parsing "2160h": invalid syntax
```

## Which issue(s) this PR fixes:

Fixes #2625

## Implementation Details

### Code Changes
- Added `ValueType` field to `MetricGauge` struct with options: `duration`, `quantity`, and default (empty string)
- Implemented `parseDurationValue()` function using Go's `time.ParseDuration`
- Updated gauge value extraction to respect `valueType` in both direct path and optimization code paths
- Maintains full backward compatibility


### Documentation
- Added "Value Type Specification" section to `customresourcestate-metrics.md`
- Documented all available value types and usage scenarios
- Included complete cert-manager Certificate monitoring example
- Added duration format reference (Go `time.ParseDuration` formats)

## Example Usage

```yaml
kind: CustomResourceStateMetrics
spec:
  resources:
    - groupVersionKind:
        group: cert-manager.io
        version: v1
        kind: Certificate
      metrics:
        - name: "certificate_duration_seconds"
          help: "Certificate validity duration in seconds"
          each:
            type: Gauge
            gauge:
              path: [spec, duration]
              valueType: duration  # Parses "2160h" → 7776000.0 seconds

        - name: "certificate_renew_before_seconds"
          help: "Time before expiration when certificate should be renewed"
          each:
            type: Gauge
            gauge:
              path: [spec, renewBefore]
              valueType: duration  # Parses "720h" → 2592000.0 seconds
```

**Resulting metrics:**
```prometheus
kube_customresource_certificate_duration_seconds{customresource_group="cert-manager.io",customresource_kind="Certificate",customresource_version="v1",name="example-cert",namespace="default"} 7776000
kube_customresource_certificate_renew_before_seconds{customresource_group="cert-manager.io",customresource_kind="Certificate",customresource_version="v1",name="example-cert",namespace="default"} 2592000
```


## Supported Duration Formats

The `duration` valueType supports Go's `time.ParseDuration` format:
- Hours: `"1h"`, `"24h"`, `"2160h"` (90 days)
- Minutes: `"30m"`, `"90m"`
- Seconds: `"45s"`
- Milliseconds: `"500ms"`
- Microseconds: `"100us"` or `"100µs"`
- Nanoseconds: `"1000ns"`
- Combined: `"1h30m45s"`, `"2h15m30s"`

All durations are converted to **seconds as float64** for Prometheus compatibility.

## Backward Compatibility

 **Fully backward compatible**
- Empty or omitted `valueType` field continues to use existing auto-detection behavior
- No breaking changes to existing configurations
- All existing tests pass without modification
- No changes to default behavior
