### PR TITLE
fix: Update base image for post-release 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,7 +36,7 @@ Maintaining the release branches for older minor releases happens on a best effo
 * Cut the new release branch, e.g. `release-1.2`, or merge/cherry-pick changes onto the minor release branch you intend to tag the release on
 * Cut the new release tag, e.g. `v1.2.0-rc.0`
 * Create a new **pre-release** on github
-* New images are automatically built and pushed to `gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics`
+* New images are automatically built and pushed to `gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics`. If `post-kube-state-metrics-push-images` seems to error due to failed pulls, try updating the image used in [cloudbuild.yaml](./cloudbuild.yaml), see [this Slack thread](https://kubernetes.slack.com/archives/C0ARY011QTW/p1779357270928509) for more information.
 * Promote image by sending a PR to [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) repository. Follow the [example PR](https://github.com/kubernetes/k8s.io/pull/3798). Use [kpromo pr](https://github.com/kubernetes-sigs/promo-tools/blob/main/docs/promotion-pull-requests.md) to update the manifest files in this repository, e.g. `kpromo pr --fork=$YOURNAME -i --project=kube-state-metrics -t=v2.5.0`
 * Create a PR to merge the changes of this release back into the main branch.
 * Once the PR to promote the image is merged, mark the pre-release as a regular release.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 2700s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20241111-71c32dbdcc'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2'
     entrypoint: make
     env:
     - TAG=$_PULL_BASE_REF


### PR DESCRIPTION
**This is a backport of #6393, to fix breaking jobs for 2.19**

[PTAL here for the complete job YAML](https://prow.k8s.io/prowjob?prowjob=4b59c65a-4208-4adf-ad07-1d2c0d67c86f):

```
  refs:
    base_link: https://github.com/kubernetes/kube-state-metrics/compare/v2.19.0
    base_ref: v2.19.0
    base_sha: b18fbda7881baa84f6cf51dff2a727191b58d049
    blobless_fetch: true
    org: kubernetes
    repo: kube-state-metrics
    repo_link: https://github.com/kubernetes/kube-state-metrics
```
