### PR TITLE
fix: Handle DeletedFinalStateUnknown panic

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -49,7 +49,15 @@ func (r *CRDiscoverer) StartDiscovery(ctx context.Context, config *rest.Config) 
 	informer := factory.Informer()
 	stopper := make(chan struct{})
 	extractGVKPs := func(obj interface{}) []groupVersionKindPlural {
-		objSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
+		if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+			obj = d.Obj
+		}
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			klog.ErrorS(nil, "expected *unstructured.Unstructured", "got", fmt.Sprintf("%T", obj))
+			return nil
+		}
+		objSpec := u.Object["spec"].(map[string]interface{})
 		var gvkps []groupVersionKindPlural
 		for _, version := range objSpec["versions"].([]interface{}) {
 			g := objSpec["group"].(string)

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"k8s.io/kube-state-metrics/v2/internal/store"
@@ -672,7 +673,15 @@ func famGen(f compiledFamily) generator.FamilyGenerator {
 		Type: f.Each.Type(),
 		Help: f.Help,
 		GenerateFunc: func(obj interface{}) *metric.Family {
-			return generate(obj.(*unstructured.Unstructured), f, errLog)
+			if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = d.Obj
+			}
+			u, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				klog.ErrorS(nil, "expected *unstructured.Unstructured", "got", fmt.Sprintf("%T", obj))
+				return &metric.Family{}
+			}
+			return generate(u, f, errLog)
 		},
 	}
 }


### PR DESCRIPTION
kube-state-metrics panics with a type assertion failure when processing deleted objects from the client-go informer cache. The informer wraps deleted objects in `cache.DeletedFinalStateUnknown`, but the code directly type-asserts to `*unstructured.Unstructured` without unwrapping first.

```
interface conversion: interface {} is cache.DeletedFinalStateUnknown, not *unstructured.Unstructured
```

<details>
<summary>Summary by Claude</summary>

# Fix DeletedFinalStateUnknown panic in kube-state-metrics

## Problem

kube-state-metrics panics with a type assertion failure when processing deleted
objects from the client-go informer cache. The informer wraps deleted objects in
`cache.DeletedFinalStateUnknown`, but the code directly type-asserts to
`*unstructured.Unstructured` without unwrapping first.

Panic: `interface conversion: interface {} is cache.DeletedFinalStateUnknown, not *unstructured.Unstructured`

## Affected Locations

### 1. `pkg/customresourcestate/registry_factory.go:674-676`

```go
GenerateFunc: func(obj interface{}) *metric.Family {
    return generate(obj.(*unstructured.Unstructured), f, errLog)
},
```

Bare type assertion panics when `obj` is `cache.DeletedFinalStateUnknown`.

### 2. `internal/discovery/discovery.go:51-52`

```go
extractGVKPs := func(obj interface{}) []groupVersionKindPlural {
    objSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
```

Same bare type assertion. Called from `AddFunc`, `UpdateFunc`, and `DeleteFunc`
informer handlers. `DeleteFunc` is the primary vector for receiving
`DeletedFinalStateUnknown` objects.

## Fix

Apply the standard `cache.DeletedFinalStateUnknown` unwrap pattern at both
locations before type-asserting to `*unstructured.Unstructured`:

```go
if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
    obj = d.Obj
}
u, ok := obj.(*unstructured.Unstructured)
if !ok {
    // log error and return
}
```

### registry_factory.go

- Add `"k8s.io/client-go/tools/cache"` import.
- In `famGen()`, unwrap `DeletedFinalStateUnknown`, use comma-ok assertion for
  `*unstructured.Unstructured`, return empty `metric.Family` on failure.

### discovery.go

- In `extractGVKPs`, unwrap `DeletedFinalStateUnknown`, use comma-ok assertion,
  return `nil` on failure.

</details>