### PR TITLE
fix: Skip landing page registration on NewLandingPage error

### DIFF
--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -346,7 +346,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		)
 	}
 
-	telemetryMux := buildTelemetryServer(ksmMetricsRegistry, opts.AuthFilter, kubeConfig)
+	telemetryMux := buildTelemetryServer(ksmMetricsRegistry, opts.AuthFilter, kubeConfig, web.NewLandingPage)
 	telemetryListenAddress := net.JoinHostPort(opts.TelemetryHost, strconv.Itoa(opts.TelemetryPort))
 	telemetryServer := http.Server{
 		Handler:           telemetryMux,
@@ -356,7 +356,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		WebConfigFile:      &tlsConfig,
 	}
 
-	metricsMux := buildMetricsServer(m, durationVec, kubeClient, opts.AuthFilter, kubeConfig)
+	metricsMux := buildMetricsServer(m, durationVec, kubeClient, opts.AuthFilter, kubeConfig, web.NewLandingPage)
 	metricsServerListenAddress := net.JoinHostPort(opts.Host, strconv.Itoa(opts.Port))
 	metricsServer := http.Server{
 		Handler:           metricsMux,
@@ -457,7 +457,7 @@ func configureResourcesAndMetrics(opts *options.Options, configFile []byte) *opt
 	return opts
 }
 
-func buildTelemetryServer(registry prometheus.Gatherer, authFilter bool, kubeConfig *rest.Config) *http.ServeMux {
+func buildTelemetryServer(registry prometheus.Gatherer, authFilter bool, kubeConfig *rest.Config, newLandingPage func(web.LandingConfig) (*web.LandingPageHandler, error)) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	loghandler := logr.ToSlogHandler(klog.Background())
@@ -539,9 +539,10 @@ func buildTelemetryServer(registry prometheus.Gatherer, authFilter bool, kubeCon
 			},
 		},
 	}
-	landingPage, err := web.NewLandingPage(landingConfig)
+	landingPage, err := newLandingPage(landingConfig)
 	if err != nil {
 		klog.ErrorS(err, "failed to create landing page")
+		return mux
 	}
 	mux.Handle("/", landingPage)
 	return mux
@@ -563,7 +564,7 @@ func handleClusterDelegationForProber(client kubernetes.Interface, probeType str
 	}
 }
 
-func buildMetricsServer(m *metricshandler.MetricsHandler, durationObserver prometheus.ObserverVec, client kubernetes.Interface, authFilter bool, kubeConfig *rest.Config) *http.ServeMux {
+func buildMetricsServer(m *metricshandler.MetricsHandler, durationObserver prometheus.ObserverVec, client kubernetes.Interface, authFilter bool, kubeConfig *rest.Config, newLandingPage func(web.LandingConfig) (*web.LandingPageHandler, error)) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Add metricsPath
@@ -621,9 +622,10 @@ func buildMetricsServer(m *metricshandler.MetricsHandler, durationObserver prome
 			},
 		},
 	}
-	landingPage, err := web.NewLandingPage(landingConfig)
+	landingPage, err := newLandingPage(landingConfig)
 	if err != nil {
 		klog.ErrorS(err, "failed to create landing page")
+		return mux
 	}
 	mux.Handle("/", landingPage)
 	return mux

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -539,12 +539,21 @@ func buildTelemetryServer(registry prometheus.Gatherer, authFilter bool, kubeCon
 			},
 		},
 	}
