### PR TITLE
feat: warn on probe failing

### DIFF
--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -515,6 +515,9 @@ func handleClusterDelegationForProber(client kubernetes.Interface, probeType str
 	return func(w http.ResponseWriter, _ *http.Request) {
 		got := client.CoreV1().RESTClient().Get().AbsPath(probeType).Do(context.Background())
 		if got.Error() != nil {
+			var statusCode int
+			got.StatusCode(&statusCode)
+			klog.Warningf("Failed to contact API server for %s: got %d", probeType, statusCode)
 			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Write([]byte(http.StatusText(http.StatusServiceUnavailable)))
 			return


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**

We have a fairly common occurence of KSM getting restarted due to its liveness probe failing. This is seemingly caused by rolling deploys of the backing API server, but we don't know exactly why. This should make it slightly more visible what kind of response the API server when a probe fails, which in turn could help either tweak probes to weather such situations where the API server may be unavailable or overwhelmed (it's entirely possible it's returning KSM a bunch of 429s) or if we have a larger problem at hand.

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*

Does not affect cardinality.

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

Potentially related to #2682.