### PR TITLE
fix(customresourcestate): handle nil path gracefully in StateSet metrics

### DIFF
--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -690,6 +690,10 @@ spec:
 Metrics of type `StateSet` will generate a metric for each value defined in `list` for each resource.
 The value will be 1, if the value matches the one in list.
 
+If `path` (or `valueFrom`, if set) does not resolve, for example because the status field is not populated yet,
+no metrics are produced for that resource and no error is logged. Once the field is set, the metrics appear.
+A value that resolves to a non-string type is reported as an error.
+
 Produces the metric:
 
 ```prometheus

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -403,6 +403,12 @@ func (c *compiledStateSet) values(v interface{}) (result []eachValue, errs []err
 	comparable := c.ValueFrom.Get(v)
 	value, ok := comparable.(string)
 	if !ok {
+		// If the path doesn't exist (nil), return empty results instead of an error.
+		// This is consistent with how Gauge handles nil values and is expected for
+		// status fields that don't exist at resource creation time.
+		if comparable == nil {
+			return []eachValue{}, nil
+		}
 		return []eachValue{}, []error{fmt.Errorf("%s: expected value for path to be string, got %T", c.path, comparable)}
 	}
 

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -399,17 +399,26 @@ func (c *compiledStateSet) Values(v interface{}) (result []eachValue, errs []err
 	return c.values(v)
 }
 
+// fullValuePath returns the path the state set value is resolved from, including
+// valueFrom if it is set, so that errors point at the field that actually failed.
+func (c *compiledStateSet) fullValuePath() valuePath {
+	if len(c.ValueFrom) == 0 {
+		return c.path
+	}
+	return append(append(valuePath{}, c.path...), c.ValueFrom...)
+}
+
 func (c *compiledStateSet) values(v interface{}) (result []eachValue, errs []error) {
 	comparable := c.ValueFrom.Get(v)
+	if comparable == nil {
+		// The path does not resolve to a value, which is expected for status fields
+		// that do not exist yet at resource creation time. Report no metrics instead
+		// of an error, consistent with how the other metric types handle nil values.
+		return nil, nil
+	}
 	value, ok := comparable.(string)
 	if !ok {
-		// If the path doesn't exist (nil), return empty results instead of an error.
-		// This is consistent with how Gauge handles nil values and is expected for
-		// status fields that don't exist at resource creation time.
-		if comparable == nil {
-			return []eachValue{}, nil
-		}
-		return []eachValue{}, []error{fmt.Errorf("%s: expected value for path to be string, got %T", c.path, comparable)}
+		return nil, []error{fmt.Errorf("%s: expected value for path to be string, got %T", c.fullValuePath(), comparable)}
 	}
 
 	for _, entry := range c.List {

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -333,6 +333,22 @@ func Test_values(t *testing.T) {
 			newEachValue(t, 0, "phase", "bar"),
 			newEachValue(t, 1, "phase", "foo"),
 		}},
+		{name: "stateset nil path", each: &compiledStateSet{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "does", "not", "exist"),
+			},
+			LabelName: "phase",
+			List:      []string{"foo", "bar"},
+		}, wantResult: []eachValue{}, wantErrors: nil},
+		{name: "stateset non-string value", each: &compiledStateSet{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "spec", "replicas"),
+			},
+			LabelName: "phase",
+			List:      []string{"1", "2"},
+		}, wantResult: []eachValue{}, wantErrors: []error{
+			errors.New("[spec,replicas]: expected value for path to be string, got float64"),
+		}},
 		{name: "status_conditions", each: &compiledGauge{
 			compiledCommon: compiledCommon{
 				path: mustCompilePath(t, "status", "conditions", "[type=Ready]", "status"),

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -339,15 +339,33 @@ func Test_values(t *testing.T) {
 			},
 			LabelName: "phase",
 			List:      []string{"foo", "bar"},
-		}, wantResult: []eachValue{}, wantErrors: nil},
+		}, wantResult: nil, wantErrors: nil},
+		{name: "stateset nil valueFrom", each: &compiledStateSet{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "status"),
+			},
+			ValueFrom: mustCompilePath(t, "does", "not", "exist"),
+			LabelName: "phase",
+			List:      []string{"foo", "bar"},
+		}, wantResult: nil, wantErrors: nil},
 		{name: "stateset non-string value", each: &compiledStateSet{
 			compiledCommon: compiledCommon{
 				path: mustCompilePath(t, "spec", "replicas"),
 			},
 			LabelName: "phase",
 			List:      []string{"1", "2"},
-		}, wantResult: []eachValue{}, wantErrors: []error{
+		}, wantResult: nil, wantErrors: []error{
 			errors.New("[spec,replicas]: expected value for path to be string, got float64"),
+		}},
+		{name: "stateset non-string valueFrom", each: &compiledStateSet{
+			compiledCommon: compiledCommon{
+				path: mustCompilePath(t, "status"),
+			},
+			ValueFrom: mustCompilePath(t, "uptime"),
+			LabelName: "phase",
+			List:      []string{"foo", "bar"},
+		}, wantResult: nil, wantErrors: []error{
+			errors.New("[status,uptime]: expected value for path to be string, got float64"),
 		}},
 		{name: "status_conditions", each: &compiledGauge{
 			compiledCommon: compiledCommon{


### PR DESCRIPTION
Fixes #2482

**What this PR does / why we need it:**

When CustomResourceDefinition status fields don't exist at resource creation time, StateSet metrics would previously log an error for each resource instance. This caused error spam like:

```
registry_factory.go:685] "cr_test" err="[status,phase]: expected value for path to be string, got <nil>"
```

Status fields are not guaranteed to exist at resource creation, so this behavior was inconsistent with known types where nil values are handled gracefully (e.g., Gauge with `NilIsZero`).

This PR modifies `compiledStateSet.values()` to return empty results instead of an error when the path resolves to nil, consistent with how Gauge handles nil values.

**How does this change affect the cardinality of KSM:** Does not change cardinality

**Which issue(s) this PR fixes:**
Fixes #2482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * State-set metrics now treat unresolved source or value paths as absent values without returning errors.
  * Improved error details for invalid non-string values by including the complete value path.

* **Documentation**
  * Clarified how unresolved paths and non-string values affect StateSet metrics.

* **Tests**
  * Added coverage for missing source paths, missing value paths, and invalid numeric values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->