### PR TITLE
fix: allow built-in Kubernetes resources in customResourceState

### DIFF
--- a/pkg/customresourcestate/config.go
+++ b/pkg/customresourcestate/config.go
@@ -192,6 +192,13 @@ func FromConfig(decoder ConfigDecoder, discovererInstance *discovery.CRDiscovere
 			if err != nil {
 				klog.ErrorS(err, "failed to resolve GVK", "gvk", resource.GroupVersionKind)
 			}
+			if len(resolvedSet) == 0 {
+				// Resource not found in CRD discovery cache. This can happen for built-in Kubernetes resources
+				// (e.g., CSINode) that are not CustomResourceDefinitions. Use the resource config as-is.
+				klog.InfoS("Resource not found in CRD cache, using as built-in resource", "gvk", resource.GroupVersionKind)
+				resolvedGVKPs = append(resolvedGVKPs, resource)
+				continue
+			}
 			for _, resolved /* GVKP */ := range resolvedSet {
 				// Set their G** attributes to various resolutions of the GVK.
 				resource.GroupVersionKind = GroupVersionKind(resolved.GroupVersionKind)

--- a/pkg/customresourcestate/config_test.go
+++ b/pkg/customresourcestate/config_test.go
@@ -66,6 +66,8 @@ func toPaths(m map[string]valuePath) map[string]string {
 
 func TestFromConfig_BuiltInResource(t *testing.T) {
 	// Test that built-in Kubernetes resources (not CRDs) work with customResourceState
+	// Issue #2681: built-in resources like CSINode were silently dropped when configured
+	// because discovery only watches CRDs and ResolveGVKToGVKPs returns empty for non-CRD resources.
 	config := `
 kind: CustomResourceStateMetrics
 spec:
@@ -87,6 +89,7 @@ spec:
               valueFrom: [metadata, name]
 `
 	// Create an empty CRDiscoverer (no CRDs registered)
+	// This simulates the behavior where CSINode (a built-in resource) won't be found in CRD discovery
 	discoverer := &discovery.CRDiscoverer{}
 
 	decoder := yaml.NewDecoder(strings.NewReader(config))
@@ -95,8 +98,13 @@ spec:
 
 	factories, err := factoryGenerator()
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(factories), "Expected one factory for CSINode")
 
-	factory := factories[0]
-	assert.Equal(t, "csinodes", factory.Name(), "Factory name should match configured resourcePlural")
+	// On main: this FAILS because built-in resources are silently dropped (len(factories) == 0)
+	// On fix branch: this PASSES because built-in resources are kept (len(factories) == 1)
+	assert.Equal(t, 1, len(factories), "Expected one factory for CSINode built-in resource")
+
+	if len(factories) > 0 {
+		factory := factories[0]
+		assert.Equal(t, "csinodes", factory.Name(), "Factory name should match configured resourcePlural")
+	}
 }

--- a/pkg/customresourcestate/config_test.go
+++ b/pkg/customresourcestate/config_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/klog/v2"
+	"k8s.io/kube-state-metrics/v2/internal/discovery"
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
@@ -61,4 +62,41 @@ func toPaths(m map[string]valuePath) map[string]string {
 		out[k] = v.String()
 	}
 	return out
+}
+
+func TestFromConfig_BuiltInResource(t *testing.T) {
+	// Test that built-in Kubernetes resources (not CRDs) work with customResourceState
+	config := `
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: storage.k8s.io
+        version: v1
+        kind: CSINode
+      resourcePlural: csinodes
+      metricNamePrefix: csi_node
+      metrics:
+        - name: labels
+          help: "CSINode basic information"
+          each:
+            type: Gauge
+            gauge:
+              labelsFromPath:
+                node: [metadata, name]
+              valueFrom: [metadata, name]
+`
+	// Create an empty CRDiscoverer (no CRDs registered)
+	discoverer := &discovery.CRDiscoverer{}
+
+	decoder := yaml.NewDecoder(strings.NewReader(config))
+	factoryGenerator, err := FromConfig(decoder, discoverer)
+	assert.NoError(t, err)
+
+	factories, err := factoryGenerator()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(factories), "Expected one factory for CSINode")
+
+	factory := factories[0]
+	assert.Equal(t, "csinodes", factory.Name(), "Factory name should match configured resourcePlural")
 }

--- a/pkg/customresourcestate/config_test.go
+++ b/pkg/customresourcestate/config_test.go
@@ -23,8 +23,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/klog/v2"
-	"k8s.io/kube-state-metrics/v2/internal/discovery"
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
+
+	"k8s.io/kube-state-metrics/v2/internal/discovery"
 )
 
 //go:embed example_config.yaml


### PR DESCRIPTION
## Summary

Built-in Kubernetes resources like CSINode are silently dropped when configured in `customResourceState` because the discovery mechanism only watches CRDs. When `ResolveGVKToGVKPs` returns an empty slice for non-CRD resources, they're never added to the resolved set.

- Adds a fallback to use the resource config directly when CRD discovery returns empty
- Preserves all existing CRD discovery behavior
- Only triggers when existing code was already broken (empty discovery result)

## Test plan
- [x] Unit test for built-in resource (CSINode) with empty CRD cache
- [x] All existing tests pass
- [ ] CI passes

Fixes #2681