### PR TITLE
fix: avoid mutating metric families during write

### DIFF
--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -123,7 +123,7 @@ func filterMetricNames(ms []string, names []string) []string {
 
 	regexps := []*regexp.Regexp{}
 	for _, n := range names {
-		regexps = append(regexps, regexp.MustCompile(fmt.Sprintf(".*%v.*$", n)))
+		regexps = append(regexps, regexp.MustCompile(fmt.Sprintf("(?m).*%v.*$", n)))
 	}
 
 	for _, m := range ms {

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -91,6 +91,7 @@ func (g *FamilyGenerator) generateHeader() string {
 	header.WriteString(g.Name)
 	header.WriteByte(' ')
 	header.WriteString(string(g.Type))
+	header.WriteByte('\n')
 
 	return header.String()
 }

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -28,11 +28,10 @@ import (
 // interface. Instead of storing entire Kubernetes objects, it stores metrics
 // generated based on those objects.
 type MetricsStore struct {
-	// metrics is a map indexed by Kubernetes object id, containing a slice of
-	// metric families, containing a slice of metrics. We need to keep metrics
-	// grouped by metric families in order to zip families with their help text in
-	// MetricsStore.WriteAll().
-	metrics sync.Map
+	// metrics points to a sync.Map indexed by Kubernetes object id, containing a slice of
+	// metric families, containing a slice of metrics. It's a pointer so cloned stores can
+	// safely share the same backing storage without copying or mutating it.
+	metrics *sync.Map
 
 	// generateMetricsFunc generates metrics based on a given Kubernetes object
 	// and returns them grouped by metric family.
@@ -48,7 +47,7 @@ func NewMetricsStore(headers []string, generateFunc func(interface{}) []metric.F
 	return &MetricsStore{
 		generateMetricsFunc: generateFunc,
 		headers:             headers,
-		metrics:             sync.Map{},
+		metrics:             &sync.Map{},
 	}
 }
 

--- a/pkg/metrics_store/metrics_writer.go
+++ b/pkg/metrics_store/metrics_writer.go
@@ -26,6 +26,21 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 )
 
+const (
+	helpPrefix = "# HELP "
+	typePrefix = "# TYPE "
+)
+
+var (
+	infoTypeString     = string(metric.Info)
+	stateSetTypeString = string(metric.StateSet)
+	gaugeTypeString    = string(metric.Gauge)
+	// gaugeNewline is the pre-built suffix used when rewriting info/stateset TYPE lines.
+	// Pre-computing it reduces rewriteTypeLine to a 2-string concat (concatstring2),
+	// avoiding the overhead of a 3-string concat (concatstring3) on every rewrite.
+	gaugeNewline = gaugeTypeString + "\n"
+)
+
 // MetricsWriterList represent a list of MetricsWriter
 type MetricsWriterList []*MetricsWriter
 
@@ -59,20 +74,28 @@ func (m MetricsWriter) WriteAll(w io.Writer) error {
 	}
 
 	for i, help := range m.stores[0].headers {
-		if help != "" && help != "\n" {
-			help += "\n"
-		}
-
 		var err error
-		m.stores[0].metrics.Range(func(_ interface{}, _ interface{}) bool {
-			_, err = w.Write([]byte(help))
+
+		// SanitizeHeaders blanks duplicate headers to preserve header/family
+		// index alignment. An empty header means suppress the header text but
+		// still emit the metric family bytes at this index.
+		if help != "" {
+			// Avoid allocating a new string if the header lacks a trailing newline:
+			// check once and emit "\n" as a second write if needed.
+			needsNewline := help[len(help)-1] != '\n'
+			m.stores[0].metrics.Range(func(_ interface{}, _ interface{}) bool {
+				_, err = io.WriteString(w, help)
+				if err != nil {
+					return false
+				}
+				if needsNewline {
+					_, err = io.WriteString(w, "\n")
+				}
+				return false
+			})
 			if err != nil {
-				err = fmt.Errorf("failed to write help text: %v", err)
+				return fmt.Errorf("failed to write help text: %v", err)
 			}
-			return false
-		})
-		if err != nil {
-			return err
 		}
 
 		for _, s := range m.stores {
@@ -93,36 +116,132 @@ func (m MetricsWriter) WriteAll(w io.Writer) error {
 	return nil
 }
 
-// SanitizeHeaders sanitizes the headers of the given MetricsWriterList.
-func SanitizeHeaders(contentType expfmt.Format, writers MetricsWriterList) MetricsWriterList {
-	var lastHeader string
-	for _, writer := range writers {
-		if len(writer.stores) > 0 {
-			for i, header := range writer.stores[0].headers {
-				// If the requested content type is text/plain, replace "info" and "statesets" with "gauge", as they are not recognized by Prometheus' plain text machinery.
-				// When Prometheus requests proto-based formats, this branch is also used because any requested format that is not OpenMetrics falls back to text/plain in metrics_handler.go.
-				if strings.HasPrefix(header, "# HELP") && contentType.FormatType() == expfmt.TypeTextPlain {
-					infoTypeString := string(metric.Info)
-					stateSetTypeString := string(metric.StateSet)
-					if strings.HasSuffix(header, infoTypeString) {
-						header = header[:len(header)-len(infoTypeString)] + string(metric.Gauge)
-					}
-					if strings.HasSuffix(header, stateSetTypeString) {
-						header = header[:len(header)-len(stateSetTypeString)] + string(metric.Gauge)
-					}
-				}
+// scanHeader inspects a header string and returns deduplication/modification metadata.
+// It does not mutate seen — callers must update that map themselves.
+// Headers are expected to have the form "# HELP <name> <desc>\n# TYPE <name> <type>\n".
+// typeLastSpace is the byte offset of the space before the type suffix in header, or -1.
+func scanHeader(header string, seen map[string]struct{}, isTextPlain bool) (shouldRemove, needsModification bool, metricName string, typeLastSpace int) {
+	rest := header
+	typeLastSpace = -1
 
-				// Keep header indexing stable with metric families. Duplicate headers are blanked instead of removed.
-				if header == "" || header == "\n" || header == lastHeader {
-					writer.stores[0].headers[i] = ""
-					continue
-				}
+	// Parse HELP line.
+	if len(rest) > len(helpPrefix) && rest[:len(helpPrefix)] == helpPrefix {
+		rest = rest[len(helpPrefix):]
+		if spaceIdx := strings.IndexByte(rest, ' '); spaceIdx > 0 {
+			metricName = rest[:spaceIdx]
+			if _, isSeen := seen[metricName]; isSeen {
+				return true, false, metricName, -1
+			}
+		}
+		// Advance past the rest of the HELP line.
+		nl := strings.IndexByte(rest, '\n')
+		if nl == -1 {
+			return false, false, metricName, -1
+		}
+		rest = rest[nl+1:]
+	}
 
-				writer.stores[0].headers[i] = header
-				lastHeader = header
+	// Parse TYPE line.
+	if len(rest) > len(typePrefix) && rest[:len(typePrefix)] == typePrefix {
+		rest = rest[len(typePrefix):]
+		if spaceIdx := strings.IndexByte(rest, ' '); spaceIdx > 0 {
+			typeName := rest[:spaceIdx]
+			if _, isSeen := seen[typeName]; isSeen {
+				return true, false, metricName, -1
+			}
+			// Record the position of the space before the type suffix within the
+			// original header string so rewriteTypeLine can avoid recomputing it.
+			typeLastSpace = len(header) - len(rest) + spaceIdx
+			if isTextPlain {
+				typeSuffix := rest[spaceIdx+1:]
+				if l := len(typeSuffix); l > 0 && typeSuffix[l-1] == '\n' {
+					typeSuffix = typeSuffix[:l-1]
+				}
+				needsModification = typeSuffix == infoTypeString || typeSuffix == stateSetTypeString
 			}
 		}
 	}
 
-	return writers
+	return false, needsModification, metricName, typeLastSpace
+}
+
+// rewriteTypeLine replaces an OpenMetrics-only type suffix (info/stateset) with "gauge"
+// in the TYPE line of header and returns the updated header.
+// lastSpace is the pre-computed byte offset of the space before the type suffix.
+func rewriteTypeLine(header string, lastSpace int) string {
+	if lastSpace < 0 {
+		return ""
+	}
+	return header[:lastSpace+1] + gaugeNewline
+}
+
+// SanitizeHeaders sanitizes the headers of the given MetricsWriterList.
+func SanitizeHeaders(contentType expfmt.Format, writers MetricsWriterList) MetricsWriterList {
+	// Pre-count total headers to size the seen map accurately upfront.
+	capHint := 0
+	for _, writer := range writers {
+		if len(writer.stores) > 0 {
+			capHint += len(writer.stores[0].headers)
+		}
+	}
+
+	isTextPlain := contentType.FormatType() == expfmt.TypeTextPlain
+	// A single map replaces the former seenHELP+seenTYPE pair: HELP and TYPE lines
+	// always share the same metric name, so one lookup per header suffices.
+	seen := make(map[string]struct{}, capHint)
+
+	clonedWriters := make(MetricsWriterList, 0, len(writers))
+	for _, writer := range writers {
+		clonedStores := make([]*MetricsStore, 0, len(writer.stores))
+		for i, store := range writer.stores {
+			clonedStore := &MetricsStore{
+				metrics: store.metrics,
+			}
+			if i == 0 {
+				clonedHeaders := make([]string, len(store.headers))
+				copy(clonedHeaders, store.headers)
+				clonedStore.headers = clonedHeaders
+			}
+			clonedStores = append(clonedStores, clonedStore)
+		}
+
+		// Deduplicate and rewrite headers on the cloned store in the same pass.
+		if len(clonedStores) > 0 {
+			headers := clonedStores[0].headers
+			for i, header := range headers {
+				if header == "" {
+					continue
+				}
+
+				shouldRemove, needsModification, metricName, lastSpace := scanHeader(header, seen, isTextPlain)
+
+				if shouldRemove {
+					headers[i] = ""
+					continue
+				}
+
+				if metricName != "" {
+					seen[metricName] = struct{}{}
+				}
+
+				if !needsModification {
+					if header[len(header)-1] != '\n' {
+						headers[i] = header + "\n"
+					}
+					continue
+				}
+
+				// Surgical replacement: only modify the TYPE line suffix.
+				if rewritten := rewriteTypeLine(header, lastSpace); rewritten != "" {
+					headers[i] = rewritten
+				} else if header[len(header)-1] != '\n' {
+					headers[i] = header + "\n"
+				}
+			}
+		}
+
+		clonedWriters = append(clonedWriters, &MetricsWriter{stores: clonedStores, ResourceName: writer.ResourceName})
+	}
+
+	return clonedWriters
 }

--- a/pkg/metrics_store/metrics_writer_test.go
+++ b/pkg/metrics_store/metrics_writer_test.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 )
@@ -63,7 +64,7 @@ func TestWriteAllWithSingleStore(t *testing.T) {
 
 		return []metric.FamilyInterface{&mf1, &mf2}
 	}
-	store := NewMetricsStore([]string{"Info 1 about services", "Info 2 about services"}, genFunc)
+	store := NewMetricsStore([]string{"Info 1 about services\n", "Info 2 about services\n"}, genFunc)
 	svcs := []v1.Service{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -151,7 +152,7 @@ func TestWriteAllWithMultipleStores(t *testing.T) {
 
 		return []metric.FamilyInterface{&mf1, &mf2}
 	}
-	s1 := NewMetricsStore([]string{"Info 1 about services", "Info 2 about services"}, genFunc)
+	s1 := NewMetricsStore([]string{"Info 1 about services\n", "Info 2 about services\n"}, genFunc)
 	svcs1 := []v1.Service{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -191,7 +192,7 @@ func TestWriteAllWithMultipleStores(t *testing.T) {
 			},
 		},
 	}
-	s2 := NewMetricsStore([]string{"Info 1 about services", "Info 2 about services"}, genFunc)
+	s2 := NewMetricsStore([]string{"Info 1 about services\n", "Info 2 about services\n"}, genFunc)
 	for _, s := range svcs2 {
 		svc := s
 		if err := s2.Add(&svc); err != nil {
@@ -251,7 +252,7 @@ func TestWriteAllWithEmptyStores(t *testing.T) {
 
 		return []metric.FamilyInterface{&mf1, &mf2}
 	}
-	store := NewMetricsStore([]string{"Info 1 about services", "Info 2 about services"}, genFunc)
+	store := NewMetricsStore([]string{"Info 1 about services\n", "Info 2 about services\n"}, genFunc)
 
 	multiNsWriter := NewMetricsWriter("test", store)
 	w := strings.Builder{}
@@ -322,10 +323,10 @@ func TestWriteAllWithSanitizedDuplicateHeadersPreservesFamilyOrder(t *testing.T)
 	}
 
 	writer := NewMetricsWriter("test", store)
-	SanitizeHeaders(expfmt.NewFormat(expfmt.TypeOpenMetrics), MetricsWriterList{writer})
+	sanitized := SanitizeHeaders(expfmt.NewFormat(expfmt.TypeOpenMetrics), MetricsWriterList{writer})
 
 	var out strings.Builder
-	if err := writer.WriteAll(&out); err != nil {
+	if err := sanitized[0].WriteAll(&out); err != nil {
 		t.Fatalf("failed to write metrics: %v", err)
 	}
 
@@ -395,10 +396,10 @@ func TestWriteAllWithSanitizedDuplicateHeadersWithoutEmptyFamiliesPreservesLater
 	}
 
 	writer := NewMetricsWriter("test", store)
-	SanitizeHeaders(expfmt.NewFormat(expfmt.TypeOpenMetrics), MetricsWriterList{writer})
+	sanitized := SanitizeHeaders(expfmt.NewFormat(expfmt.TypeOpenMetrics), MetricsWriterList{writer})
 
 	var out strings.Builder
-	if err := writer.WriteAll(&out); err != nil {
+	if err := sanitized[0].WriteAll(&out); err != nil {
 		t.Fatalf("failed to write metrics: %v", err)
 	}
 
@@ -434,10 +435,10 @@ func TestSanitizeHeaders(t *testing.T) {
 			},
 			expectedHeaders: []string{
 				"",
-				"# HELP foo foo_help\n# TYPE foo gauge",
-				"# HELP foo foo_help\n# TYPE foo info",
-				"# HELP foo foo_help\n# TYPE foo stateset",
-				"# HELP foo foo_help\n# TYPE foo counter",
+				"# HELP foo foo_help\n# TYPE foo gauge\n",
+				"",
+				"",
+				"",
 			},
 		},
 		{
@@ -460,13 +461,13 @@ func TestSanitizeHeaders(t *testing.T) {
 				"",
 				"",
 				"",
-				"# HELP foo foo_help\n# TYPE foo gauge",
+				"# HELP foo foo_help\n# TYPE foo gauge\n",
 				"",
-				"# HELP foo foo_help\n# TYPE foo info",
 				"",
-				"# HELP foo foo_help\n# TYPE foo stateset",
 				"",
-				"# HELP foo foo_help\n# TYPE foo counter",
+				"",
+				"",
+				"",
 				"",
 			},
 		},
@@ -482,10 +483,10 @@ func TestSanitizeHeaders(t *testing.T) {
 			},
 			expectedHeaders: []string{
 				"",
-				"# HELP foo foo_help\n# TYPE foo gauge",
+				"# HELP foo foo_help\n# TYPE foo gauge\n",
 				"",
 				"",
-				"# HELP foo foo_help\n# TYPE foo counter",
+				"",
 			},
 		},
 		{
@@ -508,26 +509,85 @@ func TestSanitizeHeaders(t *testing.T) {
 				"",
 				"",
 				"",
-				"# HELP foo foo_help\n# TYPE foo gauge",
+				"# HELP foo foo_help\n# TYPE foo gauge\n",
 				"",
 				"",
 				"",
 				"",
 				"",
-				"# HELP foo foo_help\n# TYPE foo counter",
+				"",
 				"",
 			},
 		},
 	}
 
 	for _, testcase := range testcases {
-		writer := NewMetricsWriter("test", NewMetricsStore(testcase.headers, nil))
+		// Snapshot the headers before passing them into NewMetricsStore so that
+		// the immutability assertion compares against an independent copy rather
+		// than the same backing slice that the store holds.
+		headerSnapshot := make([]string, len(testcase.headers))
+		copy(headerSnapshot, testcase.headers)
+		originalStore := NewMetricsStore(testcase.headers, nil)
+		writer := NewMetricsWriter("test", originalStore)
 		t.Run(testcase.name, func(t *testing.T) {
-			SanitizeHeaders(testcase.contentType, MetricsWriterList{writer})
-			if !reflect.DeepEqual(testcase.expectedHeaders, writer.stores[0].headers) {
-				t.Fatalf("(-want, +got):\n%s", cmp.Diff(testcase.expectedHeaders, writer.stores[0].headers))
+			sanitizedWriters := SanitizeHeaders(testcase.contentType, MetricsWriterList{writer})
+			if !reflect.DeepEqual(testcase.expectedHeaders, sanitizedWriters[0].stores[0].headers) {
+				t.Fatalf("(-want, +got):\n%s", cmp.Diff(testcase.expectedHeaders, sanitizedWriters[0].stores[0].headers))
+			}
+			if !reflect.DeepEqual(headerSnapshot, originalStore.headers) {
+				t.Fatalf("Original headers were mutated. Expected: %v, Got: %v", headerSnapshot, originalStore.headers)
 			}
 		})
+	}
+}
+
+func TestSanitizeHeadersImmutability(t *testing.T) {
+	originalHeaders := []string{
+		"# HELP foo_info foo_help\n# TYPE foo_info info",
+		"# HELP foo_stateset foo_help\n# TYPE foo_stateset stateset",
+		"# HELP foo_gauge foo_help\n# TYPE foo_gauge gauge",
+	}
+
+	// Snapshot before passing to NewMetricsStore: the store holds the slice
+	// directly, so originalHeaders and store.headers share the same backing
+	// array. An in-place mutation would satisfy DeepEqual(originalHeaders,
+	// store.headers) even though the original data was changed.
+	snapshot := make([]string, len(originalHeaders))
+	copy(snapshot, originalHeaders)
+
+	store := NewMetricsStore(originalHeaders, nil)
+	writer := NewMetricsWriter("test", store)
+
+	textPlainContentType := expfmt.NewFormat(expfmt.TypeTextPlain)
+	sanitizedWriters1 := SanitizeHeaders(textPlainContentType, MetricsWriterList{writer})
+
+	if !reflect.DeepEqual(snapshot, store.headers) {
+		t.Fatalf("Original headers were mutated after first request. Expected: %v, Got: %v", snapshot, store.headers)
+	}
+
+	expectedTextHeaders := []string{
+		"# HELP foo_info foo_help\n# TYPE foo_info gauge\n",
+		"# HELP foo_stateset foo_help\n# TYPE foo_stateset gauge\n",
+		"# HELP foo_gauge foo_help\n# TYPE foo_gauge gauge\n",
+	}
+	if !reflect.DeepEqual(expectedTextHeaders, sanitizedWriters1[0].stores[0].headers) {
+		t.Fatalf("First request headers mismatch. (-want, +got):\n%s", cmp.Diff(expectedTextHeaders, sanitizedWriters1[0].stores[0].headers))
+	}
+
+	openMetricsContentType := expfmt.NewFormat(expfmt.TypeOpenMetrics)
+	sanitizedWriters2 := SanitizeHeaders(openMetricsContentType, MetricsWriterList{writer})
+
+	if !reflect.DeepEqual(snapshot, store.headers) {
+		t.Fatalf("Original headers were mutated after second request. Expected: %v, Got: %v", snapshot, store.headers)
+	}
+
+	expectedOpenMetricsHeaders := []string{
+		"# HELP foo_info foo_help\n# TYPE foo_info info\n",
+		"# HELP foo_stateset foo_help\n# TYPE foo_stateset stateset\n",
+		"# HELP foo_gauge foo_help\n# TYPE foo_gauge gauge\n",
+	}
+	if !reflect.DeepEqual(expectedOpenMetricsHeaders, sanitizedWriters2[0].stores[0].headers) {
+		t.Fatalf("Second request headers mismatch. Expected OpenMetrics to preserve info/stateset. (-want, +got):\n%s", cmp.Diff(expectedOpenMetricsHeaders, sanitizedWriters2[0].stores[0].headers))
 	}
 }
 
@@ -563,9 +623,9 @@ func BenchmarkSanitizeHeaders(b *testing.B) {
 		headers := []string{}
 		for j := 0; j < 10e4; j++ {
 			if benchmark.writersContainsDuplicates {
-				headers = append(headers, "# HELP foo foo_help\n# TYPE foo info")
+				headers = append(headers, "# HELP foo foo_help\n# TYPE foo info\n")
 			} else {
-				headers = append(headers, fmt.Sprintf("# HELP foo_%d foo_help\n# TYPE foo_%d info", j, j))
+				headers = append(headers, fmt.Sprintf("# HELP foo_%d foo_help\n# TYPE foo_%d info\n", j, j))
 			}
 		}
 		writer := NewMetricsWriter("test", NewMetricsStore(headers, nil))
@@ -574,5 +634,82 @@ func BenchmarkSanitizeHeaders(b *testing.B) {
 				SanitizeHeaders(benchmark.contentType, MetricsWriterList{writer})
 			}
 		})
+	}
+
+	// Multi-store benchmark: simulates the multi-namespace case where a single
+	// writer holds one store per namespace. Only stores[0].headers is read by
+	// WriteAll; the optimization skips cloning headers for stores[1..n].
+	const multiStoreN = 100
+	const multiStoreHeaders = 200
+	multiHeaders := make([]string, multiStoreHeaders)
+	for j := 0; j < multiStoreHeaders; j++ {
+		multiHeaders[j] = fmt.Sprintf("# HELP ns_metric_%d help\n# TYPE ns_metric_%d gauge\n", j, j)
+	}
+	multiStores := make([]*MetricsStore, multiStoreN)
+	for k := 0; k < multiStoreN; k++ {
+		multiStores[k] = NewMetricsStore(multiHeaders, nil)
+	}
+	multiWriter := NewMetricsWriter("test", multiStores...)
+	b.Run("text-format multi-store", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			SanitizeHeaders(expfmt.NewFormat(expfmt.TypeTextPlain), MetricsWriterList{multiWriter})
+		}
+	})
+}
+
+// BenchmarkWriteAll exercises the hot path hit on every metrics scrape:
+// a sanitized writer with N objects each containing M metric families.
+func BenchmarkWriteAll(b *testing.B) {
+	const nObjects = 500
+	const nFamilies = 10
+
+	headers := make([]string, nFamilies)
+	for j := 0; j < nFamilies; j++ {
+		headers[j] = fmt.Sprintf("# HELP kube_bench_metric_%d benchmark metric %d\n# TYPE kube_bench_metric_%d gauge", j, j, j)
+	}
+
+	genFunc := func(obj interface{}) []metric.FamilyInterface {
+		o, _ := meta.Accessor(obj)
+		families := make([]metric.FamilyInterface, nFamilies)
+		for j := 0; j < nFamilies; j++ {
+			mf := &metric.Family{
+				Name: fmt.Sprintf("kube_bench_metric_%d", j),
+				Metrics: []*metric.Metric{
+					{
+						LabelKeys:   []string{"uid"},
+						LabelValues: []string{string(o.GetUID())},
+						Value:       float64(j),
+					},
+				},
+			}
+			families[j] = mf
+		}
+		return families
+	}
+
+	store := NewMetricsStore(headers, genFunc)
+	for k := 0; k < nObjects; k++ {
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       types.UID(fmt.Sprintf("uid-%d", k)),
+				Name:      fmt.Sprintf("svc-%d", k),
+				Namespace: "default",
+			},
+		}
+		if err := store.Add(svc); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	writers := SanitizeHeaders(expfmt.NewFormat(expfmt.TypeTextPlain), MetricsWriterList{NewMetricsWriter("bench", store)})
+	writer := writers[0]
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var w strings.Builder
+		if err := writer.WriteAll(&w); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -220,22 +220,35 @@ func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	m.metricsWriters = metricsstore.SanitizeHeaders(contentType, m.metricsWriters)
-
 	requestedResources := parseResources(r.URL.Query()["resources"])
 	excludedResources := parseResources(r.URL.Query()["exclude_resources"])
 
-	for _, w := range m.metricsWriters {
-		if requestedResources != nil {
-			if _, ok := requestedResources[w.ResourceName]; !ok {
-				continue
+	// Filter writers before sanitizing so that SanitizeHeaders only
+	// deduplicates across the writers that will actually be written.
+	// Sanitizing first can suppress HELP/TYPE headers for metrics whose
+	// only active writer is later in the list but its earlier same-named
+	// counterpart was filtered out.
+	activeWriters := m.metricsWriters
+	if requestedResources != nil || excludedResources != nil {
+		activeWriters = make(metricsstore.MetricsWriterList, 0, len(m.metricsWriters))
+		for _, mw := range m.metricsWriters {
+			if requestedResources != nil {
+				if _, ok := requestedResources[mw.ResourceName]; !ok {
+					continue
+				}
 			}
-		}
-		if excludedResources != nil {
-			if _, ok := excludedResources[w.ResourceName]; ok {
-				continue
+			if excludedResources != nil {
+				if _, ok := excludedResources[mw.ResourceName]; ok {
+					continue
+				}
 			}
+			activeWriters = append(activeWriters, mw)
 		}
+	}
+
+	sanitizedWriters := metricsstore.SanitizeHeaders(contentType, activeWriters)
+
+	for _, w := range sanitizedWriters {
 		err := w.WriteAll(writer)
 		if err != nil {
 			klog.ErrorS(err, "Failed to write metrics")


### PR DESCRIPTION
**What this PR does / why we need it:**

Fixes a bug where metric family types could be mutated across requests when serving different content types.

When serving Prometheus text output, `info` and `stateset` metrics were rewritten to `gauge` by mutating shared metric families. This caused subsequent OpenMetrics requests to return incorrect types. This change ensures per-request sanitization does not affect stored metrics.

**How does this change affect the cardinality of KSM:**  
Does not change cardinality.

**Which issue(s) this PR fixes:**  
Fixes #2805 
