### PR TITLE
fix(discovery): Stop the discoverer when the context is canceled

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -116,11 +116,9 @@ func (r *CRDiscoverer) StartDiscovery(ctx context.Context, config *rest.Config) 
 	}
 	// Respect context cancellation.
 	go func() {
-		for range ctx.Done() {
-			klog.InfoS("context cancelled, stopping discovery")
-			close(stopper)
-			return
-		}
+		<-ctx.Done()
+		klog.InfoS("context cancelled, stopping discovery")
+		close(stopper)
 	}()
 	go informer.Run(stopper)
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**

Fix a goroutine and memory leak when the context passed to `CRDDiscoverer.StartDiscovery` expires.

`StartDiscovery` spawns an informer goroutine when invoked.
It takes a `Context` as parameter and should stop the goroutine when that `Context` expires.

The currently used pattern is: https://github.com/kubernetes/kube-state-metrics/blob/e77145f237f7038fc5c6c4a25c3cb9617d9abba6/internal/discovery/discovery.go#L117-L124

A `for range ch` on a channel waits for values to be fed in the channel. But when the channel is closed, the `for` loop exits without executing its body so that the `stopper` channel is never closed and the informer goroutine is leaked.

I replaced it with:
```go
<-ch
```
which returns when either a value has been enqueued or the channel is closed.

<!-- If you are adding a new metric, provide the use case of that metric. -->

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:**
