### PR TITLE
fix: regression: React on WATCH updates for CRD informer

### DIFF
--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -39,6 +39,8 @@ type kindPlural struct {
 type CRDiscoverer struct {
 	// CRDsAddEventsCounter tracks the number of times that the CRD informer triggered the "add" event.
 	CRDsAddEventsCounter prometheus.Counter
+	// CRDsUpdateEventsCounter tracks the number of times that the CRD informer triggered the "update" event.
+	CRDsUpdateEventsCounter prometheus.Counter
 	// CRDsDeleteEventsCounter tracks the number of times that the CRD informer triggered the "remove" event.
 	CRDsDeleteEventsCounter prometheus.Counter
 	// CRDsCacheCountGauge tracks the net amount of CRDs affecting the cache at this point.
@@ -98,8 +100,10 @@ func (r *CRDiscoverer) RemoveFromMap(gvkps ...groupVersionKindPlural) {
 		}
 		for i, el := range r.Map[gvkp.Group][gvkp.Version] {
 			if el.Kind == gvkp.Kind {
-				close(r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()])
-				delete(r.GVKToReflectorStopChanMap, gvkp.GroupVersionKind.String())
+				if _, ok := r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()]; ok {
+					close(r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()])
+					delete(r.GVKToReflectorStopChanMap, gvkp.GroupVersionKind.String())
+				}
 				if len(r.Map[gvkp.Group][gvkp.Version]) == 1 {
 					delete(r.Map[gvkp.Group], gvkp.Version)
 					if len(r.Map[gvkp.Group]) == 0 {

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -122,6 +122,10 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		Name: "kube_state_metrics_custom_resource_state_add_events_total",
 		Help: "Number of times that the CRD informer triggered the add event.",
 	})
+	crdsUpdateEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
+		Name: "kube_state_metrics_custom_resource_state_update_events_total",
+		Help: "Number of times that the CRD informer triggered the update event.",
+	})
 	crdsDeleteEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
 		Name: "kube_state_metrics_custom_resource_state_delete_events_total",
 		Help: "Number of times that the CRD informer triggered the remove event.",