-	landingPage, err := web.NewLandingPage(landingConfig)
+	registerLandingPage(mux, landingConfig, web.NewLandingPage)
+	return mux
+}
+
+// registerLandingPage serves the landing page at "/". If it cannot be built the
+// page is skipped rather than registered: web.NewLandingPage returns a nil
+// handler alongside its error, and a typed nil stored in an http.Handler is not
+// nil, so the mux would accept it and panic on the first request to "/".
+func registerLandingPage(mux *http.ServeMux, landingConfig web.LandingConfig, newLandingPage func(web.LandingConfig) (*web.LandingPageHandler, error)) {
+	landingPage, err := newLandingPage(landingConfig)
 	if err != nil {
 		klog.ErrorS(err, "failed to create landing page")
+		return
 	}
 	mux.Handle("/", landingPage)
-	return mux
 }
 
 func handleClusterDelegationForProber(client kubernetes.Interface, probeType string) http.HandlerFunc {
@@ -621,11 +630,7 @@ func buildMetricsServer(m *metricshandler.MetricsHandler, durationObserver prome
 			},
 		},
 	}
-	landingPage, err := web.NewLandingPage(landingConfig)
-	if err != nil {
-		klog.ErrorS(err, "failed to create landing page")
-	}
-	mux.Handle("/", landingPage)
+	registerLandingPage(mux, landingConfig, web.NewLandingPage)
 	return mux
 }
 

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/optin"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/exporter-toolkit/web"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -395,7 +397,7 @@ kube_pod_status_reason{namespace="default",pod="pod0",uid="abc-0",reason="Unexpe
 		}
 	}
 
-	telemetryMux := buildTelemetryServer(reg, false, nil)
+	telemetryMux := buildTelemetryServer(reg, false, nil, web.NewLandingPage)
 
 	req2 := httptest.NewRequest("GET", "http://localhost:8081/metrics", nil)
 
@@ -469,7 +471,7 @@ func TestPprofRouting(t *testing.T) {
 		}
 
 		reg := prometheus.NewRegistry()
-		telemetryMux := buildTelemetryServer(reg, authEnabled, cfg)
+		telemetryMux := buildTelemetryServer(reg, authEnabled, cfg, web.NewLandingPage)
 		for _, path := range pprofPaths {
 			req := httptest.NewRequest("GET", "http://localhost:8081"+path, nil)
 			_, pattern := telemetryMux.Handler(req)
@@ -485,6 +487,7 @@ func TestPprofRouting(t *testing.T) {
 			fake.NewSimpleClientset(),
 			authEnabled,
 			cfg,
+			web.NewLandingPage,
 		)
 		for _, path := range pprofPaths {
 			req := httptest.NewRequest("GET", "http://localhost:8080"+path, nil)
@@ -1039,6 +1042,103 @@ func (f *fooFactory) ListWatch(customResourceClient interface{}, ns string, fiel
 		},
 	}
 }
