### PR TITLE
fix(discovery): log when a configured custom resource CRD is absent

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -152,6 +152,12 @@ func (r *CRDiscoverer) ResolveGVKToGVKPs(gvk schema.GroupVersionKind) (resolvedG
 				}, nil
 			}
 		}
+		// The GVK was fully specified but is absent from the discovery cache,
+		// which usually means the CRD is not installed in the cluster. Surface
+		// this so a missing or misconfigured CRD is visible instead of silently
+		// generating no metrics for it.
+		klog.InfoS("Configured custom resource was not found in the cluster, no metrics will be generated for it until its CRD is installed", "gvk", gvk)
+		return nil, nil
 	}
 	if hasVersion && !hasKind {
 		kinds := r.Map[g][v]

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -140,6 +140,9 @@ func (r *CRDiscoverer) ResolveGVKToGVKPs(gvk schema.GroupVersionKind) (resolvedG
 	if hasVersion && hasKind {
 		for _, el := range r.Map[g][v] {
 			if el.Kind == k {
+				// The CRD is present now; clear any prior "missing" warning so a
+				// future disappearance is logged again.
+				r.clearMissingGVKWarning(gvk)
 				return []groupVersionKindPlural{
 					{
 						GroupVersionKind: schema.GroupVersionKind{
@@ -155,8 +158,11 @@ func (r *CRDiscoverer) ResolveGVKToGVKPs(gvk schema.GroupVersionKind) (resolvedG
 		// The GVK was fully specified but is absent from the discovery cache,
 		// which usually means the CRD is not installed in the cluster. Surface
 		// this so a missing or misconfigured CRD is visible instead of silently
-		// generating no metrics for it.
-		klog.InfoS("Configured custom resource was not found in the cluster, no metrics will be generated for it until its CRD is installed", "gvk", gvk)
+		// generating no metrics for it. ResolveGVKToGVKPs runs on every discovery
+		// tick, so log only on the first miss to avoid flooding the log.
+		if r.markMissingGVKWarned(gvk) {
+			klog.InfoS("Configured custom resource was not found in the cluster, no metrics will be generated for it until its CRD is installed", "gvk", gvk)
+		}
 		return nil, nil
 	}
 	if hasVersion && !hasKind {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -140,8 +140,6 @@ func (r *CRDiscoverer) ResolveGVKToGVKPs(gvk schema.GroupVersionKind) (resolvedG
 	if hasVersion && hasKind {
 		for _, el := range r.Map[g][v] {
 			if el.Kind == k {
-				// The CRD is present now; clear any prior "missing" warning so a
-				// future disappearance is logged again.
 				r.clearMissingGVKWarning(gvk)
 				return []groupVersionKindPlural{
 					{

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -155,11 +155,6 @@ func (r *CRDiscoverer) ResolveGVKToGVKPs(gvk schema.GroupVersionKind) (resolvedG
 				}, nil
 			}
 		}
-		// The GVK was fully specified but is absent from the discovery cache,
-		// which usually means the CRD is not installed in the cluster. Surface
-		// this so a missing or misconfigured CRD is visible instead of silently
-		// generating no metrics for it. ResolveGVKToGVKPs runs on every discovery
-		// tick, so log only on the first miss to avoid flooding the log.
 		if r.markMissingGVKWarned(gvk) {
 			klog.InfoS("Configured custom resource was not found in the cluster, no metrics will be generated for it until its CRD is installed", "gvk", gvk)
 		}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -198,3 +198,42 @@ func TestGVKMapsResolveGVK(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveGVKToGVKPsMissingWarnDedup(t *testing.T) {
+	missing := schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject1"}
+	r := &CRDiscoverer{
+		Map: map[string]map[string][]kindPlural{
+			"testgroup": {"v1": {kindPlural{Kind: "TestObject2", Plural: "testobjects2"}}},
+		},
+	}
+
+	// First miss records the warning; the key is tracked.
+	if !r.markMissingGVKWarned(missing) {
+		t.Fatalf("expected first markMissingGVKWarned to report true")
+	}
+	// Subsequent misses must not re-warn until the GVK is resolved.
+	if r.markMissingGVKWarned(missing) {
+		t.Errorf("expected repeated markMissingGVKWarned to report false")
+	}
+
+	// Once the CRD appears, resolving it clears the warning state.
+	r.SafeWrite(func() {
+		r.Map["testgroup"]["v1"] = append(r.Map["testgroup"]["v1"], kindPlural{Kind: "TestObject1", Plural: "testobjects1"})
+	})
+	if _, err := r.ResolveGVKToGVKPs(missing); err != nil {
+		t.Fatalf("unexpected error resolving present GVK: %v", err)
+	}
+	r.SafeRead(func() {
+		if _, ok := r.warnedMissingGVKs[missing.String()]; ok {
+			t.Errorf("expected warning to be cleared after successful resolution")
+		}
+	})
+
+	// After the CRD disappears again, a fresh warning is emitted.
+	r.SafeWrite(func() {
+		r.Map["testgroup"]["v1"] = []kindPlural{{Kind: "TestObject2", Plural: "testobjects2"}}
+	})
+	if !r.markMissingGVKWarned(missing) {
+		t.Errorf("expected warning to fire again after the GVK disappeared")
+	}
+}

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -49,6 +49,10 @@ type CRDiscoverer struct {
 	Map map[string]map[string][]kindPlural
 	// GVKToReflectorStopChanMap is a map of GVKs to channels that can be used to stop their corresponding reflector.
 	GVKToReflectorStopChanMap map[string]chan struct{}
+	// warnedMissingGVKs tracks fully-specified GVKs that were already logged as
+	// absent from the cache. ResolveGVKToGVKPs runs on every discovery tick, so
+	// this avoids re-logging the same missing CRD until it is resolved.
+	warnedMissingGVKs map[string]struct{}
 	// m is a mutex to protect the cache.
 	m sync.RWMutex
 	// ShouldUpdate is a flag that indicates whether the cache was updated.
@@ -67,6 +71,32 @@ func (r *CRDiscoverer) SafeWrite(f func()) {
 	r.m.Lock()
 	defer r.m.Unlock()
 	f()
+}
+
+// markMissingGVKWarned records that the given GVK was found missing and reports
+// whether this is the first time, so the caller logs only once per missing
+// episode. The cache mutex protects warnedMissingGVKs.
+func (r *CRDiscoverer) markMissingGVKWarned(gvk schema.GroupVersionKind) bool {
+	firstTime := false
+	r.SafeWrite(func() {
+		if r.warnedMissingGVKs == nil {
+			r.warnedMissingGVKs = map[string]struct{}{}
+		}
+		key := gvk.String()
+		if _, ok := r.warnedMissingGVKs[key]; !ok {
+			r.warnedMissingGVKs[key] = struct{}{}
+			firstTime = true
+		}
+	})
+	return firstTime
+}
+
+// clearMissingGVKWarning forgets a previously recorded "missing" warning for the
+// given GVK so that a future disappearance is logged again.
+func (r *CRDiscoverer) clearMissingGVKWarning(gvk schema.GroupVersionKind) {
+	r.SafeWrite(func() {
+		delete(r.warnedMissingGVKs, gvk.String())
+	})
 }
 
 // AppendToMap appends the given GVKs to the cache.


### PR DESCRIPTION
## What this does

When a fully specified custom resource GVK in the CustomResourceState config is not present in the discovery cache (its CRD is not installed in the cluster), `ResolveGVKToGVKPs` resolved it to an empty set and returned with no log. kube-state-metrics then silently generated no metrics for that resource, with nothing surfaced even at high verbosity.

This adds a `klog.InfoS` in `ResolveGVKToGVKPs` for the fully-specified-GVK path when there is no matching discovery cache entry, naming the GVK so a missing or misconfigured CRD is visible at default verbosity.

Resolution behavior is unchanged (the path still returns an empty set). The existing `fixed version and kind, no matching cache entry` test case in `discovery_test.go` already covers the empty-return contract of this branch and now also exercises the new log.

## Which issue(s) this fixes

Fixes #2354

In the issue discussion, @sebastiangaiser reported that a CRD specified in config but not installed produced no warning/info even at `-v=10`, and @rexagod confirmed logging this is the desired behavior and marked it a good first issue.

## How to verify

```
go test ./internal/discovery/ -run TestGVKMapsResolveGVK -v
```

The `fixed version and kind, no matching cache entry` case now emits:

```
"Configured custom resource was not found in the cluster, no metrics will be generated for it until its CRD is installed" gvk="testgroup/v1, Kind=TestObject1"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom resource discovery so resolved resources no longer keep stale “missing” warnings.
  * Reduced repeated warnings when a resource is unavailable, while still logging once when it can’t be found.
  * Discovery now clears an old missing-resource warning if the resource becomes available again, so future missing events can be reported properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->