### PR TITLE
fix: prevent duplicate cluster-scoped metrics with --namespaces

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -414,11 +414,11 @@ func (b *Builder) buildLimitRangeStores() []cache.Store {
 }
 
 func (b *Builder) buildMutatingWebhookConfigurationStores() []cache.Store {
-	return b.buildStoresFunc(mutatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.MutatingWebhookConfiguration{}, createMutatingWebhookConfigurationListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(mutatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.MutatingWebhookConfiguration{}, createMutatingWebhookConfigurationListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildNamespaceStores() []cache.Store {
-	return b.buildStoresFunc(namespaceMetricFamilies(b.allowAnnotationsList["namespaces"], b.allowLabelsList["namespaces"]), &v1.Namespace{}, createNamespaceListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(namespaceMetricFamilies(b.allowAnnotationsList["namespaces"], b.allowLabelsList["namespaces"]), &v1.Namespace{}, createNamespaceListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildNetworkPolicyStores() []cache.Store {
@@ -426,7 +426,7 @@ func (b *Builder) buildNetworkPolicyStores() []cache.Store {
 }
 
 func (b *Builder) buildNodeStores() []cache.Store {
-	return b.buildStoresFunc(nodeMetricFamilies(b.allowAnnotationsList["nodes"], b.allowLabelsList["nodes"]), &v1.Node{}, createNodeListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(nodeMetricFamilies(b.allowAnnotationsList["nodes"], b.allowLabelsList["nodes"]), &v1.Node{}, createNodeListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildPersistentVolumeClaimStores() []cache.Store {
@@ -434,7 +434,7 @@ func (b *Builder) buildPersistentVolumeClaimStores() []cache.Store {
 }
 
 func (b *Builder) buildPersistentVolumeStores() []cache.Store {
-	return b.buildStoresFunc(persistentVolumeMetricFamilies(b.allowAnnotationsList["persistentvolumes"], b.allowLabelsList["persistentvolumes"]), &v1.PersistentVolume{}, createPersistentVolumeListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(persistentVolumeMetricFamilies(b.allowAnnotationsList["persistentvolumes"], b.allowLabelsList["persistentvolumes"]), &v1.PersistentVolume{}, createPersistentVolumeListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildPodDisruptionBudgetStores() []cache.Store {
@@ -470,7 +470,7 @@ func (b *Builder) buildStatefulSetStores() []cache.Store {
 }
 
 func (b *Builder) buildStorageClassStores() []cache.Store {
-	return b.buildStoresFunc(storageClassMetricFamilies(b.allowAnnotationsList["storageclasses"], b.allowLabelsList["storageclasses"]), &storagev1.StorageClass{}, createStorageClassListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(storageClassMetricFamilies(b.allowAnnotationsList["storageclasses"], b.allowLabelsList["storageclasses"]), &storagev1.StorageClass{}, createStorageClassListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildPodStores() []cache.Store {
@@ -478,15 +478,15 @@ func (b *Builder) buildPodStores() []cache.Store {
 }
 
 func (b *Builder) buildCsrStores() []cache.Store {
-	return b.buildStoresFunc(csrMetricFamilies(b.allowAnnotationsList["certificatesigningrequests"], b.allowLabelsList["certificatesigningrequests"]), &certv1.CertificateSigningRequest{}, createCSRListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(csrMetricFamilies(b.allowAnnotationsList["certificatesigningrequests"], b.allowLabelsList["certificatesigningrequests"]), &certv1.CertificateSigningRequest{}, createCSRListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildValidatingWebhookConfigurationStores() []cache.Store {
-	return b.buildStoresFunc(validatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.ValidatingWebhookConfiguration{}, createValidatingWebhookConfigurationListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(validatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.ValidatingWebhookConfiguration{}, createValidatingWebhookConfigurationListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildVolumeAttachmentStores() []cache.Store {
-	return b.buildStoresFunc(volumeAttachmentMetricFamilies, &storagev1.VolumeAttachment{}, createVolumeAttachmentListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(volumeAttachmentMetricFamilies, &storagev1.VolumeAttachment{}, createVolumeAttachmentListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildLeasesStores() []cache.Store {
@@ -494,7 +494,7 @@ func (b *Builder) buildLeasesStores() []cache.Store {
 }
 
 func (b *Builder) buildClusterRoleStores() []cache.Store {
-	return b.buildStoresFunc(clusterRoleMetricFamilies(b.allowAnnotationsList["clusterroles"], b.allowLabelsList["clusterroles"]), &rbacv1.ClusterRole{}, createClusterRoleListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(clusterRoleMetricFamilies(b.allowAnnotationsList["clusterroles"], b.allowLabelsList["clusterroles"]), &rbacv1.ClusterRole{}, createClusterRoleListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildRoleStores() []cache.Store {
@@ -502,7 +502,7 @@ func (b *Builder) buildRoleStores() []cache.Store {
 }
 
 func (b *Builder) buildClusterRoleBindingStores() []cache.Store {
-	return b.buildStoresFunc(clusterRoleBindingMetricFamilies(b.allowAnnotationsList["clusterrolebindings"], b.allowLabelsList["clusterrolebindings"]), &rbacv1.ClusterRoleBinding{}, createClusterRoleBindingListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(clusterRoleBindingMetricFamilies(b.allowAnnotationsList["clusterrolebindings"], b.allowLabelsList["clusterrolebindings"]), &rbacv1.ClusterRoleBinding{}, createClusterRoleBindingListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildRoleBindingStores() []cache.Store {
@@ -510,7 +510,33 @@ func (b *Builder) buildRoleBindingStores() []cache.Store {
 }
 
 func (b *Builder) buildIngressClassStores() []cache.Store {
-	return b.buildStoresFunc(ingressClassMetricFamilies(b.allowAnnotationsList["ingressclasses"], b.allowLabelsList["ingressclasses"]), &networkingv1.IngressClass{}, createIngressClassListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(ingressClassMetricFamilies(b.allowAnnotationsList["ingressclasses"], b.allowLabelsList["ingressclasses"]), &networkingv1.IngressClass{}, createIngressClassListWatch, b.useAPIServerCache, b.objectLimit)
+}
+
+// buildClusterScopedStores creates a single store for cluster-scoped resources
+// (e.g., nodes, PVs, namespaces, clusterroles). Unlike buildStores, this
+// always watches all objects regardless of the --namespaces flag, preventing
+// duplicate metrics when multiple namespaces are specified.
+func (b *Builder) buildClusterScopedStores(
+	metricFamilies []generator.FamilyGenerator,
+	expectedType interface{},
+	listWatchFunc func(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher,
+	useAPIServerCache bool, objectLimit int64,
+) []cache.Store {
+	metricFamilies = generator.FilterFamilyGenerators(b.familyGeneratorFilter, metricFamilies)
+	composedMetricGenFuncs := generator.ComposeMetricGenFuncs(metricFamilies)
+	familyHeaders := generator.ExtractMetricFamilyHeaders(metricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	if b.fieldSelectorFilter != "" {
+		klog.InfoS("FieldSelector is used", "fieldSelector", b.fieldSelectorFilter)
+	}
+	listWatcher := listWatchFunc(b.kubeClient, v1.NamespaceAll, b.fieldSelectorFilter)
+	b.startReflector(expectedType, store, listWatcher, useAPIServerCache, objectLimit, b.kubeClient)
+	return []cache.Store{store}
 }
 
 func (b *Builder) buildStores(


### PR DESCRIPTION
## Summary

Fixes #2878

When using `--namespaces` to filter by specific namespaces, cluster-scoped resources (nodes, PVs, namespaces, clusterroles, etc.) were creating one store per namespace. Since cluster-scoped resources ignore the namespace parameter in the list/watch call, each store watched **all** objects, producing N duplicate copies of every metric (where N = number of specified namespaces).

This caused Prometheus warnings like:
```
Error on ingesting samples with different value but same timestamp
```

## Root Cause

`buildStores()` iterates over `b.namespaces` to create one store per namespace. This is correct for namespace-scoped resources (pods, services, deployments, etc.) but wrong for cluster-scoped resources (nodes, PVs, namespaces, clusterroles, etc.) which don't have a namespace dimension.

## Fix

Added `buildClusterScopedStores()` that always creates a single store with `NamespaceAll`, bypassing the per-namespace loop. Updated all cluster-scoped resource build functions to use it:

- `nodes`
- `persistentvolumes`
- `storageclasses`
- `namespaces`
- `clusterroles`
- `clusterrolebindings`
- `mutatingwebhookconfigurations`
- `validatingwebhookconfigurations`
- `volumeattachments`
- `certificatesigningrequests`
- `ingressclasses`

Namespace-scoped resources continue using `buildStoresFunc` as before.

## Local Verification (minikube, `--namespaces=default,kube-system --resources=nodes`)

### Before (stock binary) — duplicate metrics

Each node metric appears **2 times** (once per namespace), identical values:

```
$ curl -s http://localhost:18080/metrics | grep "^kube_node_info{"
kube_node_info{node="minikube",kernel_version="6.17.0-20-generic",os_image="Debian GNU/Linux 12 (bookworm)",container_runtime_version="docker://29.2.0",kubelet_version="v1.35.0",kubeproxy_version="deprecated",provider_id="",pod_cidr="10.244.0.0/24",system_uuid="2e7c71de-c33c-4303-bc33-ee8bdb38a39b",internal_ip="192.168.49.2"} 1
kube_node_info{node="minikube",kernel_version="6.17.0-20-generic",os_image="Debian GNU/Linux 12 (bookworm)",container_runtime_version="docker://29.2.0",kubelet_version="v1.35.0",kubeproxy_version="deprecated",provider_id="",pod_cidr="10.244.0.0/24",system_uuid="2e7c71de-c33c-4303-bc33-ee8bdb38a39b",internal_ip="192.168.49.2"} 1

$ curl -s http://localhost:18080/metrics | grep "^kube_node_created{"
kube_node_created{node="minikube"} 1.770696357e+09
kube_node_created{node="minikube"} 1.770696357e+09
```

### After (patched binary) — no duplicates

Each node metric appears **exactly once**:

```
$ curl -s http://localhost:18080/metrics | grep "^kube_node_info{"
kube_node_info{node="minikube",kernel_version="6.17.0-20-generic",os_image="Debian GNU/Linux 12 (bookworm)",container_runtime_version="docker://29.2.0",kubelet_version="v1.35.0",kubeproxy_version="deprecated",provider_id="",pod_cidr="10.244.0.0/24",system_uuid="2e7c71de-c33c-4303-bc33-ee8bdb38a39b",internal_ip="192.168.49.2"} 1

$ curl -s http://localhost:18080/metrics | grep "^kube_node_created{"
kube_node_created{node="minikube"} 1.770696357e+09
```

### Namespace-scoped resources unaffected

Pods are still correctly filtered per namespace with zero duplicates:

```
$ curl -s http://localhost:18080/metrics | grep "^kube_pod_info{" | grep -oP 'namespace="[^"]*"' | sort | uniq -c
      1 namespace="default"
      7 namespace="kube-system"
```

## Test Plan

- All existing unit tests pass (only pre-existing `TestCronJobStore` failure on main)
- Build compiles cleanly
- End-to-end verified on minikube as shown above