### PR TITLE
feat: shard only resource mutation watch events

### DIFF
--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -17,9 +17,11 @@ limitations under the License.
 package sharding
 
 import (
+	"fmt"
 	"hash/fnv"
 
 	jump "github.com/dgryski/go-jump"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,10 +85,8 @@ func (s *shardedListWatch) Watch(options metav1.ListOptions) (watch.Interface, e
 	return watch.Filter(w, s.filterWatchEvent), nil
 }
 
-// filterWatchEvent shards resource state changes and passes every other event
-// through. Control and unknown events must reach every reflector so sharding
-// cannot hide stream progress, errors, or event types it does not understand.
-// Future event types that mutate resource state must be added to the switch.
+// filterWatchEvent shards resource state changes, passes control events through,
+// and rejects unknown events so new mutation types cannot bypass sharding.
 func (s *shardedListWatch) filterWatchEvent(in watch.Event) (out watch.Event, keep bool) {
 	switch in.Type {
 	case watch.Added, watch.Modified, watch.Deleted:
@@ -97,8 +97,13 @@ func (s *shardedListWatch) filterWatchEvent(in watch.Event) (out watch.Event, ke
 		}
 
 		return in, s.sharding.keep(a)
-	default:
+	case watch.Bookmark, watch.Error:
 		return in, true
+	default:
+		return watch.Event{
+			Type:   watch.Error,
+			Object: &apierrors.NewInternalError(fmt.Errorf("sharded list watch failed to recognize event type %q", in.Type)).ErrStatus,
+		}, true
 	}
 }
 

--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -92,18 +92,21 @@ func (s *shardedListWatch) filterWatchEvent(in watch.Event) (out watch.Event, ke
 	case watch.Added, watch.Modified, watch.Deleted:
 		a, err := meta.Accessor(in.Object)
 		if err != nil {
-			// TODO(brancz): needs logging
-			return in, true
+			return internalErrorEvent(fmt.Errorf("sharded list watch failed to access object metadata for event type %q: %w", in.Type, err)), true
 		}
 
 		return in, s.sharding.keep(a)
 	case watch.Bookmark, watch.Error:
 		return in, true
 	default:
-		return watch.Event{
-			Type:   watch.Error,
-			Object: &apierrors.NewInternalError(fmt.Errorf("sharded list watch failed to recognize event type %q", in.Type)).ErrStatus,
-		}, true
+		return internalErrorEvent(fmt.Errorf("sharded list watch failed to recognize event type %q", in.Type)), true
+	}
+}
+
+func internalErrorEvent(err error) watch.Event {
+	return watch.Event{
+		Type:   watch.Error,
+		Object: &apierrors.NewInternalError(err).ErrStatus,
 	}
 }
 

--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -80,13 +80,16 @@ func (s *shardedListWatch) Watch(options metav1.ListOptions) (watch.Interface, e
 		return nil, err
 	}
 
-	return watch.Filter(w, func(in watch.Event) (out watch.Event, keep bool) {
-		// Bookmarks are stream control events. They carry a resource version but
-		// no UID, so filtering them would route every bookmark to a single shard.
-		if in.Type == watch.Bookmark {
-			return in, true
-		}
+	return watch.Filter(w, s.filterWatchEvent), nil
+}
 
+// filterWatchEvent shards resource state changes and passes every other event
+// through. Control and unknown events must reach every reflector so sharding
+// cannot hide stream progress, errors, or event types it does not understand.
+// Future event types that mutate resource state must be added to the switch.
+func (s *shardedListWatch) filterWatchEvent(in watch.Event) (out watch.Event, keep bool) {
+	switch in.Type {
+	case watch.Added, watch.Modified, watch.Deleted:
 		a, err := meta.Accessor(in.Object)
 		if err != nil {
 			// TODO(brancz): needs logging
@@ -94,7 +97,9 @@ func (s *shardedListWatch) Watch(options metav1.ListOptions) (watch.Interface, e
 		}
 
 		return in, s.sharding.keep(a)
-	}), nil
+	default:
+		return in, true
+	}
 }
 
 // IsWatchListSemanticsUnSupported delegates to the underlying ListerWatcher if it implements this interface.

