### PR TITLE
feat: Add public interface to use the CRD discoverer

### DIFF
--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -55,6 +55,18 @@ type CRDiscoverer struct {
 	WasUpdated bool
 }
 
+// NewCRDiscoverer creates a new CRDiscoverer.
+func NewCRDiscoverer(crdsAddEventsCounter, crdsUpdateEventsCounter, crdsDeleteEventsCounter prometheus.Counter, crdsCacheCountGauge prometheus.Gauge) *CRDiscoverer {
+	return &CRDiscoverer{
+		CRDsAddEventsCounter:      crdsAddEventsCounter,
+		CRDsUpdateEventsCounter:   crdsUpdateEventsCounter,
+		CRDsDeleteEventsCounter:   crdsDeleteEventsCounter,
+		CRDsCacheCountGauge:       crdsCacheCountGauge,
+		Map:                       make(map[string]map[string][]kindPlural),
+		GVKToReflectorStopChanMap: make(map[string]chan struct{}),
+	}
+}
+
 // SafeRead executes the given function while holding a read lock.
 func (r *CRDiscoverer) SafeRead(f func()) {
 	r.m.RLock()

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -318,12 +318,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 
 	// A nil CRS config implies that we need to hold off on all CRS operations.
 	if config != nil {
-		discovererInstance := &discovery.CRDiscoverer{
-			CRDsAddEventsCounter:    crdsAddEventsCounter,
-			CRDsUpdateEventsCounter: crdsUpdateEventsCounter,
-			CRDsDeleteEventsCounter: crdsDeleteEventsCounter,
-			CRDsCacheCountGauge:     crdsCacheCountGauge,
-		}
+		discovererInstance := discovery.NewCRDiscoverer(crdsAddEventsCounter, crdsUpdateEventsCounter, crdsDeleteEventsCounter, crdsCacheCountGauge)
 		// storeBuilder starts reflectors for the discovered GVKs, and as such, should close them too.
 		storeBuilder.GVKToReflectorStopChanMap = &discovererInstance.GVKToReflectorStopChanMap
 		// This starts a goroutine that will watch for any new GVKs to extract from CRDs.

--- a/pkg/discovery/discoverer.go
+++ b/pkg/discovery/discoverer.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/rest"
+
+	"k8s.io/kube-state-metrics/v2/internal/discovery"
+)
+
+// Discoverer is an interface that provides a cache of the collected GVKs, along with helper utilities.
+type Discoverer interface {
+	SafeRead(f func())
+	SafeWrite(f func())
+	StartDiscovery(ctx context.Context, config *rest.Config) error
+}
+
+// ensure interface matches the struct that implements it
+var _ Discoverer = &discovery.CRDiscoverer{}
+
+// NewDiscoverer creates a new Discoverer.
+func NewDiscoverer(crdsAddEventsCounter, crdsUpdateEventsCounter, crdsDeleteEventsCounter prometheus.Counter, crdsCacheCountGauge prometheus.Gauge) Discoverer {
+	return discovery.NewCRDiscoverer(crdsAddEventsCounter, crdsUpdateEventsCounter, crdsDeleteEventsCounter, crdsCacheCountGauge)
+}

--- a/pkg/discovery/discoverer_test.go
+++ b/pkg/discovery/discoverer_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package discovery_test
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kube-state-metrics/v2/pkg/discovery"
+)
+
+func TestPublicModuleAPI(t *testing.T) {
+	// This test ensures that the public API of the library is correct and can be used by external code.
+	// It does not test any functionality, but rather that the code compiles and can be used as a library.
+
+	// This is a compile-time check that the NewDiscoverer function can be called with the correct arguments.
+	discoverer := discovery.NewDiscoverer(nil, nil, nil, nil)
+	if discoverer == nil {
+		t.Fatal("expected discoverer to be non-nil")
+	}
+
+	discoverer_type := reflect.TypeOf(discoverer)
+	if discoverer_type.Kind() != reflect.Ptr {
+		t.Fatal("expected discoverer to be a pointer")
+	}
+
+	if discoverer_type.Elem().Name() != "CRDiscoverer" {
+		t.Fatalf("expected discoverer to be of type CRDiscoverer, got %s", discoverer_type.Elem().Name())
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**
Add a public go API to use the module in other go programs.

Add a small to ensure the API is persisted and does not change.

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*

it does not.

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Fixes #

