### PR TITLE
feat: add deployment-based sharding example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ examples/prometheus-alerting-rules/alerts.yaml: jsonnet $(shell find jsonnet | g
 	mkdir -p examples/prometheus-alerting-rules
 	${JSONNET_CLI}  -J scripts/vendor scripts/mixin.jsonnet | ${GOJQ_CLI} --yaml-output > examples/prometheus-alerting-rules/alerts.yaml
 
-examples: examples/standard examples/autosharding examples/daemonsetsharding mixin
+examples: examples/standard examples/autosharding examples/daemonsetsharding examples/deploymentsharding mixin
 
 examples/standard: jsonnet $(shell find jsonnet | grep ".libsonnet") scripts/standard.jsonnet scripts/vendor
 	mkdir -p examples/standard
@@ -176,6 +176,11 @@ examples/autosharding: jsonnet $(shell find jsonnet | grep ".libsonnet") scripts
 examples/daemonsetsharding: jsonnet $(shell find jsonnet | grep ".libsonnet") scripts/daemonsetsharding.jsonnet scripts/vendor
 	mkdir -p examples/daemonsetsharding
 	${JSONNET_CLI} -J scripts/vendor -m examples/daemonsetsharding --ext-str version="$(VERSION)" scripts/daemonsetsharding.jsonnet | xargs -I{} sh -c 'cat {} | ${GOJQ_CLI} --yaml-output > `echo {} | sed "s/\(.\)\([A-Z]\)/\1-\2/g" | tr "[:upper:]" "[:lower:]"`.yaml' -- {}
+	find examples -type f ! -name '*.yaml' -delete
+
+examples/deploymentsharding: jsonnet $(shell find jsonnet | grep ".libsonnet") scripts/deploymentsharding.jsonnet scripts/vendor
+	mkdir -p examples/deploymentsharding
+	${JSONNET_CLI} -J scripts/vendor -m examples/deploymentsharding --ext-str version="$(VERSION)" scripts/deploymentsharding.jsonnet | xargs -I{} sh -c 'cat {} | ${GOJQ_CLI} --yaml-output > `echo {} | sed "s/\(.\)\([A-Z]\)/\1-\2/g" | tr "[:upper:]" "[:lower:]"`.yaml' -- {}
 	find examples -type f ! -name '*.yaml' -delete
 
 scripts/vendor: scripts/jsonnetfile.json scripts/jsonnetfile.lock.json

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ The trade-offs are that:
 
 * You must manage each shard as a separate Kubernetes `Deployment`
 * You must keep the shard configuration consistent across all shard `Deployment` objects, such as the total shard count and shared settings
+  * This means scaling the number of shards requires redeploying all of them
 
 ### Daemonset sharding for pod metrics
 

--- a/README.md
+++ b/README.md
@@ -264,12 +264,14 @@ If you prefer to manage shards as independent `Deployment` objects instead of us
 Example manifests for deployment-based sharding are available in [`/examples/deploymentsharding`](./examples/deploymentsharding).
 
 Compared to automated sharding, this approach:
-- Uses the standard `Deployment` rolling update behavior, which can reduce the risk of metric gaps during upgrades
-- Gives each shard a fixed, explicitly assigned shard index
+
+* Uses the standard `Deployment` rolling update behavior, which can reduce the risk of metric gaps during upgrades
+* Gives each shard a fixed, explicitly assigned shard index
 
 The trade-offs are that:
-- You must manage each shard as a separate Kubernetes `Deployment`
-- You must keep the shard configuration consistent across all shard `Deployment` objects, such as the total shard count and shared settings
+
+* You must manage each shard as a separate Kubernetes `Deployment`
+* You must keep the shard configuration consistent across all shard `Deployment` objects, such as the total shard count and shared settings
 
 ### Daemonset sharding for pod metrics
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ are deleted they are no longer visible on the `/metrics` endpoint.
   * [A note on costing](#a-note-on-costing)
   * [Horizontal sharding](#horizontal-sharding)
     * [Automated sharding](#automated-sharding)
+    * [Deployment sharding](#deployment-sharding)
   * [Daemonset sharding for pod metrics](#daemonset-sharding-for-pod-metrics)
   * [Resource filtering](#resource-filtering)
 * [Setup](#setup)
@@ -255,6 +256,20 @@ To enable automated sharding, kube-state-metrics must be run by a `StatefulSet` 
 This way of deploying shards is useful when you want to manage KSM shards through a single Kubernetes resource (a single `StatefulSet` in this case) instead of having one `Deployment` per shard. The advantage can be especially significant when deploying a high number of shards.
 
 The downside of using an auto-sharded setup comes from the rollout strategy supported by `StatefulSet`s. When managed by a `StatefulSet`, pods are replaced one at a time with each pod first getting terminated and then recreated. Besides such rollouts being slower, they will also lead to short downtime for each shard. If a Prometheus scrape happens during a rollout, it can miss some of the metrics exported by kube-state-metrics.
+
+#### Deployment sharding
+
+If you prefer to manage shards as independent `Deployment` objects instead of using a single `StatefulSet`, you can use deployment-based sharding. In this model, each `Deployment` is configured with an explicit shard index using `--shard=<N>` and the total number of shards using `--total-shards=<N>`.
+
+Example manifests for deployment-based sharding are available in [`/examples/deploymentsharding`](./examples/deploymentsharding).
+
+Compared to automated sharding, this approach:
+- Uses the standard `Deployment` rolling update behavior, which can reduce the risk of metric gaps during upgrades
+- Gives each shard a fixed, explicitly assigned shard index
+
+The trade-offs are that:
+- You must manage each shard as a separate Kubernetes `Deployment`
+- You must keep the shard configuration consistent across all shard `Deployment` objects, such as the total shard count and shared settings
 
 ### Daemonset sharding for pod metrics
 

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -51,6 +51,7 @@ are deleted they are no longer visible on the `/metrics` endpoint.
   * [A note on costing](#a-note-on-costing)
   * [Horizontal sharding](#horizontal-sharding)
     * [Automated sharding](#automated-sharding)
+    * [Deployment sharding](#deployment-sharding)
   * [Daemonset sharding for pod metrics](#daemonset-sharding-for-pod-metrics)
   * [Resource filtering](#resource-filtering)
 * [Setup](#setup)
@@ -256,6 +257,22 @@ To enable automated sharding, kube-state-metrics must be run by a `StatefulSet` 
 This way of deploying shards is useful when you want to manage KSM shards through a single Kubernetes resource (a single `StatefulSet` in this case) instead of having one `Deployment` per shard. The advantage can be especially significant when deploying a high number of shards.
 
 The downside of using an auto-sharded setup comes from the rollout strategy supported by `StatefulSet`s. When managed by a `StatefulSet`, pods are replaced one at a time with each pod first getting terminated and then recreated. Besides such rollouts being slower, they will also lead to short downtime for each shard. If a Prometheus scrape happens during a rollout, it can miss some of the metrics exported by kube-state-metrics.
+
+#### Deployment sharding
+
+If you prefer to manage shards as independent `Deployment` objects instead of using a single `StatefulSet`, you can use deployment-based sharding. In this model, each `Deployment` is configured with an explicit shard index using `--shard=<N>` and the total number of shards using `--total-shards=<N>`.
+
+Example manifests for deployment-based sharding are available in [`/examples/deploymentsharding`](./examples/deploymentsharding).
+
+Compared to automated sharding, this approach:
+
+* Uses the standard `Deployment` rolling update behavior, which can reduce the risk of metric gaps during upgrades
+* Gives each shard a fixed, explicitly assigned shard index
+
+The trade-offs are that:
+
+* You must manage each shard as a separate Kubernetes `Deployment`
+* You must keep the shard configuration consistent across all shard `Deployment` objects, such as the total shard count and shared settings
 
 ### Daemonset sharding for pod metrics
 

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -273,6 +273,7 @@ The trade-offs are that:
 
 * You must manage each shard as a separate Kubernetes `Deployment`
 * You must keep the shard configuration consistent across all shard `Deployment` objects, such as the total shard count and shared settings
+  * This means scaling the number of shards requires redeploying all of them
 
 ### Daemonset sharding for pod metrics
 

--- a/examples/deploymentsharding/cluster-role-binding.yaml
+++ b/examples/deploymentsharding/cluster-role-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.18.0
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: kube-state-metrics
+    namespace: kube-system

--- a/examples/deploymentsharding/cluster-role.yaml
+++ b/examples/deploymentsharding/cluster-role.yaml
@@ -1,0 +1,128 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.18.0
+  name: kube-state-metrics
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+      - nodes
+      - pods
+      - services
+      - serviceaccounts
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+      - ingressclasses
+      - ingresses
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs:
+      - list
+      - watch

--- a/examples/deploymentsharding/deployment-0.yaml
+++ b/examples/deploymentsharding/deployment-0.yaml
@@ -3,21 +3,24 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/name: kube-state-metrics-0
+    app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/version: 2.18.0
+    kube-state-metrics.io/shard: "0"
   name: kube-state-metrics-0
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: kube-state-metrics-0
+      app.kubernetes.io/name: kube-state-metrics
+      kube-state-metrics.io/shard: "0"
   template:
     metadata:
       labels:
         app.kubernetes.io/component: exporter
-        app.kubernetes.io/name: kube-state-metrics-0
+        app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/version: 2.18.0
+        kube-state-metrics.io/shard: "0"
     spec:
       automountServiceAccountToken: true
       containers:

--- a/examples/deploymentsharding/deployment-0.yaml
+++ b/examples/deploymentsharding/deployment-0.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics-0
+    app.kubernetes.io/version: 2.18.0
+  name: kube-state-metrics-0
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics-0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: kube-state-metrics-0
+        app.kubernetes.io/version: 2.18.0
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - args:
+            - --shard=0
+            - --total-shards=3
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http-metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          name: kube-state-metrics
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+            - containerPort: 8081
+              name: telemetry
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: telemetry
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: kube-state-metrics

--- a/examples/deploymentsharding/deployment-1.yaml
+++ b/examples/deploymentsharding/deployment-1.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics-1
+    app.kubernetes.io/version: 2.18.0
+  name: kube-state-metrics-1
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics-1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: kube-state-metrics-1
+        app.kubernetes.io/version: 2.18.0
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - args:
+            - --shard=1
+            - --total-shards=3
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http-metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          name: kube-state-metrics
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+            - containerPort: 8081
+              name: telemetry
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: telemetry
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: kube-state-metrics

--- a/examples/deploymentsharding/deployment-1.yaml
+++ b/examples/deploymentsharding/deployment-1.yaml
@@ -3,21 +3,24 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/name: kube-state-metrics-1
+    app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/version: 2.18.0
+    kube-state-metrics.io/shard: "1"
   name: kube-state-metrics-1
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: kube-state-metrics-1
+      app.kubernetes.io/name: kube-state-metrics
+      kube-state-metrics.io/shard: "1"
   template:
     metadata:
       labels:
         app.kubernetes.io/component: exporter
-        app.kubernetes.io/name: kube-state-metrics-1
+        app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/version: 2.18.0
+        kube-state-metrics.io/shard: "1"
     spec:
       automountServiceAccountToken: true
       containers:

--- a/examples/deploymentsharding/deployment-2.yaml
+++ b/examples/deploymentsharding/deployment-2.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics-2
+    app.kubernetes.io/version: 2.18.0
+  name: kube-state-metrics-2
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics-2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: kube-state-metrics-2
+        app.kubernetes.io/version: 2.18.0
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - args:
+            - --shard=2
+            - --total-shards=3
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http-metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          name: kube-state-metrics
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+            - containerPort: 8081
+              name: telemetry
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: telemetry
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: kube-state-metrics

--- a/examples/deploymentsharding/deployment-2.yaml
+++ b/examples/deploymentsharding/deployment-2.yaml
@@ -3,21 +3,24 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/name: kube-state-metrics-2
+    app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/version: 2.18.0
+    kube-state-metrics.io/shard: "2"
   name: kube-state-metrics-2
   namespace: kube-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: kube-state-metrics-2
+      app.kubernetes.io/name: kube-state-metrics
+      kube-state-metrics.io/shard: "2"
   template:
     metadata:
       labels:
         app.kubernetes.io/component: exporter
-        app.kubernetes.io/name: kube-state-metrics-2
+        app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/version: 2.18.0
+        kube-state-metrics.io/shard: "2"
     spec:
       automountServiceAccountToken: true
       containers:

--- a/examples/deploymentsharding/service-account.yaml
+++ b/examples/deploymentsharding/service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.18.0
+  name: kube-state-metrics
+  namespace: kube-system

--- a/examples/deploymentsharding/service.yaml
+++ b/examples/deploymentsharding/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.18.0
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 8080
+      targetPort: http-metrics
+    - name: telemetry
+      port: 8081
+      targetPort: telemetry
+  selector:
+    app.kubernetes.io/name: kube-state-metrics

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -492,15 +492,15 @@
         {
           metadata: {
             name: shardName,
-            labels: { 'app.kubernetes.io/name': shardName },
+            labels: { 'kube-state-metrics.io/shard': std.toString(shard)},
           },
           spec: {
             selector: {
-              matchLabels: { 'app.kubernetes.io/name': shardName },
+              matchLabels: { 'kube-state-metrics.io/shard': std.toString(shard) },
             },
             template: {
               metadata: {
-                labels: { 'app.kubernetes.io/name': shardName },
+                labels: { 'kube-state-metrics.io/shard': std.toString(shard) },
               },
               spec: {
                 containers: [c],

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -477,4 +477,45 @@
     clusterRole: ksm.clusterRole,
     clusterRoleBinding: ksm.clusterRoleBinding,
   },
+  deploymentsharding::
+    local totalShards = 3;
+    local deploymentShard(shard) =
+      local shardName = ksm.name + '-' + shard;
+      local c = ksm.deployment.spec.template.spec.containers[0] {
+        args: [
+          '--shard=' + shard,
+          '--total-shards=' + totalShards,
+        ],
+      };
+      std.mergePatch(
+        ksm.deployment,
+        {
+          metadata: {
+            name: shardName,
+            labels: { 'app.kubernetes.io/name': shardName },
+          },
+          spec: {
+            selector: {
+              matchLabels: { 'app.kubernetes.io/name': shardName },
+            },
+            template: {
+              metadata: {
+                labels: { 'app.kubernetes.io/name': shardName },
+              },
+              spec: {
+                containers: [c],
+              },
+            },
+          },
+        }
+      );
+    {
+      ['deployment-' + i]: deploymentShard(i)
+      for i in std.range(0, totalShards - 1)
+    } + {
+      service: ksm.service,
+      serviceAccount: ksm.serviceAccount,
+      clusterRole: ksm.clusterRole,
+      clusterRoleBinding: ksm.clusterRoleBinding,
+    },
 }

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -477,7 +477,7 @@
     clusterRole: ksm.clusterRole,
     clusterRoleBinding: ksm.clusterRoleBinding,
   },
-  deploymentsharding(totalShards=3)::
+  deploymentsharding(totalShards=3,replicas=1)::
     local deploymentShard(shard) =
       local shardName = std.toString(ksm.name) + '-' + std.toString(shard);
       local c = ksm.deployment.spec.template.spec.containers[0] {
@@ -494,6 +494,7 @@
             labels: { 'kube-state-metrics.io/shard': std.toString(shard)},
           },
           spec: {
+            replicas: replicas,
             selector: {
               matchLabels: { 'kube-state-metrics.io/shard': std.toString(shard) },
             },

--- a/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet
@@ -477,14 +477,13 @@
     clusterRole: ksm.clusterRole,
     clusterRoleBinding: ksm.clusterRoleBinding,
   },
-  deploymentsharding::
-    local totalShards = 3;
+  deploymentsharding(totalShards=3)::
     local deploymentShard(shard) =
-      local shardName = ksm.name + '-' + shard;
+      local shardName = std.toString(ksm.name) + '-' + std.toString(shard);
       local c = ksm.deployment.spec.template.spec.containers[0] {
         args: [
-          '--shard=' + shard,
-          '--total-shards=' + totalShards,
+          '--shard=' + std.toString(shard),
+          '--total-shards=' + std.toString(totalShards),
         ],
       };
       std.mergePatch(
@@ -510,7 +509,7 @@
         }
       );
     {
-      ['deployment-' + i]: deploymentShard(i)
+      ['deployment-' + std.toString(i)]: deploymentShard(i)
       for i in std.range(0, totalShards - 1)
     } + {
       service: ksm.service,

--- a/scripts/deploymentsharding.jsonnet
+++ b/scripts/deploymentsharding.jsonnet
@@ -1,0 +1,1 @@
+(import 'standard.jsonnet').deploymentsharding

--- a/scripts/deploymentsharding.jsonnet
+++ b/scripts/deploymentsharding.jsonnet
@@ -1,1 +1,1 @@
-(import 'standard.jsonnet').deploymentsharding
+(import 'standard.jsonnet').deploymentsharding()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**

This PR adds a deployment-based sharding example and documents it in the README.

The new example shows how to run kube-state-metrics shards as independent `Deployment` objects with explicit shard assignments. This is useful for users who prefer `Deployment`-based operations over automated sharding with a `StatefulSet`.

It also documents the trade-offs of this approach, including the need to manage each shard separately and to keep shard configuration consistent across all shard `Deployment` objects.


<!-- If you are adding a new metric, provide the use case of that metric. -->

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*


does not change cardinality