--- a/pkg/sharding/listwatch_test.go
+++ b/pkg/sharding/listwatch_test.go
@@ -19,10 +19,12 @@ package sharding
 import (
 	"context"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -73,13 +75,14 @@ func TestShardedListWatchFiltersOnlyResourceStateEvents(t *testing.T) {
 		name        string
 		eventType   watch.EventType
 		shouldShard bool
+		wantError   bool
 	}{
 		{name: "added", eventType: watch.Added, shouldShard: true},
 		{name: "modified", eventType: watch.Modified, shouldShard: true},
 		{name: "deleted", eventType: watch.Deleted, shouldShard: true},
 		{name: "bookmark", eventType: watch.Bookmark},
 		{name: "error", eventType: watch.Error},
-		{name: "unknown", eventType: watch.EventType("UNKNOWN")},
+		{name: "unknown", eventType: watch.EventType("UNKNOWN"), wantError: true},
 	}
 
 	for _, shardIndex := range []int32{0, 1} {
@@ -101,7 +104,18 @@ func TestShardedListWatchFiltersOnlyResourceStateEvents(t *testing.T) {
 				if gotKeep != wantKeep {
 					t.Fatalf("got keep %t, want %t", gotKeep, wantKeep)
 				}
-				if out.Type != in.Type || out.Object != in.Object {
+				if test.wantError {
+					if out.Type != watch.Error {
+						t.Fatalf("got event type %q, want %q", out.Type, watch.Error)
+					}
+					err := apierrors.FromObject(out.Object)
+					if !apierrors.IsInternalError(err) {
+						t.Fatalf("got error %v, want internal error", err)
+					}
+					if !strings.Contains(err.Error(), `failed to recognize event type "UNKNOWN"`) {
+						t.Fatalf("got error %q, want unsupported event type", err)
+					}
+				} else if out.Type != in.Type || out.Object != in.Object {
 					t.Fatalf("filter changed event from %#v to %#v", in, out)
 				}
 			})

--- a/pkg/sharding/listwatch_test.go
+++ b/pkg/sharding/listwatch_test.go
@@ -60,6 +60,55 @@ func TestSharding(t *testing.T) {
 	}
 }
 
+func TestShardedListWatchFiltersOnlyResourceStateEvents(t *testing.T) {
+	obj := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "configmap1",
+			Namespace: "ns1",
+			UID:       types.UID("test_uid"),
+		},
+	}
+
+	tests := []struct {
+		name        string
+		eventType   watch.EventType
+		shouldShard bool
+	}{
+		{name: "added", eventType: watch.Added, shouldShard: true},
+		{name: "modified", eventType: watch.Modified, shouldShard: true},
+		{name: "deleted", eventType: watch.Deleted, shouldShard: true},
+		{name: "bookmark", eventType: watch.Bookmark},
+		{name: "error", eventType: watch.Error},
+		{name: "unknown", eventType: watch.EventType("UNKNOWN")},
+	}
+
+	for _, shardIndex := range []int32{0, 1} {
+		shardedListWatch := &shardedListWatch{
+			sharding: &sharding{
+				shard:       shardIndex,
+				totalShards: 2,
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name+"/shard-"+strconv.Itoa(int(shardIndex)), func(t *testing.T) {
+				// Use a metadata-bearing payload for every event so control events
+				// pass because of their type, not because their usual payload lacks a UID.
+				in := watch.Event{Type: test.eventType, Object: obj}
+				out, gotKeep := shardedListWatch.filterWatchEvent(in)
+				wantKeep := !test.shouldShard || shardedListWatch.sharding.keep(obj)
+
+				if gotKeep != wantKeep {
+					t.Fatalf("got keep %t, want %t", gotKeep, wantKeep)
+				}
+				if out.Type != in.Type || out.Object != in.Object {
+					t.Fatalf("filter changed event from %#v to %#v", in, out)
+				}
+			})
+		}
+	}
+}
+
 func TestShardedListWatchPassesInitialEventsEndBookmarkToEveryShard(t *testing.T) {
 	bookmark := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/sharding/listwatch_test.go
+++ b/pkg/sharding/listwatch_test.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
@@ -120,6 +121,38 @@ func TestShardedListWatchFiltersOnlyResourceStateEvents(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestShardedListWatchRejectsMutationEventsWithoutMetadata(t *testing.T) {
+	shardedListWatch := &shardedListWatch{
+		sharding: &sharding{
+			shard:       0,
+			totalShards: 2,
+		},
+	}
+
+	for _, eventType := range []watch.EventType{watch.Added, watch.Modified, watch.Deleted} {
+		t.Run(string(eventType), func(t *testing.T) {
+			out, gotKeep := shardedListWatch.filterWatchEvent(watch.Event{
+				Type:   eventType,
+				Object: &runtime.Unknown{},
+			})
+
+			if !gotKeep {
+				t.Fatal("error event was filtered out")
+			}
+			if out.Type != watch.Error {
+				t.Fatalf("got event type %q, want %q", out.Type, watch.Error)
+			}
+			err := apierrors.FromObject(out.Object)
+			if !apierrors.IsInternalError(err) {
+				t.Fatalf("got error %v, want internal error", err)
+			}
+			if !strings.Contains(err.Error(), "failed to access object metadata") {
+				t.Fatalf("got error %q, want metadata access failure", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Following #2974, bookmark events are no longer filtered out when sharding is enabled.

This follow-up makes the watch-event policy explicit:

- resource mutation events (`ADDED`, `MODIFIED`, and `DELETED`) are sharded by UID;
- known control events (`BOOKMARK` and `ERROR`) are delivered to every shard;
- unknown event types, and mutation events whose object metadata cannot be read, are converted to `watch.Error` events so future or malformed mutation events fail loud instead of bypassing sharding.