### PR TITLE
fix: prevent duplicate cluster-scoped metrics when using --namespaces

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -513,28 +513,28 @@ func (b *Builder) buildIngressClassStores() []cache.Store {
 	return b.buildClusterScopedStores(ingressClassMetricFamilies(b.allowAnnotationsList["ingressclasses"], b.allowLabelsList["ingressclasses"]), &networkingv1.IngressClass{}, createIngressClassListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
-// Cluster-scoped resources have no namespace, so watch all namespaces once.
-// Building one store per --namespaces entry would duplicate every series.
+// buildClusterScopedStores delegates to the configured buildStoresFunc (honouring
+// any custom function injected via WithGenerateStoresFunc) while guaranteeing that
+// cluster-scoped resources are watched exactly once across all namespaces.
+// It achieves this by (a) wrapping listWatchFunc to always pass v1.NamespaceAll
+// and (b) temporarily replacing b.namespaces with a single-entry NamespaceAll
+// list so that buildStoresFunc creates only one store regardless of the
+// number of namespaces the caller originally configured.
 func (b *Builder) buildClusterScopedStores(
 	metricFamilies []generator.FamilyGenerator,
 	expectedType interface{},
 	listWatchFunc func(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher,
 	useAPIServerCache bool, objectLimit int64,
 ) []cache.Store {
-	metricFamilies = generator.FilterFamilyGenerators(b.familyGeneratorFilter, metricFamilies)
-	composedMetricGenFuncs := generator.ComposeMetricGenFuncs(metricFamilies)
-	familyHeaders := generator.ExtractMetricFamilyHeaders(metricFamilies)
-
-	store := metricsstore.NewMetricsStore(
-		familyHeaders,
-		composedMetricGenFuncs,
-	)
-	if b.fieldSelectorFilter != "" {
-		klog.InfoS("FieldSelector is used", "fieldSelector", b.fieldSelectorFilter)
+	clusterScopedListWatch := func(kubeClient clientset.Interface, _ string, fieldSelector string) cache.ListerWatcher {
+		return listWatchFunc(kubeClient, v1.NamespaceAll, fieldSelector)
 	}
-	listWatcher := listWatchFunc(b.kubeClient, v1.NamespaceAll, b.fieldSelectorFilter)
-	b.startReflector(expectedType, store, listWatcher, useAPIServerCache, objectLimit, b.kubeClient)
-	return []cache.Store{store}
+
+	originalNamespaces := b.namespaces
+	b.namespaces = options.NamespaceList{v1.NamespaceAll}
+	defer func() { b.namespaces = originalNamespaces }()
+
+	return b.buildStoresFunc(metricFamilies, expectedType, clusterScopedListWatch, useAPIServerCache, objectLimit)
 }
 
 func (b *Builder) buildStores(

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -414,11 +414,11 @@ func (b *Builder) buildLimitRangeStores() []cache.Store {
 }
 
 func (b *Builder) buildMutatingWebhookConfigurationStores() []cache.Store {
-	return b.buildStoresFunc(mutatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.MutatingWebhookConfiguration{}, createMutatingWebhookConfigurationListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(mutatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.MutatingWebhookConfiguration{}, createMutatingWebhookConfigurationListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildNamespaceStores() []cache.Store {
-	return b.buildStoresFunc(namespaceMetricFamilies(b.allowAnnotationsList["namespaces"], b.allowLabelsList["namespaces"]), &v1.Namespace{}, createNamespaceListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(namespaceMetricFamilies(b.allowAnnotationsList["namespaces"], b.allowLabelsList["namespaces"]), &v1.Namespace{}, createNamespaceListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildNetworkPolicyStores() []cache.Store {
@@ -426,7 +426,7 @@ func (b *Builder) buildNetworkPolicyStores() []cache.Store {
 }
 
 func (b *Builder) buildNodeStores() []cache.Store {
-	return b.buildStoresFunc(nodeMetricFamilies(b.allowAnnotationsList["nodes"], b.allowLabelsList["nodes"]), &v1.Node{}, createNodeListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(nodeMetricFamilies(b.allowAnnotationsList["nodes"], b.allowLabelsList["nodes"]), &v1.Node{}, createNodeListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildPersistentVolumeClaimStores() []cache.Store {
@@ -434,7 +434,7 @@ func (b *Builder) buildPersistentVolumeClaimStores() []cache.Store {
 }
 
 func (b *Builder) buildPersistentVolumeStores() []cache.Store {
-	return b.buildStoresFunc(persistentVolumeMetricFamilies(b.allowAnnotationsList["persistentvolumes"], b.allowLabelsList["persistentvolumes"]), &v1.PersistentVolume{}, createPersistentVolumeListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(persistentVolumeMetricFamilies(b.allowAnnotationsList["persistentvolumes"], b.allowLabelsList["persistentvolumes"]), &v1.PersistentVolume{}, createPersistentVolumeListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildPodDisruptionBudgetStores() []cache.Store {
@@ -470,7 +470,7 @@ func (b *Builder) buildStatefulSetStores() []cache.Store {
 }
 
 func (b *Builder) buildStorageClassStores() []cache.Store {
-	return b.buildStoresFunc(storageClassMetricFamilies(b.allowAnnotationsList["storageclasses"], b.allowLabelsList["storageclasses"]), &storagev1.StorageClass{}, createStorageClassListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(storageClassMetricFamilies(b.allowAnnotationsList["storageclasses"], b.allowLabelsList["storageclasses"]), &storagev1.StorageClass{}, createStorageClassListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildPodStores() []cache.Store {
@@ -478,15 +478,15 @@ func (b *Builder) buildPodStores() []cache.Store {
 }
 
 func (b *Builder) buildCsrStores() []cache.Store {
-	return b.buildStoresFunc(csrMetricFamilies(b.allowAnnotationsList["certificatesigningrequests"], b.allowLabelsList["certificatesigningrequests"]), &certv1.CertificateSigningRequest{}, createCSRListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(csrMetricFamilies(b.allowAnnotationsList["certificatesigningrequests"], b.allowLabelsList["certificatesigningrequests"]), &certv1.CertificateSigningRequest{}, createCSRListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildValidatingWebhookConfigurationStores() []cache.Store {
-	return b.buildStoresFunc(validatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.ValidatingWebhookConfiguration{}, createValidatingWebhookConfigurationListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(validatingWebhookConfigurationMetricFamilies, &admissionregistrationv1.ValidatingWebhookConfiguration{}, createValidatingWebhookConfigurationListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildVolumeAttachmentStores() []cache.Store {
-	return b.buildStoresFunc(volumeAttachmentMetricFamilies, &storagev1.VolumeAttachment{}, createVolumeAttachmentListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(volumeAttachmentMetricFamilies, &storagev1.VolumeAttachment{}, createVolumeAttachmentListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildLeasesStores() []cache.Store {
@@ -494,7 +494,7 @@ func (b *Builder) buildLeasesStores() []cache.Store {
 }
 
 func (b *Builder) buildClusterRoleStores() []cache.Store {
-	return b.buildStoresFunc(clusterRoleMetricFamilies(b.allowAnnotationsList["clusterroles"], b.allowLabelsList["clusterroles"]), &rbacv1.ClusterRole{}, createClusterRoleListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(clusterRoleMetricFamilies(b.allowAnnotationsList["clusterroles"], b.allowLabelsList["clusterroles"]), &rbacv1.ClusterRole{}, createClusterRoleListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildRoleStores() []cache.Store {
@@ -502,7 +502,7 @@ func (b *Builder) buildRoleStores() []cache.Store {
 }
 
 func (b *Builder) buildClusterRoleBindingStores() []cache.Store {
-	return b.buildStoresFunc(clusterRoleBindingMetricFamilies(b.allowAnnotationsList["clusterrolebindings"], b.allowLabelsList["clusterrolebindings"]), &rbacv1.ClusterRoleBinding{}, createClusterRoleBindingListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(clusterRoleBindingMetricFamilies(b.allowAnnotationsList["clusterrolebindings"], b.allowLabelsList["clusterrolebindings"]), &rbacv1.ClusterRoleBinding{}, createClusterRoleBindingListWatch, b.useAPIServerCache, b.objectLimit)
 }
 
 func (b *Builder) buildRoleBindingStores() []cache.Store {
@@ -510,7 +510,31 @@ func (b *Builder) buildRoleBindingStores() []cache.Store {
 }
 
 func (b *Builder) buildIngressClassStores() []cache.Store {
-	return b.buildStoresFunc(ingressClassMetricFamilies(b.allowAnnotationsList["ingressclasses"], b.allowLabelsList["ingressclasses"]), &networkingv1.IngressClass{}, createIngressClassListWatch, b.useAPIServerCache, b.objectLimit)
+	return b.buildClusterScopedStores(ingressClassMetricFamilies(b.allowAnnotationsList["ingressclasses"], b.allowLabelsList["ingressclasses"]), &networkingv1.IngressClass{}, createIngressClassListWatch, b.useAPIServerCache, b.objectLimit)
+}
+
+// Cluster-scoped resources have no namespace, so watch all namespaces once.
+// Building one store per --namespaces entry would duplicate every series.
+func (b *Builder) buildClusterScopedStores(
+	metricFamilies []generator.FamilyGenerator,
+	expectedType interface{},
+	listWatchFunc func(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher,
+	useAPIServerCache bool, objectLimit int64,
+) []cache.Store {
+	metricFamilies = generator.FilterFamilyGenerators(b.familyGeneratorFilter, metricFamilies)
+	composedMetricGenFuncs := generator.ComposeMetricGenFuncs(metricFamilies)
+	familyHeaders := generator.ExtractMetricFamilyHeaders(metricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	if b.fieldSelectorFilter != "" {
+		klog.InfoS("FieldSelector is used", "fieldSelector", b.fieldSelectorFilter)
+	}
+	listWatcher := listWatchFunc(b.kubeClient, v1.NamespaceAll, b.fieldSelectorFilter)
+	b.startReflector(expectedType, store, listWatcher, useAPIServerCache, objectLimit, b.kubeClient)
+	return []cache.Store{store}
 }
 
 func (b *Builder) buildStores(

--- a/internal/store/builder_test.go
+++ b/internal/store/builder_test.go
@@ -23,6 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"k8s.io/kube-state-metrics/v2/pkg/allowdenylist"
 	"k8s.io/kube-state-metrics/v2/pkg/options"
 )
 
@@ -311,5 +315,32 @@ func TestCRReflectorStopChanRespondsToGVKStop(t *testing.T) {
 	case <-stopCh:
 	case <-time.After(2 * time.Second):
 		t.Fatal("stopCh did not close after gvkStopCh was closed")
+	}
+}
+
+func TestClusterScopedStoresNotDuplicatedPerNamespace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	l, err := allowdenylist.New(map[string]struct{}{}, map[string]struct{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := NewBuilder()
+	b.WithMetrics(prometheus.NewRegistry())
+	b.WithKubeClient(fake.NewSimpleClientset())
+	b.WithSharding(0, 1)
+	b.WithContext(ctx)
+	b.WithNamespaces(options.NamespaceList{"ns1", "ns2", "ns3"})
+	b.WithFamilyGeneratorFilter(l)
+	b.WithGenerateStoresFunc(b.DefaultGenerateStoresFunc())
+
+	if got := len(b.buildNodeStores()); got != 1 {
+		t.Errorf("cluster-scoped node stores across 3 namespaces: got %d, want 1", got)
+	}
+
+	if got := len(b.buildPodStores()); got != 3 {
+		t.Errorf("namespaced pod stores across 3 namespaces: got %d, want 3", got)
 	}
 }


### PR DESCRIPTION
## What this fixes

When kube-state-metrics runs with `--namespaces=a,b,c`, cluster-scoped resources (nodes, persistentvolumes, namespaces, clusterroles, and similar) are built through the per-namespace store path. That creates one store per namespace and emits each cluster-scoped series once per namespace, so a metric like `kube_node_created` shows up N times. Prometheus then drops them with `Error on ingesting samples with different value but same timestamp`, and users hit the `PrometheusDuplicateTimestamps` alert. This is the behaviour reported in #2878.

## The change

Adds `buildClusterScopedStores`, which always watches all namespaces and returns a single store regardless of `--namespaces`, and routes the 11 cluster-scoped resource builders through it. Namespaced resources are unchanged and still build one store per configured namespace.

## Testing

New regression test `TestClusterScopedStoresNotDuplicatedPerNamespace` asserts a cluster-scoped resource yields one store across three namespaces while a namespaced resource still yields three. I confirmed it fails on the old code (got 3, want 1) and passes with the fix. `go test ./internal/store/...`, `go vet`, and `go build ./...` all pass.

## Credit

Reviving and completing the approach from the stalled #2923 by @vigneshakaviki, credited via Co-authored-by, with the missing regression test added.

Fixes #2878