### PR TITLE
fix: accept legacy custom_resource_config_file as deprecated alias

### DIFF
--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -12,6 +12,8 @@ Two flags can be used:
 * `--custom-resource-state-config "inline yaml (see example)"` or
 * `--custom-resource-state-config-file /path/to/config.yaml`
 
+When using a `--config` file, the equivalent YAML key is `custom_resource_state_config_file`. The pre-v2.17 key `custom_resource_config_file` is still honored as a deprecated alias and will be removed in a future release; please migrate to `custom_resource_state_config_file`.
+
 If both flags are provided, the inline configuration will take precedence.
 When multiple entries for the same resource exist, kube-state-metrics will exit with an error.
 This includes configuration which refers to a different API version.

--- a/internal/wrapper.go
+++ b/internal/wrapper.go
@@ -79,15 +79,21 @@ func RunKubeStateMetricsWrapper(opts *options.Options) {
 			configFile, err := os.ReadFile(filepath.Clean(file))
 			if err != nil {
 				klog.ErrorS(err, "failed to read options configuration file", "file", file)
-			}
-
-			yaml.Unmarshal(configFile, opts)
-
-			// TODO: Remove deprecated custom_resource_config_file support in KSM 2.21.
-			if opts.CustomResourceConfigFileDeprecated != "" {
-				klog.InfoS("The 'custom_resource_config_file' config key is deprecated and will be removed in a future release; use 'custom_resource_state_config_file' instead")
-				if opts.CustomResourceConfigFile == "" {
-					opts.CustomResourceConfigFile = opts.CustomResourceConfigFileDeprecated
+				if !opts.ContinueWithoutConfig {
+					klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+				}
+			} else {
+				if err := yaml.Unmarshal(configFile, opts); err != nil {
+					klog.ErrorS(err, "failed to unmarshal options configuration file", "file", file)
+					if !opts.ContinueWithoutConfig {
+						klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+					}
+					// TODO: Remove deprecated custom_resource_config_file support in KSM 2.21.
+				} else if opts.CustomResourceConfigFileDeprecated != "" {
+					klog.Warning("The 'custom_resource_config_file' config key is deprecated and will be removed in a future release; use 'custom_resource_state_config_file' instead")
+					if opts.CustomResourceConfigFile == "" {
+						opts.CustomResourceConfigFile = opts.CustomResourceConfigFileDeprecated
+					}
 				}
 			}
 		}

--- a/internal/wrapper.go
+++ b/internal/wrapper.go
@@ -82,6 +82,14 @@ func RunKubeStateMetricsWrapper(opts *options.Options) {
 			}
 
 			yaml.Unmarshal(configFile, opts)
+
+			// TODO: Remove deprecated custom_resource_config_file support in KSM 2.21.
+			if opts.CustomResourceConfigFileDeprecated != "" {
+				klog.InfoS("The 'custom_resource_config_file' config key is deprecated and will be removed in a future release; use 'custom_resource_state_config_file' instead")
+				if opts.CustomResourceConfigFile == "" {
+					opts.CustomResourceConfigFile = opts.CustomResourceConfigFileDeprecated
+				}
+			}
 		}
 	}
 	if opts.CustomResourceConfigFile != "" {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -47,10 +47,15 @@ type Options struct {
 	MetricOptInList      MetricSet       `yaml:"metric_opt_in_list"`
 	Resources            ResourceSet     `yaml:"resources"`
 
-	cmd                                     *cobra.Command
-	Apiserver                               string   `yaml:"apiserver"`
-	CustomResourceConfig                    string   `yaml:"custom_resource_config"`
-	CustomResourceConfigFile                string   `yaml:"custom_resource_state_config_file"`
+	cmd                      *cobra.Command
+	Apiserver                string `yaml:"apiserver"`
+	CustomResourceConfig     string `yaml:"custom_resource_config"`
+	CustomResourceConfigFile string `yaml:"custom_resource_state_config_file"`
+	// CustomResourceConfigFileDeprecated preserves backward compatibility with the
+	// pre-v2.17 config key `custom_resource_config_file`. Honored as an alias when
+	// the canonical `custom_resource_state_config_file` is not set; emits a
+	// deprecation warning at startup. Will be removed in a future release.
+	CustomResourceConfigFileDeprecated      string   `yaml:"custom_resource_config_file"`
 	ContinueWithoutCustomResourceConfigFile bool     `yaml:"continue_without_custom_resource_state_config_file"`
 	Host                                    string   `yaml:"host"`
 	Kubeconfig                              string   `yaml:"kubeconfig"`

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -19,6 +19,8 @@ package options
 import (
 	"os"
 	"testing"
+
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
 func TestOptionsParse(t *testing.T) {
@@ -62,4 +64,33 @@ func TestOptionsParse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCustomResourceConfigFileDeprecatedAlias(t *testing.T) {
+	t.Run("deprecated key populates alias field", func(t *testing.T) {
+		opts := NewOptions()
+		if err := yaml.Unmarshal([]byte("custom_resource_config_file: /etc/ksm/crs.yaml\n"), opts); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if opts.CustomResourceConfigFileDeprecated != "/etc/ksm/crs.yaml" {
+			t.Fatalf("expected deprecated alias to be set, got %q", opts.CustomResourceConfigFileDeprecated)
+		}
+		if opts.CustomResourceConfigFile != "" {
+			t.Fatalf("expected canonical field to remain empty pre-merge, got %q", opts.CustomResourceConfigFile)
+		}
+	})
+
+	t.Run("canonical key takes precedence when both are set", func(t *testing.T) {
+		opts := NewOptions()
+		yamlIn := "custom_resource_config_file: /old.yaml\ncustom_resource_state_config_file: /new.yaml\n"
+		if err := yaml.Unmarshal([]byte(yamlIn), opts); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if opts.CustomResourceConfigFile != "/new.yaml" {
+			t.Fatalf("expected canonical field to win, got %q", opts.CustomResourceConfigFile)
+		}
+		if opts.CustomResourceConfigFileDeprecated != "/old.yaml" {
+			t.Fatalf("expected deprecated field to retain its value, got %q", opts.CustomResourceConfigFileDeprecated)
+		}
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

The `custom_resource_config_file` config-file key was renamed to `custom_resource_state_config_file` in #2703 so it would match the CLI flag `--custom-resource-state-config-file`. Because YAML unmarshalling silently ignores unknown keys, users upgrading from v2.16 to v2.17+ saw their custom resource state config silently stop loading, with no error or warning.

This PR restores backward compatibility by honoring the legacy `custom_resource_config_file` key as a deprecated alias:
- When only the legacy key is set, its value is copied into `CustomResourceConfigFile` so the CRS file loads as it did pre-v2.17.
- When both keys are set, the canonical `custom_resource_state_config_file` takes precedence.
- A deprecation warning is logged at startup whenever the legacy key is present, prompting users to migrate.
- The CRS metrics guide (`docs/metrics/extend/customresourcestate-metrics.md`) now documents both keys and notes the alias is scheduled for removal.

Coverage was added in `pkg/options/options_test.go` for the unmarshal contract (alias populates the deprecated field; canonical wins when both are set).

**How does this change affect the cardinality of KSM:** *does not change cardinality*

**Which issue(s) this PR fixes:**
Fixes #2803
