### PR TITLE
chore(Dockerfile): Use Debian 13 as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . /go/src/k8s.io/kube-state-metrics/
 
 RUN make build-local
 
-FROM gcr.io/distroless/static-debian12:latest-${GOARCH}
+FROM gcr.io/distroless/static-debian13:latest-${GOARCH}
 COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 USER nobody


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**
Moves the distroless base from debian 12 to debian 13

<!-- If you are adding a new metric, provide the use case of that metric. -->

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*
None
**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Fixes #
