### PR TITLE
fix: order-dependent metric loss from header dedupe

### DIFF
--- a/pkg/metrics_store/metrics_writer.go
+++ b/pkg/metrics_store/metrics_writer.go
@@ -98,43 +98,28 @@ func SanitizeHeaders(contentType expfmt.Format, writers MetricsWriterList) Metri
 	var lastHeader string
 	for _, writer := range writers {
 		if len(writer.stores) > 0 {
-			for i := 0; i < len(writer.stores[0].headers); {
-				header := writer.stores[0].headers[i]
-
-				// Removes duplicate headers from the given MetricsWriterList for the same family (generated through CRS).
-				// These are expected to be consecutive since G** resolution generates groups of similar metrics with same headers before moving onto the next G** spec in the CRS configuration.
-				// Skip this step if we encounter a repeated header, as it will be removed.
-				if header != lastHeader && strings.HasPrefix(header, "# HELP") {
-
-					// If the requested content type is text/plain, replace "info" and "statesets" with "gauge", as they are not recognized by Prometheus' plain text machinery.
-					// When Prometheus requests proto-based formats, this branch is also used because any requested format that is not OpenMetrics falls back to text/plain in metrics_handler.go
-					if contentType.FormatType() == expfmt.TypeTextPlain {
-						infoTypeString := string(metric.Info)
-						stateSetTypeString := string(metric.StateSet)
-						if strings.HasSuffix(header, infoTypeString) {
-							header = header[:len(header)-len(infoTypeString)] + string(metric.Gauge)
-							writer.stores[0].headers[i] = header
-						}
-						if strings.HasSuffix(header, stateSetTypeString) {
-							header = header[:len(header)-len(stateSetTypeString)] + string(metric.Gauge)
-							writer.stores[0].headers[i] = header
-						}
+			for i, header := range writer.stores[0].headers {
+				// If the requested content type is text/plain, replace "info" and "statesets" with "gauge", as they are not recognized by Prometheus' plain text machinery.
+				// When Prometheus requests proto-based formats, this branch is also used because any requested format that is not OpenMetrics falls back to text/plain in metrics_handler.go.
+				if strings.HasPrefix(header, "# HELP") && contentType.FormatType() == expfmt.TypeTextPlain {
+					infoTypeString := string(metric.Info)
+					stateSetTypeString := string(metric.StateSet)
+					if strings.HasSuffix(header, infoTypeString) {
+						header = header[:len(header)-len(infoTypeString)] + string(metric.Gauge)
+					}
+					if strings.HasSuffix(header, stateSetTypeString) {
+						header = header[:len(header)-len(stateSetTypeString)] + string(metric.Gauge)
 					}
 				}
 
-				// Nullify duplicate headers after the sanitization to not miss out on any new candidates.
-				if header == lastHeader {
-					writer.stores[0].headers = append(writer.stores[0].headers[:i], writer.stores[0].headers[i+1:]...)
-
-					// Do not increment the index, as the next header is now at the current index.
+				// Keep header indexing stable with metric families. Duplicate headers are blanked instead of removed.
+				if header == "" || header == "\n" || header == lastHeader {
+					writer.stores[0].headers[i] = ""
 					continue
 				}
 
-				// Update the last header.
+				writer.stores[0].headers[i] = header
 				lastHeader = header
-
-				// Move to the next header.
-				i++
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**
Custom resource metrics could disappear depending on metric declaration order when consecutive duplicate headers were sanitized. The old SanitizeHeaders implementation removed duplicate header entries from the header slice, but metric family byte slices remained indexed at their original positions. WriteAll zips headers and families by index, so deleting headers caused index drift and could skip later metric families entirely.

This was especially visible when one duplicate family emitted no samples (e.g. missing nested paths), but the root cause is header/family misalignment and can occur even without empty families.

Fix: preserve positional alignment by blanking duplicate/empty headers instead of removing them. WriteAll already skips empty headers naturally, so output remains deduplicated while family indices stay stable.

Tests: add two regressions in metrics_writer_test
- duplicate header + empty middle family still preserves later family output
- duplicate headers without empty families still preserve later family output
Also update TestSanitizeHeaders expectations for index-preserving blanking behavior.

**How does this change affect the cardinality of KSM:** *does not change cardinality*