### PR TITLE
fix(deployment): guard nil Spec.Replicas before dereference

### DIFF
--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -271,12 +271,16 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
+				ms := []*metric.Metric{}
+
+				if d.Spec.Replicas != nil {
+					ms = append(ms, &metric.Metric{
+						Value: float64(*d.Spec.Replicas),
+					})
+				}
+
 				return &metric.Family{
-					Metrics: []*metric.Metric{
-						{
-							Value: float64(*d.Spec.Replicas),
-						},
-					},
+					Metrics: ms,
 				}
 			}),
 		),
@@ -303,7 +307,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				if d.Spec.Strategy.RollingUpdate == nil {
+				if d.Spec.Strategy.RollingUpdate == nil || d.Spec.Replicas == nil {
 					return &metric.Family{}
 				}
 
@@ -328,7 +332,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				if d.Spec.Strategy.RollingUpdate == nil {
+				if d.Spec.Strategy.RollingUpdate == nil || d.Spec.Replicas == nil {
 					return &metric.Family{}
 				}
 

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -316,6 +316,35 @@ func TestDeploymentStore(t *testing.T) {
 				kube_deployment_status_replicas_updated{deployment="deployment-without-owner",namespace="ns5"} 0
 			`,
 		},
+		{
+			Obj: &v1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment-nil-replicas",
+					Namespace: "ns6",
+				},
+				Spec: v1.DeploymentSpec{
+					Strategy: v1.DeploymentStrategy{
+						RollingUpdate: &v1.RollingUpdateDeployment{
+							MaxUnavailable: &depl1MaxUnavailable,
+							MaxSurge:       &depl1MaxSurge,
+						},
+					},
+				},
+			},
+			Want: `
+				# HELP kube_deployment_spec_replicas [STABLE] Number of desired pods for a deployment.
+				# TYPE kube_deployment_spec_replicas gauge
+				# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable [STABLE] Maximum number of unavailable replicas during a rolling update of a deployment.
+				# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
+				# HELP kube_deployment_spec_strategy_rollingupdate_max_surge [STABLE] Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
+				# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
+			`,
+			MetricNames: []string{
+				"kube_deployment_spec_replicas",
+				"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
+				"kube_deployment_spec_strategy_rollingupdate_max_surge",
+			},
+		},
 	}
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(deploymentMetricFamilies(c.AllowAnnotationsList, nil))


### PR DESCRIPTION
**What this PR does / why we need it:**

`Spec.Replicas` is `*int32` - a pointer. Three metrics dereference it without a nil check:
- `kube_deployment_spec_replicas`
- `kube_deployment_spec_strategy_rollingupdate_max_unavailable`
- `kube_deployment_spec_strategy_rollingupdate_max_surge`

`replicaset.go` and `statefulset.go` both guard this same field already. Deployment was just missing the guards, so it would straight up panic on a nil pointer if a deployment with unset `Spec.Replicas` came through (e.g. via direct API/etcd write, old migrated objects, or tests).

Reproduce:

```go
d := &v1.Deployment{
    ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
    Spec: v1.DeploymentSpec{
        Strategy: v1.DeploymentStrategy{
            RollingUpdate: &v1.RollingUpdateDeployment{
                MaxUnavailable: &maxUnavailable,
            },
        },
        // Replicas intentionally nil
    },
}
// kube-state-metrics panics when generating metrics for this object
```

Fix follows the existing pattern from `replicaset.go:160` and `statefulset.go:170`.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:**
-