### PR TITLE
feat: implement discovery of apiservices

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	k8sdiscovery "k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/rest"
@@ -43,10 +42,7 @@ func (r *CRDiscoverer) StartDiscovery(ctx context.Context, config *rest.Config) 
 	if err != nil {
 		return err
 	}
-	err = r.startAPIServiceDiscovery(ctx, config)
-	if err != nil {
-		return err
-	}
+
 	return nil
 }
 
@@ -91,22 +87,6 @@ func (r *CRDiscoverer) startCRDDiscovery(ctx context.Context, config *rest.Confi
 	}, "", 0, nil, nil)
 
 	extractor := &crdExtractor{}
-
-	return r.runInformer(ctx, factory.Informer(), extractor)
-}
-
-func (r *CRDiscoverer) startAPIServiceDiscovery(ctx context.Context, config *rest.Config) error {
-	client := dynamic.NewForConfigOrDie(config)
-	factory := dynamicinformer.NewFilteredDynamicInformer(client, schema.GroupVersionResource{
-		Group:    "apiregistration.k8s.io",
-		Version:  "v1",
-		Resource: "apiservices",
-	}, "", 0, nil, nil)
-
-	discoveryClient := k8sdiscovery.NewDiscoveryClientForConfigOrDie(config)
-	extractor := &apiServiceExtractor{
-		discoveryClient: discoveryClient,
-	}
 
 	return r.runInformer(ctx, factory.Informer(), extractor)
 }

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -17,10 +17,8 @@ package discovery
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sdiscovery "k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -38,8 +36,6 @@ import (
 
 // Interval is the time interval between two cache sync checks.
 const Interval = 3 * time.Second
-
-type gvkExtractor func(obj interface{}) []groupVersionKindPlural
 
 // StartDiscovery starts the discovery process, fetching all the objects that can be listed from the apiserver, every `Interval` seconds.
 // resolveGVK needs to be called after StartDiscovery to generate factories.
