### PR TITLE
fix: Wildcard label/annotation clobbering

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -232,7 +232,7 @@ func (b *Builder) WithCustomResourceStoreFactories(fs ...customresource.Registry
 }
 
 // allowList validates the given map and checks if the resources exists.
-// If there is a '*' as key, return new map with all enabled resources.
+// If there is a '*' as key, merge wildcard labels with resource-specific labels.
 func (b *Builder) allowList(list map[string][]string) (map[string][]string, error) {
 	if len(list) == 0 {
 		return nil, nil
@@ -244,16 +244,48 @@ func (b *Builder) allowList(list map[string][]string) (map[string][]string, erro
 		}
 	}
 
-	// "*" takes precedence over other specifications
-	allowedList, ok := list["*"]
-	if !ok {
+	wildcardList, hasWildcard := list["*"]
+	if !hasWildcard {
 		return list, nil
 	}
+
 	m := make(map[string][]string)
 	for _, resource := range b.enabledResources {
-		m[resource] = allowedList
+		resourceLabels := list[resource]
+		m[resource] = mergeLabels(wildcardList, resourceLabels)
 	}
 	return m, nil
+}
+
+// mergeLabels combines two label slices, deduplicating entries.
+func mergeLabels(base, additional []string) []string {
+	if len(additional) == 0 {
+		return base
+	}
+	if len(base) == 0 {
+		return additional
+	}
+
+	// Collision detection map
+	seen := make(map[string]struct{}, len(base)+len(additional))
+
+	// Assume there will be no name collisions; this will over-allocate
+	// space if collisions occur, but avoid reallocations otherwise.
+	result := make([]string, 0, len(base)+len(additional))
+
+	for _, l := range base {
+		if _, exists := seen[l]; !exists {
+			seen[l] = struct{}{}
+			result = append(result, l)
+		}
+	}
+	for _, l := range additional {
+		if _, exists := seen[l]; !exists {
+			seen[l] = struct{}{}
+			result = append(result, l)
+		}
+	}
+	return result
 }
 
 // WithAllowAnnotations configures which annotations can be returned for metrics

--- a/internal/store/builder_test.go
+++ b/internal/store/builder_test.go
@@ -63,6 +63,25 @@ func TestWithAllowLabels(t *testing.T) {
 			}),
 		},
 		{
+			Desc:             "wildcard merged with resource-specific labels",
+			LabelsAllowlist:  map[string][]string{"*": {"common_label"}, "pods": {"pod_specific"}, "nodes": {"node_label1", "node_label2"}},
+			EnabledResources: []string{"pods", "deployments", "nodes"},
+			Wanted: LabelsAllowList(map[string][]string{
+				"deployments": {"common_label"},
+				"pods":        {"common_label", "pod_specific"},
+				"nodes":       {"common_label", "node_label1", "node_label2"},
+			}),
+		},
+		{
+			Desc:             "wildcard merged with resource-specific labels, deduplication",
+			LabelsAllowlist:  map[string][]string{"*": {"label1", "label2"}, "pods": {"label2", "label3"}},
+			EnabledResources: []string{"pods", "deployments"},
+			Wanted: LabelsAllowList(map[string][]string{
+				"deployments": {"label1", "label2"},
+				"pods":        {"label1", "label2", "label3"},
+			}),
+		},
+		{
 			Desc:             "wildcard key-value as not the only element, with resource mismatch",
 			LabelsAllowlist:  map[string][]string{"*": {"*"}, "pods": {"*"}, "cronjobs": {"*"}, "configmaps": {"*"}},
 			EnabledResources: []string{"cronjobs", "pods", "deployments"},
@@ -197,6 +216,61 @@ func TestWithAllowAnnotations(t *testing.T) {
 			t.Log("Expected maps to be equal.")
 			t.Errorf("Test error for Desc: %s\n Want: \n%+v\n Got: \n%#+v", test.Desc, test.Wanted, resolvedAllowAnnotations)
 		}
+	}
+}
+
+func TestMergeLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		base       []string
+		additional []string
+		want       []string
+	}{
+		{
+			name:       "both empty",
+			base:       nil,
+			additional: nil,
+			want:       nil,
+		},
+		{
+			name:       "base only",
+			base:       []string{"a", "b"},
+			additional: nil,
+			want:       []string{"a", "b"},
+		},
+		{
+			name:       "additional only",
+			base:       nil,
+			additional: []string{"c", "d"},
+			want:       []string{"c", "d"},
+		},
+		{
+			name:       "merge without duplicates",
+			base:       []string{"a", "b"},
+			additional: []string{"c", "d"},
+			want:       []string{"a", "b", "c", "d"},
+		},
+		{
+			name:       "merge with duplicates",
+			base:       []string{"a", "b", "c"},
+			additional: []string{"b", "c", "d"},
+			want:       []string{"a", "b", "c", "d"},
+		},
+		{
+			name:       "all duplicates",
+			base:       []string{"a", "b"},
+			additional: []string{"a", "b"},
+			want:       []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeLabels(tt.base, tt.additional)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("mergeLabels() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Wildcard entries in `labels_allow_list` and `annotations_allow_list` clobbered resource-specific entries per https://github.com/kubernetes/kube-state-metrics/issues/2488. So it was not possible to express the configuration "label A for all resource types, and additionally label B for this specific resource type".

Fix by merging the wildcard and resource-specific discovered labels.

No effect on cardinality _except_ possibly if an existing configuration has masked config due to this bug; if any  annotations (or labels, where on mutable resources) have high rates of churn on underlying resources, the newly-unclobbered labels might increase cardinality. This is really a user misconfiguration, but was previously masked by this bug.

Fixes #2488