@@ -314,6 +318,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 	if config != nil {
 		discovererInstance := &discovery.CRDiscoverer{
 			CRDsAddEventsCounter:    crdsAddEventsCounter,
+			CRDsUpdateEventsCounter: crdsUpdateEventsCounter,
 			CRDsDeleteEventsCounter: crdsDeleteEventsCounter,
 			CRDsCacheCountGauge:     crdsCacheCountGauge,
 		}

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -248,19 +248,22 @@ klog_err=E$(date +%m%d)
 echo "check for errors in logs"
 
 echo "running authfiler tests.."
-go test -v ./tests/e2e/auth-filter_test.go
+go test -race -v ./tests/e2e/auth-filter_test.go
 
 echo "running discovery tests..."
 go test -race -v ./tests/e2e/discovery_test.go
 
 echo "running object limits test..."
-go test -v ./tests/e2e/object-limits_test.go
+go test -race -v ./tests/e2e/object-limits_test.go
 
 echo "running hot-reload tests..."
-go test -v ./tests/e2e/hot-reload_test.go
+go test -race -v ./tests/e2e/hot-reload_test.go
 
 echo "running hot-reload-kubeconfig tests..."
-go test -v ./tests/e2e/hot-reload-kubeconfig_test.go
+go test -race -v ./tests/e2e/hot-reload-kubeconfig_test.go
+
+echo "running CRD UpdateFunc handler tests..."
+go test -race -v ./tests/e2e/crd_informer_updatefunc_test.go
 
 output_logs=$(kubectl --namespace=kube-system logs deployment/kube-state-metrics kube-state-metrics)
 if echo "${output_logs}" | grep "^${klog_err}"; then

--- a/tests/e2e/crd_informer_updatefunc_test.go
+++ b/tests/e2e/crd_informer_updatefunc_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"k8s.io/kube-state-metrics/v2/internal"
+	"k8s.io/kube-state-metrics/v2/internal/discovery"
+	"k8s.io/kube-state-metrics/v2/pkg/options"
+	ksmFramework "k8s.io/kube-state-metrics/v2/tests/e2e/framework"
+)
+
+// TestCRDInformerUpdateFuncHandler tests that when an existing CRD is updated
+// to add new versions, KSM becomes aware of that change and updates metrics
+// accordingly, thus also validating the UpdateFunc in the discovery informer.
+func TestCRDInformerUpdateFuncHandler(t *testing.T) {
+	const (
+		assetDir        = "testdata/crd-informer-updatefunc"
+		populateTimeout = 10 * time.Second
+	)
+
+	m := &struct {
+		crV1          string
+		crV1alpha1    string
+		crdV1V1alpha1 string
+		crdV1alpha1   string
+		crsConfig     string
+	}{
+		crV1:          assetDir + "/cr_v1.yaml",
+		crV1alpha1:    assetDir + "/cr_v1alpha1.yaml",
+		crdV1V1alpha1: assetDir + "/crd_v1_v1alpha1.yaml",
+		crdV1alpha1:   assetDir + "/crd_v1alpha1.yaml",
+		crsConfig:     assetDir + "/crs_config.yaml",
+	}
+
+	defer func() {
+		klog.InfoS("cleaning up test resources")
+		_ = exec.Command("kubectl", "delete", "application", "test-app-alpha").Run()   //nolint:gosec
+		_ = exec.Command("kubectl", "delete", "application", "test-app-stable").Run()  //nolint:gosec
+		_ = exec.Command("kubectl", "delete", "crd", "applications.example.com").Run() //nolint:gosec
+	}()
+
+	opts := options.NewOptions()
+	cmd := options.InitCommand
+	opts.AddFlags(cmd)
+	klog.InfoS("options", "options", opts)
+
+	opts.CustomResourceConfigFile = m.crsConfig
+	kubeconfig, found := os.LookupEnv("KUBECONFIG")
+	if !found {
+		t.Fatalf("KUBECONFIG environment variable not set")
+	}
+	opts.Kubeconfig = kubeconfig
+	if err := opts.Parse(); err != nil {
+		t.Fatalf("failed to parse options: %v", err)
+	}
+	klog.InfoS("parsed options", "options", opts)
+
+	go internal.RunKubeStateMetricsWrapper(opts)
+
+	err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 20*time.Second, true, func(_ context.Context) (bool, error) {
+		conn, err := net.Dial("tcp", "localhost:8080")
+		if err != nil {
+			return false, nil
+		}
+		err = conn.Close()
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("failed while waiting for port 8080 to come up: %v", err)
+	}
+
+	f, err := ksmFramework.New("http://localhost:8080", "http://localhost:8081")
+	if err != nil {
+		t.Fatalf("failed to create test framework: %v", err)
+	}
+
+	// Apply v1alpha assets.
+	err = exec.Command("kubectl", "apply", "-f", m.crdV1alpha1).Run() //nolint:gosec
+	if err != nil {
+		t.Fatalf("failed to apply v1alpha1 crd: %v", err)
+	}
+	err = exec.Command("kubectl", "apply", "-f", m.crV1alpha1).Run() //nolint:gosec
+	if err != nil {
+		t.Fatalf("failed to apply v1alpha1 cr: %v", err)
+	}
+
+	v1alpha1Labels := map[string]string{
+		"customresource_group":   "example.com",
+		"customresource_kind":    "Application",
+		"customresource_version": "v1alpha1",
+		"name":                   "test-app-alpha",
+	}
+	err = wait.PollUntilContextTimeout(context.TODO(), discovery.Interval, populateTimeout, true, func(_ context.Context) (bool, error) {
+		found, err := f.HasMetricWithLabels("kube_customresource_test_metric_info", v1alpha1Labels)
+		if err != nil {
+			klog.ErrorS(err, "failed to check for metric")
+			return false, nil
+		}
+		if found {
+			klog.InfoS("v1alpha1 metric found")
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed while waiting for v1alpha1 metrics to be available: %v", err)
+	}
+
+	// Update the CRD to include both v1alpha1 and v1 versions (with v1 as the storage version).
+	err = exec.Command("kubectl", "apply", "-f", m.crdV1V1alpha1).Run() //nolint:gosec
+	if err != nil {
+		t.Fatalf("failed to apply updated crd with both versions: %v", err)
+	}
+
+	// Apply v1 CR.
+	err = exec.Command("kubectl", "apply", "-f", m.crV1).Run() //nolint:gosec
+	if err != nil {
+		t.Fatalf("failed to apply v1 cr: %v", err)
+	}
+
+	// Wait for v1 metrics to be available.
+	// Note: After the CRD update makes v1 the storage version, both CRs will be
+	// converted to v1, so we expect to see v1 metrics for both.
+	v1LabelsAlpha := map[string]string{
+		"customresource_group":   "example.com",
+		"customresource_kind":    "Application",
+		"customresource_version": "v1",
+		"name":                   "test-app-alpha",
+	}
+	v1LabelsStable := map[string]string{
+		"customresource_group":   "example.com",
+		"customresource_kind":    "Application",
+		"customresource_version": "v1",
+		"name":                   "test-app-stable",
+	}
+	err = wait.PollUntilContextTimeout(context.TODO(), discovery.Interval, populateTimeout*2, true, func(_ context.Context) (bool, error) {
+		hasV1Alpha, err := f.HasMetricWithLabels("kube_customresource_test_metric_info", v1LabelsAlpha)
+		if err != nil {
+			klog.ErrorS(err, "failed to check for v1 metric (test-app-alpha)")
+			return false, nil
+		}
+		hasV1Stable, err := f.HasMetricWithLabels("kube_customresource_test_metric_info", v1LabelsStable)
+		if err != nil {
+			klog.ErrorS(err, "failed to check for v1 metric (test-app-stable)")
+			return false, nil
+		}
+
+		if hasV1Alpha && hasV1Stable {
+			klog.InfoS("both CRs now showing with v1 version label")
+			return true, nil
+		}
+
+		if !hasV1Alpha {
+			klog.InfoS("v1 metric for test-app-alpha not found yet")
+		}
+		if !hasV1Stable {
+			klog.InfoS("v1 metric for test-app-stable not found yet")
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed while waiting for v1 version metrics to be available: %v", err)
+	}
+}

--- a/tests/e2e/testdata/crd-informer-updatefunc/cr_v1.yaml
+++ b/tests/e2e/testdata/crd-informer-updatefunc/cr_v1.yaml
@@ -1,0 +1,7 @@
+apiVersion: example.com/v1
+kind: Application
+metadata:
+  name: test-app-stable
+spec:
+  appName: myapp-stable
+  replicas: 5

--- a/tests/e2e/testdata/crd-informer-updatefunc/cr_v1alpha1.yaml
+++ b/tests/e2e/testdata/crd-informer-updatefunc/cr_v1alpha1.yaml
@@ -1,0 +1,7 @@
+apiVersion: example.com/v1alpha1
+kind: Application
+metadata:
+  name: test-app-alpha
+spec:
+  appName: myapp-alpha
+  replicas: 3

--- a/tests/e2e/testdata/crd-informer-updatefunc/crd_v1_v1alpha1.yaml
+++ b/tests/e2e/testdata/crd-informer-updatefunc/crd_v1_v1alpha1.yaml
@@ -1,0 +1,48 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.example.com
+spec:
+  group: example.com
+  names:
+    plural: applications
+    singular: application
+    kind: Application
+    shortNames:
+    - app
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                appName:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+              required: ["appName"]
+          required: ["spec"]
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                appName:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+              required: ["appName"]
+          required: ["spec"]

--- a/tests/e2e/testdata/crd-informer-updatefunc/crd_v1alpha1.yaml
+++ b/tests/e2e/testdata/crd-informer-updatefunc/crd_v1alpha1.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.example.com
+spec:
+  group: example.com
+  names:
+    plural: applications
+    singular: application
+    kind: Application
+    shortNames:
+    - app
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                appName:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+              required: ["appName"]
+          required: ["spec"]

--- a/tests/e2e/testdata/crd-informer-updatefunc/crs_config.yaml
+++ b/tests/e2e/testdata/crd-informer-updatefunc/crs_config.yaml
@@ -1,0 +1,16 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: "example.com"
+        version: "*"
+        kind: "Application"
+      metrics:
+        - name: "test_metric_info"
+          help: "helpless"
+          each:
+            type: Info
+            info:
+              path: [metadata]
+              labelsFromPath:
+                name: [name]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:** OpenShift CI observed instances, albeit rare, in which the binary seemed to panic due to a nil entry on the reflectors map.

Since there was no UpdateFunc specified in CRD discovery machinery, CRD records are only curated at the time of initialization and when a CRD is deleted.

This is problematic because if someone updates a CRD to accommodate for more versions, it won't be reflected in the informers local cache, and thus, no entry for that reflector will be created and tracked. When such a CRD gets deleted, it will trigger the DeleteFunc which, as seen below, will try to delete informers for a version that was never recorded in the map.

Note that the reflectors map is only responsible for tracking reflector channels for all initialized reflectors. The resources themselves (for which the reflectors will be created for) are tracked by the main `r.Map` member of the discovery machinery. However, both of these have resources appended to, and deleted in the same manner.

This fix consists of two changes:
* checking if a reflector exists on the map before attempting to close it, and,
* adding an UpdateFunc to make the CRD informer aware on changes, so new reflectors may be created, and dangling reflectors may be closed in time, i.e., folks shouldn't have to restart KSM to see their changes after adding more versions to an existing CRD.

Note that the absent UpdateFunc also truncates the wildcard functionality for cases where the version is set to "*", under which, a v1 addition in a CRD will not be reflected in KSM until the binary restarts or the CRD is recreated.

This patch aims to address all of the above.

```
E0103 05:11:05.947159       1 chan.go:416] "Observed a panic" panic="close of nil channel" panicGoValue="\"close of nil channel\"" stacktrace=<
	goroutine 111 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2973260, 0xc00207c8d0}, {0x21f6de0, 0x29421f0})
		/go/src/k8s.io/kube-state-metrics/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:132 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x2973260, 0xc00207c8a0}, {0x21f6de0, 0x29421f0}, {0x0, 0x0, 0x422f0b?})
		/go/src/k8s.io/kube-state-metrics/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0x116
	k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithLogger({{0x297a8c8?, 0xc000146440?}, 0xc00071fa00?}, {0x0, 0x0, 0x0})
		/go/src/k8s.io/kube-state-metrics/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:91 +0x115
	panic({0x21f6de0?, 0x29421f0?})
		/usr/lib/golang/src/runtime/panic.go:792 +0x132
	k8s.io/kube-state-metrics/v2/internal/discovery.(*CRDiscoverer).RemoveFromMap(0xc000364ba0, {0xc00071fca0?, 0x1?, 0x0?})
		/go/src/k8s.io/kube-state-metrics/internal/discovery/types.go:101 +0x21f
	k8s.io/kube-state-metrics/v2/internal/discovery.(*CRDiscoverer).StartDiscovery.func2.1()
		/go/src/k8s.io/kube-state-metrics/internal/discovery/discovery.go:93 +0x65
	k8s.io/kube-state-metrics/v2/internal/discovery.(*CRDiscoverer).SafeWrite(0x0?, 0xc00071fe00)
		/go/src/k8s.io/kube-state-metrics/internal/discovery/types.go:67 +0x5e
	k8s.io/kube-state-metrics/v2/internal/discovery.(*CRDiscoverer).StartDiscovery.func2({0x25c3300?, 0xc002a520d8?})
		/go/src/k8s.io/kube-state-metrics/internal/discovery/discovery.go:92 +0x1b6
	k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
		/go/src/k8s.io/kube-state-metrics/vendor/k8s.io/client-go/tools/cache/controller.go:271
	k8s.io/client-go/tools/cache.(*processorListener).run.func1(0xc00071ff5f, 0xc000628aa0, {0x228b260?, 0xc001d288b0?})
		/go/src/k8s.io/kube-state-metrics/vendor/k8s.io/client-go/tools/cache/shared_informer.go:1082 +0x13d
	k8s.io/client-go/tools/cache.(*processorListener).run(0xc000628aa0)
		/go/src/k8s.io/kube-state-metrics/vendor/k8s.io/client-go/tools/cache/shared_informer.go:1087 +0x3c
	k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
		/go/src/k8s.io/kube-state-metrics/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4c
	created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 87
		/go/src/k8s.io/kube-state-metrics/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
 >
panic: close of nil channel [recovered]
	panic: close of nil channel
```

<!-- If you are adding a new metric, provide the use case of that metric. -->

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)* None, but introduces a new metric.
