### PR TITLE
fix(hpa): handle omitted minReplicas in HPA metrics

### DIFF
--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -171,10 +171,15 @@ func createHPASpecMinReplicas() generator.FamilyGenerator {
 		basemetrics.STABLE,
 		"",
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
+			minReplicas := float64(1)
+			if a.Spec.MinReplicas != nil {
+				minReplicas = float64(*a.Spec.MinReplicas)
+			}
+
 			return &metric.Family{
 				Metrics: []*metric.Metric{
 					{
-						Value: float64(*a.Spec.MinReplicas),
+						Value: minReplicas,
 					},
 				},
 			}

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -260,6 +260,30 @@ func TestHPAStore(t *testing.T) {
 			},
 		},
 		{
+			// Verify omitted minReplicas falls back to the API default.
+			Obj: &autoscaling.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hpa-default-min-replicas",
+					Namespace: "ns1",
+				},
+				Spec: autoscaling.HorizontalPodAutoscalerSpec{
+					MaxReplicas: 3,
+					ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "deployment-default-min",
+					},
+				},
+			},
+			Want: `
+				# HELP kube_horizontalpodautoscaler_spec_min_replicas [STABLE] Lower limit for the number of pods that can be set by the autoscaler, default 1.
+				# TYPE kube_horizontalpodautoscaler_spec_min_replicas gauge
+				kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="hpa-default-min-replicas",namespace="ns1"} 1
+			`,
+			MetricNames: []string{
+				"kube_horizontalpodautoscaler_spec_min_replicas",
+			},
+		},
+		{
 			// Verify populating base metric.
 			AllowAnnotationsList: []string{
 				"app.k8s.io/owner",


### PR DESCRIPTION
What this PR does / why we need it:

Fixes a nil deref in `kube_horizontalpodautoscaler_spec_min_replicas`.
`spec.minReplicas` is optional in the HPA API and defaults to `1`, so omitting it is a valid object shape. Old code could just blow up on `*a.Spec.MinReplicas`. This patch falls back to `1`.

How does this change affect the cardinality of KSM:

does not change cardinality

Which issue(s) this PR fixes:

none

Repro:

1. Apply an HPA without `spec.minReplicas`, for example:
```yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: repro
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: repro
  maxReplicas: 3
```
2. Scrape the HPA metrics.
3. Before this patch, the `kube_horizontalpodautoscaler_spec_min_replicas` path could panic.
4. After this patch, it exports `1`.

Tests:

`go test ./internal/store -run TestHPAStore -count=1`
`go test $(go list ./... | grep -v '/tests/e2e')`
