### PR TITLE
chore(wrapper): removed viper os fallback due to underlying update

### DIFF
--- a/internal/wrapper.go
+++ b/internal/wrapper.go
@@ -52,10 +52,6 @@ func RunKubeStateMetricsWrapper(opts *options.Options) {
 		if cfgViperReadInConfigErr = cfgViper.ReadInConfig(); cfgViperReadInConfigErr != nil {
 			if errors.Is(cfgViperReadInConfigErr, viper.ConfigFileNotFoundError{}) {
 				klog.ErrorS(cfgViperReadInConfigErr, "Options configuration file not found at startup", "file", file)
-			} else if _, isNotExisterr := os.Stat(filepath.Clean(file)); isNotExisterr != nil {
-				// TODO: Remove this check once viper.ConfigFileNotFoundError is working as expected, see this issue -
-				// https://github.com/spf13/viper/issues/1783
-				klog.ErrorS(isNotExisterr, "Options configuration file not found at startup", "file", file)
 			} else {
 				klog.ErrorS(cfgViperReadInConfigErr, "Error reading options configuration file", "file", file)
 			}
@@ -90,10 +86,6 @@ func RunKubeStateMetricsWrapper(opts *options.Options) {
 		if cfgViperReadInConfigErr := crcViper.ReadInConfig(); cfgViperReadInConfigErr != nil {
 			if errors.Is(cfgViperReadInConfigErr, viper.ConfigFileNotFoundError{}) {
 				klog.ErrorS(cfgViperReadInConfigErr, "Custom resource configuration file not found at startup", "file", opts.CustomResourceConfigFile)
-			} else if _, isNotExisterr := os.Stat(filepath.Clean(opts.CustomResourceConfigFile)); isNotExisterr != nil {
-				// Adding this check in addition to the above since viper.ConfigFileNotFoundError is not working as expected due to this issue -
-				// https://github.com/spf13/viper/issues/1783
-				klog.ErrorS(isNotExisterr, "Custom resource configuration file not found at startup", "file", opts.CustomResourceConfigFile)
 			} else {
 				klog.ErrorS(cfgViperReadInConfigErr, "Error reading Custom resource configuration file", "file", opts.CustomResourceConfigFile)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
 1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
 2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
 3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
 4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
 -->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**

This PR removes a workaround in `internal/wrapper.go` that was added to handle a bug in viper's `ConfigFileNotFoundError` (see [viper#1783](https://github.com/spf13/viper/issues/1783)). The workaround used `os.Stat` as a fallback to check if a config file exists when viper failed to detect it.

Since the viper issue has been resolved, this workaround is no longer needed and can be removed.

**Changes made:**
- Removed `os.Stat` fallback for main config file and for custom resource config file
- Removed associated TODO comments referencing the viper issue

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*

Does not change cardinality - this is a code cleanup with no functional changes, but is in hot path.

**Which issue(s) this PR fixes:** 

#2895