@@ -59,7 +55,7 @@ func (r *CRDiscoverer) runInformer(ctx context.Context, informer cache.SharedInd
 	stopper := make(chan struct{})
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			gvkps := gvkExtractor(obj)
+			gvkps := gvkExtractor.ExtractGVKs(obj)
 			r.SafeWrite(func() {
 				r.AppendToMap(gvkps...)
 				r.WasUpdated = true
@@ -70,8 +66,8 @@ func (r *CRDiscoverer) runInformer(ctx context.Context, informer cache.SharedInd
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			oldGVKPs := gvkExtractor(oldObj)
-			newGVKPs := gvkExtractor(newObj)
+			oldGVKPs := gvkExtractor.ExtractGVKs(oldObj)
+			newGVKPs := gvkExtractor.ExtractGVKs(newObj)
 			r.SafeWrite(func() {
 				r.RemoveFromMap(oldGVKPs...)
 				r.AppendToMap(newGVKPs...)
@@ -82,7 +78,7 @@ func (r *CRDiscoverer) runInformer(ctx context.Context, informer cache.SharedInd
 			})
 		},
 		DeleteFunc: func(obj interface{}) {
-			gvkps := gvkExtractor(obj)
+			gvkps := gvkExtractor.ExtractGVKs(obj)
 			r.SafeWrite(func() {
 				r.RemoveFromMap(gvkps...)
 				r.WasUpdated = true
@@ -117,27 +113,9 @@ func (r *CRDiscoverer) startCRDDiscovery(ctx context.Context, config *rest.Confi
 		Resource: "customresourcedefinitions",
 	}, "", 0, nil, nil)
 
-	extractGVKPs := func(obj interface{}) []groupVersionKindPlural {
-		objSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
-		var gvkps []groupVersionKindPlural
-		for _, version := range objSpec["versions"].([]interface{}) {
-			g := objSpec["group"].(string)
-			v := version.(map[string]interface{})["name"].(string)
-			k := objSpec["names"].(map[string]interface{})["kind"].(string)
-			p := objSpec["names"].(map[string]interface{})["plural"].(string)
-			gvkps = append(gvkps, groupVersionKindPlural{
-				GroupVersionKind: schema.GroupVersionKind{
-					Group:   g,
-					Version: v,
-					Kind:    k,
-				},
-				Plural: p,
-			})
-		}
-		return gvkps
-	}
+	gvkExtractor := &crdGVKExtractor{}
 
-	return r.runInformer(ctx, factory.Informer(), extractGVKPs)
+	return r.runInformer(ctx, factory.Informer(), gvkExtractor)
 }
 
 func (r *CRDiscoverer) startAPIServiceDiscovery(ctx context.Context, config *rest.Config) error {
@@ -149,42 +127,11 @@ func (r *CRDiscoverer) startAPIServiceDiscovery(ctx context.Context, config *res
 	}, "", 0, nil, nil)
 
 	discoveryClient := k8sdiscovery.NewDiscoveryClientForConfigOrDie(config)
-
-	processAPIService := func(obj interface{}) []groupVersionKindPlural {
-		serviceSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
-		if svc, ok := serviceSpec["service"]; !ok || svc == nil {
-			return nil
-		}
-
-		group := serviceSpec["group"].(string)
-		version := serviceSpec["version"].(string)
-
-		resourceList, err := discoveryClient.ServerResourcesForGroupVersion(fmt.Sprintf("%s/%s", group, version))
-		if err != nil {
-			klog.ErrorS(err, "failed to fetch server resources for group version", "groupVersion", fmt.Sprintf("%s/%s", group, version))
-			return nil
-		}
-
-		var gvkps []groupVersionKindPlural
-		for _, resource := range resourceList.APIResources {
-			// Skip subresources
-			if strings.Contains(resource.Name, "/") {
-				continue
-			}
-
-			gvkps = append(gvkps, groupVersionKindPlural{
-				GroupVersionKind: schema.GroupVersionKind{
-					Group:   group,
-					Version: version,
-					Kind:    resource.Kind,
-				},
-				Plural: resource.Name,
-			})
-		}
-		return gvkps
+	gvkExtractor := &apiServiceGVKExtractor{
+		discoveryClient: discoveryClient,
 	}
 
-	return r.runInformer(ctx, factory.Informer(), processAPIService)
+	return r.runInformer(ctx, factory.Informer(), gvkExtractor)
 }
 
 // ResolveGVKToGVKPs resolves the variable VKs to a GVK list, based on the current cache.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sdiscovery "k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/rest"
@@ -42,7 +43,10 @@ func (r *CRDiscoverer) StartDiscovery(ctx context.Context, config *rest.Config) 
 	if err != nil {
 		return err
 	}
-
+	err = r.startAPIServiceDiscovery(ctx, config)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -87,6 +91,22 @@ func (r *CRDiscoverer) startCRDDiscovery(ctx context.Context, config *rest.Confi
 	}, "", 0, nil, nil)
 
 	extractor := &crdExtractor{}
+
+	return r.runInformer(ctx, factory.Informer(), extractor)
+}
+
+func (r *CRDiscoverer) startAPIServiceDiscovery(ctx context.Context, config *rest.Config) error {
+	client := dynamic.NewForConfigOrDie(config)
+	factory := dynamicinformer.NewFilteredDynamicInformer(client, schema.GroupVersionResource{
+		Group:    "apiregistration.k8s.io",
+		Version:  "v1",
+		Resource: "apiservices",
+	}, "", 0, nil, nil)
+
+	discoveryClient := k8sdiscovery.NewDiscoveryClientForConfigOrDie(config)
+	extractor := &apiServiceExtractor{
+		discoveryClient: discoveryClient,
+	}
 
 	return r.runInformer(ctx, factory.Informer(), extractor)
 }

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -58,7 +58,7 @@ func (r *CRDiscoverer) runInformer(ctx context.Context, informer cache.SharedInd
 			resources := extractor.ExtractGVKs(obj)
 			r.UpdateSource(sourceID, resources)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(_, newObj interface{}) {
 			sourceID := extractor.SourceID(newObj)
 			resources := extractor.ExtractGVKs(newObj)
 			r.UpdateSource(sourceID, resources)

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -297,9 +297,9 @@ func TestUpdateSourceNilSkipsUpdate(t *testing.T) {
 			Plural:           "testobjects1",
 		},
 	}
-	discoverer.UpdateSource("apiservice:testobjects.testgroup", resources)
+	discoverer.UpdateSource("crd:testobjects.testgroup", resources)
 	// Update with nil (simulating skipping update)
-	discoverer.UpdateSource("apiservice:testobjects.testgroup", nil)
+	discoverer.UpdateSource("crd:testobjects.testgroup", nil)
 
 	// Verify original resource is still present
 	got, err := discoverer.Resolve(schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"})
@@ -321,10 +321,10 @@ func TestUpdateSourceEmptyRemovesResources(t *testing.T) {
 			Plural:           "testobjects1",
 		},
 	}
-	discoverer.UpdateSource("apiservice:testobjects.testgroup", resources)
+	discoverer.UpdateSource("crd:testobjects.testgroup", resources)
 
 	// Update with empty slice (simulating removal)
-	discoverer.UpdateSource("apiservice:testobjects.testgroup", []*DiscoveredResource{})
+	discoverer.UpdateSource("crd:testobjects.testgroup", []*DiscoveredResource{})
 
 	// Verify resource is removed
 	got, err := discoverer.Resolve(schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"})

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -25,6 +25,7 @@ import (
 // newTestCRDiscoverer creates a CRDiscoverer with no-op metrics for testing.
 func newTestCRDiscoverer() *CRDiscoverer {
 	return NewCRDiscoverer(
+		prometheus.NewCounter(prometheus.CounterOpts{Name: "test_add"}),
 		prometheus.NewCounter(prometheus.CounterOpts{Name: "test_update"}),
 		prometheus.NewCounter(prometheus.CounterOpts{Name: "test_delete"}),
 		prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_count"}),

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -18,37 +18,51 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func TestGVKMapsResolveGVK(t *testing.T) {
+// newTestCRDiscoverer creates a CRDiscoverer with no-op metrics for testing.
+func newTestCRDiscoverer() *CRDiscoverer {
+	return NewCRDiscoverer(
+		prometheus.NewCounter(prometheus.CounterOpts{Name: "test_update"}),
+		prometheus.NewCounter(prometheus.CounterOpts{Name: "test_delete"}),
+		prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_count"}),
+	)
+}
+
+func TestResolve(t *testing.T) {
 	type testcase struct {
-		desc    string
-		gvkmaps *CRDiscoverer
-		gvk     schema.GroupVersionKind
-		want    []groupVersionKindPlural
+		desc      string
+		resources map[string][]*DiscoveredResource // map[sourceID] -> []resources
+		gvk       schema.GroupVersionKind
+		want      []DiscoveredResource
 	}
 	testcases := []testcase{
 		{
 			desc: "variable version and kind",
-			gvkmaps: &CRDiscoverer{
-				Map: map[string]map[string][]kindPlural{
-					"apps": {
-						"v1": {
-							kindPlural{
-								Kind:   "Deployment",
-								Plural: "deployments",
-							},
-							kindPlural{
-								Kind:   "StatefulSet",
-								Plural: "statefulsets",
-							},
+			resources: map[string][]*DiscoveredResource{
+				"crd:deployments.apps": {
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
 						},
+						Plural: "deployments",
+					},
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "StatefulSet",
+						},
+						Plural: "statefulsets",
 					},
 				},
 			},
 			gvk: schema.GroupVersionKind{Group: "apps", Version: "*", Kind: "*"},
-			want: []groupVersionKindPlural{
+			want: []DiscoveredResource{
 				{
 					GroupVersionKind: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
 					Plural:           "deployments",
@@ -61,30 +75,36 @@ func TestGVKMapsResolveGVK(t *testing.T) {
 		},
 		{
 			desc: "variable version",
-			gvkmaps: &CRDiscoverer{
-				Map: map[string]map[string][]kindPlural{
-					"testgroup": {
-						"v1": {
-							kindPlural{
-								Kind:   "TestObject1",
-								Plural: "testobjects1",
-							},
-							kindPlural{
-								Kind:   "TestObject2",
-								Plural: "testobjects2",
-							},
+			resources: map[string][]*DiscoveredResource{
+				"crd:testobjects.testgroup": {
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "testgroup",
+							Version: "v1",
+							Kind:    "TestObject1",
 						},
-						"v1alpha1": {
-							kindPlural{
-								Kind:   "TestObject1",
-								Plural: "testobjects1",
-							},
+						Plural: "testobjects1",
+					},
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "testgroup",
+							Version: "v1",
+							Kind:    "TestObject2",
 						},
+						Plural: "testobjects2",
+					},
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "testgroup",
+							Version: "v1alpha1",
+							Kind:    "TestObject1",
+						},
+						Plural: "testobjects1",
 					},
 				},
 			},
 			gvk: schema.GroupVersionKind{Group: "testgroup", Version: "*", Kind: "TestObject1"},
-			want: []groupVersionKindPlural{
+			want: []DiscoveredResource{
 				{
 					GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
 					Plural:           "testobjects1",
@@ -97,30 +117,36 @@ func TestGVKMapsResolveGVK(t *testing.T) {
 		},
 		{
 			desc: "variable kind",
-			gvkmaps: &CRDiscoverer{
-				Map: map[string]map[string][]kindPlural{
-					"testgroup": {
-						"v1": {
-							kindPlural{
-								Kind:   "TestObject1",
-								Plural: "testobjects1",
-							},
-							kindPlural{
-								Kind:   "TestObject2",
-								Plural: "testobjects2",
-							},
+			resources: map[string][]*DiscoveredResource{
+				"crd:testobjects.testgroup": {
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "testgroup",
+							Version: "v1",
+							Kind:    "TestObject1",
 						},
-						"v1alpha1": {
-							kindPlural{
-								Kind:   "TestObject1",
-								Plural: "testobjects1",
-							},
+						Plural: "testobjects1",
+					},
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "testgroup",
+							Version: "v1",
+							Kind:    "TestObject2",
 						},
+						Plural: "testobjects2",
+					},
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "testgroup",
+							Version: "v1alpha1",
+							Kind:    "TestObject1",
+						},
+						Plural: "testobjects1",
 					},
 				},
 			},
 			gvk: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "*"},
-			want: []groupVersionKindPlural{
+			want: []DiscoveredResource{
 				{
 					GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
 					Plural:           "testobjects1",
@@ -133,30 +159,36 @@ func TestGVKMapsResolveGVK(t *testing.T) {
 		},
 		{
 			desc: "fixed version and kind",
-			gvkmaps: &CRDiscoverer{
-				Map: map[string]map[string][]kindPlural{
-					"testgroup": {
-						"v1": {
-							kindPlural{
-								Kind:   "TestObject1",
-								Plural: "testobjects1",
-							},
-							kindPlural{
-								Kind:   "TestObject2",
-								Plural: "testobjects2",
-							},
+			resources: map[string][]*DiscoveredResource{
+				"crd:testobjects.testgroup": {
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "testgroup",
+							Version: "v1",
+							Kind:    "TestObject1",
 						},
-						"v1alpha1": {
-							kindPlural{
-								Kind:   "TestObject1",
-								Plural: "testobjects1",
-							},
+						Plural: "testobjects1",
+					},
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "testgroup",
+							Version: "v1",
+							Kind:    "TestObject2",
 						},
+						Plural: "testobjects2",
+					},
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "testgroup",
+							Version: "v1alpha1",
+							Kind:    "TestObject1",
+						},
+						Plural: "testobjects1",
 					},
 				},
 			},
 			gvk: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
-			want: []groupVersionKindPlural{
+			want: []DiscoveredResource{
 				{
 					GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
 					Plural:           "testobjects1",
@@ -165,15 +197,15 @@ func TestGVKMapsResolveGVK(t *testing.T) {
 		},
 		{
 			desc: "fixed version and kind, no matching cache entry",
-			gvkmaps: &CRDiscoverer{
-				Map: map[string]map[string][]kindPlural{
-					"testgroup": {
-						"v1": {
-							kindPlural{
-								Kind:   "TestObject2",
-								Plural: "testobjects2",
-							},
+			resources: map[string][]*DiscoveredResource{
+				"crd:testobjects.testgroup": {
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "testgroup",
+							Version: "v1",
+							Kind:    "TestObject2",
 						},
+						Plural: "testobjects2",
 					},
 				},
 			},
@@ -182,19 +214,150 @@ func TestGVKMapsResolveGVK(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		got, err := tc.gvkmaps.ResolveGVKToGVKPs(tc.gvk)
-		if err != nil {
-			t.Errorf("testcase: %s: got error %v", tc.desc, err)
-		}
-		// Sort got and tc.want to ensure the order of the elements.
-		sort.Slice(got, func(i, j int) bool {
-			return got[i].String() < got[j].String()
+		t.Run(tc.desc, func(t *testing.T) {
+			discoverer := newTestCRDiscoverer()
+			// Populate the discoverer with test data
+			for sourceID, resources := range tc.resources {
+				discoverer.UpdateSource(sourceID, resources)
+			}
+
+			got, err := discoverer.Resolve(tc.gvk)
+			if err != nil {
+				t.Errorf("got error %v", err)
+			}
+			// Sort got and tc.want to ensure the order of the elements.
+			sort.Slice(got, func(i, j int) bool {
+				return got[i].String() < got[j].String()
+			})
+			sort.Slice(tc.want, func(i, j int) bool {
+				return tc.want[i].String() < tc.want[j].String()
+			})
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
 		})
-		sort.Slice(tc.want, func(i, j int) bool {
-			return tc.want[i].String() < tc.want[j].String()
-		})
-		if !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("testcase: %s: got %v, want %v", tc.desc, got, tc.want)
-		}
+	}
+}
+
+func TestUpdateSourceAndDeleteSource(t *testing.T) {
+	discoverer := newTestCRDiscoverer()
+
+	// Add resources for a source
+	resources := []*DiscoveredResource{
+		{
+			GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
+			Plural:           "testobjects1",
+		},
+	}
+	discoverer.UpdateSource("crd:testobjects.testgroup", resources)
+	// Verify resource is present
+	got, err := discoverer.Resolve(schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(got))
+	}
+
+	// Get stop channel
+	stopChan, ok := discoverer.GetStopChan(schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"})
+	if !ok {
+		t.Fatal("expected stop channel to exist")
+	}
+
+	// Delete the source
+	discoverer.DeleteSource("crd:testobjects.testgroup")
+
+	// Verify resource is removed
+	got, err = discoverer.Resolve(schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 resources, got %d", len(got))
+	}
+
+	// Verify stop channel is closed
+	select {
+	case <-stopChan:
+		// expected - channel is closed
+	default:
+		t.Fatal("expected stop channel to be closed")
+	}
+}
+
+func TestUpdateSourceNilSkipsUpdate(t *testing.T) {
+	discoverer := newTestCRDiscoverer()
+
+	// Add initial resources
+	resources := []*DiscoveredResource{
+		{
+			GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
+			Plural:           "testobjects1",
+		},
+	}
+	discoverer.UpdateSource("apiservice:testobjects.testgroup", resources)
+	// Update with nil (simulating skipping update)
+	discoverer.UpdateSource("apiservice:testobjects.testgroup", nil)
+
+	// Verify original resource is still present
+	got, err := discoverer.Resolve(schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 resource (nil should skip update), got %d", len(got))
+	}
+}
+
+func TestUpdateSourceEmptyRemovesResources(t *testing.T) {
+	discoverer := newTestCRDiscoverer()
+
+	// Add initial resources
+	resources := []*DiscoveredResource{
+		{
+			GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
+			Plural:           "testobjects1",
+		},
+	}
+	discoverer.UpdateSource("apiservice:testobjects.testgroup", resources)
+
+	// Update with empty slice (simulating removal)
+	discoverer.UpdateSource("apiservice:testobjects.testgroup", []*DiscoveredResource{})
+
+	// Verify resource is removed
+	got, err := discoverer.Resolve(schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 resources, got %d", len(got))
+	}
+}
+
+func TestCheckAndResetUpdated(t *testing.T) {
+	discoverer := newTestCRDiscoverer()
+
+	// Initially not updated
+	if discoverer.CheckAndResetUpdated() {
+		t.Fatal("expected wasUpdated to be false initially")
+	}
+
+	// Add a resource
+	discoverer.UpdateSource("crd:testobjects.testgroup", []*DiscoveredResource{
+		{
+			GroupVersionKind: schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"},
+			Plural:           "testobjects1",
+		},
+	})
+
+	// Should be updated now
+	if !discoverer.CheckAndResetUpdated() {
+		t.Fatal("expected wasUpdated to be true after UpdateSource")
+	}
+
+	// Should be reset
+	if discoverer.CheckAndResetUpdated() {
+		t.Fatal("expected wasUpdated to be false after CheckAndResetUpdated")
 	}
 }

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -297,9 +297,9 @@ func TestUpdateSourceNilSkipsUpdate(t *testing.T) {
 			Plural:           "testobjects1",
 		},
 	}
-	discoverer.UpdateSource("crd:testobjects.testgroup", resources)
+	discoverer.UpdateSource("apiservice:testobjects.testgroup", resources)
 	// Update with nil (simulating skipping update)
-	discoverer.UpdateSource("crd:testobjects.testgroup", nil)
+	discoverer.UpdateSource("apiservice:testobjects.testgroup", nil)
 
 	// Verify original resource is still present
 	got, err := discoverer.Resolve(schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"})
@@ -321,10 +321,10 @@ func TestUpdateSourceEmptyRemovesResources(t *testing.T) {
 			Plural:           "testobjects1",
 		},
 	}
-	discoverer.UpdateSource("crd:testobjects.testgroup", resources)
+	discoverer.UpdateSource("apiservice:testobjects.testgroup", resources)
 
 	// Update with empty slice (simulating removal)
-	discoverer.UpdateSource("crd:testobjects.testgroup", []*DiscoveredResource{})
+	discoverer.UpdateSource("apiservice:testobjects.testgroup", []*DiscoveredResource{})
 
 	// Verify resource is removed
 	got, err := discoverer.Resolve(schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"})

--- a/internal/discovery/gvk_extractors.go
+++ b/internal/discovery/gvk_extractors.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2023 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package discovery
 
 import (

--- a/internal/discovery/gvk_extractors.go
+++ b/internal/discovery/gvk_extractors.go
@@ -14,13 +14,8 @@ limitations under the License.
 package discovery
 
 import (
-	"fmt"
-	"strings"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	k8sdiscovery "k8s.io/client-go/discovery"
-	"k8s.io/klog/v2"
 )
 
 type crdExtractor struct{}
@@ -49,88 +44,5 @@ func (e *crdExtractor) ExtractGVKs(obj interface{}) []*DiscoveredResource {
 			Plural: p,
 		})
 	}
-	return resources
-}
-
-func isAPIServiceReady(obj interface{}) bool {
-	status, found, err := unstructured.NestedSlice(obj.(*unstructured.Unstructured).Object, "status", "conditions")
-	if err != nil || !found {
-		return false
-	}
-
-	for _, condition := range status {
-		conditionMap, ok := condition.(map[string]interface{})
-		if !ok {
-			continue // skip invalid condition
-		}
-		if conditionMap["type"] == "Available" && conditionMap["status"] == "True" {
-			return true
-		}
-	}
-	return false
-}
-
-type apiServiceExtractor struct {
-	discoveryClient *k8sdiscovery.DiscoveryClient
-}
-
-// SourceID returns a unique identifier for the APIService.
-func (e *apiServiceExtractor) SourceID(obj interface{}) string {
-	u := obj.(*unstructured.Unstructured)
-	return "apiservice:" + u.GetName()
-}
-
-// ExtractGVKs extracts GVK information from an APIService object.
-// Returns nil if the APIService is not ready (signals "skip update").
-func (e *apiServiceExtractor) ExtractGVKs(obj interface{}) []*DiscoveredResource {
-	serviceSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
-	group, _, err := unstructured.NestedString(serviceSpec, "group")
-	if err != nil {
-		klog.ErrorS(err, "failed to extract group from APIService")
-		return nil
-	}
-	version, _, err := unstructured.NestedString(serviceSpec, "version")
-	if err != nil {
-		klog.ErrorS(err, "failed to extract version from APIService")
-		return nil
-	}
-
-	// Check if APIService has a service defined - i.e. not local
-	if svc, ok := serviceSpec["service"]; !ok || svc == nil {
-		klog.V(5).InfoS("skipping local APIService", "group", group, "version", version)
-		// Return empty slice to clear any existing resources for this source
-		return []*DiscoveredResource{}
-	}
-
-	if !isAPIServiceReady(obj) {
-		klog.InfoS("skipping non-ready APIService", "group", group, "version", version)
-		// Return empty slice to remove resources for non-ready APIService
-		return []*DiscoveredResource{}
-	}
-
-	resourceList, err := e.discoveryClient.ServerResourcesForGroupVersion(fmt.Sprintf("%s/%s", group, version))
-	if err != nil {
-		klog.ErrorS(err, "failed to fetch server resources for group version", "groupVersion", fmt.Sprintf("%s/%s", group, version))
-		// Return nil to skip resources update
-		return nil
-	}
-
-	var resources []*DiscoveredResource
-	for _, resource := range resourceList.APIResources {
-		// Skip subresources
-		if strings.Contains(resource.Name, "/") {
-			continue
-		}
-
-		resources = append(resources, &DiscoveredResource{
-			GroupVersionKind: schema.GroupVersionKind{
-				Group:   group,
-				Version: version,
-				Kind:    resource.Kind,
-			},
-			Plural: resource.Name,
-		})
-	}
-
 	return resources
 }

--- a/internal/discovery/gvk_extractors.go
+++ b/internal/discovery/gvk_extractors.go
@@ -1,0 +1,104 @@
+package discovery
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sdiscovery "k8s.io/client-go/discovery"
+	"k8s.io/klog/v2"
+)
+
+type crdGVKExtractor struct{}
+
+func (e *crdGVKExtractor) ExtractGVKs(obj interface{}) []groupVersionKindPlural {
+	objSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
+	var gvkps []groupVersionKindPlural
+	for _, version := range objSpec["versions"].([]interface{}) {
+		g := objSpec["group"].(string)
+		v := version.(map[string]interface{})["name"].(string)
+		k := objSpec["names"].(map[string]interface{})["kind"].(string)
+		p := objSpec["names"].(map[string]interface{})["plural"].(string)
+		gvkps = append(gvkps, groupVersionKindPlural{
+			GroupVersionKind: schema.GroupVersionKind{
+				Group:   g,
+				Version: v,
+				Kind:    k,
+			},
+			Plural: p,
+		})
+	}
+	return gvkps
+}
+
+func isAPIServiceReady(obj interface{}) bool {
+	status, found, err := unstructured.NestedSlice(obj.(*unstructured.Unstructured).Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+
+	for _, condition := range status {
+		conditionMap, ok := condition.(map[string]interface{})
+		if !ok {
+			continue // skip invalid condition
+		}
+		if conditionMap["type"] == "Available" && conditionMap["status"] == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+type apiServiceGVKExtractor struct {
+	discoveryClient *k8sdiscovery.DiscoveryClient
+}
+
+func (e *apiServiceGVKExtractor) ExtractGVKs(obj interface{}) []groupVersionKindPlural {
+	serviceSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
+	group, _, err := unstructured.NestedString(serviceSpec, "group")
+	if err != nil {
+		klog.ErrorS(err, "failed to extract group from APIService")
+		return nil
+	}
+	version, _, err := unstructured.NestedString(serviceSpec, "version")
+	if err != nil {
+		klog.ErrorS(err, "failed to extract version from APIService")
+		return nil
+	}
+
+	// check if APIService has a service defined - i.e. not local
+	if svc, ok := serviceSpec["service"]; !ok || svc == nil {
+		klog.V(5).InfoS("skipping local APIService", "group", group, "version", version)
+		return nil
+	}
+
+	if !isAPIServiceReady(obj) {
+		klog.V(5).InfoS("skipping non-ready APIService", "group", group, "version", version)
+		return nil
+	}
+
+	resourceList, err := e.discoveryClient.ServerResourcesForGroupVersion(fmt.Sprintf("%s/%s", group, version))
+	if err != nil {
+		klog.ErrorS(err, "failed to fetch server resources for group version", "groupVersion", fmt.Sprintf("%s/%s", group, version))
+		return nil
+	}
+
+	var gvkps []groupVersionKindPlural
+	for _, resource := range resourceList.APIResources {
+		// Skip subresources
+		if strings.Contains(resource.Name, "/") {
+			continue
+		}
+
+		gvkps = append(gvkps, groupVersionKindPlural{
+			GroupVersionKind: schema.GroupVersionKind{
+				Group:   group,
+				Version: version,
+				Kind:    resource.Kind,
+			},
+			Plural: resource.Name,
+		})
+	}
+	return gvkps
+}

--- a/internal/discovery/gvk_extractors.go
+++ b/internal/discovery/gvk_extractors.go
@@ -14,8 +14,13 @@ limitations under the License.
 package discovery
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sdiscovery "k8s.io/client-go/discovery"
+	"k8s.io/klog/v2"
 )
 
 type crdExtractor struct{}
@@ -44,5 +49,88 @@ func (e *crdExtractor) ExtractGVKs(obj interface{}) []*DiscoveredResource {
 			Plural: p,
 		})
 	}
+	return resources
+}
+
+func isAPIServiceReady(obj interface{}) bool {
+	status, found, err := unstructured.NestedSlice(obj.(*unstructured.Unstructured).Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+
+	for _, condition := range status {
+		conditionMap, ok := condition.(map[string]interface{})
+		if !ok {
+			continue // skip invalid condition
+		}
+		if conditionMap["type"] == "Available" && conditionMap["status"] == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+type apiServiceExtractor struct {
+	discoveryClient *k8sdiscovery.DiscoveryClient
+}
+
+// SourceID returns a unique identifier for the APIService.
+func (e *apiServiceExtractor) SourceID(obj interface{}) string {
+	u := obj.(*unstructured.Unstructured)
+	return "apiservice:" + u.GetName()
+}
+
+// ExtractGVKs extracts GVK information from an APIService object.
+// Returns nil if the APIService is not ready (signals "skip update").
+func (e *apiServiceExtractor) ExtractGVKs(obj interface{}) []*DiscoveredResource {
+	serviceSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
+	group, _, err := unstructured.NestedString(serviceSpec, "group")
+	if err != nil {
+		klog.ErrorS(err, "failed to extract group from APIService")
+		return nil
+	}
+	version, _, err := unstructured.NestedString(serviceSpec, "version")
+	if err != nil {
+		klog.ErrorS(err, "failed to extract version from APIService")
+		return nil
+	}
+
+	// Check if APIService has a service defined - i.e. not local
+	if svc, ok := serviceSpec["service"]; !ok || svc == nil {
+		klog.V(5).InfoS("skipping local APIService", "group", group, "version", version)
+		// Return empty slice to clear any existing resources for this source
+		return []*DiscoveredResource{}
+	}
+
+	if !isAPIServiceReady(obj) {
+		klog.InfoS("skipping non-ready APIService", "group", group, "version", version)
+		// Return empty slice to remove resources for non-ready APIService
+		return []*DiscoveredResource{}
+	}
+
+	resourceList, err := e.discoveryClient.ServerResourcesForGroupVersion(fmt.Sprintf("%s/%s", group, version))
+	if err != nil {
+		klog.ErrorS(err, "failed to fetch server resources for group version", "groupVersion", fmt.Sprintf("%s/%s", group, version))
+		// Return nil to skip resources update
+		return nil
+	}
+
+	var resources []*DiscoveredResource
+	for _, resource := range resourceList.APIResources {
+		// Skip subresources
+		if strings.Contains(resource.Name, "/") {
+			continue
+		}
+
+		resources = append(resources, &DiscoveredResource{
+			GroupVersionKind: schema.GroupVersionKind{
+				Group:   group,
+				Version: version,
+				Kind:    resource.Kind,
+			},
+			Plural: resource.Name,
+		})
+	}
+
 	return resources
 }

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -62,6 +62,7 @@ type CRDiscoverer struct {
 	CacheCount prometheus.Gauge
 }
 
+// NewCRDiscoverer creates a new CRDiscoverer instance.
 func NewCRDiscoverer(
 	updateEvents prometheus.Counter,
 	deleteEvents prometheus.Counter,
@@ -172,13 +173,13 @@ func (r *CRDiscoverer) Resolve(gvk schema.GroupVersionKind) ([]DiscoveredResourc
 	var results []DiscoveredResource
 	for _, resources := range r.resourcesBySource {
 		for _, res := range resources {
-			if res.GroupVersionKind.Group != g {
+			if res.Group != g {
 				continue
 			}
-			if hasVersion && res.GroupVersionKind.Version != v {
+			if hasVersion && res.Version != v {
 				continue
 			}
-			if hasKind && res.GroupVersionKind.Kind != k {
+			if hasKind && res.Kind != k {
 				continue
 			}
 			results = append(results, DiscoveredResource{

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -35,6 +35,10 @@ type kindPlural struct {
 	Plural string
 }
 
+type gvkExtractor interface {
+	ExtractGVKs(obj interface{}) []groupVersionKindPlural
+}
+
 // CRDiscoverer provides a cache of the collected GVKs, along with helper utilities.
 type CRDiscoverer struct {
 	// CRDsAddEventsCounter tracks the number of times that the CRD informer triggered the "add" event.

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -21,103 +21,193 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type groupVersionKindPlural struct {
+// DiscoveredResource represents a discovered custom resource type.
+type DiscoveredResource struct {
 	schema.GroupVersionKind
-	Plural string
+	Plural   string
+	stopChan chan struct{}
 }
 
-func (g groupVersionKindPlural) String() string {
-	return fmt.Sprintf("%s/%s, Kind=%s, Plural=%s", g.Group, g.Version, g.Kind, g.Plural)
+// String returns a string representation of the DiscoveredResource.
+func (d DiscoveredResource) String() string {
+	return fmt.Sprintf("%s/%s, Kind=%s, Plural=%s", d.Group, d.Version, d.Kind, d.Plural)
 }
 
-type kindPlural struct {
-	Kind   string
-	Plural string
+// extractor defines the interface for extracting DiscoveredResources from CRDs/APIServices.
+type extractor interface {
+	// SourceID returns a unique identifier for the source object.
+	// For CRDs: "crd:<name>", for APIServices: "apiservice:<name>"
+	SourceID(obj interface{}) string
+	// ExtractGVKs extracts discovered resources from the object.
+	// Return nil to skip, empty array to signal deletion of all resources for the source.
+	ExtractGVKs(obj interface{}) []*DiscoveredResource
 }
 
-type gvkExtractor interface {
-	ExtractGVKs(obj interface{}) []groupVersionKindPlural
-}
-
-// CRDiscoverer provides a cache of the collected GVKs, along with helper utilities.
+// CRDiscoverer provides discovery and lifecycle management for custom resources.
 type CRDiscoverer struct {
-	// CRDsAddEventsCounter tracks the number of times that the CRD informer triggered the "add" event.
-	CRDsAddEventsCounter prometheus.Counter
-	// CRDsUpdateEventsCounter tracks the number of times that the CRD informer triggered the "update" event.
-	CRDsUpdateEventsCounter prometheus.Counter
-	// CRDsDeleteEventsCounter tracks the number of times that the CRD informer triggered the "remove" event.
-	CRDsDeleteEventsCounter prometheus.Counter
-	// CRDsCacheCountGauge tracks the net amount of CRDs affecting the cache at this point.
-	CRDsCacheCountGauge prometheus.Gauge
-	// Map is a cache of the collected GVKs.
-	Map map[string]map[string][]kindPlural
-	// GVKToReflectorStopChanMap is a map of GVKs to channels that can be used to stop their corresponding reflector.
-	GVKToReflectorStopChanMap map[string]chan struct{}
-	// m is a mutex to protect the cache.
-	m sync.RWMutex
-	// ShouldUpdate is a flag that indicates whether the cache was updated.
-	WasUpdated bool
+	// mu protects all fields below.
+	mu sync.RWMutex
+	// resourcesBySource maps source objects to their discovered resources.
+	// Keys: "crd:<name>" or "apiservice:<name>"
+	resourcesBySource map[string][]*DiscoveredResource
+	// wasUpdated indicates whether the cache was updated since last check.
+	wasUpdated bool
+
+	// Metrics for discovery events.
+	// UpdateEvents counts add and update operations (any source mutation).
+	UpdateEvents prometheus.Counter
+	// DeleteEvents counts source deletions.
+	DeleteEvents prometheus.Counter
+	// CacheCount tracks the current number of discovered resources.
+	CacheCount prometheus.Gauge
 }
 
-// SafeRead executes the given function while holding a read lock.
-func (r *CRDiscoverer) SafeRead(f func()) {
-	r.m.RLock()
-	defer r.m.RUnlock()
-	f()
-}
-
-// SafeWrite executes the given function while holding a write lock.
-func (r *CRDiscoverer) SafeWrite(f func()) {
-	r.m.Lock()
-	defer r.m.Unlock()
-	f()
-}
-
-// AppendToMap appends the given GVKs to the cache.
-func (r *CRDiscoverer) AppendToMap(gvkps ...groupVersionKindPlural) {
-	if r.Map == nil {
-		r.Map = map[string]map[string][]kindPlural{}
-	}
-	if r.GVKToReflectorStopChanMap == nil {
-		r.GVKToReflectorStopChanMap = map[string]chan struct{}{}
-	}
-	for _, gvkp := range gvkps {
-		if _, ok := r.Map[gvkp.Group]; !ok {
-			r.Map[gvkp.Group] = map[string][]kindPlural{}
-		}
-		if _, ok := r.Map[gvkp.Group][gvkp.Version]; !ok {
-			r.Map[gvkp.Group][gvkp.Version] = []kindPlural{}
-		}
-		r.Map[gvkp.Group][gvkp.Version] = append(r.Map[gvkp.Group][gvkp.Version], kindPlural{Kind: gvkp.Kind, Plural: gvkp.Plural})
-		r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()] = make(chan struct{})
+func NewCRDiscoverer(
+	updateEvents prometheus.Counter,
+	deleteEvents prometheus.Counter,
+	cacheCount prometheus.Gauge,
+) *CRDiscoverer {
+	return &CRDiscoverer{
+		resourcesBySource: make(map[string][]*DiscoveredResource),
+		UpdateEvents:      updateEvents,
+		DeleteEvents:      deleteEvents,
+		CacheCount:        cacheCount,
 	}
 }
 
-// RemoveFromMap removes the given GVKs from the cache.
-func (r *CRDiscoverer) RemoveFromMap(gvkps ...groupVersionKindPlural) {
-	for _, gvkp := range gvkps {
-		if _, ok := r.Map[gvkp.Group]; !ok {
-			continue
-		}
-		if _, ok := r.Map[gvkp.Group][gvkp.Version]; !ok {
-			continue
-		}
-		for i, el := range r.Map[gvkp.Group][gvkp.Version] {
-			if el.Kind == gvkp.Kind {
-				if _, ok := r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()]; ok {
-					close(r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()])
-					delete(r.GVKToReflectorStopChanMap, gvkp.GroupVersionKind.String())
-				}
-				if len(r.Map[gvkp.Group][gvkp.Version]) == 1 {
-					delete(r.Map[gvkp.Group], gvkp.Version)
-					if len(r.Map[gvkp.Group]) == 0 {
-						delete(r.Map, gvkp.Group)
-					}
-					break
-				}
-				r.Map[gvkp.Group][gvkp.Version] = append(r.Map[gvkp.Group][gvkp.Version][:i], r.Map[gvkp.Group][gvkp.Version][i+1:]...)
-				break
+// UpdateSource replaces all resources for a source with new resources.
+// If resources is nil, this is a noop.
+// If resources is empty, all resources for the source are removed.
+func (r *CRDiscoverer) UpdateSource(sourceID string, resources []*DiscoveredResource) {
+	if resources == nil {
+		return // Skip if nil resources
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Close stop channels for old resources
+	if oldResources, ok := r.resourcesBySource[sourceID]; ok {
+		for _, old := range oldResources {
+			if old.stopChan != nil {
+				close(old.stopChan)
 			}
 		}
 	}
+
+	// Create stop channels for new resources
+	for _, res := range resources {
+		res.stopChan = make(chan struct{})
+	}
+
+	if len(resources) == 0 {
+		delete(r.resourcesBySource, sourceID) // empty slice signals deletion
+	} else {
+		r.resourcesBySource[sourceID] = resources
+	}
+
+	r.wasUpdated = true
+
+	r.UpdateEvents.Inc()
+	r.updateCacheCountLocked()
+}
+
+// DeleteSource removes all resources for a source and closes their stop channels.
+func (r *CRDiscoverer) DeleteSource(sourceID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	oldResources, ok := r.resourcesBySource[sourceID]
+	if !ok {
+		return
+	}
+
+	// Close stop channels
+	for _, res := range oldResources {
+		if res.stopChan != nil {
+			close(res.stopChan)
+		}
+	}
+
+	delete(r.resourcesBySource, sourceID)
+	r.wasUpdated = true
+
+	r.DeleteEvents.Inc()
+	r.updateCacheCountLocked()
+}
+
+// GetStopChan returns the stop channel for the given GVK.
+func (r *CRDiscoverer) GetStopChan(gvk schema.GroupVersionKind) (chan struct{}, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, resources := range r.resourcesBySource {
+		for _, res := range resources {
+			if res.GroupVersionKind == gvk {
+				return res.stopChan, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// Resolve resolves a GVK pattern to matching DiscoveredResources.
+// Group is required and cannot be a wildcard.
+// Supports "*" for Version and/or Kind.
+func (r *CRDiscoverer) Resolve(gvk schema.GroupVersionKind) ([]DiscoveredResource, error) {
+	g := gvk.Group
+	v := gvk.Version
+	k := gvk.Kind
+
+	if g == "" || g == "*" {
+		return nil, fmt.Errorf("group is required in the defined GVK %v", gvk)
+	}
+
+	hasVersion := v != "" && v != "*"
+	hasKind := k != "" && k != "*"
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var results []DiscoveredResource
+	for _, resources := range r.resourcesBySource {
+		for _, res := range resources {
+			if res.GroupVersionKind.Group != g {
+				continue
+			}
+			if hasVersion && res.GroupVersionKind.Version != v {
+				continue
+			}
+			if hasKind && res.GroupVersionKind.Kind != k {
+				continue
+			}
+			results = append(results, DiscoveredResource{
+				GroupVersionKind: res.GroupVersionKind,
+				Plural:           res.Plural,
+			})
+			// exit if exact match
+			if hasVersion && hasKind {
+				return results, nil
+			}
+		}
+	}
+	return results, nil
+}
+
+// CheckAndResetUpdated checks if the cache was updated and resets the flag.
+func (r *CRDiscoverer) CheckAndResetUpdated() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	updated := r.wasUpdated
+	r.wasUpdated = false
+	return updated
+}
+
+// updateCacheCountLocked updates the cache count gauge. Must be called with mu held.
+func (r *CRDiscoverer) updateCacheCountLocked() {
+	count := 0
+	for _, resources := range r.resourcesBySource {
+		count += len(resources)
+	}
+	r.CacheCount.Set(float64(count))
 }

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -33,10 +33,10 @@ func (d DiscoveredResource) String() string {
 	return fmt.Sprintf("%s/%s, Kind=%s, Plural=%s", d.Group, d.Version, d.Kind, d.Plural)
 }
 
-// extractor defines the interface for extracting DiscoveredResources
+// extractor defines the interface for extracting DiscoveredResources from CRDs/APIServices.
 type extractor interface {
 	// SourceID returns a unique identifier for the source object.
-	// For CRDs: "crd:<name>"
+	// For CRDs: "crd:<name>", for APIServices: "apiservice:<name>"
 	SourceID(obj interface{}) string
 	// ExtractGVKs extracts discovered resources from the object.
 	// Return nil to skip, empty array to signal deletion of all resources for the source.
@@ -48,7 +48,7 @@ type CRDiscoverer struct {
 	// mu protects all fields below.
 	mu sync.RWMutex
 	// resourcesBySource maps source objects to their discovered resources.
-	// Keys e.g. "crd:<name>"
+	// Keys: "crd:<name>" or "apiservice:<name>"
 	resourcesBySource map[string][]*DiscoveredResource
 	// wasUpdated indicates whether the cache was updated since last check.
 	wasUpdated bool

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -33,10 +33,10 @@ func (d DiscoveredResource) String() string {
 	return fmt.Sprintf("%s/%s, Kind=%s, Plural=%s", d.Group, d.Version, d.Kind, d.Plural)
 }
 
-// extractor defines the interface for extracting DiscoveredResources from CRDs/APIServices.
+// extractor defines the interface for extracting DiscoveredResources
 type extractor interface {
 	// SourceID returns a unique identifier for the source object.
-	// For CRDs: "crd:<name>", for APIServices: "apiservice:<name>"
+	// For CRDs: "crd:<name>"
 	SourceID(obj interface{}) string
 	// ExtractGVKs extracts discovered resources from the object.
 	// Return nil to skip, empty array to signal deletion of all resources for the source.
@@ -48,7 +48,7 @@ type CRDiscoverer struct {
 	// mu protects all fields below.
 	mu sync.RWMutex
 	// resourcesBySource maps source objects to their discovered resources.
-	// Keys: "crd:<name>" or "apiservice:<name>"
+	// Keys e.g. "crd:<name>"
 	resourcesBySource map[string][]*DiscoveredResource
 	// wasUpdated indicates whether the cache was updated since last check.
 	wasUpdated bool

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -118,6 +118,10 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		}, []string{"type", "filename"})
 
 	// Register self-metrics to track the state of the cache.
+	crsAddEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
+		Name: "kube_state_metrics_custom_resource_state_add_events_total",
+		Help: "Number of times that the Custom Resource discovery triggered the add event.",
+	})
 	crsUpdateEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
 		Name: "kube_state_metrics_custom_resource_state_update_events_total",
 		Help: "Number of times that the Custom Resource discovery triggered the update event.",
@@ -313,6 +317,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 	// A nil CRS config implies that we need to hold off on all CRS operations.
 	if config != nil {
 		discovererInstance := discovery.NewCRDiscoverer(
+			crsAddEventsCounter,
 			crsUpdateEventsCounter,
 			crsDeleteEventsCounter,
 			crsCacheCountGauge,

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -118,21 +118,17 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		}, []string{"type", "filename"})
 
 	// Register self-metrics to track the state of the cache.
-	crdsAddEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
-		Name: "kube_state_metrics_custom_resource_state_add_events_total",
-		Help: "Number of times that the CRD informer triggered the add event.",
-	})
-	crdsUpdateEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
+	crsUpdateEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
 		Name: "kube_state_metrics_custom_resource_state_update_events_total",
-		Help: "Number of times that the CRD informer triggered the update event.",
+		Help: "Number of times that the Custom Resource discovery triggered the update event.",
 	})
-	crdsDeleteEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
+	crsDeleteEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
 		Name: "kube_state_metrics_custom_resource_state_delete_events_total",
-		Help: "Number of times that the CRD informer triggered the remove event.",
+		Help: "Number of times that the Custom Resource discovery triggered the remove event.",
 	})
-	crdsCacheCountGauge := promauto.With(ksmMetricsRegistry).NewGauge(prometheus.GaugeOpts{
+	crsCacheCountGauge := promauto.With(ksmMetricsRegistry).NewGauge(prometheus.GaugeOpts{
 		Name: "kube_state_metrics_custom_resource_state_cache",
-		Help: "Net amount of CRDs affecting the cache currently.",
+		Help: "Net amount of Custom Resources affecting the cache currently.",
 	})
 	storeBuilder := store.NewBuilder()
 	storeBuilder.WithMetrics(ksmMetricsRegistry)
@@ -316,14 +312,13 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	// A nil CRS config implies that we need to hold off on all CRS operations.
 	if config != nil {
-		discovererInstance := &discovery.CRDiscoverer{
-			CRDsAddEventsCounter:    crdsAddEventsCounter,
-			CRDsUpdateEventsCounter: crdsUpdateEventsCounter,
-			CRDsDeleteEventsCounter: crdsDeleteEventsCounter,
-			CRDsCacheCountGauge:     crdsCacheCountGauge,
-		}
-		// storeBuilder starts reflectors for the discovered GVKs, and as such, should close them too.
-		storeBuilder.GVKToReflectorStopChanMap = &discovererInstance.GVKToReflectorStopChanMap
+		discovererInstance := discovery.NewCRDiscoverer(
+			crsUpdateEventsCounter,
+			crsDeleteEventsCounter,
+			crsCacheCountGauge,
+		)
+		// storeBuilder uses the discoverer to get stop channels for reflectors.
+		storeBuilder.GVKStopChanProvider = discovererInstance
 		// This starts a goroutine that will watch for any new GVKs to extract from CRDs.
 		err = discovererInstance.StartDiscovery(ctx, kubeConfig)
 		if err != nil {

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -22,6 +22,7 @@ import (
 	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
@@ -29,6 +30,13 @@ import (
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
 	"k8s.io/kube-state-metrics/v2/pkg/options"
 )
+
+// StopChanProvider provides thread-safe access to stop channels for reflectors.
+type StopChanProvider interface {
+	// GetStopChan returns the stop channel for the given GVK.
+	// Returns false if no stop channel exists for this GVK.
+	GetStopChan(gvk schema.GroupVersionKind) (chan struct{}, bool)
+}
 
 // BuilderInterface represent all methods that a Builder should implements
 type BuilderInterface interface {

--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -188,7 +188,7 @@ func FromConfig(decoder ConfigDecoder, discovererInstance *discovery.CRDiscovere
 		// resolvedGVKPs will have the final list of GVKs, in addition to the resolved G** resources.
 		var resolvedGVKPs []Resource
 		for _, resource := range resources /* G** */ {
-			resolvedSet /* GVKPs */, err := discovererInstance.ResolveGVKToGVKPs(schema.GroupVersionKind(resource.GroupVersionKind))
+			resolvedSet /* DiscoveredResources */, err := discovererInstance.Resolve(schema.GroupVersionKind(resource.GroupVersionKind))
 			if err != nil {
 				klog.ErrorS(err, "failed to resolve GVK", "gvk", resource.GroupVersionKind)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**
Enables discovery and metric collection for Custom Resources managed by aggregated API servers which do not have a local CRD. It does this by querying non-local apiservices for the resources they handle.


<!-- If you are adding a new metric, provide the use case of that metric. -->

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*
By default, no change 

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Fixes #2471 