+
+func failingLandingPage(_ web.LandingConfig) (*web.LandingPageHandler, error) {
+	return nil, fmt.Errorf("injected landing page error")
+}
+
+func TestBuildTelemetryServerLandingPage(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	mux := buildTelemetryServer(reg, false, nil, web.NewLandingPage)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for landing page at /, got %d", w.Code)
+	}
+}
+
+func TestBuildTelemetryServerLandingPageError(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	mux := buildTelemetryServer(reg, false, nil, failingLandingPage)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for / when landing page creation fails, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest("GET", "/metrics", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for /metrics even when landing page fails, got %d", w.Code)
+	}
+}
+
+func TestBuildMetricsServerLandingPage(t *testing.T) {
+	t.Parallel()
+	kubeClient := fake.NewSimpleClientset()
+
+	durationVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:        "http_request_duration_seconds",
+		ConstLabels: prometheus.Labels{"handler": "metrics"},
+	}, []string{"method"})
+
+	builder := store.NewBuilder()
+	builder.WithMetrics(prometheus.NewRegistry())
+	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
+
+	mux := buildMetricsServer(handler, durationVec, kubeClient, false, nil, web.NewLandingPage)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for landing page at /, got %d", w.Code)
+	}
+}
+
+func TestBuildMetricsServerLandingPageError(t *testing.T) {
+	t.Parallel()
+	kubeClient := fake.NewSimpleClientset()
+
+	durationVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:        "http_request_duration_seconds",
+		ConstLabels: prometheus.Labels{"handler": "metrics"},
+	}, []string{"method"})
+
+	builder := store.NewBuilder()
+	builder.WithMetrics(prometheus.NewRegistry())
+	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
+
+	mux := buildMetricsServer(handler, durationVec, kubeClient, false, nil, failingLandingPage)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for / when landing page creation fails, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest("GET", "/healthz", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for /healthz even when landing page fails, got %d", w.Code)
+	}
+}
+
 func TestConfigureResourcesAndMetrics(t *testing.T) {
 	// Prepare a config file in YAML format
 	configYAML := `

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/optin"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/exporter-toolkit/web"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1047,6 +1049,70 @@ func (f *fooFactory) ListWatch(customResourceClient interface{}, ns string, fiel
 		},
 	}
 }
+
+func failingLandingPage(_ web.LandingConfig) (*web.LandingPageHandler, error) {
+	return nil, fmt.Errorf("injected landing page error")
+}
+
+func TestRegisterLandingPage(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	registerLandingPage(mux, web.LandingConfig{Name: "kube-state-metrics"}, web.NewLandingPage)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for landing page at /, got %d", w.Code)
+	}
+}
+
+// A failing factory returns a nil *web.LandingPageHandler. Registering that would
+// store a non-nil http.Handler holding a nil pointer, which panics on the first
+// request to "/", so nothing must be registered at all.
+func TestRegisterLandingPageError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	registerLandingPage(mux, web.LandingConfig{Name: "kube-state-metrics"}, failingLandingPage)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for / when landing page creation fails, got %d", w.Code)
+	}
+}
+
+// The builders wire the landing page up for real, so "/" must be served.
+func TestBuildServersServeLandingPage(t *testing.T) {
+	t.Parallel()
+	kubeClient := fake.NewSimpleClientset()
+
+	durationVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:        "http_request_duration_seconds",
+		ConstLabels: prometheus.Labels{"handler": "metrics"},
+	}, []string{"method"})
+
+	builder := store.NewBuilder()
+	builder.WithMetrics(prometheus.NewRegistry())
+	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
+
+	for name, mux := range map[string]*http.ServeMux{
+		"telemetry": buildTelemetryServer(prometheus.NewRegistry(), false, nil),
+		"metrics":   buildMetricsServer(handler, durationVec, kubeClient, false, nil),
+	} {
+		req := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("%s server: expected 200 for landing page at /, got %d", name, w.Code)
+		}
+	}
+}
+
 func TestConfigureResourcesAndMetrics(t *testing.T) {
 	// Prepare a config file in YAML format
 	configYAML := `


### PR DESCRIPTION
**What this PR does / why we need it:**

When `web.NewLandingPage()` returns an error, the handler value is nil and the API is telling us not to use it. The previous code logged the error but still called `mux.Handle("/", landingPage)`, registering a nil `*web.LandingPageHandler`. Because a nil pointer stored in an `http.Handler` interface is non-nil in Go, the default mux accepts it silently. The first `GET /` then panics when `ServeHTTP` dereferences the nil receiver (e.g. reading `routePrefix`).

This change:
- Adds a `newLandingPage` function parameter to `buildTelemetryServer()` and `buildMetricsServer()` so the landing page factory is injected per call. Production code passes `web.NewLandingPage`; tests can inject a failing factory without mutable global state or data races.
- Returns the mux after logging, without registering the `/` handler, when the factory returns an error. The rest of the server (metrics, health, pprof, etc.) continues to work and the process does not crash on the root path if landing page construction fails.
- Adds focused tests for both the happy path (landing page registered, `/` returns 200) and the error path (landing page skipped, `/` returns 404, other routes like `/metrics` and `/healthz` still work). All tests are safe to run with `t.Parallel()` and pass `go test -race`.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup handling when landing pages cannot be created.
  * Prevented invalid landing-page handlers from being registered.
  * Ensured telemetry and metrics servers serve valid landing pages correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->