### PR TITLE
fix: stop custom resource reflectors on context cancellation

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -621,7 +621,16 @@ func (b *Builder) startReflector(
 	instrumentedListWatch := watch.NewInstrumentedListerWatcher(listWatcher, b.listWatchMetrics, reflect.TypeOf(expectedType).String(), useAPIServerCache, objectLimit)
 	reflector := cache.NewReflectorWithOptions(sharding.NewShardedListWatch(b.shard, b.totalShards, instrumentedListWatch), expectedType, store, cache.ReflectorOptions{ResyncPeriod: 0})
 	if cr, ok := expectedType.(*unstructured.Unstructured); ok {
-		go reflector.Run((*b.GVKToReflectorStopChanMap)[cr.GroupVersionKind().String()])
+		stopCh := make(chan struct{})
+		crStopCh := (*b.GVKToReflectorStopChanMap)[cr.GroupVersionKind().String()]
+		go func() {
+			select {
+			case <-b.ctx.Done():
+			case <-crStopCh:
+			}
+			close(stopCh)
+		}()
+		go reflector.Run(stopCh)
 	} else {
 		go reflector.Run(b.ctx.Done())
 	}

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -68,6 +68,7 @@ var _ ksmtypes.BuilderInterface = &Builder{}
 type Builder struct {
 	kubeClient                    clientset.Interface
 	ctx                           context.Context
+	cancel                        func()
 	familyGeneratorFilter         generator.FamilyGeneratorFilter
 	customResourceClients         map[string]interface{}
 	listWatchMetrics              *watch.ListWatchMetrics
@@ -91,7 +92,8 @@ type Builder struct {
 
 // NewBuilder returns a new builder.
 func NewBuilder() *Builder {
-	b := &Builder{}
+	ctx, cancel := context.WithCancel(context.Background())
+	b := &Builder{ctx: ctx, cancel: cancel}
 	return b
 }
 
@@ -149,9 +151,17 @@ func (b *Builder) WithSharding(shard int32, totalShards int) {
 	b.shardingMetrics.Total.Set(float64(totalShards))
 }
 
-// WithContext sets the ctx property of a Builder.
+// WithContext will observe the cancellations of the provided context
+// to cancel the internal b.ctx.
 func (b *Builder) WithContext(ctx context.Context) {
-	b.ctx = ctx
+	// WithContext might be called concurrently with startReflector.
+	// In order to avoid the data race, and also to notify the reflectors that
+	// are already running with the context, we don't replace b.ctx,
+	// but just subscribe to the cancellations of the provided context.
+	go func() {
+		<-ctx.Done()
+		b.cancel()
+	}()
 }
 
 // WithKubeClient sets the kubeClient property of a Builder.
@@ -623,13 +633,13 @@ func (b *Builder) startReflector(
 	if cr, ok := expectedType.(*unstructured.Unstructured); ok {
 		stopCh := make(chan struct{})
 		crStopCh := (*b.GVKToReflectorStopChanMap)[cr.GroupVersionKind().String()]
-		go func() {
+		go func(builderContext context.Context) {
 			select {
-			case <-b.ctx.Done():
+			case <-builderContext.Done():
 			case <-crStopCh:
 			}
 			close(stopCh)
-		}()
+		}(b.ctx)
 		go reflector.Run(stopCh)
 	} else {
 		go reflector.Run(b.ctx.Done())


### PR DESCRIPTION
## Summary

Fixes #2867

Custom resource reflectors only listened to their per-GVK stop channel, ignoring context cancellation from `BuildWriters`. When `BuildWriters` rebuilt stores after a CRD update event, it cancelled the context to stop old reflectors, but custom resource reflectors kept running since they were waiting on a different stop channel. Each rebuild accumulated leaked `Reflector.Run` and `StreamWatcher.receive` goroutine pairs, causing unbounded memory, CPU, and network growth.

This merges both stop signals so CR reflectors stop on either context cancellation or per-GVK stop channel close.

I found one caveat however: the `Builder`'s context is replaced after we start the resource reflectors, so I changed how `WithContext` behaves: instead of replacing the context, we subscribe to that context's cancellations. I think this can be achieved in some more cleaner way, for example removing `WithContext` and exporting a `Stop()` method on builder's interface, but I'm not familiar with the codebase and I don't know whether this exported contract can be modified.