### PR TITLE
fix(cronjob): replace panic on timezone load failure with graceful error skip

### DIFF
--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	basemetrics "k8s.io/component-base/metrics"
 
+	"k8s.io/klog/v2"
+
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
 )
@@ -251,8 +253,10 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				// If the cron job is suspended, don't track the next scheduled time
 				nextScheduledTime, err := getNextScheduledTime(j.Spec.Schedule, j.Status.LastScheduleTime, j.CreationTimestamp, j.Spec.TimeZone)
 				if err != nil {
-					panic(err)
-				} else if j.Spec.Suspend == nil || !*j.Spec.Suspend {
+					klog.ErrorS(err, "Failed to compute next schedule time for cronjob", "namespace", j.Namespace, "cronjob", j.Name, "schedule", j.Spec.Schedule, "timezone", j.Spec.TimeZone)
+					return &metric.Family{Metrics: ms}
+				}
+				if j.Spec.Suspend == nil || !*j.Spec.Suspend {
 					ms = append(ms, &metric.Metric{
 						LabelKeys:   []string{},
 						LabelValues: []string{},

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -533,13 +533,16 @@ func TestCronJobStore(t *testing.T) {
 func TestGetNextScheduledTime(t *testing.T) {
 
 	testCases := []struct {
+		Desc             string
 		schedule         string
 		lastScheduleTime metav1.Time
 		createdTime      metav1.Time
 		timeZone         string
 		expected         time.Time
+		expectErr        bool
 	}{
 		{
+			Desc:             "valid schedule with UTC timezone",
 			schedule:         "0 */6 * * *",
 			lastScheduleTime: metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
 			createdTime:      metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
@@ -547,18 +550,48 @@ func TestGetNextScheduledTime(t *testing.T) {
 			expected:         ActiveRunningCronJob1LastScheduleTime.Add(time.Second*4 + time.Minute*25 + time.Hour),
 		},
 		{
+			Desc:             "valid schedule with named timezone",
 			schedule:         "0 */6 * * *",
 			lastScheduleTime: metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
 			createdTime:      metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
 			timeZone:         TimeZone,
 			expected:         ActiveRunningCronJob1LastScheduleTime.Add(time.Second*4 + time.Minute*25 + time.Hour*5),
 		},
+		{
+			Desc:             "invalid timezone returns error",
+			schedule:         "0 */6 * * *",
+			lastScheduleTime: metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
+			createdTime:      metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
+			timeZone:         "Not/A_Real_Zone",
+			expectErr:        true,
+		},
+		{
+			Desc:             "invalid schedule expression returns error",
+			schedule:         "not a cron expression",
+			lastScheduleTime: metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
+			createdTime:      metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
+			timeZone:         "UTC",
+			expectErr:        true,
+		},
 	}
 
 	for _, test := range testCases {
-		actual, _ := getNextScheduledTime(test.schedule, &test.lastScheduleTime, test.createdTime, &test.timeZone) // #nosec G601
+		actual, err := getNextScheduledTime(test.schedule, &test.lastScheduleTime, test.createdTime, &test.timeZone) // #nosec G601
+		if test.expectErr {
+			if err == nil {
+				t.Errorf("%s: expected error, got nil (actual=%v)", test.Desc, actual)
+			}
+			if !actual.IsZero() {
+				t.Errorf("%s: expected zero time on error, got %v", test.Desc, actual)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", test.Desc, err)
+			continue
+		}
 		if !actual.Equal(test.expected) {
-			t.Fatalf("%v: expected %v, actual %v", test.schedule, test.expected, actual)
+			t.Fatalf("%s: expected %v, actual %v", test.Desc, test.expected, actual)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it:**

When a CronJob has `spec.timeZone` set to a named timezone (e.g. `Asia/Singapore`) and the kube-state-metrics container image does not include `tzdata`, `cron.ParseStandard` cannot resolve the location. The error was passed directly to `panic(err)` in the `kube_cronjob_next_schedule_time` generator, crashing the process and taking down all cluster metrics collection.

This change replaces `panic(err)` with `klog.Errorf` so the failure is logged at error level and the `kube_cronjob_next_schedule_time` metric is silently skipped for the affected CronJob. All other CronJobs and resource types continue serving metrics normally. Also adds `"k8s.io/klog/v2"` to the import block, which was previously absent from this file.

**How does this change affect the cardinality of KSM:** Does not change cardinality. The affected metric is omitted for CronJobs whose timezone cannot be resolved; it was previously not emittable at all because the process crashed.

**Which issue(s) this PR fixes:** Fixes #2898

**Special notes for your reviewer:** The fix is two lines in `internal/store/cronjob.go`. No new tests needed beyond running existing tests with a CronJob that has a named timezone -- the process no longer panics.