### PR TITLE
fix(customresourcestate): log when configured CRD is not installed in cluster

### DIFF
--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -191,6 +191,8 @@ func FromConfig(decoder ConfigDecoder, discovererInstance *discovery.CRDiscovere
 			resolvedSet /* GVKPs */, err := discovererInstance.ResolveGVKToGVKPs(schema.GroupVersionKind(resource.GroupVersionKind))
 			if err != nil {
 				klog.ErrorS(err, "failed to resolve GVK", "gvk", resource.GroupVersionKind)
+			} else if len(resolvedSet) == 0 {
+				klog.InfoS("no matching CRD found for configured GVK, skipping", "gvk", resource.GroupVersionKind)
 			}
 			for _, resolved /* GVKP */ := range resolvedSet {
 				// Set their G** attributes to various resolutions of the GVK.


### PR DESCRIPTION
## What happened

When a resource is listed in the custom resource state config but its CRD is not installed in the cluster, `ResolveGVKToGVKPs` returns an empty list with no error. Previously this was silently skipped with no indication to the user.

## What this PR does

Adds an `InfoS` log when a configured CRD is not found in the cluster, so users understand why metrics are not being collected for that resource.

## How to test

1. Create a CRS config referencing a CRD that is not installed in the cluster
2. Run KSM with `--custom-resource-state-config-file` pointing to that config
3. Observe the log: `CRD for resource is not installed in the cluster, skipping`

Ref #2354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an informational log when a configured resource has no matching custom resource definitions.
  * Resources without matching definitions continue to be skipped safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->