### PR TITLE
fix: protect /debug/pprof endpoints with auth filter

### DIFF
--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -466,24 +466,53 @@ func buildTelemetryServer(registry prometheus.Gatherer, authFilter bool, kubeCon
 	// Add metricsPath
 	metricsHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorLog: sLogger})
 
+	pprofHandlers := map[string]http.Handler{
+		"/debug/pprof/":        http.HandlerFunc(pprof.Index),
+		"/debug/pprof/cmdline": http.HandlerFunc(pprof.Cmdline),
+		"/debug/pprof/profile": http.HandlerFunc(pprof.Profile),
+		"/debug/pprof/symbol":  http.HandlerFunc(pprof.Symbol),
+		"/debug/pprof/trace":   http.HandlerFunc(pprof.Trace),
+	}
+
 	// Add Authentication/Authorization via Kubernetes API
 	if authFilter {
+		unavailable := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "auth filter unavailable", http.StatusServiceUnavailable)
+		})
+
 		client, err := rest.HTTPClientFor(kubeConfig)
 		if err != nil {
 			klog.ErrorS(err, "failed to create HTTP client from config")
-		}
-
-		metricsFilter, err := filters.WithAuthenticationAndAuthorization(kubeConfig, client)
-		if err != nil {
+			metricsHandler = unavailable
+			pprofHandlers = map[string]http.Handler{}
+		} else if metricsFilter, err := filters.WithAuthenticationAndAuthorization(kubeConfig, client); err != nil {
 			klog.ErrorS(err, "failed to create auth handler")
-		}
-
-		metricsHandler, err = metricsFilter(klog.Background(), metricsHandler)
-		if err != nil {
-			klog.ErrorS(err, "failed to apply metrics filter")
+			metricsHandler = unavailable
+			pprofHandlers = map[string]http.Handler{}
+		} else {
+			metricsHandler, err = metricsFilter(klog.Background(), metricsHandler)
+			if err != nil {
+				klog.ErrorS(err, "failed to apply metrics filter")
+				metricsHandler = unavailable
+				pprofHandlers = map[string]http.Handler{}
+			} else {
+				for path, h := range pprofHandlers {
+					protected, err := metricsFilter(klog.Background(), h)
+					if err != nil {
+						klog.ErrorS(err, "failed to apply auth filter to pprof handler", "path", path)
+						delete(pprofHandlers, path)
+						continue
+					}
+					pprofHandlers[path] = protected
+				}
+			}
 		}
 	}
 	mux.Handle(metricsPath, metricsHandler)
+
+	for path, h := range pprofHandlers {
+		mux.Handle(path, h)
+	}
 
 	// Add readyzPath
 	mux.Handle(readyzPath, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -537,34 +566,28 @@ func handleClusterDelegationForProber(client kubernetes.Interface, probeType str
 func buildMetricsServer(m *metricshandler.MetricsHandler, durationObserver prometheus.ObserverVec, client kubernetes.Interface, authFilter bool, kubeConfig *rest.Config) *http.ServeMux {
 	mux := http.NewServeMux()
 
-	// TODO: This doesn't belong into serveMetrics
-	mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
-	mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-	mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-	mux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-	mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
-
 	// Add metricsPath
-	metricsHandler := promhttp.InstrumentHandlerDuration(durationObserver, m)
+	var metricsHandler http.Handler = promhttp.InstrumentHandlerDuration(durationObserver, m)
 
 	// Add Authentication/Authorization via Kubernetes API
 	if authFilter {
+		unavailable := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "auth filter unavailable", http.StatusServiceUnavailable)
+		})
+
 		client, err := rest.HTTPClientFor(kubeConfig)
 		if err != nil {
 			klog.ErrorS(err, "failed to create HTTP client from config")
-		}
-
-		metricsFilter, err := filters.WithAuthenticationAndAuthorization(kubeConfig, client)
-		if err != nil {
+			metricsHandler = unavailable
+		} else if metricsFilter, err := filters.WithAuthenticationAndAuthorization(kubeConfig, client); err != nil {
 			klog.ErrorS(err, "failed to create auth handler")
-		}
-
-		handler, err := metricsFilter(klog.Background(), metricsHandler)
-		if err != nil {
+			metricsHandler = unavailable
+		} else if handler, err := metricsFilter(klog.Background(), metricsHandler); err != nil {
 			klog.ErrorS(err, "failed to apply metrics filter")
+			metricsHandler = unavailable
+		} else {
+			metricsHandler = handler
 		}
-		metricsHandler = handler.(http.HandlerFunc)
-
 	}
 
 	mux.Handle(metricsPath, metricsHandler)

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -444,6 +444,58 @@ kube_state_metrics_total_shards 1
 	}
 }
 
