### PR TITLE
fix: watch-list bookmarks with sharding

### DIFF
--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -81,6 +81,12 @@ func (s *shardedListWatch) Watch(options metav1.ListOptions) (watch.Interface, e
 	}
 
 	return watch.Filter(w, func(in watch.Event) (out watch.Event, keep bool) {
+		// Bookmarks are stream control events. They carry a resource version but
+		// no UID, so filtering them would route every bookmark to a single shard.
+		if in.Type == watch.Bookmark {
+			return in, true
+		}
+
 		a, err := meta.Accessor(in.Object)
 		if err != nil {
 			// TODO(brancz): needs logging

--- a/pkg/sharding/listwatch_test.go
+++ b/pkg/sharding/listwatch_test.go
@@ -70,23 +70,31 @@ func TestShardedListWatchPassesInitialEventsEndBookmarkToEveryShard(t *testing.T
 		},
 	}
 
+	source := watch.NewBroadcaster(1, watch.WaitIfChannelFull)
+	t.Cleanup(source.Shutdown)
+
+	var shardedWatches []watch.Interface
 	for shard := int32(0); shard < 4; shard++ {
-		t.Run(strconv.Itoa(int(shard)), func(t *testing.T) {
-			source := watch.NewRaceFreeFake()
-			lw := &cache.ListWatch{
-				WatchFunc: func(metav1.ListOptions) (watch.Interface, error) {
-					return source, nil
-				},
-			}
+		lw := &cache.ListWatch{
+			WatchFunc: func(metav1.ListOptions) (watch.Interface, error) {
+				return source.Watch()
+			},
+		}
 
-			shardedWatch, err := cache.ToWatcherWithContext(NewShardedListWatch(shard, 4, lw)).WatchWithContext(context.Background(), metav1.ListOptions{})
-			if err != nil {
-				t.Fatalf("failed to create sharded watch: %v", err)
-			}
-			defer shardedWatch.Stop()
+		shardedWatch, err := cache.ToWatcherWithContext(NewShardedListWatch(shard, 4, lw)).WatchWithContext(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			t.Fatalf("failed to create sharded watch: %v", err)
+		}
+		t.Cleanup(shardedWatch.Stop)
+		shardedWatches = append(shardedWatches, shardedWatch)
+	}
 
-			source.Action(watch.Bookmark, bookmark)
+	if err := source.Action(watch.Bookmark, bookmark); err != nil {
+		t.Fatalf("failed to broadcast initial events end bookmark: %v", err)
+	}
 
+	for shard, shardedWatch := range shardedWatches {
+		t.Run(strconv.Itoa(shard), func(t *testing.T) {
 			select {
 			case event := <-shardedWatch.ResultChan():
 				if event.Type != watch.Bookmark {

--- a/pkg/sharding/listwatch_test.go
+++ b/pkg/sharding/listwatch_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sharding
 
 import (
+	"context"
 	"strconv"
 	"testing"
 	"time"
@@ -78,7 +79,7 @@ func TestShardedListWatchPassesInitialEventsEndBookmarkToEveryShard(t *testing.T
 				},
 			}
 
-			shardedWatch, err := NewShardedListWatch(shard, 4, lw).Watch(metav1.ListOptions{})
+			shardedWatch, err := cache.ToWatcherWithContext(NewShardedListWatch(shard, 4, lw)).WatchWithContext(context.Background(), metav1.ListOptions{})
 			if err != nil {
 				t.Fatalf("failed to create sharded watch: %v", err)
 			}

--- a/pkg/sharding/listwatch_test.go
+++ b/pkg/sharding/listwatch_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package sharding
 
 import (
+	"strconv"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestSharding(t *testing.T) {
@@ -52,5 +56,44 @@ func TestSharding(t *testing.T) {
 
 	if s2.keep(cm) {
 		t.Fatal("Shard two should not pick up the object.")
+	}
+}
+
+func TestShardedListWatchPassesInitialEventsEndBookmarkToEveryShard(t *testing.T) {
+	bookmark := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "1",
+			Annotations: map[string]string{
+				metav1.InitialEventsAnnotationKey: "true",
+			},
+		},
+	}
+
+	for shard := int32(0); shard < 4; shard++ {
+		t.Run(strconv.Itoa(int(shard)), func(t *testing.T) {
+			source := watch.NewRaceFreeFake()
+			lw := &cache.ListWatch{
+				WatchFunc: func(metav1.ListOptions) (watch.Interface, error) {
+					return source, nil
+				},
+			}
+
+			shardedWatch, err := NewShardedListWatch(shard, 4, lw).Watch(metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("failed to create sharded watch: %v", err)
+			}
+			defer shardedWatch.Stop()
+
+			source.Action(watch.Bookmark, bookmark)
+
+			select {
+			case event := <-shardedWatch.ResultChan():
+				if event.Type != watch.Bookmark {
+					t.Fatalf("got event type %q, want %q", event.Type, watch.Bookmark)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for initial events end bookmark")
+			}
+		})
 	}
 }


### PR DESCRIPTION
KSM 2.19.0 switched to client-go 0.35.4 which enables the `WatchListClient` feature by default.
The sharding code does not handle it properly. 
Bookmark events are processed by the shard filter while they should be propagated to every shard (so they know the initial sync is complete).
As a result when using KSM 2.19.0 with sharding, only one shard can initialize successfully (the one which receives the bookmark event)
This change special case bookmark events and make sure every shard will see them

Fixes #2973 