### PR TITLE
perf: Reduce allocations when creating metric families

### DIFF
--- a/pkg/metric/family.go
+++ b/pkg/metric/family.go
@@ -17,7 +17,7 @@ limitations under the License.
 package metric
 
 import (
-	"strings"
+	"bytes"
 )
 
 // FamilyInterface interface for a family
@@ -40,11 +40,11 @@ func (f Family) Inspect(inspect func(Family)) {
 
 // ByteSlice returns the given Family in its string representation.
 func (f Family) ByteSlice() []byte {
-	b := strings.Builder{}
+	b := bytes.Buffer{}
 	for _, m := range f.Metrics {
 		b.WriteString(f.Name)
 		m.Write(&b)
 	}
 
-	return []byte(b.String())
+	return b.Bytes()
 }

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metric
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"strconv"
@@ -64,7 +65,7 @@ type Metric struct {
 	Value       float64
 }
 
-func (m *Metric) Write(s *strings.Builder) {
+func (m *Metric) Write(s *bytes.Buffer) {
 	if len(m.LabelKeys) != len(m.LabelValues) {
 		panic(fmt.Sprintf(
 			"expected labelKeys %q to be of same length as labelValues %q",
@@ -78,7 +79,7 @@ func (m *Metric) Write(s *strings.Builder) {
 	s.WriteByte('\n')
 }
 
-func labelsToString(m *strings.Builder, keys, values []string) {
+func labelsToString(m *bytes.Buffer, keys, values []string) {
 	if len(keys) > 0 {
 		var separator byte = '{'
 
@@ -102,7 +103,7 @@ var (
 // escapeString replaces '\' by '\\', new line character by '\n', and '"' by
 // '\"'.
 // Taken from github.com/prometheus/common/expfmt/text_create.go.
-func escapeString(m *strings.Builder, v string) {
+func escapeString(m *bytes.Buffer, v string) {
 	escapeWithDoubleQuote.WriteString(m, v)
 }
 
@@ -110,7 +111,7 @@ func escapeString(m *strings.Builder, v string) {
 // a few common cases for increased efficiency. For non-hardcoded cases, it uses
 // strconv.AppendFloat to avoid allocations, similar to writeInt.
 // Taken from github.com/prometheus/common/expfmt/text_create.go.
-func writeFloat(w *strings.Builder, f float64) {
+func writeFloat(w *bytes.Buffer, f float64) {
 	switch {
 	case f == 1:
 		w.WriteByte('1')

--- a/pkg/metric/metric_test.go
+++ b/pkg/metric/metric_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metric
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -70,11 +71,11 @@ func BenchmarkMetricWrite(b *testing.B) {
 	for _, test := range tests {
 		b.Run(test.testName, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				builder := strings.Builder{}
+				builder := bytes.Buffer{}
 
 				test.metric.Write(&builder)
 
-				s := builder.String()
+				s := builder.Bytes()
 
 				// Ensuring that the string is actually build, not optimized
 				// away by compilation.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**

The metric family generates a series by using a `strings.Builder` to write data into, and then converts the string into a byte slice. This causes extra allocations which are not needed since we can directly write into a byte slice.

Benchmarks in CI show an improvement: https://github.com/kubernetes/kube-state-metrics/actions/runs/19236033135?pr=2807.

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*
Has no effect.

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Fixes #