+func TestPprofRouting(t *testing.T) {
+	t.Parallel()
+
+	pprofPaths := []string{
+		"/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/profile",
+		"/debug/pprof/symbol",
+		"/debug/pprof/trace",
+	}
+
+	pprofPatterns := make(map[string]struct{}, len(pprofPaths))
+	for _, path := range pprofPaths {
+		pprofPatterns[path] = struct{}{}
+	}
+
+	fakeConfig := &rest.Config{Host: "https://fake-server:443"}
+
+	for _, authEnabled := range []bool{false, true} {
+		var cfg *rest.Config
+		if authEnabled {
+			cfg = fakeConfig
+		}
+
+		reg := prometheus.NewRegistry()
+		telemetryMux := buildTelemetryServer(reg, authEnabled, cfg)
+		for _, path := range pprofPaths {
+			req := httptest.NewRequest("GET", "http://localhost:8081"+path, nil)
+			_, pattern := telemetryMux.Handler(req)
+			if _, ok := pprofPatterns[pattern]; !ok {
+				t.Errorf("authFilter=%v: expected pprof path %s to be registered on telemetry server, matched pattern %q", authEnabled, path, pattern)
+			}
+		}
+
+		opts := options.NewOptions()
+		metricsMux := buildMetricsServer(
+			metricshandler.New(opts, fake.NewSimpleClientset(), nil, false),
+			prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "test_duration_seconds"}, []string{"method"}),
+			fake.NewSimpleClientset(),
+			authEnabled,
+			cfg,
+		)
+		for _, path := range pprofPaths {
+			req := httptest.NewRequest("GET", "http://localhost:8080"+path, nil)
+			_, pattern := metricsMux.Handler(req)
+			if _, ok := pprofPatterns[pattern]; ok {
+				t.Errorf("authFilter=%v: expected pprof path %s to be unregistered on metrics server, matched pattern %q", authEnabled, path, pattern)
+			}
+		}
+	}
+}
+
 // TestShardingEquivalenceScrapeCycle is a simple smoke test covering the entire cycle from
 // cache filling to scraping comparing a sharded with an unsharded setup.
 func TestShardingEquivalenceScrapeCycle(t *testing.T) {

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -481,7 +481,7 @@ func TestPprofRouting(t *testing.T) {
 		opts := options.NewOptions()
 		metricsMux := buildMetricsServer(
 			metricshandler.New(opts, fake.NewSimpleClientset(), nil, false),
-			prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "test_duration_seconds"}, []string{"method"}),
+			prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "test_duration_seconds", Help: "Duration of test requests in seconds."}, []string{"method"}),
 			fake.NewSimpleClientset(),
 			authEnabled,
 			cfg,


### PR DESCRIPTION
GHSA Report: https://github.com/kubernetes/kube-state-metrics/security/advisories/GHSA-g3c8-4qh2-rhrg
Credits to @vldevadath for reporting this authentication bypass.

**Summary (Reported via GHSA report)**

The /debug/pprof/* endpoints in kube-state-metrics are registered unconditionally on the metrics server and are not protected by the --auth-filter flag. When --auth-filter is enabled, /metrics correctly returns 401 Unauthorized, but all /debug/pprof/* endpoints return 200 OK without any authentication - completely bypassing the intended security control.

**Fix**

1. Removed the 5 /debug/pprof/* route registrations from buildMetricsServer (metrics port)
2. Added those same 5 routes to buildTelemetryServer (telemetry port), wrapped with the auth filter when --auth-filter is enabled