### PR TITLE
feat(nestedArray): parsing * on array of array

### DIFF
--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -26,12 +26,12 @@ spec:
   template:
     spec:
       containers:
-      - name: kube-state-metrics
-        args:
-          - --custom-resource-state-config
-          # in YAML files, | allows a multi-line string to be passed as a flag value
-          # see https://yaml-multiline.info
-          -  |
+        - name: kube-state-metrics
+          args:
+            - --custom-resource-state-config
+            # in YAML files, | allows a multi-line string to be passed as a flag value
+            # see https://yaml-multiline.info
+            -  |
               kind: CustomResourceStateMetrics
               spec:
                 resources:
@@ -60,12 +60,12 @@ spec:
   template:
     spec:
       containers:
-      - name: kube-state-metrics
-        args:
-          - --custom-resource-state-config
-          # in YAML files, | allows a multi-line string to be passed as a flag value
-          # see https://yaml-multiline.info
-          -  |
+        - name: kube-state-metrics
+          args:
+            - --custom-resource-state-config
+            # in YAML files, | allows a multi-line string to be passed as a flag value
+            # see https://yaml-multiline.info
+            -  |
               kind: CustomResourceStateMetrics
               spec:
                 resources:
@@ -79,7 +79,7 @@ spec:
                         each:
                           type: Gauge
                           ...
-          - --custom-resource-state-only=true
+            - --custom-resource-state-only=true
 ```
 
 NOTE: The `customresource_group`, `customresource_version`, and `customresource_kind` common labels are reserved, and will be overwritten by the values from the `groupVersionKind` field.
@@ -96,42 +96,42 @@ The examples in this section will use the following custom resource:
 kind: Foo
 apiVersion: myteam.io/vl
 metadata:
-    annotations:
-        bar: baz
-        qux: quxx
-    labels:
-        foo: bar
-    name: foo
+  annotations:
+    bar: baz
+    qux: quxx
+  labels:
+    foo: bar
+  name: foo
 spec:
-    version: v1.2.3
-    order:
-        - id: 1
-          value: true
-        - id: 3
-          value: false
-    replicas: 1
-    refs:
-        - my_other_foo
-        - foo_2
-        - foo_with_extensions
+  version: v1.2.3
+  order:
+    - id: 1
+      value: true
+    - id: 3
+      value: false
+  replicas: 1
+  refs:
+    - my_other_foo
+    - foo_2
+    - foo_with_extensions
 status:
-    phase: Pending
-    active:
-        type-a: 1
-        type-b: 3
-    conditions:
-        - name: a
-          value: 45
-        - name: b
-          value: 66
-    sub:
-        type-a:
-            active: 1
-            ready: 2
-        type-b:
-            active: 3
-            ready: 4
-    uptime: 43.21
+  phase: Pending
+  active:
+    type-a: 1
+    type-b: 3
+  conditions:
+    - name: a
+      value: 45
+    - name: b
+      value: 66
+  sub:
+    type-a:
+      active: 1
+      ready: 2
+    type-b:
+      active: 3
+      ready: 4
+  uptime: 43.21
 ```
 
 #### Single Values
@@ -203,7 +203,7 @@ spec:
             # a prefix before the asterisk will be used as a label prefix
             "lorem_*": [metadata, annotations]
             "**": [metadata, annotations]
-            
+
             # or specific fields may be copied. these fields will always override values from *s
             name: [metadata, name]
             foo: [metadata, labels, foo]
