### PR TITLE
fix: use previous release tag for benchmark comparison instead of release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Go 1.x
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -169,7 +172,7 @@ jobs:
       run: |
         BENCHSTAT_OUTPUT_FILE=result.txt make test-benchmark-compare-release
     - run: |
-        echo "Comparison against release branch" >> "$GITHUB_STEP_SUMMARY"
+        echo "Comparison against previous release tag" >> "$GITHUB_STEP_SUMMARY"
         echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
         cat result.txt >> "$GITHUB_STEP_SUMMARY"
         echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ REGISTRY ?= gcr.io/k8s-staging-kube-state-metrics
 TAG_PREFIX = v
 VERSION = $(shell grep '^version:' data.yaml | grep -oE "[0-9]+.[0-9]+.[0-9]+")
 TAG ?= $(TAG_PREFIX)$(VERSION)
-LATEST_RELEASE_BRANCH := release-$(shell echo $(VERSION) | grep -ohE "[0-9]+.[0-9]+")
 BRANCH = $(strip $(shell git rev-parse --abbrev-ref HEAD))
 PKGS = $(shell go list ./... | grep -v /vendor/ | grep -v /tests/e2e)
 ARCH ?= $(shell go env GOARCH)
@@ -99,7 +98,7 @@ generate-template:
 validate-template: generate-template
 	git diff --no-ext-diff --quiet --exit-code README.md
 
-# Runs benchmark tests on the current git ref and the last release and compares
+# Runs benchmark tests on the current git ref and the previous release tag and compares
 # the two.
 test-benchmark-compare:
 	$(MAKE) test-benchmark-compare-main test-benchmark-compare-release
@@ -109,8 +108,8 @@ test-benchmark-compare-main:
 	./tests/compare_benchmarks.sh main 6
 
 test-benchmark-compare-release:
-	@git fetch origin ${LATEST_RELEASE_BRANCH}
-	./tests/compare_benchmarks.sh ${LATEST_RELEASE_BRANCH} 6
+	@git fetch --tags origin
+	./tests/compare_benchmarks.sh $$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-*' HEAD^) 6
 
 all: all-container
 


### PR DESCRIPTION
The `ci-benchmark-tests-releasebranch` job compares benchmarks against release branch by fetching it from upstream. This requires the release branch to exist on the upstream repo before the release PR can merge.

The CI job to always fail on release PRs. Example https://github.com/kubernetes/kube-state-metrics/actions/runs/25844106890/job/75935367272?pr=2949

Fix by switching to compare prior tags instead. Tags always exist on upstream, so this works in all cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release benchmark comparisons by using the previous repository tag.
  * Enabled full repository history access for release benchmark checks.
  * Disabled credential persistence during benchmark checkouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->