@@ -261,10 +261,10 @@ kube_customresource_ref_info{customresource_group="myteam.io", customresource_ki
 ```yaml
   recommendation:
     containerRecommendations:
-    - containerName: consumer
-      lowerBound:
-        cpu: 100m
-        memory: 262144k
+      - containerName: consumer
+        lowerBound:
+          cpu: 100m
+          memory: 262144k
 ```
 
 For example in VPA we have above attributes and we want to have a same metrics for both CPU and Memory, you can use below config:
@@ -618,7 +618,7 @@ Supported types are:
 * for bool `true` is mapped to `1.0` and `false` is mapped to `0.0`
 * for string the following logic applies
   * `"true"` and `"yes"` are mapped to `1.0`, `"false"`, `"no"` and `"unknown"` are mapped to `0.0` (all case-insensitive)
-  * RFC3339 times are parsed to float timestamp  
+  * RFC3339 times are parsed to float timestamp
   * Quantities like "250m" or "512Gi" are parsed to float using <https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go>
   * Percentages ending with a "%" are parsed to float
   * finally the string is parsed to float using <https://pkg.go.dev/strconv#ParseFloat> which should support all common number formats. If that fails an error is yielded
@@ -629,27 +629,27 @@ Supported types are:
 kind: CustomResourceStateMetrics
 spec:
   resources:
-  - groupVersionKind:
-      group: myteam.io
-      kind: "Foo"
-      version: "v1"
-    labelsFromPath:
-      name:
-      - metadata
-      - name
-      namespace:
-      - metadata
-      - namespace
-    metrics:
-    - name: "foo_status"
-      help: "status condition "
-      each:
-        type: Gauge
-        gauge:
-          path: [status, conditions]
-          labelsFromPath:
-            type: ["type"]
-          valueFrom: ["status"]
+    - groupVersionKind:
+        group: myteam.io
+        kind: "Foo"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+      metrics:
+        - name: "foo_status"
+          help: "status condition "
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                type: ["type"]
+              valueFrom: ["status"]
 ```
 
 This will work for kubernetes controller CRs which expose status conditions according to the kubernetes api (<https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition>):
@@ -811,6 +811,58 @@ Examples:
 
 # For generally matching against a field in an object schema, use the following syntax:
 [metadata, "name=foo"] # if v, ok := metadata[name]; ok && v == "foo" { return v; } else { /* ignore */ }
+
+# Fanning out over every element of an array using the wildcard "[*]".
+# Each "[*]" segment iterates the current array and continues the walk per element.
+[status, parents, "[*]", parentRef, name]   # collects parentRef.name from every parents[] entry
+```
+
+#### Nested arrays with `[*]` (Gauge only)
+
+When a `Gauge`'s `valueFrom` path contains `[*]`, kube-state-metrics fans the
+gauge out into one metric per element of the wildcarded array. Sibling
+`labelsFromPath` paths that also contain `[*]` (over the same array) are paired
+positionally by index; label paths without `[*]` are broadcast as constants
+across all emitted rows. This makes it possible to expose per-element metrics
+from doubly-nested structures (e.g. Gateway API `HTTPRoute.status.parents[].conditions[]`,
+[#2368](https://github.com/kubernetes/kube-state-metrics/issues/2368)).
+
+```yaml
+- name: "parent_conditions"
+  help: "Parent conditions of an HTTPRoute-like resource"
+  each:
+    type: Gauge
+    gauge:
+      path: [status, parents]
+      labelsFromPath:
+        reason:     [conditions, "[*]", reason]   # fans out with valueFrom
+        parentName: [parentRef, name]             # constant per parent
+      valueFrom:    [conditions, "[*]", status]   # drives row count
+```
+
+Given a custom resource like:
+
+```yaml
+status:
+  parents:
+    - parentRef: {name: baz-1}
+      conditions:
+        - {type: Ready,  status: "True",  reason: AsExpected}
+        - {type: Synced, status: "False", reason: SyncError}
+    - parentRef: {name: grault-1}
+      conditions:
+        - {type: Ready,  status: "False", reason: NotReady}
+    - parentRef: {name: fred-1}
+      conditions: []
+```
+
+the configuration above produces three metrics (parents whose inner array is
+empty produce no rows):
+
+```prometheus
+kube_customresource_parent_conditions{parentName="baz-1",    reason="AsExpected"} 1
+kube_customresource_parent_conditions{parentName="baz-1",    reason="SyncError"}  0
+kube_customresource_parent_conditions{parentName="grault-1", reason="NotReady"}   0
 ```
 
 ### Wildcard matching of version and kind fields

--- a/pkg/customresourcestate/example_config.yaml
+++ b/pkg/customresourcestate/example_config.yaml
@@ -47,6 +47,24 @@ spec:
               path: [status, other]
           errorLogV: 5
 
+        - name: "other_count_array_deep"
+          each:
+            type: Gauge
+            gauge:
+              path: [ status, other, '[*]', '[detail]' ]
+          errorLogV: 5
+
+        - name: "other_count_array_deep_multiple"
+          each:
+            type: Gauge
+            gauge:
+              path: [ status, other, '[*]' ]
+              labelsFromPath:
+                bar: [ detail ]
+                foo: [ foo, bar ]
+              valueFrom: [ count ]
+          errorLogV: 5
+
         - name: "info"
           each:
             type: Info

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -279,6 +279,14 @@ func (c *compiledGauge) Values(v interface{}) (result []eachValue, errs []error)
 		}
 	case []interface{}:
 		for i, it := range iter {
+			if c.ValueFrom.hasWildcard() {
+				evs, fanErrs := c.fanout(it)
+				for _, e := range fanErrs {
+					onError(fmt.Errorf("[%d]: %w", i, e))
+				}
+				result = append(result, evs...)
+				continue
+			}
 			value, err := c.value(it)
 			if err != nil {
 				onError(fmt.Errorf("[%d]: %w", i, err))
@@ -444,6 +452,48 @@ func less(a, b map[string]string) bool {
 	return len(aKeys) < len(bKeys)
 }
 
+// fanout expands a single iteration context `it` into N eachValues by walking
+// `ValueFrom` and any `[*]`-containing label paths in parallel. Label paths
+// without `[*]` are broadcast as constants across all rows. Driven by the
+// length of `ValueFrom.GetAll(it)`.
+func (c *compiledGauge) fanout(it interface{}) ([]eachValue, []error) {
+	valueVals := c.ValueFrom.GetAll(it)
+	labelVals := make(map[string][]interface{}, len(c.LabelFromPath()))
+	for k, lp := range c.LabelFromPath() {
+		labelVals[k] = lp.GetAll(it)
+	}
+	var (
+		res  []eachValue
+		errs []error
+	)
+	for i, raw := range valueVals {
+		if raw == nil && !c.NilIsZero {
+			continue
+		}
+		f, err := toFloat64(raw, c.NilIsZero)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", c.ValueFrom, err))
+			continue
+		}
+		labels := map[string]string{}
+		for k, lvs := range labelVals {
+			var v interface{}
+			switch {
+			case i < len(lvs):
+				v = lvs[i]
+			case len(lvs) > 0:
+				v = lvs[0]
+			}
+			if v == nil {
+				continue
+			}
+			labels[store.SanitizeLabelName(k)] = fmt.Sprintf("%v", v)
+		}
+		res = append(res, eachValue{Value: f, Labels: labels})
+	}
+	return res, errs
+}
+
 func (c compiledGauge) value(it interface{}) (*eachValue, error) {
 	labels := make(map[string]string)
 	got := c.ValueFrom.Get(it)
@@ -566,6 +616,45 @@ func (p valuePath) Get(obj interface{}) interface{} {
 	return obj
 }
 
+// hasWildcard reports whether the path contains a `[*]` fan-out marker.
+func (p valuePath) hasWildcard() bool {
+	for _, op := range p {
+		if op.part == "[*]" {
+			return true
+		}
+	}
+	return false
+}
+
+// GetAll walks the path like Get, but fans the walk out across `[*]` markers
+// when the current node is a []interface{}. For paths without `[*]`, it
+// returns a single-element slice containing what Get would return, so callers
+// can treat fan-out and single-value paths uniformly.
+func (p valuePath) GetAll(obj interface{}) []interface{} {
+	return getAll(p, obj)
+}
+
+func getAll(p valuePath, obj interface{}) []interface{} {
+	for i, op := range p {
+		if obj == nil {
+			return []interface{}{nil}
+		}
+		if op.part == "[*]" {
+			arr, ok := obj.([]interface{})
+			if !ok {
+				return []interface{}{nil}
+			}
+			var out []interface{}
+			for _, el := range arr {
+				out = append(out, getAll(p[i+1:], el)...)
+			}
+			return out
+		}
+		obj = op.op(obj)
+	}
+	return []interface{}{obj}
+}
+
 func (p valuePath) String() string {
 	var b strings.Builder
 	b.WriteRune('[')
@@ -582,6 +671,17 @@ func (p valuePath) String() string {
 func compilePath(path []string) (out valuePath, _ error) {
 	for i := range path {
 		part := path[i]
+		if part == "[*]" {
+			// array fan-out marker. The op is identity; the fan-out itself is
+			// performed by valuePath.GetAll when it encounters this part.
+			// Keeping the op as identity preserves backward compatibility for
+			// callers that still use Get (single-value) on such a path.
+			out = append(out, pathOp{
+				part: part,
+				op:   func(m interface{}) interface{} { return m },
+			})
+			continue
+		}
 		if strings.HasPrefix(part, "[") && strings.HasSuffix(part, "]") {
 			// list lookup: [key=value]
 			eq := strings.SplitN(part[1:len(part)-1], "=", 2)

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -88,6 +88,64 @@ func init() {
 					"status": "False",
 				},
 			},
+			"parents": Array{
+				Obj{
+					"conditions": Array{
+						Obj{
+							"type":               "Ready",
+							"status":             "True",
+							"message":            "All good",
+							"reason":             "AsExpected",
+							"lastTransitionTime": "2022-06-28T00:00:00Z",
+							"observedGeneration": 42,
+						},
+						Obj{
+							"type":               "Synced",
+							"status":             "False",
+							"message":            "Not synced",
+							"reason":             "SyncError",
+							"lastTransitionTime": "2022-06-28T00:00:00Z",
+							"observedGeneration": 43,
+						},
+					},
+					"controllerName": "foo.bar/baz",
+					"parentRef": Obj{
+						"group":     "foo.bar",
+						"kind":      "Baz",
+						"name":      "baz-1",
+						"namespace": "default",
+					},
+				},
+				Obj{
+					"conditions": Array{
+						Obj{
+							"type":               "Ready",
+							"status":             "False",
+							"message":            "Not ready",
+							"reason":             "NotReady",
+							"lastTransitionTime": "2022-06-28T00:00:00Z",
+							"observedGeneration": 44,
+						},
+					},
+					"controllerName": "qux.corge/grault",
+					"parentRef": Obj{
+						"group":     "qux.corge",
+						"kind":      "Grault",
+						"name":      "grault-1",
+						"namespace": "default",
+					},
+				},
+				Obj{
+					"conditions":     Array{},
+					"controllerName": "garply.waldo/fred",
+					"parentRef": Obj{
+						"group":     "garply.waldo",
+						"kind":      "Fred",
+						"name":      "fred-1",
+						"namespace": "default",
+					},
+				},
+			},
 		},
 		"metadata": Obj{
 			"name": "foo",
@@ -351,6 +409,20 @@ func Test_values(t *testing.T) {
 		}, wantResult: []eachValue{
 			newEachValue(t, 0, "type", "Provisioned"),
 			newEachValue(t, 1, "type", "Ready"),
+		}},
+		{name: "nested_array_wildcard_gauge (issue #2368)", each: &compiledGauge{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "status", "parents"),
+				labelFromPath: map[string]valuePath{
+					"reason":     mustCompilePath(t, "conditions", "[*]", "reason"),
+					"parentName": mustCompilePath(t, "parentRef", "name"),
+				},
+			},
+			ValueFrom: mustCompilePath(t, "conditions", "[*]", "status"),
+		}, wantResult: []eachValue{
+			newEachValue(t, 1, "parentName", "baz-1", "reason", "AsExpected"),
+			newEachValue(t, 0, "parentName", "baz-1", "reason", "SyncError"),
+			newEachValue(t, 0, "parentName", "grault-1", "reason", "NotReady"),
 		}},
 		{name: "= expression matching", each: &compiledInfo{
 			compiledCommon: compiledCommon{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:** Enable parsing nested arrays.

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*
We can now write this kind of path: `"status", "parents", "[*]", "conditions"`. 

Where `[*]`means listing all the parents object inside the list.

I updated the PR on this day (Jan 16, 2026) to allow the use of `[*]` at the `labelsFromPath` & `valueFrom`. This has been tested on our side and enable us to recover the `parentRef` name and the `condition` reason for each `condition` on `HTTPRoute->Status->Parents`

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Fixes #2368 
