### PR TITLE
feat: Add stable metrics golden file presubmit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,23 @@ jobs:
       run: |
         make doccheck
 
+  ci-verify-stable-metrics:
+    name: ci-verify-stable-metrics
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: '.go-version'
+      id: go
+
+    - name: Verify stable metrics golden list
+      run: |
+        hack/verify-stable-metrics.sh
+
   ci-unit-tests:
     name: ci-unit-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
 
     - name: Verify stable metrics golden list
       run: |
-        hack/verify-stable-metrics.sh
+        make verify-stable-metrics
 
   ci-unit-tests:
     name: ci-unit-tests

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,16 @@ test-unit:
 test-rules:
 	${PROMTOOL_CLI} test rules tests/rules/alerts-test.yaml
 
+# Regenerates the golden list of STABLE metrics. Run this when you
+# intentionally add, remove, or rename a STABLE metric, then commit the
+# updated golden file.
+update-stable-metrics:
+	hack/update-stable-metrics.sh
+
+# Verifies that the golden list of STABLE metrics is up to date. Runs in CI.
+verify-stable-metrics:
+	hack/verify-stable-metrics.sh
+
 shellcheck:
 	${DOCKER_CLI} run -v "${PWD}:/mnt" koalaman/shellcheck:stable $(shell find . -type f -name "*.sh" -not -path "*vendor*")
 
@@ -190,4 +200,4 @@ install-promtool:
 	@wget -qO- "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.${OS}-${ARCH}.tar.gz" |\
 	tar xvz --strip-components=1 prometheus-${PROMETHEUS_VERSION}.${OS}-${ARCH}/promtool
 
-.PHONY: all build build-local all-push all-container container container-* do-push-* sub-push-* push push-multi-arch test-unit test-rules test-benchmark-compare clean e2e validate-modules shellcheck licensecheck lint lint-fix generate generate-template validate-template 
+.PHONY: all build build-local all-push all-container container container-* do-push-* sub-push-* push push-multi-arch test-unit test-rules test-benchmark-compare update-stable-metrics verify-stable-metrics clean e2e validate-modules shellcheck licensecheck lint lint-fix generate generate-template validate-template 

--- a/hack/update-stable-metrics.sh
+++ b/hack/update-stable-metrics.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2024 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# update-stable-metrics.sh regenerates the golden list of STABLE metrics.
+#
+# Run this script when you intentionally add, remove, or rename a STABLE
+# metric.  Commit the updated golden file together with your code change so
+# the presubmit CI check passes.
+#
+# Usage:  hack/update-stable-metrics.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Regenerating stable metrics golden file..."
+cd "${REPO_ROOT}"
+UPDATE_STABLE_METRICS=true go test ./internal/store/ -run TestStableMetrics -count=1
+
+echo ""
+echo "Updated: internal/store/testdata/stable-metrics-list.yaml"
+echo "Please review the diff and commit the updated file."

--- a/hack/verify-stable-metrics.sh
+++ b/hack/verify-stable-metrics.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright 2024 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# verify-stable-metrics.sh checks that the golden list of STABLE metrics has
+# not changed without a corresponding update to the golden file.
+#
+# Usage:  hack/verify-stable-metrics.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Verifying stable metrics list..."
+cd "${REPO_ROOT}"
+go test ./internal/store/ -run TestStableMetrics -count=1
+
+echo ""
+echo "PASS: stable metrics list is up to date."

--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -40,6 +40,14 @@ var (
 	descCSRLabelsDefaultLabels = []string{"certificatesigningrequest", "signer_name"}
 )
 
+func wrapCSRDefaultLabels(labels []string) []string {
+	return mergeKeys(descCSRLabelsDefaultLabels, labels)
+}
+
+func wrapCSRDefaultLabelValues(name, signerName string, values []string) []string {
+	return mergeValues([]string{name, signerName}, values)
+}
+
 func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
@@ -64,12 +72,13 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descCSRLabelsName,
 			descCSRLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCSRDefaultLabels(nil),
 			wrapCSRFunc(func(j *certv1.CertificateSigningRequest) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -86,12 +95,13 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_certificatesigningrequest_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCSRDefaultLabels(nil),
 			wrapCSRFunc(func(csr *certv1.CertificateSigningRequest) *metric.Family {
 				ms := []*metric.Metric{}
 				if !csr.CreationTimestamp.IsZero() {
@@ -107,24 +117,26 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_certificatesigningrequest_condition",
 			"The number of each certificatesigningrequest condition",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCSRDefaultLabels(nil),
 			wrapCSRFunc(func(csr *certv1.CertificateSigningRequest) *metric.Family {
 				return &metric.Family{
 					Metrics: addCSRConditionMetrics(csr.Status),
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_certificatesigningrequest_cert_length",
 			"Length of the issued cert",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCSRDefaultLabels(nil),
 			wrapCSRFunc(func(csr *certv1.CertificateSigningRequest) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -146,7 +158,8 @@ func wrapCSRFunc(f func(*certv1.CertificateSigningRequest) *metric.Family) func(
 		metricFamily := f(csr)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descCSRLabelsDefaultLabels, []string{csr.Name, csr.Spec.SignerName}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapCSRDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapCSRDefaultLabelValues(csr.Name, csr.Spec.SignerName, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -78,7 +78,7 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
-			wrapCSRDefaultLabels(nil),
+			wrapCSRDefaultLabels([]string{"label_CERTIFICATESIGNINGREQUEST_LABEL"}),
 			wrapCSRFunc(func(j *certv1.CertificateSigningRequest) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -123,7 +123,7 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
-			wrapCSRDefaultLabels(nil),
+			wrapCSRDefaultLabels([]string{"condition"}),
 			wrapCSRFunc(func(csr *certv1.CertificateSigningRequest) *metric.Family {
 				return &metric.Family{
 					Metrics: addCSRConditionMetrics(csr.Status),

--- a/internal/store/certificatesigningrequest.go
+++ b/internal/store/certificatesigningrequest.go
@@ -38,6 +38,8 @@ var (
 	descCSRLabelsName          = "kube_certificatesigningrequest_labels"
 	descCSRLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descCSRLabelsDefaultLabels = []string{"certificatesigningrequest", "signer_name"}
+
+	csrConditionLabelKeys = []string{"condition"}
 )
 
 func wrapCSRDefaultLabels(labels []string) []string {
@@ -123,7 +125,7 @@ func csrMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
-			wrapCSRDefaultLabels([]string{"condition"}),
+			wrapCSRDefaultLabels(csrConditionLabelKeys),
 			wrapCSRFunc(func(csr *certv1.CertificateSigningRequest) *metric.Family {
 				return &metric.Family{
 					Metrics: addCSRConditionMetrics(csr.Status),
@@ -198,17 +200,17 @@ func addCSRConditionMetrics(cs certv1.CertificateSigningRequestStatus) []*metric
 		{
 			LabelValues: []string{"approved"},
 			Value:       float64(cApproved),
-			LabelKeys:   []string{"condition"},
+			LabelKeys:   csrConditionLabelKeys,
 		},
 		{
 			LabelValues: []string{"denied"},
 			Value:       float64(cDenied),
-			LabelKeys:   []string{"condition"},
+			LabelKeys:   csrConditionLabelKeys,
 		},
 		{
 			LabelValues: []string{"failed"},
 			Value:       float64(cFailed),
-			LabelKeys:   []string{"condition"},
+			LabelKeys:   csrConditionLabelKeys,
 		},
 	}
 }

--- a/internal/store/certificatesigningrequest_test.go
+++ b/internal/store/certificatesigningrequest_test.go
@@ -266,8 +266,9 @@ func TestCsrStore(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		c.Func = generator.ComposeMetricGenFuncs(csrMetricFamilies(nil, nil))
-		c.Headers = generator.ExtractMetricFamilyHeaders(csrMetricFamilies(nil, nil))
+		c.Func = generator.ComposeMetricGenFuncs(csrMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.Headers = generator.ExtractMetricFamilyHeaders(csrMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = csrMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected error when collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/clusterrole_test.go
+++ b/internal/store/clusterrole_test.go
@@ -96,6 +96,7 @@ func TestClusterRoleStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(clusterRoleMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(clusterRoleMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = clusterRoleMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/clusterrolebinding_test.go
+++ b/internal/store/clusterrolebinding_test.go
@@ -106,6 +106,7 @@ func TestClusterRoleBindingStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(clusterRoleBindingMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(clusterRoleBindingMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = clusterRoleBindingMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/configmap.go
+++ b/internal/store/configmap.go
@@ -35,6 +35,14 @@ var (
 	descConfigMapLabelsDefaultLabels = []string{"namespace", "configmap"}
 )
 
+func wrapConfigMapDefaultLabels(labels []string) []string {
+	return mergeKeys(descConfigMapLabelsDefaultLabels, labels)
+}
+
+func wrapConfigMapDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
@@ -59,12 +67,13 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_configmap_labels",
 			"Kubernetes labels converted to Prometheus labels.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapConfigMapDefaultLabels([]string{"label_CONFIGMAP_LABEL"}),
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -81,12 +90,13 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_configmap_info",
 			"Information about configmap.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapConfigMapDefaultLabels(nil),
 			wrapConfigMapFunc(func(_ *v1.ConfigMap) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{{
@@ -97,12 +107,13 @@ func configMapMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_configmap_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapConfigMapDefaultLabels(nil),
 			wrapConfigMapFunc(func(c *v1.ConfigMap) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -154,7 +165,8 @@ func wrapConfigMapFunc(f func(*v1.ConfigMap) *metric.Family) func(interface{}) *
 		metricFamily := f(configMap)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descConfigMapLabelsDefaultLabels, []string{configMap.Namespace, configMap.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapConfigMapDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapConfigMapDefaultLabelValues(configMap.Namespace, configMap.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/configmap_test.go
+++ b/internal/store/configmap_test.go
@@ -98,6 +98,7 @@ func TestConfigMapStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(configMapMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(configMapMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = configMapMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -43,7 +43,17 @@ var (
 	descCronJobLabelsDefaultLabels = []string{"namespace", "cronjob"}
 )
 
+func wrapCronJobDefaultLabels(labels []string) []string {
+	return mergeKeys(descCronJobLabelsDefaultLabels, labels)
+}
+
+func wrapCronJobDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	infoLabelKeys := []string{"schedule", "concurrency_policy", "timezone"}
+
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
 			descCronJobAnnotationsName,
@@ -67,12 +77,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descCronJobLabelsName,
 			descCronJobLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels([]string{"label_CRONJOB_LABEL"}),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -89,12 +100,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_info",
 			"Info about cronjob.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(infoLabelKeys),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				timeZone := "local"
 				if j.Spec.TimeZone != nil {
@@ -103,7 +115,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   []string{"schedule", "concurrency_policy", "timezone"},
+							LabelKeys:   infoLabelKeys,
 							LabelValues: []string{j.Spec.Schedule, string(j.Spec.ConcurrencyPolicy), timeZone},
 							Value:       1,
 						},
@@ -111,12 +123,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 				if !j.CreationTimestamp.IsZero() {
@@ -132,12 +145,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_status_active",
 			"Active holds pointers to currently running jobs.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -150,12 +164,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_status_last_schedule_time",
 			"LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -172,12 +187,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_status_last_successful_time",
 			"LastSuccessfulTime keeps information of when was the last time the job was completed successfully.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -194,12 +210,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_spec_suspend",
 			"Suspend flag tells the controller to suspend subsequent executions.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -212,12 +229,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_spec_starting_deadline_seconds",
 			"Deadline in seconds for starting the job if it misses scheduled time for any reason.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -235,12 +253,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_next_schedule_time",
 			"Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -285,12 +304,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_metadata_resource_version",
 			"Resource version representing a specific version of the cronjob.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: resourceVersionMetric(j.ResourceVersion),
@@ -351,7 +371,8 @@ func wrapCronJobFunc(f func(*batchv1.CronJob) *metric.Family) func(interface{}) 
 		metricFamily := f(cronJob)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descCronJobLabelsDefaultLabels, []string{cronJob.Namespace, cronJob.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapCronJobDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapCronJobDefaultLabelValues(cronJob.Namespace, cronJob.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -48,7 +48,17 @@ var (
 	descCronJobLabelsDefaultLabels = []string{"namespace", "cronjob"}
 )
 
+func wrapCronJobDefaultLabels(labels []string) []string {
+	return mergeKeys(descCronJobLabelsDefaultLabels, labels)
+}
+
+func wrapCronJobDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	infoLabelKeys := []string{"schedule", "concurrency_policy", "timezone"}
+
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
 			descCronJobAnnotationsName,
@@ -72,12 +82,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descCronJobLabelsName,
 			descCronJobLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels([]string{"label_CRONJOB_LABEL"}),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -94,12 +105,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_info",
 			"Info about cronjob.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(infoLabelKeys),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				timeZone := "local"
 				if j.Spec.TimeZone != nil {
@@ -108,7 +120,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   []string{"schedule", "concurrency_policy", "timezone"},
+							LabelKeys:   infoLabelKeys,
 							LabelValues: []string{j.Spec.Schedule, string(j.Spec.ConcurrencyPolicy), timeZone},
 							Value:       1,
 						},
@@ -116,12 +128,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 				if !j.CreationTimestamp.IsZero() {
@@ -137,12 +150,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_status_active",
 			"Active holds pointers to currently running jobs.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -155,12 +169,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_status_last_schedule_time",
 			"LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -177,12 +192,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_status_last_successful_time",
 			"LastSuccessfulTime keeps information of when was the last time the job was completed successfully.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -199,12 +215,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_spec_suspend",
 			"Suspend flag tells the controller to suspend subsequent executions.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -217,12 +234,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_spec_starting_deadline_seconds",
 			"Deadline in seconds for starting the job if it misses scheduled time for any reason.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -240,12 +258,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_next_schedule_time",
 			"Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -290,12 +309,13 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_cronjob_metadata_resource_version",
 			"Resource version representing a specific version of the cronjob.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapCronJobDefaultLabels(nil),
 			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: resourceVersionMetric(j.ResourceVersion),
@@ -356,7 +376,8 @@ func wrapCronJobFunc(f func(*batchv1.CronJob) *metric.Family) func(interface{}) 
 		metricFamily := f(cronJob)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descCronJobLabelsDefaultLabels, []string{cronJob.Namespace, cronJob.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapCronJobDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapCronJobDefaultLabelValues(cronJob.Namespace, cronJob.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -528,6 +528,7 @@ func TestCronJobStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}
@@ -657,6 +658,7 @@ func TestCronJobStoreScheduleParsing(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -537,6 +537,7 @@ func TestCronJobStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}
@@ -695,6 +696,7 @@ func TestCronJobStoreScheduleParsing(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = cronJobMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/daemonset.go
+++ b/internal/store/daemonset.go
@@ -39,14 +39,23 @@ var (
 	descDaemonSetLabelsDefaultLabels = []string{"namespace", "daemonset"}
 )
 
+func wrapDaemonSetDefaultLabels(labels []string) []string {
+	return mergeKeys(descDaemonSetLabelsDefaultLabels, labels)
+}
+
+func wrapDaemonSetDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_daemonset_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels(nil),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -63,12 +72,13 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_daemonset_status_current_number_scheduled",
 			"The number of nodes running at least one daemon pod and are supposed to.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels(nil),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -81,12 +91,13 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_daemonset_status_desired_number_scheduled",
 			"The number of nodes that should be running the daemon pod.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels(nil),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -99,12 +110,13 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_daemonset_status_number_available",
 			"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels(nil),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -117,12 +129,13 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_daemonset_status_number_misscheduled",
 			"The number of nodes running a daemon pod but are not supposed to.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels(nil),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -135,12 +148,13 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_daemonset_status_number_ready",
 			"The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels(nil),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -153,12 +167,13 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_daemonset_status_number_unavailable",
 			"The number of nodes that should be running the daemon pod and have none of the daemon pod running and available",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels(nil),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -171,12 +186,13 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_daemonset_status_observed_generation",
 			"The most recent generation observed by the daemon set controller.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels(nil),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -189,12 +205,13 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_daemonset_status_updated_number_scheduled",
 			"The total number of nodes that are running updated daemon pod",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels(nil),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -205,12 +222,13 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_daemonset_metadata_generation",
 			"Sequence number representing a specific generation of the desired state.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels(nil),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -265,12 +283,13 @@ func daemonSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descDaemonSetLabelsName,
 			descDaemonSetLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDaemonSetDefaultLabels([]string{"label_DAEMONSET_LABEL"}),
 			wrapDaemonSetFunc(func(d *v1.DaemonSet) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -297,7 +316,8 @@ func wrapDaemonSetFunc(f func(*v1.DaemonSet) *metric.Family) func(interface{}) *
 		metricFamily := f(daemonSet)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descDaemonSetLabelsDefaultLabels, []string{daemonSet.Namespace, daemonSet.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapDaemonSetDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapDaemonSetDefaultLabelValues(daemonSet.Namespace, daemonSet.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/daemonset_test.go
+++ b/internal/store/daemonset_test.go
@@ -260,6 +260,7 @@ func TestDaemonSetStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(daemonSetMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(daemonSetMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = daemonSetMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -41,6 +41,14 @@ var (
 	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
 )
 
+func wrapDeploymentDefaultLabels(labels []string) []string {
+	return mergeKeys(descDeploymentLabelsDefaultLabels, labels)
+}
+
+func wrapDeploymentDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 // Reasons copied from kubernetes/pkg/controller/deployment/deployment_utils.go.
 var (
 	allowedDeploymentReasons = map[string]struct{}{
@@ -59,6 +67,8 @@ var (
 )
 
 func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	statusConditionLabelKeys := []string{"reason", "condition", "status"}
+
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
 			"kube_deployment_owner",
@@ -97,12 +107,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -117,12 +128,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_replicas",
 			"The number of replicas per deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -133,12 +145,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_replicas_ready",
 			"The number of ready replicas per deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -149,12 +162,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_replicas_available",
 			"The number of available replicas per deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -165,12 +179,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_replicas_unavailable",
 			"The number of unavailable replicas per deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -181,12 +196,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_replicas_updated",
 			"The number of updated replicas per deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -217,12 +233,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_observed_generation",
 			"The generation observed by the deployment controller.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -233,12 +250,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_condition",
 			"The current status conditions of a deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(statusConditionLabelKeys),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := make([]*metric.Metric, len(d.Status.Conditions)*len(conditionStatuses))
 
@@ -253,7 +271,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 							reason = "unknown"
 						}
 
-						metric.LabelKeys = []string{"reason", "condition", "status"}
+						metric.LabelKeys = statusConditionLabelKeys
 						metric.LabelValues = append([]string{reason, string(c.Type)}, metric.LabelValues...)
 						ms[i*len(conditionStatuses)+j] = metric
 					}
@@ -264,12 +282,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_spec_replicas",
 			"Number of desired pods for a deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -284,12 +303,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_spec_paused",
 			"Whether the deployment is paused and will not be processed by the deployment controller.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -300,12 +320,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
 			"Maximum number of unavailable replicas during a rolling update of a deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.Spec.Strategy.RollingUpdate == nil || d.Spec.Replicas == nil {
 					return &metric.Family{}
@@ -325,12 +346,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_spec_strategy_rollingupdate_max_surge",
 			"Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.Spec.Strategy.RollingUpdate == nil || d.Spec.Replicas == nil {
 					return &metric.Family{}
@@ -350,12 +372,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_metadata_generation",
 			"Sequence number representing a specific generation of the desired state.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -408,12 +431,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descDeploymentLabelsName,
 			descDeploymentLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels([]string{"label_DEPLOYMENT_LABEL"}),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -440,7 +464,8 @@ func wrapDeploymentFunc(f func(*v1.Deployment) *metric.Family) func(interface{})
 		metricFamily := f(deployment)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descDeploymentLabelsDefaultLabels, []string{deployment.Namespace, deployment.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapDeploymentDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapDeploymentDefaultLabelValues(deployment.Namespace, deployment.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -41,6 +41,14 @@ var (
 	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
 )
 
+func wrapDeploymentDefaultLabels(labels []string) []string {
+	return mergeKeys(descDeploymentLabelsDefaultLabels, labels)
+}
+
+func wrapDeploymentDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 // Reasons copied from kubernetes/pkg/controller/deployment/deployment_utils.go.
 var (
 	allowedDeploymentReasons = map[string]struct{}{
@@ -59,6 +67,8 @@ var (
 )
 
 func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	statusConditionLabelKeys := []string{"reason", "condition", "status"}
+
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
 			"kube_deployment_owner",
@@ -97,12 +107,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -117,12 +128,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_replicas",
 			"The number of replicas per deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -133,12 +145,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_replicas_ready",
 			"The number of ready replicas per deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -149,12 +162,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_replicas_available",
 			"The number of available replicas per deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -165,12 +179,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_replicas_unavailable",
 			"The number of unavailable replicas per deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -181,12 +196,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_replicas_updated",
 			"The number of updated replicas per deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -217,12 +233,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_observed_generation",
 			"The generation observed by the deployment controller.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -233,12 +250,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_status_condition",
 			"The current status conditions of a deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(statusConditionLabelKeys),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := make([]*metric.Metric, len(d.Status.Conditions)*len(conditionStatuses))
 
@@ -253,7 +271,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 							reason = "unknown"
 						}
 
-						metric.LabelKeys = []string{"reason", "condition", "status"}
+						metric.LabelKeys = statusConditionLabelKeys
 						metric.LabelValues = append([]string{reason, string(c.Type)}, metric.LabelValues...)
 						ms[i*len(conditionStatuses)+j] = metric
 					}
@@ -264,12 +282,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_spec_replicas",
 			"Number of desired pods for a deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -284,12 +303,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_spec_paused",
 			"Whether the deployment is paused and will not be processed by the deployment controller.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -300,12 +320,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
 			"Maximum number of unavailable replicas during a rolling update of a deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.Spec.Strategy.RollingUpdate == nil || d.Spec.Replicas == nil {
 					return &metric.Family{}
@@ -329,12 +350,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_spec_strategy_rollingupdate_max_surge",
 			"Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if d.Spec.Strategy.RollingUpdate == nil || d.Spec.Replicas == nil {
 					return &metric.Family{}
@@ -356,12 +378,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_deployment_metadata_generation",
 			"Sequence number representing a specific generation of the desired state.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels(nil),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -414,12 +437,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descDeploymentLabelsName,
 			descDeploymentLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapDeploymentDefaultLabels([]string{"label_DEPLOYMENT_LABEL"}),
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -446,7 +470,8 @@ func wrapDeploymentFunc(f func(*v1.Deployment) *metric.Family) func(interface{})
 		metricFamily := f(deployment)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descDeploymentLabelsDefaultLabels, []string{deployment.Namespace, deployment.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapDeploymentDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapDeploymentDefaultLabelValues(deployment.Namespace, deployment.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -349,6 +349,7 @@ func TestDeploymentStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(deploymentMetricFamilies(c.AllowAnnotationsList, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(deploymentMetricFamilies(c.AllowAnnotationsList, nil))
+		c.FamilyGens = deploymentMetricFamilies(c.AllowAnnotationsList, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -418,6 +418,7 @@ func TestDeploymentStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(deploymentMetricFamilies(c.AllowAnnotationsList, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(deploymentMetricFamilies(c.AllowAnnotationsList, nil))
+		c.FamilyGens = deploymentMetricFamilies(c.AllowAnnotationsList, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/endpoint.go
+++ b/internal/store/endpoint.go
@@ -40,14 +40,26 @@ var (
 	descEndpointLabelsDefaultLabels = []string{"namespace", "endpoint"}
 )
 
+func wrapEndpointDefaultLabels(labels []string) []string {
+	return mergeKeys(descEndpointLabelsDefaultLabels, labels)
+}
+
+func wrapEndpointDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	addressLabelKeys := []string{"port_protocol", "port_number", "port_name", "ip", "ready"}
+	portsLabelKeys := []string{"port_name", "port_protocol", "port_number"}
+
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_endpoint_info",
 			"Information about endpoint.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapEndpointDefaultLabels(nil),
 			wrapEndpointFunc(func(_ *v1.Endpoints) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -58,12 +70,13 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_endpoint_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapEndpointDefaultLabels(nil),
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -101,12 +114,13 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descEndpointLabelsName,
 			descEndpointLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapEndpointDefaultLabels([]string{"label_ENDPOINT_LABEL"}),
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -123,15 +137,15 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_endpoint_address",
 			"Information about Endpoint available and non available addresses.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapEndpointDefaultLabels(addressLabelKeys),
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				ms := []*metric.Metric{}
-				labelKeys := []string{"port_protocol", "port_number", "port_name", "ip", "ready"}
 
 				for _, s := range e.Subsets {
 					for _, port := range s.Ports {
@@ -140,7 +154,7 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 
 							ms = append(ms, &metric.Metric{
 								LabelValues: append(labelValues, available.IP, "true"),
-								LabelKeys:   labelKeys,
+								LabelKeys:   addressLabelKeys,
 								Value:       1,
 							})
 						}
@@ -149,7 +163,7 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 
 							ms = append(ms, &metric.Metric{
 								LabelValues: append(labelValues, notReadyAddresses.IP, "false"),
-								LabelKeys:   labelKeys,
+								LabelKeys:   addressLabelKeys,
 								Value:       1,
 							})
 						}
@@ -160,19 +174,20 @@ func endpointMetricFamilies(allowAnnotationsList, allowLabelsList []string) []ge
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_endpoint_ports",
 			"Information about the Endpoint ports.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"v2.14.0",
+			wrapEndpointDefaultLabels(portsLabelKeys),
 			wrapEndpointFunc(func(e *v1.Endpoints) *metric.Family {
 				ms := []*metric.Metric{}
 				for _, s := range e.Subsets {
 					for _, port := range s.Ports {
 						ms = append(ms, &metric.Metric{
 							LabelValues: []string{port.Name, string(port.Protocol), strconv.FormatInt(int64(port.Port), 10)},
-							LabelKeys:   []string{"port_name", "port_protocol", "port_number"},
+							LabelKeys:   portsLabelKeys,
 							Value:       1,
 						})
 					}
@@ -192,7 +207,8 @@ func wrapEndpointFunc(f func(*v1.Endpoints) *metric.Family) func(interface{}) *m
 		metricFamily := f(endpoint)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descEndpointLabelsDefaultLabels, []string{endpoint.Namespace, endpoint.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapEndpointDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapEndpointDefaultLabelValues(endpoint.Namespace, endpoint.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/endpoint_test.go
+++ b/internal/store/endpoint_test.go
@@ -144,6 +144,7 @@ func TestEndpointStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(endpointMetricFamilies(nil, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(endpointMetricFamilies(nil, nil))
+		c.FamilyGens = endpointMetricFamilies(nil, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}
@@ -284,6 +285,7 @@ func TestEndpointStoreWithLabels(t *testing.T) {
 		}
 		c.Func = generator.ComposeMetricGenFuncs(endpointMetricFamilies(allowAnnotations, allowLabels))
 		c.Headers = generator.ExtractMetricFamilyHeaders(endpointMetricFamilies(allowAnnotations, allowLabels))
+		c.FamilyGens = endpointMetricFamilies(allowAnnotations, allowLabels)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/endpointslice_test.go
+++ b/internal/store/endpointslice_test.go
@@ -199,6 +199,7 @@ func TestEndpointSliceStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(endpointSliceMetricFamilies(c.AllowAnnotationsList, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(endpointSliceMetricFamilies(c.AllowAnnotationsList, nil))
+		c.FamilyGens = endpointSliceMetricFamilies(c.AllowAnnotationsList, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/endpointslice_test.go
+++ b/internal/store/endpointslice_test.go
@@ -228,6 +228,7 @@ func TestEndpointSliceStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(endpointSliceMetricFamilies(c.AllowAnnotationsList, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(endpointSliceMetricFamilies(c.AllowAnnotationsList, nil))
+		c.FamilyGens = endpointSliceMetricFamilies(c.AllowAnnotationsList, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -267,7 +267,7 @@ func createHPAStatusTargetMetric() generator.FamilyGenerator {
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
-		wrapHPADefaultLabels(nil),
+		wrapHPADefaultLabels(targetMetricLabels),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
 			for _, m := range a.Status.CurrentMetrics {

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -53,6 +53,14 @@ var (
 	targetMetricLabels = []string{"metric_name", "metric_target_type", "container"}
 )
 
+func wrapHPADefaultLabels(labels []string) []string {
+	return mergeKeys(descHorizontalPodAutoscalerLabelsDefaultLabels, labels)
+}
+
+func wrapHPADefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		createHPAInfo(),
@@ -78,7 +86,8 @@ func wrapHPAFunc(f func(*autoscaling.HorizontalPodAutoscaler) *metric.Family) fu
 		metricFamily := f(hpa)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descHorizontalPodAutoscalerLabelsDefaultLabels, []string{hpa.Namespace, hpa.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapHPADefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapHPADefaultLabelValues(hpa.Namespace, hpa.Name, m.LabelValues)
 		}
 
 		return metricFamily
@@ -126,12 +135,13 @@ func createHPAInfo() generator.FamilyGenerator {
 }
 
 func createHPAMetaDataGeneration() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_metadata_generation",
 		"The generation observed by the HorizontalPodAutoscaler controller.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -145,12 +155,13 @@ func createHPAMetaDataGeneration() generator.FamilyGenerator {
 }
 
 func createHPASpecMaxReplicas() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_spec_max_replicas",
 		"Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -164,12 +175,13 @@ func createHPASpecMaxReplicas() generator.FamilyGenerator {
 }
 
 func createHPASpecMinReplicas() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_spec_min_replicas",
 		"Lower limit for the number of pods that can be set by the autoscaler, default 1.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			minReplicas := float64(1)
 			if a.Spec.MinReplicas != nil {
@@ -249,12 +261,13 @@ func createHPASpecTargetMetric() generator.FamilyGenerator {
 }
 
 func createHPAStatusTargetMetric() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_status_target_metric",
 		"The current metric status used by this autoscaler when calculating the desired replica count.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
 			for _, m := range a.Status.CurrentMetrics {
@@ -310,12 +323,13 @@ func createHPAStatusTargetMetric() generator.FamilyGenerator {
 }
 
 func createHPAStatusCurrentReplicas() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_status_current_replicas",
 		"Current number of replicas of pods managed by this autoscaler.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -329,12 +343,13 @@ func createHPAStatusCurrentReplicas() generator.FamilyGenerator {
 }
 
 func createHPAStatusDesiredReplicas() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_status_desired_replicas",
 		"Desired number of replicas of pods managed by this autoscaler.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -373,12 +388,13 @@ func createHPAAnnotations(allowAnnotationsList []string) generator.FamilyGenerat
 }
 
 func createHPALabels(allowLabelsList []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		descHorizontalPodAutoscalerLabelsName,
 		descHorizontalPodAutoscalerLabelsHelp,
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			if len(allowLabelsList) == 0 {
 				return &metric.Family{}
@@ -398,12 +414,15 @@ func createHPALabels(allowLabelsList []string) generator.FamilyGenerator {
 }
 
 func createHPAStatusCondition() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	statusConditionLabelKeys := []string{"condition", "status"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_status_condition",
 		"The condition of this autoscaler.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(statusConditionLabelKeys),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(a.Status.Conditions)*len(conditionStatuses))
 
@@ -412,7 +431,7 @@ func createHPAStatusCondition() generator.FamilyGenerator {
 
 				for _, m := range metrics {
 					metric := m
-					metric.LabelKeys = []string{"condition", "status"}
+					metric.LabelKeys = statusConditionLabelKeys
 					metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
 					ms = append(ms, metric)
 				}

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -394,7 +394,7 @@ func createHPALabels(allowLabelsList []string) generator.FamilyGenerator {
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
-		wrapHPADefaultLabels(nil),
+		wrapHPADefaultLabels([]string{"label_HPA_LABEL"}),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			if len(allowLabelsList) == 0 {
 				return &metric.Family{}

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -415,7 +415,7 @@ func createHPALabels(allowLabelsList []string) generator.FamilyGenerator {
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
-		wrapHPADefaultLabels(nil),
+		wrapHPADefaultLabels([]string{"label_HPA_LABEL"}),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			if len(allowLabelsList) == 0 {
 				return &metric.Family{}

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -53,6 +53,14 @@ var (
 	targetMetricLabels = []string{"metric_name", "metric_target_type", "container"}
 )
 
+func wrapHPADefaultLabels(labels []string) []string {
+	return mergeKeys(descHorizontalPodAutoscalerLabelsDefaultLabels, labels)
+}
+
+func wrapHPADefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func hpaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		createHPAInfo(),
@@ -80,7 +88,8 @@ func wrapHPAFunc(f func(*autoscaling.HorizontalPodAutoscaler) *metric.Family) fu
 		metricFamily := f(hpa)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descHorizontalPodAutoscalerLabelsDefaultLabels, []string{hpa.Namespace, hpa.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapHPADefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapHPADefaultLabelValues(hpa.Namespace, hpa.Name, m.LabelValues)
 		}
 
 		return metricFamily
@@ -128,12 +137,13 @@ func createHPAInfo() generator.FamilyGenerator {
 }
 
 func createHPAMetaDataGeneration() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_metadata_generation",
 		"The generation observed by the HorizontalPodAutoscaler controller.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -147,12 +157,13 @@ func createHPAMetaDataGeneration() generator.FamilyGenerator {
 }
 
 func createHPASpecMaxReplicas() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_spec_max_replicas",
 		"Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -166,12 +177,13 @@ func createHPASpecMaxReplicas() generator.FamilyGenerator {
 }
 
 func createHPASpecMinReplicas() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_spec_min_replicas",
 		"Lower limit for the number of pods that can be set by the autoscaler, default 1.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			minReplicas := float64(1)
 			if a.Spec.MinReplicas != nil {
@@ -251,12 +263,13 @@ func createHPASpecTargetMetric() generator.FamilyGenerator {
 }
 
 func createHPAStatusTargetMetric() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_status_target_metric",
 		"The current metric status used by this autoscaler when calculating the desired replica count.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
 			for _, m := range a.Status.CurrentMetrics {
@@ -331,12 +344,13 @@ func createHPAStatusTargetMetric() generator.FamilyGenerator {
 }
 
 func createHPAStatusCurrentReplicas() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_status_current_replicas",
 		"Current number of replicas of pods managed by this autoscaler.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -350,12 +364,13 @@ func createHPAStatusCurrentReplicas() generator.FamilyGenerator {
 }
 
 func createHPAStatusDesiredReplicas() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_status_desired_replicas",
 		"Desired number of replicas of pods managed by this autoscaler.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -394,12 +409,13 @@ func createHPAAnnotations(allowAnnotationsList []string) generator.FamilyGenerat
 }
 
 func createHPALabels(allowLabelsList []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		descHorizontalPodAutoscalerLabelsName,
 		descHorizontalPodAutoscalerLabelsHelp,
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(nil),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			if len(allowLabelsList) == 0 {
 				return &metric.Family{}
@@ -419,12 +435,15 @@ func createHPALabels(allowLabelsList []string) generator.FamilyGenerator {
 }
 
 func createHPAStatusCondition() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	statusConditionLabelKeys := []string{"condition", "status"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_horizontalpodautoscaler_status_condition",
 		"The condition of this autoscaler.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapHPADefaultLabels(statusConditionLabelKeys),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(a.Status.Conditions)*len(conditionStatuses))
 
@@ -433,7 +452,7 @@ func createHPAStatusCondition() generator.FamilyGenerator {
 
 				for _, m := range metrics {
 					metric := m
-					metric.LabelKeys = []string{"condition", "status"}
+					metric.LabelKeys = statusConditionLabelKeys
 					metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
 					ms = append(ms, metric)
 				}

--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -269,7 +269,7 @@ func createHPAStatusTargetMetric() generator.FamilyGenerator {
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
-		wrapHPADefaultLabels(nil),
+		wrapHPADefaultLabels(targetMetricLabels),
 		wrapHPAFunc(func(a *autoscaling.HorizontalPodAutoscaler) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(a.Status.CurrentMetrics))
 			for _, m := range a.Status.CurrentMetrics {

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -606,6 +606,7 @@ func TestHPAStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(hpaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(hpaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = hpaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -635,6 +635,7 @@ func TestHPAStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(hpaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(hpaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = hpaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -41,14 +41,29 @@ var (
 	descIngressLabelsDefaultLabels = []string{"namespace", "ingress"}
 )
 
+func wrapIngressDefaultLabels(labels []string) []string {
+	return mergeKeys(descIngressLabelsDefaultLabels, labels)
+}
+
+func wrapIngressDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	infoLabelKeys := []string{"ingressclass"}
+	pathLabelKeys := []string{"host", "path", "path_type", "service_name", "service_port", "resource_api_group", "resource_kind", "resource_name"}
+	servicePathLabelKeys := []string{"host", "path", "path_type", "service_name", "service_port"}
+	resourcePathLabelKeys := []string{"host", "path", "path_type", "resource_api_group", "resource_kind", "resource_name"}
+	tlsLabelKeys := []string{"tls_host", "secret"}
+
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_ingress_info",
 			"Information about ingress.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapIngressDefaultLabels(infoLabelKeys),
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				ingressClassName := "_default"
 				if i.Spec.IngressClassName != nil {
@@ -61,7 +76,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   []string{"ingressclass"},
+							LabelKeys:   infoLabelKeys,
 							LabelValues: []string{ingressClassName},
 							Value:       1,
 						},
@@ -90,12 +105,13 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descIngressLabelsName,
 			descIngressLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapIngressDefaultLabels([]string{"label_INGRESS_LABEL"}),
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -112,12 +128,13 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_ingress_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapIngressDefaultLabels(nil),
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -144,12 +161,13 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_ingress_path",
 			"Ingress host, paths and backend service information.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapIngressDefaultLabels(pathLabelKeys),
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				ms := []*metric.Metric{}
 				for _, rule := range i.Spec.Rules {
@@ -161,7 +179,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 							}
 							if path.Backend.Service != nil {
 								ms = append(ms, &metric.Metric{
-									LabelKeys:   []string{"host", "path", "path_type", "service_name", "service_port"},
+									LabelKeys:   servicePathLabelKeys,
 									LabelValues: []string{rule.Host, path.Path, pathType, path.Backend.Service.Name, strconv.Itoa(int(path.Backend.Service.Port.Number))},
 									Value:       1,
 								})
@@ -171,7 +189,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 									apiGroup = *path.Backend.Resource.APIGroup
 								}
 								ms = append(ms, &metric.Metric{
-									LabelKeys:   []string{"host", "path", "path_type", "resource_api_group", "resource_kind", "resource_name"},
+									LabelKeys:   resourcePathLabelKeys,
 									LabelValues: []string{rule.Host, path.Path, pathType, apiGroup, path.Backend.Resource.Kind, path.Backend.Resource.Name},
 									Value:       1,
 								})
@@ -184,18 +202,19 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_ingress_tls",
 			"Ingress TLS host and secret information.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapIngressDefaultLabels(tlsLabelKeys),
 			wrapIngressFunc(func(i *networkingv1.Ingress) *metric.Family {
 				ms := []*metric.Metric{}
 				for _, tls := range i.Spec.TLS {
 					for _, host := range tls.Hosts {
 						ms = append(ms, &metric.Metric{
-							LabelKeys:   []string{"tls_host", "secret"},
+							LabelKeys:   tlsLabelKeys,
 							LabelValues: []string{host, tls.SecretName},
 							Value:       1,
 						})
@@ -216,7 +235,8 @@ func wrapIngressFunc(f func(*networkingv1.Ingress) *metric.Family) func(interfac
 		metricFamily := f(ingress)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descIngressLabelsDefaultLabels, []string{ingress.Namespace, ingress.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapIngressDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapIngressDefaultLabelValues(ingress.Namespace, ingress.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/ingress_test.go
+++ b/internal/store/ingress_test.go
@@ -239,6 +239,7 @@ func TestIngressStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(ingressMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(ingressMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = ingressMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/ingressclass_test.go
+++ b/internal/store/ingressclass_test.go
@@ -97,6 +97,7 @@ func TestIngressClassStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(ingressClassMetricFamilies(c.AllowAnnotationsList, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(ingressClassMetricFamilies(c.AllowAnnotationsList, nil))
+		c.FamilyGens = ingressClassMetricFamilies(c.AllowAnnotationsList, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/job.go
+++ b/internal/store/job.go
@@ -43,7 +43,20 @@ var (
 	jobFailureReasons          = []string{"BackoffLimitExceeded", "DeadlineExceeded", "Evicted"}
 )
 
+func wrapJobDefaultLabels(labels []string) []string {
+	return mergeKeys(descJobLabelsDefaultLabels, labels)
+}
+
+func wrapJobDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	statusFailedLabelKeys := []string{"reason"}
+	completeLabelKeys := []string{"condition"}
+	failedLabelKeys := []string{"condition"}
+	ownerLabelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
+
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
 			descJobAnnotationsName,
@@ -67,12 +80,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descJobLabelsName,
 			descJobLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels([]string{"label_JOB_LABEL"}),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -89,12 +103,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_info",
 			"Information about job.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(nil),
 			wrapJobFunc(func(_ *v1batch.Job) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -105,12 +120,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(nil),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -125,12 +141,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_spec_parallelism",
 			"The maximum desired number of pods the job should run at any given time.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(nil),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -145,12 +162,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_spec_completions",
 			"The desired number of successfully finished pods the job should be run with.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(nil),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -165,12 +183,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_spec_active_deadline_seconds",
 			"The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(nil),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -185,12 +204,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_status_succeeded",
 			"The number of pods which reached Phase Succeeded.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(nil),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -201,12 +221,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_status_failed",
 			"The number of pods which reached Phase Failed and the reason for failure.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(statusFailedLabelKeys),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				var ms []*metric.Metric
 
@@ -229,7 +250,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 
 							// for known reasons
 							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"reason"},
+								LabelKeys:   statusFailedLabelKeys,
 								LabelValues: []string{reason},
 								Value:       boolFloat64(failureReason(&condition, reason)),
 							})
@@ -239,7 +260,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				// for unknown reasons
 				if !reasonKnown {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"reason"},
+						LabelKeys:   statusFailedLabelKeys,
 						LabelValues: []string{""},
 						Value:       float64(j.Status.Failed),
 					})
@@ -250,12 +271,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_status_active",
 			"The number of actively running pods.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(nil),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -286,12 +308,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_complete",
 			"The job has completed its execution.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(completeLabelKeys),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 				for _, c := range j.Status.Conditions {
@@ -299,7 +322,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 						metrics := addConditionMetrics(c.Status)
 						for _, m := range metrics {
 							metric := m
-							metric.LabelKeys = []string{"condition"}
+							metric.LabelKeys = completeLabelKeys
 							ms = append(ms, metric)
 						}
 					}
@@ -310,12 +333,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_failed",
 			"The job has failed its execution.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(failedLabelKeys),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -324,7 +348,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 						metrics := addConditionMetrics(c.Status)
 						for _, m := range metrics {
 							metric := m
-							metric.LabelKeys = []string{"condition"}
+							metric.LabelKeys = failedLabelKeys
 							ms = append(ms, metric)
 						}
 					}
@@ -335,12 +359,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_status_start_time",
 			"StartTime represents time when the job was acknowledged by the Job Manager.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(nil),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -356,12 +381,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_status_completion_time",
 			"CompletionTime represents time when the job was completed.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(nil),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
 				ms := []*metric.Metric{}
 				if j.Status.CompletionTime != nil {
@@ -397,14 +423,14 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_job_owner",
 			"Information about the Job's owner.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapJobDefaultLabels(ownerLabelKeys),
 			wrapJobFunc(func(j *v1batch.Job) *metric.Family {
-				labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
 
 				owners := j.GetOwnerReferences()
 
@@ -412,7 +438,7 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 					return &metric.Family{
 						Metrics: []*metric.Metric{
 							{
-								LabelKeys:   labelKeys,
+								LabelKeys:   ownerLabelKeys,
 								LabelValues: []string{"", "", ""},
 								Value:       1,
 							},
@@ -425,13 +451,13 @@ func jobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 				for i, owner := range owners {
 					if owner.Controller != nil {
 						ms[i] = &metric.Metric{
-							LabelKeys:   labelKeys,
+							LabelKeys:   ownerLabelKeys,
 							LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
 							Value:       1,
 						}
 					} else {
 						ms[i] = &metric.Metric{
-							LabelKeys:   labelKeys,
+							LabelKeys:   ownerLabelKeys,
 							LabelValues: []string{owner.Kind, owner.Name, "false"},
 							Value:       1,
 						}
@@ -453,7 +479,8 @@ func wrapJobFunc(f func(*v1batch.Job) *metric.Family) func(interface{}) *metric.
 		metricFamily := f(job)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descJobLabelsDefaultLabels, []string{job.Namespace, job.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapJobDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapJobDefaultLabelValues(job.Namespace, job.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/job_test.go
+++ b/internal/store/job_test.go
@@ -382,6 +382,7 @@ func TestJobStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(jobMetricFamilies(nil, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(jobMetricFamilies(nil, nil))
+		c.FamilyGens = jobMetricFamilies(nil, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/lease_test.go
+++ b/internal/store/lease_test.go
@@ -96,6 +96,7 @@ func TestLeaseStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(leaseMetricFamilies)
 		c.Headers = generator.ExtractMetricFamilyHeaders(leaseMetricFamilies)
+		c.FamilyGens = leaseMetricFamilies
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %dth run:\n%v", i, err)
 		}

--- a/internal/store/limitrange.go
+++ b/internal/store/limitrange.go
@@ -33,14 +33,16 @@ import (
 
 var (
 	descLimitRangeLabelsDefaultLabels = []string{"namespace", "limitrange"}
+	descLimitRangeLabels              = []string{"resource", "type", "constraint"}
 
 	limitRangeMetricFamilies = []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_limitrange",
 			"Information about limit range.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapLimitRangeDefaultLabels(descLimitRangeLabels),
 			wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -83,7 +85,7 @@ var (
 				}
 
 				for _, m := range ms {
-					m.LabelKeys = []string{"resource", "type", "constraint"}
+					m.LabelKeys = descLimitRangeLabels
 				}
 
 				return &metric.Family{
@@ -91,12 +93,13 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_limitrange_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapLimitRangeDefaultLabels(nil),
 			wrapLimitRangeFunc(func(r *v1.LimitRange) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -122,11 +125,20 @@ func wrapLimitRangeFunc(f func(*v1.LimitRange) *metric.Family) func(interface{})
 		metricFamily := f(limitRange)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descLimitRangeLabelsDefaultLabels, []string{limitRange.Namespace, limitRange.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapLimitRangeDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapLimitRangeDefaultLabelValues(limitRange.Namespace, limitRange.Name, m.LabelValues)
 		}
 
 		return metricFamily
 	}
+}
+
+func wrapLimitRangeDefaultLabels(labels []string) []string {
+	return mergeKeys(descLimitRangeLabelsDefaultLabels, labels)
+}
+
+func wrapLimitRangeDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
 }
 
 func createLimitRangeListWatch(kubeClient clientset.Interface, ns string, fieldSelector string) cache.ListerWatcher {

--- a/internal/store/limitrange_test.go
+++ b/internal/store/limitrange_test.go
@@ -83,6 +83,7 @@ func TestLimitRangeStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(limitRangeMetricFamilies)
 		c.Headers = generator.ExtractMetricFamilyHeaders(limitRangeMetricFamilies)
+		c.FamilyGens = limitRangeMetricFamilies
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/mutatingwebhookconfiguration_test.go
+++ b/internal/store/mutatingwebhookconfiguration_test.go
@@ -105,6 +105,7 @@ func TestMutatingWebhookConfigurationStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(mutatingWebhookConfigurationMetricFamilies)
 		c.Headers = generator.ExtractMetricFamilyHeaders(mutatingWebhookConfigurationMetricFamilies)
+		c.FamilyGens = mutatingWebhookConfigurationMetricFamilies
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/namespace.go
+++ b/internal/store/namespace.go
@@ -40,14 +40,25 @@ var (
 	descNamespaceLabelsDefaultLabels = []string{"namespace"}
 )
 
+func wrapNamespaceDefaultLabels(labels []string) []string {
+	return mergeKeys(descNamespaceLabelsDefaultLabels, labels)
+}
+
+func wrapNamespaceDefaultLabelValues(name string, values []string) []string {
+	return mergeValues([]string{name}, values)
+}
+
 func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	statusPhaseLabelKeys := []string{"phase"}
+
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_namespace_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapNamespaceDefaultLabels(nil),
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := []*metric.Metric{}
 				if !n.CreationTimestamp.IsZero() {
@@ -84,12 +95,13 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descNamespaceLabelsName,
 			descNamespaceLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapNamespaceDefaultLabels([]string{"label_NS_LABEL"}),
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -106,12 +118,13 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_namespace_status_phase",
 			"kubernetes namespace status phase.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapNamespaceDefaultLabels(statusPhaseLabelKeys),
 			wrapNamespaceFunc(func(n *v1.Namespace) *metric.Family {
 				ms := []*metric.Metric{
 					{
@@ -125,7 +138,7 @@ func namespaceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []g
 				}
 
 				for _, metric := range ms {
-					metric.LabelKeys = []string{"phase"}
+					metric.LabelKeys = statusPhaseLabelKeys
 				}
 
 				return &metric.Family{
@@ -169,7 +182,8 @@ func wrapNamespaceFunc(f func(*v1.Namespace) *metric.Family) func(interface{}) *
 		metricFamily := f(namespace)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descNamespaceLabelsDefaultLabels, []string{namespace.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapNamespaceDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapNamespaceDefaultLabelValues(namespace.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/namespace_test.go
+++ b/internal/store/namespace_test.go
@@ -157,6 +157,7 @@ func TestNamespaceStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(namespaceMetricFamilies(nil, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(namespaceMetricFamilies(nil, nil))
+		c.FamilyGens = namespaceMetricFamilies(nil, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/networkpolicy_test.go
+++ b/internal/store/networkpolicy_test.go
@@ -64,6 +64,7 @@ func TestNetworkPolicyStore(t *testing.T) {
 	}
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(networkPolicyMetricFamilies(nil, nil))
+		c.FamilyGens = networkPolicyMetricFamilies(nil, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %dth run:\n%s", i, err)
 		}

--- a/internal/store/node.go
+++ b/internal/store/node.go
@@ -42,6 +42,19 @@ var (
 	descNodeLabelsDefaultLabels = []string{"node"}
 )
 
+const (
+	descNodeAnnotationAllowlistLabel = "annotation_NODE_ANNOTATION"
+	descNodeLabelAllowlistLabel      = "label_NODE_LABEL"
+)
+
+func wrapNodeDefaultLabels(labels []string) []string {
+	return mergeKeys(descNodeLabelsDefaultLabels, labels)
+}
+
+func wrapNodeDefaultLabelValues(nodeName string, values []string) []string {
+	return mergeValues([]string{nodeName}, values)
+}
+
 func nodeMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		createNodeAnnotationsGenerator(allowAnnotationsList),
@@ -61,12 +74,13 @@ func nodeMetricFamilies(allowAnnotationsList, allowLabelsList []string) []genera
 }
 
 func createNodeDeletionTimestampFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_deletion_timestamp",
 		"Unix deletion timestamp",
 		metric.Gauge,
 		basemetrics.ALPHA,
 		"",
+		wrapNodeDefaultLabels(nil),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			var ms []*metric.Metric
 
@@ -84,12 +98,13 @@ func createNodeDeletionTimestampFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createNodeCreatedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_created",
 		"Unix creation timestamp",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapNodeDefaultLabels(nil),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -108,17 +123,20 @@ func createNodeCreatedFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createNodeStateAddressFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	labels := []string{"type", "address"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_status_addresses",
 		"Node address information.",
 		metric.Gauge,
 		basemetrics.ALPHA,
 		"",
+		wrapNodeDefaultLabels(labels),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := []*metric.Metric{}
 			for _, address := range n.Status.Addresses {
 				ms = append(ms, &metric.Metric{
-					LabelKeys:   []string{"type", "address"},
+					LabelKeys:   labels,
 					LabelValues: []string{string(address.Type), address.Address},
 					Value:       1,
 				})
@@ -131,23 +149,26 @@ func createNodeStateAddressFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createNodeInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	labels := []string{
+		"kernel_version",
+		"os_image",
+		"container_runtime_version",
+		"kubelet_version",
+		"kubeproxy_version",
+		"provider_id",
+		"pod_cidr",
+		"system_uuid",
+		"internal_ip",
+	}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_info",
 		"Information about a cluster node.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapNodeDefaultLabels(labels),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
-			labelKeys := []string{
-				"kernel_version",
-				"os_image",
-				"container_runtime_version",
-				"kubelet_version",
-				"kubeproxy_version",
-				"provider_id",
-				"pod_cidr",
-				"system_uuid",
-			}
 			labelValues := []string{
 				n.Status.NodeInfo.KernelVersion,
 				n.Status.NodeInfo.OSImage,
@@ -166,13 +187,12 @@ func createNodeInfoFamilyGenerator() generator.FamilyGenerator {
 					internalIP = address.Address
 				}
 			}
-			labelKeys = append(labelKeys, "internal_ip")
 			labelValues = append(labelValues, internalIP)
 
 			return &metric.Family{
 				Metrics: []*metric.Metric{
 					{
-						LabelKeys:   labelKeys,
+						LabelKeys:   labels,
 						LabelValues: labelValues,
 						Value:       1,
 					},
@@ -183,12 +203,13 @@ func createNodeInfoFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createNodeAnnotationsGenerator(allowAnnotationsList []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		descNodeAnnotationsName,
 		descNodeAnnotationsHelp,
 		metric.Gauge,
 		basemetrics.ALPHA,
 		"",
+		wrapNodeDefaultLabels([]string{descNodeAnnotationAllowlistLabel}),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			if len(allowAnnotationsList) == 0 {
 				return &metric.Family{}
@@ -208,12 +229,13 @@ func createNodeAnnotationsGenerator(allowAnnotationsList []string) generator.Fam
 }
 
 func createNodeLabelsGenerator(allowLabelsList []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		descNodeLabelsName,
 		descNodeLabelsHelp,
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapNodeDefaultLabels([]string{descNodeLabelAllowlistLabel}),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			if len(allowLabelsList) == 0 {
 				return &metric.Family{}
@@ -233,19 +255,22 @@ func createNodeLabelsGenerator(allowLabelsList []string) generator.FamilyGenerat
 }
 
 func createNodeRoleFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	labels := []string{"role"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_role",
 		"The role of a cluster node.",
 		metric.Gauge,
 		basemetrics.ALPHA,
 		"",
+		wrapNodeDefaultLabels(labels),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			const prefix = "node-role.kubernetes.io/"
 			ms := []*metric.Metric{}
 			for lbl := range n.Labels {
 				if strings.HasPrefix(lbl, prefix) {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"role"},
+						LabelKeys:   labels,
 						LabelValues: []string{strings.TrimPrefix(lbl, prefix)},
 						Value:       float64(1),
 					})
@@ -259,12 +284,15 @@ func createNodeRoleFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createNodeSpecPodCIDRFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	labels := []string{"pod_cidr"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_spec_pod_cidrs",
 		"The pod CIDRs of a cluster node.",
 		metric.Gauge,
 		basemetrics.ALPHA,
 		"",
+		wrapNodeDefaultLabels(labels),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := make([]*metric.Metric, len(n.Spec.PodCIDRs))
 
@@ -273,7 +301,7 @@ func createNodeSpecPodCIDRFamilyGenerator() generator.FamilyGenerator {
 			// that isn't surfaced anywhere else.
 			for i, podCIDR := range n.Spec.PodCIDRs {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"pod_cidr"},
+					LabelKeys:   labels,
 					LabelValues: []string{podCIDR},
 					Value:       1,
 				}
@@ -287,12 +315,15 @@ func createNodeSpecPodCIDRFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createNodeSpecTaintFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	labels := []string{"key", "value", "effect"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_spec_taint",
 		"The taint of a cluster node.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapNodeDefaultLabels(labels),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := make([]*metric.Metric, len(n.Spec.Taints))
 
@@ -301,7 +332,7 @@ func createNodeSpecTaintFamilyGenerator() generator.FamilyGenerator {
 				// toleration.  Many node conditions are optionally reflected as taints
 				// by the node controller in order to simplify scheduling constraints.
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"key", "value", "effect"},
+					LabelKeys:   labels,
 					LabelValues: []string{taint.Key, taint.Value, string(taint.Effect)},
 					Value:       1,
 				}
@@ -315,12 +346,13 @@ func createNodeSpecTaintFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createNodeSpecUnschedulableFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_spec_unschedulable",
 		"Whether a node can schedule new pods.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapNodeDefaultLabels(nil),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
@@ -334,12 +366,15 @@ func createNodeSpecUnschedulableFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createNodeStatusAllocatableFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	labels := []string{"resource", "unit"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_status_allocatable",
 		"The allocatable for different resources of a node that are available for scheduling.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapNodeDefaultLabels(labels),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -407,7 +442,7 @@ func createNodeStatusAllocatableFamilyGenerator() generator.FamilyGenerator {
 			}
 
 			for _, m := range ms {
-				m.LabelKeys = []string{"resource", "unit"}
+				m.LabelKeys = labels
 			}
 
 			return &metric.Family{
@@ -418,12 +453,15 @@ func createNodeStatusAllocatableFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createNodeStatusCapacityFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	labels := []string{"resource", "unit"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_status_capacity",
 		"The capacity for different resources of a node.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapNodeDefaultLabels(labels),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -490,7 +528,7 @@ func createNodeStatusCapacityFamilyGenerator() generator.FamilyGenerator {
 			}
 
 			for _, metric := range ms {
-				metric.LabelKeys = []string{"resource", "unit"}
+				metric.LabelKeys = labels
 			}
 
 			return &metric.Family{
@@ -505,12 +543,15 @@ func createNodeStatusCapacityFamilyGenerator() generator.FamilyGenerator {
 // customized condition for cluster node (e.g. node-problem-detector), and
 // Kubernetes may add new core conditions in future.
 func createNodeStatusConditionFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	labels := []string{"condition", "status"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_node_status_condition",
 		"The condition of a cluster node.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapNodeDefaultLabels(labels),
 		wrapNodeFunc(func(n *v1.Node) *metric.Family {
 			ms := make([]*metric.Metric, len(n.Status.Conditions)*len(conditionStatuses))
 
@@ -521,7 +562,7 @@ func createNodeStatusConditionFamilyGenerator() generator.FamilyGenerator {
 				for j, m := range conditionMetrics {
 					metric := m
 
-					metric.LabelKeys = []string{"condition", "status"}
+					metric.LabelKeys = labels
 					metric.LabelValues = append([]string{string(c.Type)}, metric.LabelValues...)
 
 					ms[i*len(conditionStatuses)+j] = metric
@@ -542,7 +583,8 @@ func wrapNodeFunc(f func(*v1.Node) *metric.Family) func(interface{}) *metric.Fam
 		metricFamily := f(node)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descNodeLabelsDefaultLabels, []string{node.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapNodeDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapNodeDefaultLabelValues(node.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/node_test.go
+++ b/internal/store/node_test.go
@@ -408,6 +408,7 @@ func TestNodeStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(nodeMetricFamilies(nil, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(nodeMetricFamilies(nil, nil))
+		c.FamilyGens = nodeMetricFamilies(nil, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -47,6 +47,14 @@ var (
 	descPersistentVolumeCSIAttributesHelp = "CSI attributes of the Persistent Volume."
 )
 
+func wrapPersistentVolumeDefaultLabels(labels []string) []string {
+	return mergeKeys(descPersistentVolumeLabelsDefaultLabels, labels)
+}
+
+func wrapPersistentVolumeDefaultLabelValues(name string, values []string) []string {
+	return mergeValues([]string{name}, values)
+}
+
 func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		createPersistentVolumeClaimRef(),
@@ -69,7 +77,8 @@ func wrapPersistentVolumeFunc(f func(*v1.PersistentVolume) *metric.Family) func(
 		metricFamily := f(persistentVolume)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descPersistentVolumeLabelsDefaultLabels, []string{persistentVolume.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapPersistentVolumeDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapPersistentVolumeDefaultLabelValues(persistentVolume.Name, m.LabelValues)
 		}
 
 		return metricFamily
@@ -88,12 +97,15 @@ func createPersistentVolumeListWatch(kubeClient clientset.Interface, _ string, _
 }
 
 func createPersistentVolumeClaimRef() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	claimRefLabelKeys := []string{"name", "claim_namespace"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		descPersistentVolumeClaimRefName,
 		descPersistentVolumeClaimRefHelp,
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPersistentVolumeDefaultLabels(claimRefLabelKeys),
 		wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 			claimRef := p.Spec.ClaimRef
 
@@ -105,10 +117,7 @@ func createPersistentVolumeClaimRef() generator.FamilyGenerator {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
 					{
-						LabelKeys: []string{
-							"name",
-							"claim_namespace",
-						},
+						LabelKeys: claimRefLabelKeys,
 						LabelValues: []string{
 							p.Spec.ClaimRef.Name,
 							p.Spec.ClaimRef.Namespace,
@@ -147,12 +156,13 @@ func createPersistentVolumeAnnotations(allowAnnotationsList []string) generator.
 }
 
 func createPersistentVolumeLabels(allowLabelsList []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		descPersistentVolumeLabelsName,
 		descPersistentVolumeLabelsHelp,
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPersistentVolumeDefaultLabels([]string{"label_PERSISTENTVOLUME_LABEL"}),
 		wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 			if len(allowLabelsList) == 0 {
 				return &metric.Family{}
@@ -172,12 +182,15 @@ func createPersistentVolumeLabels(allowLabelsList []string) generator.FamilyGene
 }
 
 func createPersistentVolumeStatusPhase() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	statusPhaseLabelKeys := []string{"phase"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_persistentvolume_status_phase",
 		"The phase indicates if a volume is available, bound to a claim, or released by a claim.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPersistentVolumeDefaultLabels(statusPhaseLabelKeys),
 		wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 			phase := p.Status.Phase
 
@@ -212,7 +225,7 @@ func createPersistentVolumeStatusPhase() generator.FamilyGenerator {
 			}
 
 			for _, m := range ms {
-				m.LabelKeys = []string{"phase"}
+				m.LabelKeys = statusPhaseLabelKeys
 			}
 
 			return &metric.Family{
@@ -223,12 +236,15 @@ func createPersistentVolumeStatusPhase() generator.FamilyGenerator {
 }
 
 func createPersistentVolumeInfo() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	infoLabelKeys := []string{"storageclass", "gce_persistent_disk_name", "ebs_volume_id", "azure_disk_name", "fc_wwids", "fc_lun", "fc_target_wwns", "iscsi_target_portal", "iscsi_iqn", "iscsi_lun", "iscsi_initiator_name", "nfs_server", "nfs_path", "csi_driver", "csi_volume_handle", "local_path", "local_fs", "host_path", "host_path_type", "reclaim_policy"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_persistentvolume_info",
 		"Information about persistentvolume.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPersistentVolumeDefaultLabels(infoLabelKeys),
 		wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 			var (
 				gcePDDiskName,
@@ -293,28 +309,7 @@ func createPersistentVolumeInfo() generator.FamilyGenerator {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
 					{
-						LabelKeys: []string{
-							"storageclass",
-							"gce_persistent_disk_name",
-							"ebs_volume_id",
-							"azure_disk_name",
-							"fc_wwids",
-							"fc_lun",
-							"fc_target_wwns",
-							"iscsi_target_portal",
-							"iscsi_iqn",
-							"iscsi_lun",
-							"iscsi_initiator_name",
-							"nfs_server",
-							"nfs_path",
-							"csi_driver",
-							"csi_volume_handle",
-							"local_path",
-							"local_fs",
-							"host_path",
-							"host_path_type",
-							"reclaim_policy",
-						},
+						LabelKeys: infoLabelKeys,
 						LabelValues: []string{
 							p.Spec.StorageClassName,
 							gcePDDiskName,
@@ -346,12 +341,13 @@ func createPersistentVolumeInfo() generator.FamilyGenerator {
 }
 
 func createPersistentVolumeCapacityBytes() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_persistentvolume_capacity_bytes",
 		"Persistentvolume capacity in bytes.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPersistentVolumeDefaultLabels(nil),
 		wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 			storage := p.Spec.Capacity[v1.ResourceStorage]
 			return &metric.Family{

--- a/internal/store/persistentvolume.go
+++ b/internal/store/persistentvolume.go
@@ -47,6 +47,14 @@ var (
 	descPersistentVolumeCSIAttributesHelp = "CSI attributes of the Persistent Volume."
 )
 
+func wrapPersistentVolumeDefaultLabels(labels []string) []string {
+	return mergeKeys(descPersistentVolumeLabelsDefaultLabels, labels)
+}
+
+func wrapPersistentVolumeDefaultLabelValues(name string, values []string) []string {
+	return mergeValues([]string{name}, values)
+}
+
 func persistentVolumeMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		createPersistentVolumeClaimRef(),
@@ -70,7 +78,8 @@ func wrapPersistentVolumeFunc(f func(*v1.PersistentVolume) *metric.Family) func(
 		metricFamily := f(persistentVolume)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descPersistentVolumeLabelsDefaultLabels, []string{persistentVolume.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapPersistentVolumeDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapPersistentVolumeDefaultLabelValues(persistentVolume.Name, m.LabelValues)
 		}
 
 		return metricFamily
@@ -89,12 +98,15 @@ func createPersistentVolumeListWatch(kubeClient clientset.Interface, _ string, _
 }
 
 func createPersistentVolumeClaimRef() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	claimRefLabelKeys := []string{"name", "claim_namespace"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		descPersistentVolumeClaimRefName,
 		descPersistentVolumeClaimRefHelp,
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPersistentVolumeDefaultLabels(claimRefLabelKeys),
 		wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 			claimRef := p.Spec.ClaimRef
 
@@ -106,10 +118,7 @@ func createPersistentVolumeClaimRef() generator.FamilyGenerator {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
 					{
-						LabelKeys: []string{
-							"name",
-							"claim_namespace",
-						},
+						LabelKeys: claimRefLabelKeys,
 						LabelValues: []string{
 							p.Spec.ClaimRef.Name,
 							p.Spec.ClaimRef.Namespace,
@@ -148,12 +157,13 @@ func createPersistentVolumeAnnotations(allowAnnotationsList []string) generator.
 }
 
 func createPersistentVolumeLabels(allowLabelsList []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		descPersistentVolumeLabelsName,
 		descPersistentVolumeLabelsHelp,
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPersistentVolumeDefaultLabels([]string{"label_PERSISTENTVOLUME_LABEL"}),
 		wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 			if len(allowLabelsList) == 0 {
 				return &metric.Family{}
@@ -173,12 +183,15 @@ func createPersistentVolumeLabels(allowLabelsList []string) generator.FamilyGene
 }
 
 func createPersistentVolumeStatusPhase() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	statusPhaseLabelKeys := []string{"phase"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_persistentvolume_status_phase",
 		"The phase indicates if a volume is available, bound to a claim, or released by a claim.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPersistentVolumeDefaultLabels(statusPhaseLabelKeys),
 		wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 			phase := p.Status.Phase
 
@@ -213,7 +226,7 @@ func createPersistentVolumeStatusPhase() generator.FamilyGenerator {
 			}
 
 			for _, m := range ms {
-				m.LabelKeys = []string{"phase"}
+				m.LabelKeys = statusPhaseLabelKeys
 			}
 
 			return &metric.Family{
@@ -224,12 +237,15 @@ func createPersistentVolumeStatusPhase() generator.FamilyGenerator {
 }
 
 func createPersistentVolumeInfo() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	infoLabelKeys := []string{"storageclass", "gce_persistent_disk_name", "ebs_volume_id", "azure_disk_name", "fc_wwids", "fc_lun", "fc_target_wwns", "iscsi_target_portal", "iscsi_iqn", "iscsi_lun", "iscsi_initiator_name", "nfs_server", "nfs_path", "csi_driver", "csi_volume_handle", "local_path", "local_fs", "host_path", "host_path_type", "reclaim_policy"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_persistentvolume_info",
 		"Information about persistentvolume.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPersistentVolumeDefaultLabels(infoLabelKeys),
 		wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 			var (
 				gcePDDiskName,
@@ -294,28 +310,7 @@ func createPersistentVolumeInfo() generator.FamilyGenerator {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
 					{
-						LabelKeys: []string{
-							"storageclass",
-							"gce_persistent_disk_name",
-							"ebs_volume_id",
-							"azure_disk_name",
-							"fc_wwids",
-							"fc_lun",
-							"fc_target_wwns",
-							"iscsi_target_portal",
-							"iscsi_iqn",
-							"iscsi_lun",
-							"iscsi_initiator_name",
-							"nfs_server",
-							"nfs_path",
-							"csi_driver",
-							"csi_volume_handle",
-							"local_path",
-							"local_fs",
-							"host_path",
-							"host_path_type",
-							"reclaim_policy",
-						},
+						LabelKeys: infoLabelKeys,
 						LabelValues: []string{
 							p.Spec.StorageClassName,
 							gcePDDiskName,
@@ -347,12 +342,13 @@ func createPersistentVolumeInfo() generator.FamilyGenerator {
 }
 
 func createPersistentVolumeCapacityBytes() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_persistentvolume_capacity_bytes",
 		"Persistentvolume capacity in bytes.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPersistentVolumeDefaultLabels(nil),
 		wrapPersistentVolumeFunc(func(p *v1.PersistentVolume) *metric.Family {
 			storage := p.Spec.Capacity[v1.ResourceStorage]
 			return &metric.Family{

--- a/internal/store/persistentvolume_test.go
+++ b/internal/store/persistentvolume_test.go
@@ -784,6 +784,7 @@ func TestPersistentVolumeStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(persistentVolumeMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(persistentVolumeMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = persistentVolumeMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/persistentvolume_test.go
+++ b/internal/store/persistentvolume_test.go
@@ -804,6 +804,7 @@ func TestPersistentVolumeStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(persistentVolumeMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(persistentVolumeMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = persistentVolumeMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/persistentvolumeclaim.go
+++ b/internal/store/persistentvolumeclaim.go
@@ -40,14 +40,27 @@ var (
 	descPersistentVolumeClaimLabelsDefaultLabels = []string{"namespace", "persistentvolumeclaim"}
 )
 
+func wrapPersistentVolumeClaimDefaultLabels(labels []string) []string {
+	return mergeKeys(descPersistentVolumeClaimLabelsDefaultLabels, labels)
+}
+
+func wrapPersistentVolumeClaimDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	infoLabelKeys := []string{"storageclass", "volumename", "volumemode"}
+	statusPhaseLabelKeys := []string{"phase"}
+	accessModeLabelKeys := []string{"access_mode"}
+
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descPersistentVolumeClaimLabelsName,
 			descPersistentVolumeClaimLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPersistentVolumeClaimDefaultLabels([]string{"label_PERSISTENTVOLUMECLAIM_LABEL"}),
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -86,12 +99,13 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_persistentvolumeclaim_info",
 			"Information about persistent volume claim.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPersistentVolumeClaimDefaultLabels(infoLabelKeys),
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				storageClassName := getPersistentVolumeClaimClass(p)
 				volumeName := p.Spec.VolumeName
@@ -104,7 +118,7 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   []string{"storageclass", "volumename", "volumemode"},
+							LabelKeys:   infoLabelKeys,
 							LabelValues: []string{storageClassName, volumeName, volumeMode},
 							Value:       1,
 						},
@@ -112,12 +126,13 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_persistentvolumeclaim_status_phase",
 			"The phase the persistent volume claim is currently in.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPersistentVolumeClaimDefaultLabels(statusPhaseLabelKeys),
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				phase := p.Status.Phase
 
@@ -144,7 +159,7 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 				}
 
 				for _, m := range ms {
-					m.LabelKeys = []string{"phase"}
+					m.LabelKeys = statusPhaseLabelKeys
 				}
 
 				return &metric.Family{
@@ -152,12 +167,13 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_persistentvolumeclaim_resource_requests_storage_bytes",
 			"The capacity of storage requested by the persistent volume claim.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPersistentVolumeClaimDefaultLabels(nil),
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -172,18 +188,19 @@ func persistentVolumeClaimMetricFamilies(allowAnnotationsList, allowLabelsList [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_persistentvolumeclaim_access_mode",
 			"The access mode(s) specified by the persistent volume claim.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPersistentVolumeClaimDefaultLabels(accessModeLabelKeys),
 			wrapPersistentVolumeClaimFunc(func(p *v1.PersistentVolumeClaim) *metric.Family {
 				ms := make([]*metric.Metric, len(p.Spec.AccessModes))
 
 				for i, mode := range p.Spec.AccessModes {
 					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"access_mode"},
+						LabelKeys:   accessModeLabelKeys,
 						LabelValues: []string{string(mode)},
 						Value:       1,
 					}
@@ -275,7 +292,8 @@ func wrapPersistentVolumeClaimFunc(f func(*v1.PersistentVolumeClaim) *metric.Fam
 		metricFamily := f(persistentVolumeClaim)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descPersistentVolumeClaimLabelsDefaultLabels, []string{persistentVolumeClaim.Namespace, persistentVolumeClaim.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapPersistentVolumeClaimDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapPersistentVolumeClaimDefaultLabelValues(persistentVolumeClaim.Namespace, persistentVolumeClaim.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/persistentvolumeclaim_test.go
+++ b/internal/store/persistentvolumeclaim_test.go
@@ -315,6 +315,7 @@ func TestPersistentVolumeClaimStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(persistentVolumeClaimMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(persistentVolumeClaimMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = persistentVolumeClaimMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -40,6 +40,14 @@ var (
 	podStatusReasons           = []string{"Evicted", "NodeAffinity", "NodeLost", "PreemptionByScheduler", "SchedulingGated", "Shutdown", "TerminationByKubelet", "UnexpectedAdmissionError"}
 )
 
+func wrapPodDefaultLabels(labels []string) []string {
+	return mergeKeys(descPodLabelsDefaultLabels, labels)
+}
+
+func wrapPodDefaultLabelValues(namespace, name, uid string, values []string) []string {
+	return mergeValues([]string{namespace, name, uid}, values)
+}
+
 func podMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		createPodCompletionTimeFamilyGenerator(),
@@ -105,12 +113,13 @@ func podMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 }
 
 func createPodCompletionTimeFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_completion_time",
 		"Completion time in unix timestamp for a pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(nil),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -140,15 +149,17 @@ func createPodCompletionTimeFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerInfoLabelKeys := []string{"container", "image_spec", "image", "image_id", "container_id"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_info",
 		"Information about a container in a pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerInfoLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
-			labelKeys := []string{"container", "image_spec", "image", "image_id", "container_id"}
 
 			for _, c := range p.Spec.Containers {
 				for _, cs := range p.Status.ContainerStatuses {
@@ -156,7 +167,7 @@ func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
 						continue
 					}
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   labelKeys,
+						LabelKeys:   containerInfoLabelKeys,
 						LabelValues: []string{cs.Name, c.Image, cs.Image, cs.ImageID, cs.ContainerID},
 						Value:       1,
 					})
@@ -170,12 +181,15 @@ func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerResourceLimitsLabelKeys := []string{"container", "node", "resource", "unit"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_resource_limits",
 		"The number of requested limit resource by a container. It is recommended to use the kube_pod_resource_limits metric exposed by kube-scheduler instead, as it is more precise.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerResourceLimitsLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -223,7 +237,7 @@ func createPodContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator
 			}
 
 			for _, metric := range ms {
-				metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+				metric.LabelKeys = containerResourceLimitsLabelKeys
 			}
 
 			return &metric.Family{
@@ -234,12 +248,15 @@ func createPodContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator
 }
 
 func createPodContainerResourceRequestsFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerResourceRequestsLabelKeys := []string{"container", "node", "resource", "unit"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_resource_requests",
 		"The number of requested request resource by a container. It is recommended to use the kube_pod_resource_requests metric exposed by kube-scheduler instead, as it is more precise.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerResourceRequestsLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -286,7 +303,7 @@ func createPodContainerResourceRequestsFamilyGenerator() generator.FamilyGenerat
 			}
 
 			for _, metric := range ms {
-				metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+				metric.LabelKeys = containerResourceRequestsLabelKeys
 			}
 
 			return &metric.Family{
@@ -297,25 +314,28 @@ func createPodContainerResourceRequestsFamilyGenerator() generator.FamilyGenerat
 }
 
 func createPodContainerStateStartedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStateStartedLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_state_started",
 		"Start time in unix timestamp for a pod container.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStateStartedLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
 			for _, cs := range p.Status.ContainerStatuses {
 				if cs.State.Running != nil {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"container"},
+						LabelKeys:   containerStateStartedLabelKeys,
 						LabelValues: []string{cs.Name},
 						Value:       float64((cs.State.Running.StartedAt).Unix()),
 					})
 				} else if cs.State.Terminated != nil {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"container"},
+						LabelKeys:   containerStateStartedLabelKeys,
 						LabelValues: []string{cs.Name},
 						Value:       float64((cs.State.Terminated.StartedAt).Unix()),
 					})
@@ -408,17 +428,20 @@ func createPodContainerStatusLastTerminatedTimestampFamilyGenerator() generator.
 }
 
 func createPodContainerStatusReadyFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusReadyLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_ready",
 		"Describes whether the containers readiness check succeeded.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusReadyLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   containerStatusReadyLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.Ready),
 				}
@@ -432,17 +455,20 @@ func createPodContainerStatusReadyFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodContainerStatusRestartsTotalFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusRestartsTotalLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_restarts_total",
 		"The number of container restarts per container.",
 		metric.Counter, basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusRestartsTotalLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   containerStatusRestartsTotalLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       float64(cs.RestartCount),
 				}
@@ -456,18 +482,21 @@ func createPodContainerStatusRestartsTotalFamilyGenerator() generator.FamilyGene
 }
 
 func createPodContainerStatusRunningFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusRunningLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_running",
 		"Describes whether the container is currently in running state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusRunningLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   containerStatusRunningLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Running != nil),
 				}
@@ -481,18 +510,21 @@ func createPodContainerStatusRunningFamilyGenerator() generator.FamilyGenerator 
 }
 
 func createPodContainerStatusTerminatedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusTerminatedLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_terminated",
 		"Describes whether the container is currently in terminated state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusTerminatedLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   containerStatusTerminatedLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Terminated != nil),
 				}
@@ -532,18 +564,21 @@ func createPodContainerStatusTerminatedReasonFamilyGenerator() generator.FamilyG
 }
 
 func createPodContainerStatusWaitingFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusWaitingLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_waiting",
 		"Describes whether the container is currently in waiting state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusWaitingLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   containerStatusWaitingLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Waiting != nil),
 				}
@@ -557,19 +592,22 @@ func createPodContainerStatusWaitingFamilyGenerator() generator.FamilyGenerator 
 }
 
 func createPodContainerStatusWaitingReasonFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusWaitingReasonLabelKeys := []string{"container", "reason"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_waiting_reason",
 		"Describes the reason the container is currently in waiting state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusWaitingReasonLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.ContainerStatuses))
 			for _, cs := range p.Status.ContainerStatuses {
 				// Skip creating series for running containers.
 				if cs.State.Waiting != nil {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"container", "reason"},
+						LabelKeys:   containerStatusWaitingReasonLabelKeys,
 						LabelValues: []string{cs.Name, cs.State.Waiting.Reason},
 						Value:       1,
 					})
@@ -583,12 +621,13 @@ func createPodContainerStatusWaitingReasonFamilyGenerator() generator.FamilyGene
 }
 
 func createPodCreatedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_created",
 		"Unix creation timestamp",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(nil),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -633,12 +672,15 @@ func createPodDeletionTimestampFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	infoLabelKeys := []string{"host_ip", "pod_ip", "node", "created_by_kind", "created_by_name", "priority_class", "host_network"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_info",
 		"Information about pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(infoLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			createdBy := metav1.GetControllerOf(p)
 			createdByKind := ""
@@ -653,7 +695,7 @@ func createPodInfoFamilyGenerator() generator.FamilyGenerator {
 			}
 
 			m := metric.Metric{
-				LabelKeys:   []string{"host_ip", "pod_ip", "node", "created_by_kind", "created_by_name", "priority_class", "host_network"},
+				LabelKeys:   infoLabelKeys,
 				LabelValues: []string{p.Status.HostIP, p.Status.PodIP, p.Spec.NodeName, createdByKind, createdByName, p.Spec.PriorityClassName, strconv.FormatBool(p.Spec.HostNetwork)},
 				Value:       1,
 			}
@@ -757,15 +799,17 @@ func createPodIPFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodInitContainerInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerInfoLabelKeys := []string{"container", "image_spec", "image", "image_id", "container_id", "restart_policy"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_info",
 		"Information about an init container in a pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerInfoLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
-			labelKeys := []string{"container", "image_spec", "image", "image_id", "container_id", "restart_policy"}
 
 			for _, c := range p.Spec.InitContainers {
 				restartPolicy := ""
@@ -778,7 +822,7 @@ func createPodInitContainerInfoFamilyGenerator() generator.FamilyGenerator {
 						continue
 					}
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   labelKeys,
+						LabelKeys:   initContainerInfoLabelKeys,
 						LabelValues: []string{cs.Name, c.Image, cs.Image, cs.ImageID, cs.ContainerID, restartPolicy},
 						Value:       1,
 					})
@@ -945,18 +989,21 @@ func createPodInitContainerStatusLastTerminatedReasonFamilyGenerator() generator
 }
 
 func createPodInitContainerStatusReadyFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerStatusReadyLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_status_ready",
 		"Describes whether the init containers readiness check succeeded.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerStatusReadyLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 			for i, cs := range p.Status.InitContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   initContainerStatusReadyLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.Ready),
 				}
@@ -970,17 +1017,20 @@ func createPodInitContainerStatusReadyFamilyGenerator() generator.FamilyGenerato
 }
 
 func createPodInitContainerStatusRestartsTotalFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerStatusRestartsTotalLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_status_restarts_total",
 		"The number of restarts for the init container.",
 		metric.Counter, basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerStatusRestartsTotalLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 			for i, cs := range p.Status.InitContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   initContainerStatusRestartsTotalLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       float64(cs.RestartCount),
 				}
@@ -994,18 +1044,21 @@ func createPodInitContainerStatusRestartsTotalFamilyGenerator() generator.Family
 }
 
 func createPodInitContainerStatusRunningFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerStatusRunningLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_status_running",
 		"Describes whether the init container is currently in running state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerStatusRunningLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 			for i, cs := range p.Status.InitContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   initContainerStatusRunningLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Running != nil),
 				}
@@ -1019,18 +1072,21 @@ func createPodInitContainerStatusRunningFamilyGenerator() generator.FamilyGenera
 }
 
 func createPodInitContainerStatusTerminatedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerStatusTerminatedLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_status_terminated",
 		"Describes whether the init container is currently in terminated state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerStatusTerminatedLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 			for i, cs := range p.Status.InitContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   initContainerStatusTerminatedLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Terminated != nil),
 				}
@@ -1070,18 +1126,21 @@ func createPodInitContainerStatusTerminatedReasonFamilyGenerator() generator.Fam
 }
 
 func createPodInitContainerStatusWaitingFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerStatusWaitingLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_status_waiting",
 		"Describes whether the init container is currently in waiting state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerStatusWaitingLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 			for i, cs := range p.Status.InitContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   initContainerStatusWaitingLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Waiting != nil),
 				}
@@ -1231,12 +1290,13 @@ func createPodAnnotationsGenerator(allowAnnotations []string) generator.FamilyGe
 }
 
 func createPodLabelsGenerator(allowLabelsList []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_labels",
 		"Kubernetes labels converted to Prometheus labels.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels([]string{"label_POD_LABEL"}),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			if len(allowLabelsList) == 0 {
 				return &metric.Family{}
@@ -1308,21 +1368,23 @@ func createPodOverheadMemoryBytesFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodOwnerFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	ownerLabelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_owner",
 		"Information about the Pod's owner.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(ownerLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
-			labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
 
 			owners := p.GetOwnerReferences()
 			if len(owners) == 0 {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   labelKeys,
+							LabelKeys:   ownerLabelKeys,
 							LabelValues: []string{"", "", ""},
 							Value:       1,
 						},
@@ -1335,13 +1397,13 @@ func createPodOwnerFamilyGenerator() generator.FamilyGenerator {
 			for i, owner := range owners {
 				if owner.Controller != nil {
 					ms[i] = &metric.Metric{
-						LabelKeys:   labelKeys,
+						LabelKeys:   ownerLabelKeys,
 						LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
 						Value:       1,
 					}
 				} else {
 					ms[i] = &metric.Metric{
-						LabelKeys:   labelKeys,
+						LabelKeys:   ownerLabelKeys,
 						LabelValues: []string{owner.Kind, owner.Name, "false"},
 						Value:       1,
 					}
@@ -1356,17 +1418,20 @@ func createPodOwnerFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodRestartPolicyFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	restartPolicyLabelKeys := []string{"type"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_restart_policy",
 		"Describes the restart policy in use by this pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(restartPolicyLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
 					{
-						LabelKeys:   []string{"type"},
+						LabelKeys:   restartPolicyLabelKeys,
 						LabelValues: []string{string(p.Spec.RestartPolicy)},
 						Value:       float64(1),
 					},
@@ -1402,19 +1467,22 @@ func createPodRuntimeClassNameInfoFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodSpecVolumesPersistentVolumeClaimsInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	specVolumesPersistentvolumeclaimsInfoLabelKeys := []string{"volume", "persistentvolumeclaim"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_spec_volumes_persistentvolumeclaims_info",
 		"Information about persistentvolumeclaim volumes in a pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(specVolumesPersistentvolumeclaimsInfoLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
 			for _, v := range p.Spec.Volumes {
 				if v.PersistentVolumeClaim != nil {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"volume", "persistentvolumeclaim"},
+						LabelKeys:   specVolumesPersistentvolumeclaimsInfoLabelKeys,
 						LabelValues: []string{v.Name, v.PersistentVolumeClaim.ClaimName},
 						Value:       1,
 					})
@@ -1429,19 +1497,22 @@ func createPodSpecVolumesPersistentVolumeClaimsInfoFamilyGenerator() generator.F
 }
 
 func createPodSpecVolumesPersistentVolumeClaimsReadonlyFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	specVolumesPersistentvolumeclaimsReadonlyLabelKeys := []string{"volume", "persistentvolumeclaim"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_spec_volumes_persistentvolumeclaims_readonly",
 		"Describes whether a persistentvolumeclaim is mounted read only.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(specVolumesPersistentvolumeclaimsReadonlyLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
 			for _, v := range p.Spec.Volumes {
 				if v.PersistentVolumeClaim != nil {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"volume", "persistentvolumeclaim"},
+						LabelKeys:   specVolumesPersistentvolumeclaimsReadonlyLabelKeys,
 						LabelValues: []string{v.Name, v.PersistentVolumeClaim.ClaimName},
 						Value:       boolFloat64(v.PersistentVolumeClaim.ReadOnly),
 					})
@@ -1456,12 +1527,13 @@ func createPodSpecVolumesPersistentVolumeClaimsReadonlyFamilyGenerator() generat
 }
 
 func createPodStartTimeFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_start_time",
 		"Start time in unix timestamp for a pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(nil),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1480,12 +1552,15 @@ func createPodStartTimeFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodStatusPhaseFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	statusPhaseLabelKeys := []string{"phase"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_status_phase",
 		"The pods current phase.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(statusPhaseLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			phase := p.Status.Phase
 			if phase == "" {
@@ -1510,7 +1585,7 @@ func createPodStatusPhaseFamilyGenerator() generator.FamilyGenerator {
 			for i, p := range phases {
 				ms[i] = &metric.Metric{
 
-					LabelKeys:   []string{"phase"},
+					LabelKeys:   statusPhaseLabelKeys,
 					LabelValues: []string{p.n},
 					Value:       boolFloat64(p.v),
 				}
@@ -1648,12 +1723,15 @@ func createPodStatusQosClassFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodStatusReadyFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	statusReadyLabelKeys := []string{"condition"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_status_ready",
 		"Describes whether the pod is ready to serve requests.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(statusReadyLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1663,7 +1741,7 @@ func createPodStatusReadyFamilyGenerator() generator.FamilyGenerator {
 
 					for _, m := range conditionMetrics {
 						metric := m
-						metric.LabelKeys = []string{"condition"}
+						metric.LabelKeys = statusReadyLabelKeys
 						ms = append(ms, metric)
 					}
 				}
@@ -1720,12 +1798,15 @@ func getPodStatusReasonValue(p *v1.Pod, reason string) float64 {
 }
 
 func createPodStatusScheduledFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	statusScheduledLabelKeys := []string{"condition"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_status_scheduled",
 		"Describes the status of the scheduling process for the pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(statusScheduledLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1735,7 +1816,7 @@ func createPodStatusScheduledFamilyGenerator() generator.FamilyGenerator {
 
 					for _, m := range conditionMetrics {
 						metric := m
-						metric.LabelKeys = []string{"condition"}
+						metric.LabelKeys = statusScheduledLabelKeys
 						ms = append(ms, metric)
 					}
 				}
@@ -1749,12 +1830,13 @@ func createPodStatusScheduledFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodStatusScheduledTimeFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_status_scheduled_time",
 		"Unix timestamp when pod moved into scheduled status",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(nil),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1776,12 +1858,13 @@ func createPodStatusScheduledTimeFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_status_unschedulable",
 		"Describes the unschedulable status for the pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(nil),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1978,7 +2061,8 @@ func wrapPodFunc(f func(*v1.Pod) *metric.Family) func(interface{}) *metric.Famil
 		metricFamily := f(pod)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descPodLabelsDefaultLabels, []string{pod.Namespace, pod.Name, string(pod.UID)}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapPodDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapPodDefaultLabelValues(pod.Namespace, pod.Name, string(pod.UID), m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -44,6 +44,14 @@ var (
 	descPodIPsLabelKeys           = []string{"ip", "ip_family"}
 )
 
+func wrapPodDefaultLabels(labels []string) []string {
+	return mergeKeys(descPodLabelsDefaultLabels, labels)
+}
+
+func wrapPodDefaultLabelValues(namespace, name, uid string, values []string) []string {
+	return mergeValues([]string{namespace, name, uid}, values)
+}
+
 func podMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		createPodCompletionTimeFamilyGenerator(),
@@ -110,12 +118,13 @@ func podMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generat
 }
 
 func createPodCompletionTimeFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_completion_time",
 		"Completion time in unix timestamp for a pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(nil),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -145,15 +154,17 @@ func createPodCompletionTimeFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerInfoLabelKeys := []string{"container", "image_spec", "image", "image_id", "container_id"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_info",
 		"Information about a container in a pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerInfoLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
-			labelKeys := []string{"container", "image_spec", "image", "image_id", "container_id"}
 
 			for _, c := range p.Spec.Containers {
 				for _, cs := range p.Status.ContainerStatuses {
@@ -161,7 +172,7 @@ func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
 						continue
 					}
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   labelKeys,
+						LabelKeys:   containerInfoLabelKeys,
 						LabelValues: []string{cs.Name, c.Image, cs.Image, cs.ImageID, cs.ContainerID},
 						Value:       1,
 					})
@@ -175,12 +186,15 @@ func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerResourceLimitsLabelKeys := []string{"container", "node", "resource", "unit"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_resource_limits",
 		"The number of requested limit resource by a container. It is recommended to use the kube_pod_resource_limits metric exposed by kube-scheduler instead, as it is more precise.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerResourceLimitsLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -228,7 +242,7 @@ func createPodContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator
 			}
 
 			for _, metric := range ms {
-				metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+				metric.LabelKeys = containerResourceLimitsLabelKeys
 			}
 
 			return &metric.Family{
@@ -239,12 +253,15 @@ func createPodContainerResourceLimitsFamilyGenerator() generator.FamilyGenerator
 }
 
 func createPodContainerResourceRequestsFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerResourceRequestsLabelKeys := []string{"container", "node", "resource", "unit"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_resource_requests",
 		"The number of requested request resource by a container. It is recommended to use the kube_pod_resource_requests metric exposed by kube-scheduler instead, as it is more precise.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerResourceRequestsLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -291,7 +308,7 @@ func createPodContainerResourceRequestsFamilyGenerator() generator.FamilyGenerat
 			}
 
 			for _, metric := range ms {
-				metric.LabelKeys = []string{"container", "node", "resource", "unit"}
+				metric.LabelKeys = containerResourceRequestsLabelKeys
 			}
 
 			return &metric.Family{
@@ -302,25 +319,28 @@ func createPodContainerResourceRequestsFamilyGenerator() generator.FamilyGenerat
 }
 
 func createPodContainerStateStartedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStateStartedLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_state_started",
 		"Start time in unix timestamp for a pod container.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStateStartedLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
 			for _, cs := range p.Status.ContainerStatuses {
 				if cs.State.Running != nil {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"container"},
+						LabelKeys:   containerStateStartedLabelKeys,
 						LabelValues: []string{cs.Name},
 						Value:       float64((cs.State.Running.StartedAt).Unix()),
 					})
 				} else if cs.State.Terminated != nil {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"container"},
+						LabelKeys:   containerStateStartedLabelKeys,
 						LabelValues: []string{cs.Name},
 						Value:       float64((cs.State.Terminated.StartedAt).Unix()),
 					})
@@ -413,17 +433,20 @@ func createPodContainerStatusLastTerminatedTimestampFamilyGenerator() generator.
 }
 
 func createPodContainerStatusReadyFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusReadyLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_ready",
 		"Describes whether the containers readiness check succeeded.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusReadyLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   containerStatusReadyLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.Ready),
 				}
@@ -437,17 +460,20 @@ func createPodContainerStatusReadyFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodContainerStatusRestartsTotalFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusRestartsTotalLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_restarts_total",
 		"The number of container restarts per container.",
 		metric.Counter, basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusRestartsTotalLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   containerStatusRestartsTotalLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       float64(cs.RestartCount),
 				}
@@ -461,18 +487,21 @@ func createPodContainerStatusRestartsTotalFamilyGenerator() generator.FamilyGene
 }
 
 func createPodContainerStatusRunningFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusRunningLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_running",
 		"Describes whether the container is currently in running state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusRunningLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   containerStatusRunningLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Running != nil),
 				}
@@ -486,18 +515,21 @@ func createPodContainerStatusRunningFamilyGenerator() generator.FamilyGenerator 
 }
 
 func createPodContainerStatusTerminatedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusTerminatedLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_terminated",
 		"Describes whether the container is currently in terminated state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusTerminatedLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   containerStatusTerminatedLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Terminated != nil),
 				}
@@ -537,18 +569,21 @@ func createPodContainerStatusTerminatedReasonFamilyGenerator() generator.FamilyG
 }
 
 func createPodContainerStatusWaitingFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusWaitingLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_waiting",
 		"Describes whether the container is currently in waiting state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusWaitingLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
 
 			for i, cs := range p.Status.ContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   containerStatusWaitingLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Waiting != nil),
 				}
@@ -562,19 +597,22 @@ func createPodContainerStatusWaitingFamilyGenerator() generator.FamilyGenerator 
 }
 
 func createPodContainerStatusWaitingReasonFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	containerStatusWaitingReasonLabelKeys := []string{"container", "reason"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_container_status_waiting_reason",
 		"Describes the reason the container is currently in waiting state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(containerStatusWaitingReasonLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, 0, len(p.Status.ContainerStatuses))
 			for _, cs := range p.Status.ContainerStatuses {
 				// Skip creating series for running containers.
 				if cs.State.Waiting != nil {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"container", "reason"},
+						LabelKeys:   containerStatusWaitingReasonLabelKeys,
 						LabelValues: []string{cs.Name, cs.State.Waiting.Reason},
 						Value:       1,
 					})
@@ -588,12 +626,13 @@ func createPodContainerStatusWaitingReasonFamilyGenerator() generator.FamilyGene
 }
 
 func createPodCreatedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_created",
 		"Unix creation timestamp",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(nil),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -638,12 +677,15 @@ func createPodDeletionTimestampFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	infoLabelKeys := []string{"host_ip", "pod_ip", "node", "created_by_kind", "created_by_name", "priority_class", "host_network"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_info",
 		"Information about pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(infoLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			createdBy := metav1.GetControllerOf(p)
 			createdByKind := ""
@@ -658,7 +700,7 @@ func createPodInfoFamilyGenerator() generator.FamilyGenerator {
 			}
 
 			m := metric.Metric{
-				LabelKeys:   []string{"host_ip", "pod_ip", "node", "created_by_kind", "created_by_name", "priority_class", "host_network"},
+				LabelKeys:   infoLabelKeys,
 				LabelValues: []string{p.Status.HostIP, p.Status.PodIP, p.Spec.NodeName, createdByKind, createdByName, p.Spec.PriorityClassName, strconv.FormatBool(p.Spec.HostNetwork)},
 				Value:       1,
 			}
@@ -765,15 +807,17 @@ func createPodIPFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodInitContainerInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerInfoLabelKeys := []string{"container", "image_spec", "image", "image_id", "container_id", "restart_policy"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_info",
 		"Information about an init container in a pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerInfoLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
-			labelKeys := []string{"container", "image_spec", "image", "image_id", "container_id", "restart_policy"}
 
 			for _, c := range p.Spec.InitContainers {
 				restartPolicy := ""
@@ -786,7 +830,7 @@ func createPodInitContainerInfoFamilyGenerator() generator.FamilyGenerator {
 						continue
 					}
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   labelKeys,
+						LabelKeys:   initContainerInfoLabelKeys,
 						LabelValues: []string{cs.Name, c.Image, cs.Image, cs.ImageID, cs.ContainerID, restartPolicy},
 						Value:       1,
 					})
@@ -953,18 +997,21 @@ func createPodInitContainerStatusLastTerminatedReasonFamilyGenerator() generator
 }
 
 func createPodInitContainerStatusReadyFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerStatusReadyLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_status_ready",
 		"Describes whether the init containers readiness check succeeded.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerStatusReadyLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 			for i, cs := range p.Status.InitContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   initContainerStatusReadyLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.Ready),
 				}
@@ -978,17 +1025,20 @@ func createPodInitContainerStatusReadyFamilyGenerator() generator.FamilyGenerato
 }
 
 func createPodInitContainerStatusRestartsTotalFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerStatusRestartsTotalLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_status_restarts_total",
 		"The number of restarts for the init container.",
 		metric.Counter, basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerStatusRestartsTotalLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 			for i, cs := range p.Status.InitContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   initContainerStatusRestartsTotalLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       float64(cs.RestartCount),
 				}
@@ -1002,18 +1052,21 @@ func createPodInitContainerStatusRestartsTotalFamilyGenerator() generator.Family
 }
 
 func createPodInitContainerStatusRunningFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerStatusRunningLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_status_running",
 		"Describes whether the init container is currently in running state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerStatusRunningLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 			for i, cs := range p.Status.InitContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   initContainerStatusRunningLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Running != nil),
 				}
@@ -1027,18 +1080,21 @@ func createPodInitContainerStatusRunningFamilyGenerator() generator.FamilyGenera
 }
 
 func createPodInitContainerStatusTerminatedFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerStatusTerminatedLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_status_terminated",
 		"Describes whether the init container is currently in terminated state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerStatusTerminatedLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 			for i, cs := range p.Status.InitContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   initContainerStatusTerminatedLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Terminated != nil),
 				}
@@ -1078,18 +1134,21 @@ func createPodInitContainerStatusTerminatedReasonFamilyGenerator() generator.Fam
 }
 
 func createPodInitContainerStatusWaitingFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	initContainerStatusWaitingLabelKeys := []string{"container"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_init_container_status_waiting",
 		"Describes whether the init container is currently in waiting state.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(initContainerStatusWaitingLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := make([]*metric.Metric, len(p.Status.InitContainerStatuses))
 
 			for i, cs := range p.Status.InitContainerStatuses {
 				ms[i] = &metric.Metric{
-					LabelKeys:   []string{"container"},
+					LabelKeys:   initContainerStatusWaitingLabelKeys,
 					LabelValues: []string{cs.Name},
 					Value:       boolFloat64(cs.State.Waiting != nil),
 				}
@@ -1239,12 +1298,13 @@ func createPodAnnotationsGenerator(allowAnnotations []string) generator.FamilyGe
 }
 
 func createPodLabelsGenerator(allowLabelsList []string) generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_labels",
 		"Kubernetes labels converted to Prometheus labels.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels([]string{"label_POD_LABEL"}),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			if len(allowLabelsList) == 0 {
 				return &metric.Family{}
@@ -1316,21 +1376,23 @@ func createPodOverheadMemoryBytesFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodOwnerFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	ownerLabelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_owner",
 		"Information about the Pod's owner.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(ownerLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
-			labelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
 
 			owners := p.GetOwnerReferences()
 			if len(owners) == 0 {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   labelKeys,
+							LabelKeys:   ownerLabelKeys,
 							LabelValues: []string{"", "", ""},
 							Value:       1,
 						},
@@ -1343,13 +1405,13 @@ func createPodOwnerFamilyGenerator() generator.FamilyGenerator {
 			for i, owner := range owners {
 				if owner.Controller != nil {
 					ms[i] = &metric.Metric{
-						LabelKeys:   labelKeys,
+						LabelKeys:   ownerLabelKeys,
 						LabelValues: []string{owner.Kind, owner.Name, strconv.FormatBool(*owner.Controller)},
 						Value:       1,
 					}
 				} else {
 					ms[i] = &metric.Metric{
-						LabelKeys:   labelKeys,
+						LabelKeys:   ownerLabelKeys,
 						LabelValues: []string{owner.Kind, owner.Name, "false"},
 						Value:       1,
 					}
@@ -1364,17 +1426,20 @@ func createPodOwnerFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodRestartPolicyFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	restartPolicyLabelKeys := []string{"type"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_restart_policy",
 		"Describes the restart policy in use by this pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(restartPolicyLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			return &metric.Family{
 				Metrics: []*metric.Metric{
 					{
-						LabelKeys:   []string{"type"},
+						LabelKeys:   restartPolicyLabelKeys,
 						LabelValues: []string{string(p.Spec.RestartPolicy)},
 						Value:       float64(1),
 					},
@@ -1410,12 +1475,15 @@ func createPodRuntimeClassNameInfoFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodSpecVolumesPersistentVolumeClaimsInfoFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	specVolumesPersistentvolumeclaimsInfoLabelKeys := []string{"volume", "persistentvolumeclaim", "ephemeral"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_spec_volumes_persistentvolumeclaims_info",
 		"Information about persistentvolumeclaim and ephemeral volumes in a pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(specVolumesPersistentvolumeclaimsInfoLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1443,12 +1511,15 @@ func createPodSpecVolumesPersistentVolumeClaimsInfoFamilyGenerator() generator.F
 }
 
 func createPodSpecVolumesPersistentVolumeClaimsReadonlyFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	specVolumesPersistentvolumeclaimsReadonlyLabelKeys := []string{"volume", "persistentvolumeclaim", "ephemeral"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_spec_volumes_persistentvolumeclaims_readonly",
 		"Describes whether a persistentvolumeclaim is mounted read only. Ephemeral volumes always report 0 since the ephemeral volume source does not support a read-only flag.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(specVolumesPersistentvolumeclaimsReadonlyLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1476,12 +1547,13 @@ func createPodSpecVolumesPersistentVolumeClaimsReadonlyFamilyGenerator() generat
 }
 
 func createPodStartTimeFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_start_time",
 		"Start time in unix timestamp for a pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(nil),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1500,12 +1572,15 @@ func createPodStartTimeFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodStatusPhaseFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	statusPhaseLabelKeys := []string{"phase"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_status_phase",
 		"The pods current phase.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(statusPhaseLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			phase := p.Status.Phase
 			if phase == "" {
@@ -1530,7 +1605,7 @@ func createPodStatusPhaseFamilyGenerator() generator.FamilyGenerator {
 			for i, p := range phases {
 				ms[i] = &metric.Metric{
 
-					LabelKeys:   []string{"phase"},
+					LabelKeys:   statusPhaseLabelKeys,
 					LabelValues: []string{p.n},
 					Value:       boolFloat64(p.v),
 				}
@@ -1668,12 +1743,15 @@ func createPodStatusQosClassFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodStatusReadyFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	statusReadyLabelKeys := []string{"condition"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_status_ready",
 		"Describes whether the pod is ready to serve requests.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(statusReadyLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1683,7 +1761,7 @@ func createPodStatusReadyFamilyGenerator() generator.FamilyGenerator {
 
 					for _, m := range conditionMetrics {
 						metric := m
-						metric.LabelKeys = []string{"condition"}
+						metric.LabelKeys = statusReadyLabelKeys
 						ms = append(ms, metric)
 					}
 				}
@@ -1782,12 +1860,15 @@ func createPodStatusDisruptionReasonFamilyGenerator() generator.FamilyGenerator 
 }
 
 func createPodStatusScheduledFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	statusScheduledLabelKeys := []string{"condition"}
+
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_status_scheduled",
 		"Describes the status of the scheduling process for the pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(statusScheduledLabelKeys),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1797,7 +1878,7 @@ func createPodStatusScheduledFamilyGenerator() generator.FamilyGenerator {
 
 					for _, m := range conditionMetrics {
 						metric := m
-						metric.LabelKeys = []string{"condition"}
+						metric.LabelKeys = statusScheduledLabelKeys
 						ms = append(ms, metric)
 					}
 				}
@@ -1811,12 +1892,13 @@ func createPodStatusScheduledFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodStatusScheduledTimeFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_status_scheduled_time",
 		"Unix timestamp when pod moved into scheduled status",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(nil),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -1838,12 +1920,13 @@ func createPodStatusScheduledTimeFamilyGenerator() generator.FamilyGenerator {
 }
 
 func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
-	return *generator.NewFamilyGeneratorWithStability(
+	return *generator.NewFamilyGeneratorWithLabels(
 		"kube_pod_status_unschedulable",
 		"Describes the unschedulable status for the pod.",
 		metric.Gauge,
 		basemetrics.STABLE,
 		"",
+		wrapPodDefaultLabels(nil),
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
 			ms := []*metric.Metric{}
 
@@ -2040,7 +2123,8 @@ func wrapPodFunc(f func(*v1.Pod) *metric.Family) func(interface{}) *metric.Famil
 		metricFamily := f(pod)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descPodLabelsDefaultLabels, []string{pod.Namespace, pod.Name, string(pod.UID)}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapPodDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapPodDefaultLabelValues(pod.Namespace, pod.Name, string(pod.UID), m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -2449,6 +2449,7 @@ func TestPodStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(podMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(podMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = podMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -2465,6 +2465,7 @@ func TestPodStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(podMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(podMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = podMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -39,6 +39,14 @@ var (
 	descPodDisruptionBudgetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 )
 
+func wrapPodDisruptionBudgetDefaultLabels(labels []string) []string {
+	return mergeKeys(descPodDisruptionBudgetLabelsDefaultLabels, labels)
+}
+
+func wrapPodDisruptionBudgetDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
 	return []generator.FamilyGenerator{
 		*generator.NewFamilyGeneratorWithStability(
@@ -85,12 +93,13 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_poddisruptionbudget_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPodDisruptionBudgetDefaultLabels(nil),
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -105,12 +114,13 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_poddisruptionbudget_status_current_healthy",
 			"Current number of healthy pods",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPodDisruptionBudgetDefaultLabels(nil),
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -121,12 +131,13 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_poddisruptionbudget_status_desired_healthy",
 			"Minimum desired number of healthy pods",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPodDisruptionBudgetDefaultLabels(nil),
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -137,12 +148,13 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_poddisruptionbudget_status_pod_disruptions_allowed",
 			"Number of pod disruptions that are currently allowed",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPodDisruptionBudgetDefaultLabels(nil),
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -153,12 +165,13 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_poddisruptionbudget_status_expected_pods",
 			"Total number of pods counted by this disruption budget",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPodDisruptionBudgetDefaultLabels(nil),
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -169,12 +182,13 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_poddisruptionbudget_status_observed_generation",
 			"Most recent generation observed when updating this PDB status",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapPodDisruptionBudgetDefaultLabels(nil),
 			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -215,7 +229,8 @@ func wrapPodDisruptionBudgetFunc(f func(*policyv1.PodDisruptionBudget) *metric.F
 		metricFamily := f(podDisruptionBudget)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descPodDisruptionBudgetLabelsDefaultLabels, []string{podDisruptionBudget.Namespace, podDisruptionBudget.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapPodDisruptionBudgetDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapPodDisruptionBudgetDefaultLabelValues(podDisruptionBudget.Namespace, podDisruptionBudget.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/poddisruptionbudget_test.go
+++ b/internal/store/poddisruptionbudget_test.go
@@ -156,6 +156,7 @@ func TestPodDisruptionBudgetStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(podDisruptionBudgetMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(podDisruptionBudgetMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = podDisruptionBudgetMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/replicaset.go
+++ b/internal/store/replicaset.go
@@ -41,14 +41,25 @@ var (
 	descReplicaSetLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 )
 
+func wrapReplicaSetDefaultLabels(labels []string) []string {
+	return mergeKeys(descReplicaSetLabelsDefaultLabels, labels)
+}
+
+func wrapReplicaSetDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	ownerLabelKeys := []string{"owner_kind", "owner_name", "owner_is_controller"}
+
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicaset_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicaSetDefaultLabels(nil),
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -64,12 +75,13 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicaset_status_replicas",
 			"The number of replicas per ReplicaSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicaSetDefaultLabels(nil),
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -80,12 +92,13 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicaset_status_fully_labeled_replicas",
 			"The number of fully labeled replicas per ReplicaSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicaSetDefaultLabels(nil),
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -96,12 +109,13 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicaset_status_ready_replicas",
 			"The number of ready replicas per ReplicaSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicaSetDefaultLabels(nil),
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -132,12 +146,13 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicaset_status_observed_generation",
 			"The generation observed by the ReplicaSet controller.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicaSetDefaultLabels(nil),
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -148,12 +163,13 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicaset_spec_replicas",
 			"Number of desired pods for a ReplicaSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicaSetDefaultLabels(nil),
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -168,12 +184,13 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicaset_metadata_generation",
 			"Sequence number representing a specific generation of the desired state.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicaSetDefaultLabels(nil),
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -184,12 +201,13 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicaset_owner",
 			"Information about the ReplicaSet's owner.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicaSetDefaultLabels(ownerLabelKeys),
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				owners := r.GetOwnerReferences()
 
@@ -197,7 +215,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 					return &metric.Family{
 						Metrics: []*metric.Metric{
 							{
-								LabelKeys:   []string{"owner_kind", "owner_name", "owner_is_controller"},
+								LabelKeys:   ownerLabelKeys,
 								LabelValues: []string{"", "", ""},
 								Value:       1,
 							},
@@ -220,7 +238,7 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 
 				for _, m := range ms {
-					m.LabelKeys = []string{"owner_kind", "owner_name", "owner_is_controller"}
+					m.LabelKeys = ownerLabelKeys
 					m.Value = 1
 				}
 
@@ -251,12 +269,13 @@ func replicaSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descReplicaSetLabelsName,
 			descReplicaSetLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicaSetDefaultLabels([]string{"label_REPLICASET_LABEL"}),
 			wrapReplicaSetFunc(func(r *v1.ReplicaSet) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -283,7 +302,8 @@ func wrapReplicaSetFunc(f func(*v1.ReplicaSet) *metric.Family) func(interface{})
 		metricFamily := f(replicaSet)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descReplicaSetLabelsDefaultLabels, []string{replicaSet.Namespace, replicaSet.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapReplicaSetDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapReplicaSetDefaultLabelValues(replicaSet.Namespace, replicaSet.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/replicaset_test.go
+++ b/internal/store/replicaset_test.go
@@ -138,6 +138,7 @@ func TestReplicaSetStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(replicaSetMetricFamilies(nil, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(replicaSetMetricFamilies(nil, nil))
+		c.FamilyGens = replicaSetMetricFamilies(nil, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/replicationcontroller.go
+++ b/internal/store/replicationcontroller.go
@@ -36,12 +36,13 @@ var (
 	descReplicationControllerLabelsDefaultLabels = []string{"namespace", "replicationcontroller"}
 
 	replicationControllerMetricFamilies = []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicationcontroller_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicationControllerDefaultLabels(nil),
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -56,12 +57,13 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicationcontroller_status_replicas",
 			"The number of replicas per ReplicationController.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicationControllerDefaultLabels(nil),
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -72,12 +74,13 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicationcontroller_status_fully_labeled_replicas",
 			"The number of fully labeled replicas per ReplicationController.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicationControllerDefaultLabels(nil),
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -88,12 +91,13 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicationcontroller_status_ready_replicas",
 			"The number of ready replicas per ReplicationController.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicationControllerDefaultLabels(nil),
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -104,12 +108,13 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicationcontroller_status_available_replicas",
 			"The number of available replicas per ReplicationController.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicationControllerDefaultLabels(nil),
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -120,12 +125,13 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicationcontroller_status_observed_generation",
 			"The generation observed by the ReplicationController controller.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicationControllerDefaultLabels(nil),
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -136,12 +142,13 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicationcontroller_spec_replicas",
 			"Number of desired pods for a ReplicationController.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicationControllerDefaultLabels(nil),
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -156,12 +163,13 @@ var (
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_replicationcontroller_metadata_generation",
 			"Sequence number representing a specific generation of the desired state.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapReplicationControllerDefaultLabels(nil),
 			wrapReplicationControllerFunc(func(r *v1.ReplicationController) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -212,6 +220,14 @@ var (
 	}
 )
 
+func wrapReplicationControllerDefaultLabels(labels []string) []string {
+	return mergeKeys(descReplicationControllerLabelsDefaultLabels, labels)
+}
+
+func wrapReplicationControllerDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func wrapReplicationControllerFunc(f func(*v1.ReplicationController) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {
 		replicationController := obj.(*v1.ReplicationController)
@@ -219,7 +235,8 @@ func wrapReplicationControllerFunc(f func(*v1.ReplicationController) *metric.Fam
 		metricFamily := f(replicationController)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descReplicationControllerLabelsDefaultLabels, []string{replicationController.Namespace, replicationController.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapReplicationControllerDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapReplicationControllerDefaultLabelValues(replicationController.Namespace, replicationController.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/replicationcontroller_test.go
+++ b/internal/store/replicationcontroller_test.go
@@ -165,6 +165,7 @@ func TestReplicationControllerStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(replicationControllerMetricFamilies)
 		c.Headers = generator.ExtractMetricFamilyHeaders(replicationControllerMetricFamilies)
+		c.FamilyGens = replicationControllerMetricFamilies
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/resourcequota.go
+++ b/internal/store/resourcequota.go
@@ -39,14 +39,25 @@ var (
 	descResourceQuotaLabelsDefaultLabels = []string{"namespace", "resourcequota"}
 )
 
+func wrapResourceQuotaDefaultLabels(labels []string) []string {
+	return mergeKeys(descResourceQuotaLabelsDefaultLabels, labels)
+}
+
+func wrapResourceQuotaDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func resourceQuotaMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	resourcequotaLabelKeys := []string{"resource", "type"}
+
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_resourcequota_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapResourceQuotaDefaultLabels(nil),
 			wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -62,12 +73,13 @@ func resourceQuotaMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_resourcequota",
 			"Information about resource quota.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapResourceQuotaDefaultLabels(resourcequotaLabelKeys),
 			wrapResourceQuotaFunc(func(r *v1.ResourceQuota) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -85,7 +97,7 @@ func resourceQuotaMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 				}
 
 				for _, m := range ms {
-					m.LabelKeys = []string{"resource", "type"}
+					m.LabelKeys = resourcequotaLabelKeys
 				}
 
 				return &metric.Family{
@@ -115,12 +127,13 @@ func resourceQuotaMetricFamilies(allowAnnotationsList, allowLabelsList []string)
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descResourceQuotaLabelsName,
 			descResourceQuotaLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapResourceQuotaDefaultLabels([]string{"label_RESOURCE_QUOTA_LABEL"}),
 			wrapResourceQuotaFunc(func(d *v1.ResourceQuota) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -147,7 +160,8 @@ func wrapResourceQuotaFunc(f func(*v1.ResourceQuota) *metric.Family) func(interf
 		metricFamily := f(resourceQuota)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descResourceQuotaLabelsDefaultLabels, []string{resourceQuota.Namespace, resourceQuota.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapResourceQuotaDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapResourceQuotaDefaultLabelValues(resourceQuota.Namespace, resourceQuota.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/resourcequota_test.go
+++ b/internal/store/resourcequota_test.go
@@ -168,6 +168,7 @@ func TestResourceQuotaStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(resourceQuotaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(resourceQuotaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = resourceQuotaMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/role_test.go
+++ b/internal/store/role_test.go
@@ -98,6 +98,7 @@ func TestRoleStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(roleMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(roleMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = roleMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/rolebinding_test.go
+++ b/internal/store/rolebinding_test.go
@@ -108,6 +108,7 @@ func TestRoleBindingStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(roleBindingMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(roleBindingMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = roleBindingMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/secret.go
+++ b/internal/store/secret.go
@@ -40,14 +40,25 @@ var (
 	descSecretLabelsDefaultLabels = []string{"namespace", "secret"}
 )
 
+func wrapSecretDefaultLabels(labels []string) []string {
+	return mergeKeys(descSecretLabelsDefaultLabels, labels)
+}
+
+func wrapSecretDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	typeLabelKeys := []string{"type"}
+
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_secret_info",
 			"Information about secret.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapSecretDefaultLabels(nil),
 			wrapSecretFunc(func(_ *v1.Secret) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -58,17 +69,18 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_secret_type",
 			"Type about secret.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapSecretDefaultLabels(typeLabelKeys),
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   []string{"type"},
+							LabelKeys:   typeLabelKeys,
 							LabelValues: []string{string(s.Type)},
 							Value:       1,
 						},
@@ -99,12 +111,13 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descSecretLabelsName,
 			descSecretLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapSecretDefaultLabels([]string{"label_SECRET_LABEL"}),
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -122,12 +135,13 @@ func secretMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gene
 
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_secret_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapSecretDefaultLabels(nil),
 			wrapSecretFunc(func(s *v1.Secret) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -211,7 +225,8 @@ func wrapSecretFunc(f func(*v1.Secret) *metric.Family) func(interface{}) *metric
 		metricFamily := f(secret)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descSecretLabelsDefaultLabels, []string{secret.Namespace, secret.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapSecretDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapSecretDefaultLabelValues(secret.Namespace, secret.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/secret_test.go
+++ b/internal/store/secret_test.go
@@ -164,6 +164,7 @@ func TestSecretStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(secretMetricFamilies(nil, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(secretMetricFamilies(nil, nil))
+		c.FamilyGens = secretMetricFamilies(nil, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -39,29 +39,44 @@ var (
 	descServiceLabelsDefaultLabels = []string{"namespace", "service", "uid"}
 )
 
+func wrapServiceDefaultLabels(labels []string) []string {
+	return mergeKeys(descServiceLabelsDefaultLabels, labels)
+}
+
+func wrapServiceDefaultLabelValues(namespace, name, uid string, values []string) []string {
+	return mergeValues([]string{namespace, name, uid}, values)
+}
+
 func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	infoLabelKeys := []string{"cluster_ip", "external_name", "load_balancer_ip", "external_traffic_policy"}
+	specTypeLabelKeys := []string{"type"}
+	specExternalIpLabelKeys := []string{"external_ip"}
+	statusLoadBalancerIngressLabelKeys := []string{"ip", "hostname"}
+
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_service_info",
 			"Information about service.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapServiceDefaultLabels(infoLabelKeys),
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				m := metric.Metric{
-					LabelKeys:   []string{"cluster_ip", "external_name", "load_balancer_ip", "external_traffic_policy"},
+					LabelKeys:   infoLabelKeys,
 					LabelValues: []string{s.Spec.ClusterIP, s.Spec.ExternalName, s.Spec.LoadBalancerIP, string(s.Spec.ExternalTrafficPolicy)},
 					Value:       1,
 				}
 				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_service_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapServiceDefaultLabels(nil),
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if !s.CreationTimestamp.IsZero() {
 					m := metric.Metric{
@@ -74,16 +89,17 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				return &metric.Family{Metrics: []*metric.Metric{}}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_service_spec_type",
 			"Type about service.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapServiceDefaultLabels(specTypeLabelKeys),
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				m := metric.Metric{
 
-					LabelKeys:   []string{"type"},
+					LabelKeys:   specTypeLabelKeys,
 					LabelValues: []string{string(s.Spec.Type)},
 					Value:       1,
 				}
@@ -109,12 +125,13 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descServiceLabelsName,
 			descServiceLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapServiceDefaultLabels([]string{"label_SERVICE_LABEL"}),
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -128,12 +145,13 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_service_spec_external_ip",
 			"Service external ips. One series for each ip",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapServiceDefaultLabels(specExternalIpLabelKeys),
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if len(s.Spec.ExternalIPs) == 0 {
 					return &metric.Family{
@@ -145,7 +163,7 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 
 				for i, externalIP := range s.Spec.ExternalIPs {
 					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"external_ip"},
+						LabelKeys:   specExternalIpLabelKeys,
 						LabelValues: []string{externalIP},
 						Value:       1,
 					}
@@ -156,12 +174,13 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_service_status_load_balancer_ingress",
 			"Service load balancer ingress status",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapServiceDefaultLabels(statusLoadBalancerIngressLabelKeys),
 			wrapSvcFunc(func(s *v1.Service) *metric.Family {
 				if len(s.Status.LoadBalancer.Ingress) == 0 {
 					return &metric.Family{
@@ -173,7 +192,7 @@ func serviceMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 
 				for i, ingress := range s.Status.LoadBalancer.Ingress {
 					ms[i] = &metric.Metric{
-						LabelKeys:   []string{"ip", "hostname"},
+						LabelKeys:   statusLoadBalancerIngressLabelKeys,
 						LabelValues: []string{ingress.IP, ingress.Hostname},
 						Value:       1,
 					}
@@ -213,7 +232,8 @@ func wrapSvcFunc(f func(*v1.Service) *metric.Family) func(interface{}) *metric.F
 		metricFamily := f(svc)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descServiceLabelsDefaultLabels, []string{svc.Namespace, svc.Name, string(svc.UID)}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapServiceDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapServiceDefaultLabelValues(svc.Namespace, svc.Name, string(svc.UID), m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/service_test.go
+++ b/internal/store/service_test.go
@@ -291,6 +291,7 @@ func TestServiceStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(serviceMetricFamilies(nil, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(serviceMetricFamilies(nil, nil))
+		c.FamilyGens = serviceMetricFamilies(nil, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/serviceaccount_test.go
+++ b/internal/store/serviceaccount_test.go
@@ -81,6 +81,7 @@ func TestServiceAccountStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(serviceAccountMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
 		c.Headers = generator.ExtractMetricFamilyHeaders(serviceAccountMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList))
+		c.FamilyGens = serviceAccountMetricFamilies(c.AllowAnnotationsList, c.AllowLabelsList)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/stable_metrics_test.go
+++ b/internal/store/stable_metrics_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2024 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+// TestStableMetrics verifies the golden list of stable metrics has not changed.
+//
+// It collects all FamilyGenerators from every store resource, filters for
+// StabilityLevel == STABLE, and compares the sorted list to a golden YAML file.
+// The fixture uses BETA as the serialized stability level because KSM stable
+// metrics are consumed as beta metrics in k/k's stable metrics tooling.
+//
+// Workflow:
+//   - To verify (CI presubmit):  go test ./internal/store/ -run TestStableMetrics
+//   - To regenerate golden file: UPDATE_STABLE_METRICS=true go test ./internal/store/ -run TestStableMetrics
+//     or equivalently:           hack/update-stable-metrics.sh
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	basemetrics "k8s.io/component-base/metrics"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
+
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+)
+
+// stableMetricEntry matches the schema in the k/k stable-metrics-list.yaml
+// golden file format for easy cross-project comparison.
+type stableMetricEntry struct {
+	Name           string    `json:"name" yaml:"name"`
+	Help           string    `json:"help" yaml:"help"`
+	Type           string    `json:"type" yaml:"type"`
+	StabilityLevel string    `json:"stabilityLevel" yaml:"stabilityLevel"`
+	Labels         []string  `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Buckets        []float64 `json:"buckets,omitempty" yaml:"buckets,omitempty"`
+}
+
+// k8sMetricType maps KSM's lowercase OpenMetrics type names to the capitalized
+// type names used by k/k's stable-metrics-list.yaml format (Counter, Gauge,
+// Histogram, Summary). KSM's info and stateset metrics are exposed on the wire
+// as gauges, so they map to "Gauge".
+var k8sMetricType = map[metric.Type]string{
+	metric.Gauge:    "Gauge",
+	metric.Counter:  "Counter",
+	metric.Info:     "Gauge",
+	metric.StateSet: "Gauge",
+}
+
+const goldenFile = "testdata/stable-metrics-list.yaml"
+
+func TestStableMetrics(t *testing.T) {
+	// Locate testdata/ relative to this source file so the test works when
+	// run from any working directory.
+	_, thisFile, _, _ := runtime.Caller(0)
+	goldenPath := filepath.Join(filepath.Dir(thisFile), goldenFile)
+	updateGolden := os.Getenv("UPDATE_STABLE_METRICS") == "true"
+
+	raw, err := os.ReadFile(goldenPath) //nolint:gosec // G304: goldenPath is derived from this source file's directory and a constant testdata path.
+	if err != nil {
+		if updateGolden && os.IsNotExist(err) {
+			raw = nil
+		} else {
+			t.Fatalf("Cannot read golden file %s: %v\n"+
+				"Run hack/update-stable-metrics.sh to generate it.", goldenPath, err)
+		}
+	}
+
+	var golden []stableMetricEntry
+	if len(raw) > 0 {
+		if err := yaml.Unmarshal(raw, &golden); err != nil {
+			t.Fatalf("Cannot parse golden file: %v", err)
+		}
+	}
+
+	entries := collectStableMetrics(t)
+
+	if updateGolden {
+		writeGolden(t, goldenPath, entries)
+		t.Logf("Updated golden file: %s", goldenPath)
+		return
+	}
+
+	if len(raw) == 0 {
+		t.Fatalf("Cannot read golden file %s: %v\n"+
+			"Run hack/update-stable-metrics.sh to generate it.", goldenPath, os.ErrNotExist)
+	}
+
+	current, err := yaml.Marshal(entries)
+	if err != nil {
+		t.Fatalf("Cannot marshal current metrics: %v", err)
+	}
+	expected, err := yaml.Marshal(golden)
+	if err != nil {
+		t.Fatalf("Cannot marshal golden metrics: %v", err)
+	}
+
+	if diff := cmp.Diff(string(expected), string(current)); diff != "" {
+		t.Errorf("Stable metrics list has changed.\n\n"+
+			"Run hack/update-stable-metrics.sh to update the golden file if this is intentional.\n\n"+
+			"diff (- expected, + current):\n%s",
+			diff)
+	}
+}
+
+// collectStableMetrics gathers all FamilyGenerators with StabilityLevel == STABLE
+// across every store resource and returns them sorted by metric name.
+func collectStableMetrics(t *testing.T) []stableMetricEntry {
+	t.Helper()
+	empty := []string{} // allow-lists don't affect stability metadata
+
+	var all []generator.FamilyGenerator
+	all = append(all, csrMetricFamilies(empty, empty)...)
+	all = append(all, clusterRoleMetricFamilies(empty, empty)...)
+	all = append(all, clusterRoleBindingMetricFamilies(empty, empty)...)
+	all = append(all, configMapMetricFamilies(empty, empty)...)
+	all = append(all, cronJobMetricFamilies(empty, empty)...)
+	all = append(all, daemonSetMetricFamilies(empty, empty)...)
+	all = append(all, deploymentMetricFamilies(empty, empty)...)
+	all = append(all, endpointMetricFamilies(empty, empty)...)
+	all = append(all, endpointSliceMetricFamilies(empty, empty)...)
+	all = append(all, hpaMetricFamilies(empty, empty)...)
+	all = append(all, ingressMetricFamilies(empty, empty)...)
+	all = append(all, ingressClassMetricFamilies(empty, empty)...)
+	all = append(all, jobMetricFamilies(empty, empty)...)
+	all = append(all, leaseMetricFamilies...)
+	all = append(all, limitRangeMetricFamilies...)
+	all = append(all, mutatingWebhookConfigurationMetricFamilies...)
+	all = append(all, namespaceMetricFamilies(empty, empty)...)
+	all = append(all, networkPolicyMetricFamilies(empty, empty)...)
+	all = append(all, nodeMetricFamilies(empty, empty)...)
+	all = append(all, persistentVolumeMetricFamilies(empty, empty)...)
+	all = append(all, persistentVolumeClaimMetricFamilies(empty, empty)...)
+	all = append(all, podMetricFamilies(empty, empty)...)
+	all = append(all, podDisruptionBudgetMetricFamilies(empty, empty)...)
+	all = append(all, replicaSetMetricFamilies(empty, empty)...)
+	all = append(all, replicationControllerMetricFamilies...)
+	all = append(all, resourceQuotaMetricFamilies(empty, empty)...)
+	all = append(all, roleMetricFamilies(empty, empty)...)
+	all = append(all, roleBindingMetricFamilies(empty, empty)...)
+	all = append(all, secretMetricFamilies(empty, empty)...)
+	all = append(all, serviceMetricFamilies(empty, empty)...)
+	all = append(all, serviceAccountMetricFamilies(empty, empty)...)
+	all = append(all, statefulSetMetricFamilies(empty, empty)...)
+	all = append(all, storageClassMetricFamilies(empty, empty)...)
+	all = append(all, validatingWebhookConfigurationMetricFamilies...)
+	all = append(all, volumeAttachmentMetricFamilies...)
+
+	var stable []stableMetricEntry
+	for _, fg := range all {
+		if fg.StabilityLevel != basemetrics.STABLE {
+			continue
+		}
+		// Strip the "[STABLE] " annotation prefix that KSM prepends to help text
+		// in the rendered header; we store the clean help text in the golden file.
+		help := strings.TrimPrefix(fg.Help, "[STABLE] ")
+		typeName, ok := k8sMetricType[fg.Type]
+		if !ok {
+			t.Errorf("metric %q has unknown type %q; add it to k8sMetricType", fg.Name, fg.Type)
+			typeName = string(fg.Type)
+		}
+		if fg.Labels == nil {
+			continue
+		}
+		stable = append(stable, stableMetricEntry{
+			Name:           fg.Name,
+			Help:           help,
+			Type:           typeName,
+			StabilityLevel: string(basemetrics.BETA),
+			Labels:         fg.Labels,
+		})
+	}
+
+	sort.Slice(stable, func(i, j int) bool {
+		return stable[i].Name < stable[j].Name
+	})
+
+	// Detect duplicates (same metric name from multiple stores would be a bug).
+	for i := 1; i < len(stable); i++ {
+		if stable[i].Name == stable[i-1].Name {
+			t.Errorf("Duplicate stable metric name: %s", stable[i].Name)
+		}
+	}
+
+	return stable
+}
+
+func writeGolden(t *testing.T, path string, entries []stableMetricEntry) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		t.Fatalf("Cannot create testdata dir: %v", err)
+	}
+	raw, err := yaml.Marshal(entries)
+	if err != nil {
+		t.Fatalf("Cannot marshal entries: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatalf("Cannot write golden file: %v", err)
+	}
+}

--- a/internal/store/stable_metrics_test.go
+++ b/internal/store/stable_metrics_test.go
@@ -179,6 +179,7 @@ func collectStableMetrics(t *testing.T) []stableMetricEntry {
 			typeName = string(fg.Type)
 		}
 		if fg.Labels == nil {
+			t.Errorf("STABLE metric %q is missing an explicit label schema. Use NewFamilyGeneratorWithLabels to define its labels.", fg.Name)
 			continue
 		}
 		stable = append(stable, stableMetricEntry{

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -40,14 +40,27 @@ var (
 	descStatefulSetLabelsDefaultLabels = []string{"namespace", "statefulset"}
 )
 
+func wrapStatefulSetDefaultLabels(labels []string) []string {
+	return mergeKeys(descStatefulSetLabelsDefaultLabels, labels)
+}
+
+func wrapStatefulSetDefaultLabelValues(namespace, name string, values []string) []string {
+	return mergeValues([]string{namespace, name}, values)
+}
+
 func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	persistentvolumeclaimRetentionPolicyLabelKeys := []string{"when_deleted", "when_scaled"}
+	statusCurrentRevisionLabelKeys := []string{"revision"}
+	statusUpdateRevisionLabelKeys := []string{"revision"}
+
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -62,12 +75,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_status_replicas",
 			"The number of replicas per StatefulSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -78,12 +92,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_status_replicas_available",
 			"The number of available replicas per StatefulSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -94,12 +109,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_status_replicas_current",
 			"The number of current replicas per StatefulSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -110,12 +126,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_status_replicas_ready",
 			"The number of ready replicas per StatefulSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -126,12 +143,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_status_replicas_updated",
 			"The number of updated replicas per StatefulSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -142,12 +160,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_status_observed_generation",
 			"The generation observed by the StatefulSet controller.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -158,12 +177,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_replicas",
 			"Number of desired pods for a StatefulSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -178,12 +198,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_ordinals_start",
 			"Start ordinal of the StatefulSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -198,12 +219,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_metadata_generation",
 			"Sequence number representing a specific generation of the desired state for the StatefulSet.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -214,13 +236,14 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_persistentvolumeclaim_retention_policy",
 			"Count of retention policy for StatefulSet template PVCs",
 			metric.Gauge,
 			basemetrics.STABLE,
 
 			"",
+			wrapStatefulSetDefaultLabels(persistentvolumeclaimRetentionPolicyLabelKeys),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				deletedPolicyLabel := ""
 				scaledPolicyLabel := ""
@@ -231,7 +254,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				ms := []*metric.Metric{}
 				if deletedPolicyLabel != "" || scaledPolicyLabel != "" {
 					ms = append(ms, &metric.Metric{
-						LabelKeys:   []string{"when_deleted", "when_scaled"},
+						LabelKeys:   persistentvolumeclaimRetentionPolicyLabelKeys,
 						LabelValues: []string{deletedPolicyLabel, scaledPolicyLabel},
 						Value:       1,
 					})
@@ -241,12 +264,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descStatefulSetAnnotationsName,
 			descStatefulSetAnnotationsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				if len(allowAnnotationsList) == 0 {
 					return &metric.Family{}
@@ -263,12 +287,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descStatefulSetLabelsName,
 			descStatefulSetLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels([]string{"label_STATEFULSET_LABEL"}),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -285,17 +310,18 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_status_current_revision",
 			"Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(statusCurrentRevisionLabelKeys),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   []string{"revision"},
+							LabelKeys:   statusCurrentRevisionLabelKeys,
 							LabelValues: []string{s.Status.CurrentRevision},
 							Value:       1,
 						},
@@ -303,17 +329,18 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_status_update_revision",
 			"Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(statusUpdateRevisionLabelKeys),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							LabelKeys:   []string{"revision"},
+							LabelKeys:   statusUpdateRevisionLabelKeys,
 							LabelValues: []string{s.Status.UpdateRevision},
 							Value:       1,
 						},
@@ -321,12 +348,13 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_statefulset_deletion_timestamp",
 			"Unix deletion timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStatefulSetDefaultLabels(nil),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				ms := []*metric.Metric{}
 
@@ -351,7 +379,8 @@ func wrapStatefulSetFunc(f func(*v1.StatefulSet) *metric.Family) func(interface{
 		metricFamily := f(statefulSet)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descStatefulSetLabelsDefaultLabels, []string{statefulSet.Namespace, statefulSet.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapStatefulSetDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapStatefulSetDefaultLabelValues(statefulSet.Namespace, statefulSet.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/statefulset.go
+++ b/internal/store/statefulset.go
@@ -270,7 +270,7 @@ func statefulSetMetricFamilies(allowAnnotationsList, allowLabelsList []string) [
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
-			wrapStatefulSetDefaultLabels(nil),
+			wrapStatefulSetDefaultLabels([]string{"annotation_STATEFULSET_ANNOTATION"}),
 			wrapStatefulSetFunc(func(s *v1.StatefulSet) *metric.Family {
 				if len(allowAnnotationsList) == 0 {
 					return &metric.Family{}

--- a/internal/store/statefulset_test.go
+++ b/internal/store/statefulset_test.go
@@ -444,6 +444,7 @@ func TestStatefulSetStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(statefulSetMetricFamilies(nil, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(statefulSetMetricFamilies(nil, nil))
+		c.FamilyGens = statefulSetMetricFamilies(nil, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result for statefulset%d run:\n%s", i+1, err)
 		}

--- a/internal/store/storageclass.go
+++ b/internal/store/storageclass.go
@@ -40,14 +40,25 @@ var (
 	defaultVolumeBindingMode            = storagev1.VolumeBindingImmediate
 )
 
+func wrapStorageClassDefaultLabels(labels []string) []string {
+	return mergeKeys(descStorageClassLabelsDefaultLabels, labels)
+}
+
+func wrapStorageClassDefaultLabelValues(name string, values []string) []string {
+	return mergeValues([]string{name}, values)
+}
+
 func storageClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
+	infoLabelKeys := []string{"provisioner", "reclaim_policy", "volume_binding_mode"}
+
 	return []generator.FamilyGenerator{
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_storageclass_info",
 			"Information about storageclass.",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStorageClassDefaultLabels(infoLabelKeys),
 			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 
 				// Add default values if missing.
@@ -60,19 +71,20 @@ func storageClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 				}
 
 				m := metric.Metric{
-					LabelKeys:   []string{"provisioner", "reclaim_policy", "volume_binding_mode"},
+					LabelKeys:   infoLabelKeys,
 					LabelValues: []string{s.Provisioner, string(*s.ReclaimPolicy), string(*s.VolumeBindingMode)},
 					Value:       1,
 				}
 				return &metric.Family{Metrics: []*metric.Metric{&m}}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			"kube_storageclass_created",
 			"Unix creation timestamp",
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStorageClassDefaultLabels(nil),
 			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 				ms := []*metric.Metric{}
 				if !s.CreationTimestamp.IsZero() {
@@ -107,12 +119,13 @@ func storageClassMetricFamilies(allowAnnotationsList, allowLabelsList []string) 
 				}
 			}),
 		),
-		*generator.NewFamilyGeneratorWithStability(
+		*generator.NewFamilyGeneratorWithLabels(
 			descStorageClassLabelsName,
 			descStorageClassLabelsHelp,
 			metric.Gauge,
 			basemetrics.STABLE,
 			"",
+			wrapStorageClassDefaultLabels([]string{"label_STORAGECLASS_LABEL"}),
 			wrapStorageClassFunc(func(s *storagev1.StorageClass) *metric.Family {
 				if len(allowLabelsList) == 0 {
 					return &metric.Family{}
@@ -139,7 +152,8 @@ func wrapStorageClassFunc(f func(*storagev1.StorageClass) *metric.Family) func(i
 		metricFamily := f(storageClass)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descStorageClassLabelsDefaultLabels, []string{storageClass.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys = wrapStorageClassDefaultLabels(m.LabelKeys)
+			m.LabelValues = wrapStorageClassDefaultLabelValues(storageClass.Name, m.LabelValues)
 		}
 
 		return metricFamily

--- a/internal/store/storageclass_test.go
+++ b/internal/store/storageclass_test.go
@@ -109,6 +109,7 @@ func TestStorageClassStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(storageClassMetricFamilies(nil, nil))
 		c.Headers = generator.ExtractMetricFamilyHeaders(storageClassMetricFamilies(nil, nil))
+		c.FamilyGens = storageClassMetricFamilies(nil, nil)
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/testdata/stable-metrics-list.yaml
+++ b/internal/store/testdata/stable-metrics-list.yaml
@@ -12,6 +12,7 @@
   labels:
     - certificatesigningrequest
     - signer_name
+    - condition
 - name: kube_certificatesigningrequest_created
   help: Unix creation timestamp
   type: Gauge
@@ -26,6 +27,7 @@
   labels:
     - certificatesigningrequest
     - signer_name
+    - label_CERTIFICATESIGNINGREQUEST_LABEL
 - name: kube_configmap_created
   help: Unix creation timestamp
   type: Gauge
@@ -405,6 +407,9 @@
   labels:
     - namespace
     - horizontalpodautoscaler
+    - metric_name
+    - metric_target_type
+    - container
 - name: kube_ingress_created
   help: Unix creation timestamp
   type: Gauge
@@ -1330,6 +1335,7 @@
   labels:
     - namespace
     - statefulset
+    - annotation_STATEFULSET_ANNOTATION
 - name: kube_statefulset_created
   help: Unix creation timestamp
   type: Gauge

--- a/internal/store/testdata/stable-metrics-list.yaml
+++ b/internal/store/testdata/stable-metrics-list.yaml
@@ -1,0 +1,1463 @@
+- name: kube_certificatesigningrequest_cert_length
+  help: Length of the issued cert
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - certificatesigningrequest
+    - signer_name
+- name: kube_certificatesigningrequest_condition
+  help: The number of each certificatesigningrequest condition
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - certificatesigningrequest
+    - signer_name
+- name: kube_certificatesigningrequest_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - certificatesigningrequest
+    - signer_name
+- name: kube_certificatesigningrequest_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - certificatesigningrequest
+    - signer_name
+- name: kube_configmap_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - configmap
+- name: kube_configmap_info
+  help: Information about configmap.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - configmap
+- name: kube_configmap_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - configmap
+    - label_CONFIGMAP_LABEL
+- name: kube_cronjob_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - cronjob
+- name: kube_cronjob_info
+  help: Info about cronjob.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - cronjob
+    - schedule
+    - concurrency_policy
+    - timezone
+- name: kube_cronjob_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - cronjob
+    - label_CRONJOB_LABEL
+- name: kube_cronjob_metadata_resource_version
+  help: Resource version representing a specific version of the cronjob.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - cronjob
+- name: kube_cronjob_next_schedule_time
+  help: Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - cronjob
+- name: kube_cronjob_spec_starting_deadline_seconds
+  help: Deadline in seconds for starting the job if it misses scheduled time for any reason.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - cronjob
+- name: kube_cronjob_spec_suspend
+  help: Suspend flag tells the controller to suspend subsequent executions.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - cronjob
+- name: kube_cronjob_status_active
+  help: Active holds pointers to currently running jobs.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - cronjob
+- name: kube_cronjob_status_last_schedule_time
+  help: LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - cronjob
+- name: kube_cronjob_status_last_successful_time
+  help: LastSuccessfulTime keeps information of when was the last time the job was completed successfully.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - cronjob
+- name: kube_daemonset_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+- name: kube_daemonset_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+    - label_DAEMONSET_LABEL
+- name: kube_daemonset_metadata_generation
+  help: Sequence number representing a specific generation of the desired state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+- name: kube_daemonset_status_current_number_scheduled
+  help: The number of nodes running at least one daemon pod and are supposed to.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+- name: kube_daemonset_status_desired_number_scheduled
+  help: The number of nodes that should be running the daemon pod.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+- name: kube_daemonset_status_number_available
+  help: The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+- name: kube_daemonset_status_number_misscheduled
+  help: The number of nodes running a daemon pod but are not supposed to.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+- name: kube_daemonset_status_number_ready
+  help: The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+- name: kube_daemonset_status_number_unavailable
+  help: The number of nodes that should be running the daemon pod and have none of the daemon pod running and available
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+- name: kube_daemonset_status_observed_generation
+  help: The most recent generation observed by the daemon set controller.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+- name: kube_daemonset_status_updated_number_scheduled
+  help: The total number of nodes that are running updated daemon pod
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - daemonset
+- name: kube_deployment_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+    - label_DEPLOYMENT_LABEL
+- name: kube_deployment_metadata_generation
+  help: Sequence number representing a specific generation of the desired state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_spec_paused
+  help: Whether the deployment is paused and will not be processed by the deployment controller.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_spec_replicas
+  help: Number of desired pods for a deployment.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_spec_strategy_rollingupdate_max_surge
+  help: Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_spec_strategy_rollingupdate_max_unavailable
+  help: Maximum number of unavailable replicas during a rolling update of a deployment.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_status_condition
+  help: The current status conditions of a deployment.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+    - reason
+    - condition
+    - status
+- name: kube_deployment_status_observed_generation
+  help: The generation observed by the deployment controller.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_status_replicas
+  help: The number of replicas per deployment.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_status_replicas_available
+  help: The number of available replicas per deployment.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_status_replicas_ready
+  help: The number of ready replicas per deployment.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_status_replicas_unavailable
+  help: The number of unavailable replicas per deployment.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_deployment_status_replicas_updated
+  help: The number of updated replicas per deployment.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - deployment
+- name: kube_endpoint_address
+  help: Information about Endpoint available and non available addresses.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - endpoint
+    - port_protocol
+    - port_number
+    - port_name
+    - ip
+    - ready
+- name: kube_endpoint_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - endpoint
+- name: kube_endpoint_info
+  help: Information about endpoint.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - endpoint
+- name: kube_endpoint_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - endpoint
+    - label_ENDPOINT_LABEL
+- name: kube_endpoint_ports
+  help: (Deprecated since v2.14.0) Information about the Endpoint ports.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - endpoint
+    - port_name
+    - port_protocol
+    - port_number
+- name: kube_horizontalpodautoscaler_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - horizontalpodautoscaler
+- name: kube_horizontalpodautoscaler_metadata_generation
+  help: The generation observed by the HorizontalPodAutoscaler controller.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - horizontalpodautoscaler
+- name: kube_horizontalpodautoscaler_spec_max_replicas
+  help: Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - horizontalpodautoscaler
+- name: kube_horizontalpodautoscaler_spec_min_replicas
+  help: Lower limit for the number of pods that can be set by the autoscaler, default 1.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - horizontalpodautoscaler
+- name: kube_horizontalpodautoscaler_status_condition
+  help: The condition of this autoscaler.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - horizontalpodautoscaler
+    - condition
+    - status
+- name: kube_horizontalpodautoscaler_status_current_replicas
+  help: Current number of replicas of pods managed by this autoscaler.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - horizontalpodautoscaler
+- name: kube_horizontalpodautoscaler_status_desired_replicas
+  help: Desired number of replicas of pods managed by this autoscaler.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - horizontalpodautoscaler
+- name: kube_horizontalpodautoscaler_status_target_metric
+  help: The current metric status used by this autoscaler when calculating the desired replica count.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - horizontalpodautoscaler
+- name: kube_ingress_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - ingress
+- name: kube_ingress_info
+  help: Information about ingress.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - ingress
+    - ingressclass
+- name: kube_ingress_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - ingress
+    - label_INGRESS_LABEL
+- name: kube_ingress_path
+  help: Ingress host, paths and backend service information.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - ingress
+    - host
+    - path
+    - path_type
+    - service_name
+    - service_port
+    - resource_api_group
+    - resource_kind
+    - resource_name
+- name: kube_ingress_tls
+  help: Ingress TLS host and secret information.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - ingress
+    - tls_host
+    - secret
+- name: kube_job_complete
+  help: The job has completed its execution.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+    - condition
+- name: kube_job_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+- name: kube_job_failed
+  help: The job has failed its execution.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+    - condition
+- name: kube_job_info
+  help: Information about job.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+- name: kube_job_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+    - label_JOB_LABEL
+- name: kube_job_owner
+  help: Information about the Job's owner.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+    - owner_kind
+    - owner_name
+    - owner_is_controller
+- name: kube_job_spec_active_deadline_seconds
+  help: The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+- name: kube_job_spec_completions
+  help: The desired number of successfully finished pods the job should be run with.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+- name: kube_job_spec_parallelism
+  help: The maximum desired number of pods the job should run at any given time.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+- name: kube_job_status_active
+  help: The number of actively running pods.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+- name: kube_job_status_completion_time
+  help: CompletionTime represents time when the job was completed.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+- name: kube_job_status_failed
+  help: The number of pods which reached Phase Failed and the reason for failure.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+    - reason
+- name: kube_job_status_start_time
+  help: StartTime represents time when the job was acknowledged by the Job Manager.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+- name: kube_job_status_succeeded
+  help: The number of pods which reached Phase Succeeded.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - job_name
+- name: kube_limitrange
+  help: Information about limit range.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - limitrange
+    - resource
+    - type
+    - constraint
+- name: kube_limitrange_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - limitrange
+- name: kube_namespace_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+- name: kube_namespace_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - label_NS_LABEL
+- name: kube_namespace_status_phase
+  help: kubernetes namespace status phase.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - phase
+- name: kube_node_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - node
+- name: kube_node_info
+  help: Information about a cluster node.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - node
+    - kernel_version
+    - os_image
+    - container_runtime_version
+    - kubelet_version
+    - kubeproxy_version
+    - provider_id
+    - pod_cidr
+    - system_uuid
+    - internal_ip
+- name: kube_node_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - node
+    - label_NODE_LABEL
+- name: kube_node_spec_taint
+  help: The taint of a cluster node.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - node
+    - key
+    - value
+    - effect
+- name: kube_node_spec_unschedulable
+  help: Whether a node can schedule new pods.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - node
+- name: kube_node_status_allocatable
+  help: The allocatable for different resources of a node that are available for scheduling.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - node
+    - resource
+    - unit
+- name: kube_node_status_capacity
+  help: The capacity for different resources of a node.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - node
+    - resource
+    - unit
+- name: kube_node_status_condition
+  help: The condition of a cluster node.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - node
+    - condition
+    - status
+- name: kube_persistentvolume_capacity_bytes
+  help: Persistentvolume capacity in bytes.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - persistentvolume
+- name: kube_persistentvolume_claim_ref
+  help: Information about the Persistent Volume Claim Reference.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - persistentvolume
+    - name
+    - claim_namespace
+- name: kube_persistentvolume_info
+  help: Information about persistentvolume.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - persistentvolume
+    - storageclass
+    - gce_persistent_disk_name
+    - ebs_volume_id
+    - azure_disk_name
+    - fc_wwids
+    - fc_lun
+    - fc_target_wwns
+    - iscsi_target_portal
+    - iscsi_iqn
+    - iscsi_lun
+    - iscsi_initiator_name
+    - nfs_server
+    - nfs_path
+    - csi_driver
+    - csi_volume_handle
+    - local_path
+    - local_fs
+    - host_path
+    - host_path_type
+    - reclaim_policy
+- name: kube_persistentvolume_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - persistentvolume
+    - label_PERSISTENTVOLUME_LABEL
+- name: kube_persistentvolume_status_phase
+  help: The phase indicates if a volume is available, bound to a claim, or released by a claim.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - persistentvolume
+    - phase
+- name: kube_persistentvolumeclaim_access_mode
+  help: The access mode(s) specified by the persistent volume claim.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - persistentvolumeclaim
+    - access_mode
+- name: kube_persistentvolumeclaim_info
+  help: Information about persistent volume claim.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - persistentvolumeclaim
+    - storageclass
+    - volumename
+    - volumemode
+- name: kube_persistentvolumeclaim_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - persistentvolumeclaim
+    - label_PERSISTENTVOLUMECLAIM_LABEL
+- name: kube_persistentvolumeclaim_resource_requests_storage_bytes
+  help: The capacity of storage requested by the persistent volume claim.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - persistentvolumeclaim
+- name: kube_persistentvolumeclaim_status_phase
+  help: The phase the persistent volume claim is currently in.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - persistentvolumeclaim
+    - phase
+- name: kube_pod_completion_time
+  help: Completion time in unix timestamp for a pod.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+- name: kube_pod_container_info
+  help: Information about a container in a pod.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+    - image_spec
+    - image
+    - image_id
+    - container_id
+- name: kube_pod_container_resource_limits
+  help: The number of requested limit resource by a container. It is recommended to use the kube_pod_resource_limits metric exposed by kube-scheduler instead, as it is more precise.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+    - node
+    - resource
+    - unit
+- name: kube_pod_container_resource_requests
+  help: The number of requested request resource by a container. It is recommended to use the kube_pod_resource_requests metric exposed by kube-scheduler instead, as it is more precise.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+    - node
+    - resource
+    - unit
+- name: kube_pod_container_state_started
+  help: Start time in unix timestamp for a pod container.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_container_status_ready
+  help: Describes whether the containers readiness check succeeded.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_container_status_restarts_total
+  help: The number of container restarts per container.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_container_status_running
+  help: Describes whether the container is currently in running state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_container_status_terminated
+  help: Describes whether the container is currently in terminated state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_container_status_waiting
+  help: Describes whether the container is currently in waiting state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_container_status_waiting_reason
+  help: Describes the reason the container is currently in waiting state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+    - reason
+- name: kube_pod_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+- name: kube_pod_info
+  help: Information about pod.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - host_ip
+    - pod_ip
+    - node
+    - created_by_kind
+    - created_by_name
+    - priority_class
+    - host_network
+- name: kube_pod_init_container_info
+  help: Information about an init container in a pod.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+    - image_spec
+    - image
+    - image_id
+    - container_id
+    - restart_policy
+- name: kube_pod_init_container_status_ready
+  help: Describes whether the init containers readiness check succeeded.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_init_container_status_restarts_total
+  help: The number of restarts for the init container.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_init_container_status_running
+  help: Describes whether the init container is currently in running state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_init_container_status_terminated
+  help: Describes whether the init container is currently in terminated state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_init_container_status_waiting
+  help: Describes whether the init container is currently in waiting state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - container
+- name: kube_pod_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - label_POD_LABEL
+- name: kube_pod_owner
+  help: Information about the Pod's owner.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - owner_kind
+    - owner_name
+    - owner_is_controller
+- name: kube_pod_restart_policy
+  help: Describes the restart policy in use by this pod.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - type
+- name: kube_pod_spec_volumes_persistentvolumeclaims_info
+  help: Information about persistentvolumeclaim volumes in a pod.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - volume
+    - persistentvolumeclaim
+- name: kube_pod_spec_volumes_persistentvolumeclaims_readonly
+  help: Describes whether a persistentvolumeclaim is mounted read only.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - volume
+    - persistentvolumeclaim
+- name: kube_pod_start_time
+  help: Start time in unix timestamp for a pod.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+- name: kube_pod_status_phase
+  help: The pods current phase.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - phase
+- name: kube_pod_status_ready
+  help: Describes whether the pod is ready to serve requests.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - condition
+- name: kube_pod_status_scheduled
+  help: Describes the status of the scheduling process for the pod.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+    - condition
+- name: kube_pod_status_scheduled_time
+  help: Unix timestamp when pod moved into scheduled status
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+- name: kube_pod_status_unschedulable
+  help: Describes the unschedulable status for the pod.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - pod
+    - uid
+- name: kube_poddisruptionbudget_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - poddisruptionbudget
+- name: kube_poddisruptionbudget_status_current_healthy
+  help: Current number of healthy pods
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - poddisruptionbudget
+- name: kube_poddisruptionbudget_status_desired_healthy
+  help: Minimum desired number of healthy pods
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - poddisruptionbudget
+- name: kube_poddisruptionbudget_status_expected_pods
+  help: Total number of pods counted by this disruption budget
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - poddisruptionbudget
+- name: kube_poddisruptionbudget_status_observed_generation
+  help: Most recent generation observed when updating this PDB status
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - poddisruptionbudget
+- name: kube_poddisruptionbudget_status_pod_disruptions_allowed
+  help: Number of pod disruptions that are currently allowed
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - poddisruptionbudget
+- name: kube_replicaset_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicaset
+- name: kube_replicaset_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicaset
+    - label_REPLICASET_LABEL
+- name: kube_replicaset_metadata_generation
+  help: Sequence number representing a specific generation of the desired state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicaset
+- name: kube_replicaset_owner
+  help: Information about the ReplicaSet's owner.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicaset
+    - owner_kind
+    - owner_name
+    - owner_is_controller
+- name: kube_replicaset_spec_replicas
+  help: Number of desired pods for a ReplicaSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicaset
+- name: kube_replicaset_status_fully_labeled_replicas
+  help: The number of fully labeled replicas per ReplicaSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicaset
+- name: kube_replicaset_status_observed_generation
+  help: The generation observed by the ReplicaSet controller.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicaset
+- name: kube_replicaset_status_ready_replicas
+  help: The number of ready replicas per ReplicaSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicaset
+- name: kube_replicaset_status_replicas
+  help: The number of replicas per ReplicaSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicaset
+- name: kube_replicationcontroller_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicationcontroller
+- name: kube_replicationcontroller_metadata_generation
+  help: Sequence number representing a specific generation of the desired state.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicationcontroller
+- name: kube_replicationcontroller_spec_replicas
+  help: Number of desired pods for a ReplicationController.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicationcontroller
+- name: kube_replicationcontroller_status_available_replicas
+  help: The number of available replicas per ReplicationController.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicationcontroller
+- name: kube_replicationcontroller_status_fully_labeled_replicas
+  help: The number of fully labeled replicas per ReplicationController.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicationcontroller
+- name: kube_replicationcontroller_status_observed_generation
+  help: The generation observed by the ReplicationController controller.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicationcontroller
+- name: kube_replicationcontroller_status_ready_replicas
+  help: The number of ready replicas per ReplicationController.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicationcontroller
+- name: kube_replicationcontroller_status_replicas
+  help: The number of replicas per ReplicationController.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - replicationcontroller
+- name: kube_resourcequota
+  help: Information about resource quota.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - resourcequota
+    - resource
+    - type
+- name: kube_resourcequota_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - resourcequota
+- name: kube_resourcequota_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - resourcequota
+    - label_RESOURCE_QUOTA_LABEL
+- name: kube_secret_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - secret
+- name: kube_secret_info
+  help: Information about secret.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - secret
+- name: kube_secret_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - secret
+    - label_SECRET_LABEL
+- name: kube_secret_type
+  help: Type about secret.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - secret
+    - type
+- name: kube_service_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - service
+    - uid
+- name: kube_service_info
+  help: Information about service.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - service
+    - uid
+    - cluster_ip
+    - external_name
+    - load_balancer_ip
+    - external_traffic_policy
+- name: kube_service_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - service
+    - uid
+    - label_SERVICE_LABEL
+- name: kube_service_spec_external_ip
+  help: Service external ips. One series for each ip
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - service
+    - uid
+    - external_ip
+- name: kube_service_spec_type
+  help: Type about service.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - service
+    - uid
+    - type
+- name: kube_service_status_load_balancer_ingress
+  help: Service load balancer ingress status
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - service
+    - uid
+    - ip
+    - hostname
+- name: kube_statefulset_annotations
+  help: Kubernetes annotations converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_deletion_timestamp
+  help: Unix deletion timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+    - label_STATEFULSET_LABEL
+- name: kube_statefulset_metadata_generation
+  help: Sequence number representing a specific generation of the desired state for the StatefulSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_ordinals_start
+  help: Start ordinal of the StatefulSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_persistentvolumeclaim_retention_policy
+  help: Count of retention policy for StatefulSet template PVCs
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+    - when_deleted
+    - when_scaled
+- name: kube_statefulset_replicas
+  help: Number of desired pods for a StatefulSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_status_current_revision
+  help: Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+    - revision
+- name: kube_statefulset_status_observed_generation
+  help: The generation observed by the StatefulSet controller.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_status_replicas
+  help: The number of replicas per StatefulSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_status_replicas_available
+  help: The number of available replicas per StatefulSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_status_replicas_current
+  help: The number of current replicas per StatefulSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_status_replicas_ready
+  help: The number of ready replicas per StatefulSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_status_replicas_updated
+  help: The number of updated replicas per StatefulSet.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+- name: kube_statefulset_status_update_revision
+  help: Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - namespace
+    - statefulset
+    - revision
+- name: kube_storageclass_created
+  help: Unix creation timestamp
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - storageclass
+- name: kube_storageclass_info
+  help: Information about storageclass.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - storageclass
+    - provisioner
+    - reclaim_policy
+    - volume_binding_mode
+- name: kube_storageclass_labels
+  help: Kubernetes labels converted to Prometheus labels.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+    - storageclass
+    - label_STORAGECLASS_LABEL

--- a/internal/store/testdata/stable-metrics-list.yaml
+++ b/internal/store/testdata/stable-metrics-list.yaml
@@ -353,6 +353,7 @@
   labels:
     - namespace
     - horizontalpodautoscaler
+    - label_HPA_LABEL
 - name: kube_horizontalpodautoscaler_metadata_generation
   help: The generation observed by the HorizontalPodAutoscaler controller.
   type: Gauge

--- a/internal/store/testdata/stable-metrics-list.yaml
+++ b/internal/store/testdata/stable-metrics-list.yaml
@@ -12,6 +12,7 @@
   labels:
     - certificatesigningrequest
     - signer_name
+    - condition
 - name: kube_certificatesigningrequest_created
   help: Unix creation timestamp
   type: Gauge
@@ -26,6 +27,7 @@
   labels:
     - certificatesigningrequest
     - signer_name
+    - label_CERTIFICATESIGNINGREQUEST_LABEL
 - name: kube_configmap_created
   help: Unix creation timestamp
   type: Gauge
@@ -405,6 +407,9 @@
   labels:
     - namespace
     - horizontalpodautoscaler
+    - metric_name
+    - metric_target_type
+    - container
 - name: kube_ingress_created
   help: Unix creation timestamp
   type: Gauge
@@ -977,7 +982,7 @@
     - uid
     - type
 - name: kube_pod_spec_volumes_persistentvolumeclaims_info
-  help: Information about persistentvolumeclaim volumes in a pod.
+  help: Information about persistentvolumeclaim and ephemeral volumes in a pod.
   type: Gauge
   stabilityLevel: BETA
   labels:
@@ -986,8 +991,9 @@
     - uid
     - volume
     - persistentvolumeclaim
+    - ephemeral
 - name: kube_pod_spec_volumes_persistentvolumeclaims_readonly
-  help: Describes whether a persistentvolumeclaim is mounted read only.
+  help: Describes whether a persistentvolumeclaim is mounted read only. Ephemeral volumes always report 0 since the ephemeral volume source does not support a read-only flag.
   type: Gauge
   stabilityLevel: BETA
   labels:
@@ -996,6 +1002,7 @@
     - uid
     - volume
     - persistentvolumeclaim
+    - ephemeral
 - name: kube_pod_start_time
   help: Start time in unix timestamp for a pod.
   type: Gauge
@@ -1330,6 +1337,7 @@
   labels:
     - namespace
     - statefulset
+    - annotation_STATEFULSET_ANNOTATION
 - name: kube_statefulset_created
   help: Unix creation timestamp
   type: Gauge

--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -21,12 +21,15 @@ package store
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+	basemetrics "k8s.io/component-base/metrics"
 )
 
 type generateMetricsTestCase struct {
@@ -37,10 +40,16 @@ type generateMetricsTestCase struct {
 	AllowAnnotationsList []string
 	AllowLabelsList      []string
 	Headers              []string
+	FamilyGens           []generator.FamilyGenerator
 }
 
 func (testCase *generateMetricsTestCase) run() error {
 	metricFamilies := testCase.Func(testCase.Obj)
+
+	if err := testCase.validateLabels(metricFamilies); err != nil {
+		return err
+	}
+
 	metricFamilyStrings := []string{}
 	for _, f := range metricFamilies {
 		metricFamilyStrings = append(metricFamilyStrings, string(f.ByteSlice()))
@@ -157,4 +166,69 @@ func removeUnusedWhitespace(s string) string {
 	}
 
 	return strings.Join(trimmedLines, "\n")
+}
+
+func (testCase *generateMetricsTestCase) validateLabels(metricFamilies []metric.FamilyInterface) error {
+	if testCase.FamilyGens == nil {
+		if strings.Contains(testCase.Want, "[STABLE]") {
+			return fmt.Errorf("test case expects STABLE metrics but FamilyGens is nil")
+		}
+		return nil
+	}
+
+	genMap := make(map[string]generator.FamilyGenerator, len(testCase.FamilyGens))
+	for _, gen := range testCase.FamilyGens {
+		genMap[gen.Name] = gen
+	}
+
+	for _, f := range metricFamilies {
+		var actualFamily metric.Family
+		f.Inspect(func(fam metric.Family) {
+			actualFamily = fam
+		})
+
+		gen, ok := genMap[actualFamily.Name]
+		if !ok {
+			return fmt.Errorf("metric %q emitted but has no corresponding generator in FamilyGens", actualFamily.Name)
+		}
+
+		if gen.StabilityLevel != basemetrics.STABLE {
+			continue
+		}
+
+		if err := validateFamilyLabels(actualFamily, gen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateFamilyLabels(family metric.Family, gen generator.FamilyGenerator) error {
+	for _, m := range family.Metrics {
+		for _, actualKey := range m.LabelKeys {
+			if slices.Contains(gen.Labels, actualKey) {
+				continue
+			}
+			if isDynamicLabelCompatible(actualKey, gen.Labels) {
+				continue
+			}
+			return fmt.Errorf("metric %q output undeclared label %q. Declared labels: %v", family.Name, actualKey, gen.Labels)
+		}
+	}
+	return nil
+}
+
+func isDynamicLabelCompatible(key string, declaredLabels []string) bool {
+	var prefix string
+	if strings.HasPrefix(key, "label_") {
+		prefix = "label_"
+	} else if strings.HasPrefix(key, "annotation_") {
+		prefix = "annotation_"
+	} else {
+		return false
+	}
+
+	return slices.ContainsFunc(declaredLabels, func(l string) bool {
+		return strings.HasPrefix(l, prefix)
+	})
 }

--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -25,8 +25,10 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
+	basemetrics "k8s.io/component-base/metrics"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
 )
 
 type generateMetricsTestCase struct {
@@ -37,10 +39,16 @@ type generateMetricsTestCase struct {
 	AllowAnnotationsList []string
 	AllowLabelsList      []string
 	Headers              []string
+	FamilyGens           []generator.FamilyGenerator
 }
 
 func (testCase *generateMetricsTestCase) run() error {
 	metricFamilies := testCase.Func(testCase.Obj)
+
+	if err := testCase.validateLabels(metricFamilies); err != nil {
+		return err
+	}
+
 	metricFamilyStrings := []string{}
 	for _, f := range metricFamilies {
 		metricFamilyStrings = append(metricFamilyStrings, string(f.ByteSlice()))
@@ -157,4 +165,70 @@ func removeUnusedWhitespace(s string) string {
 	}
 
 	return strings.Join(trimmedLines, "\n")
+}
+
+func (testCase *generateMetricsTestCase) validateLabels(metricFamilies []metric.FamilyInterface) error {
+	if testCase.FamilyGens == nil {
+		if strings.Contains(testCase.Want, "[STABLE]") {
+			return fmt.Errorf("test case expects STABLE metrics but FamilyGens is nil")
+		}
+		return nil
+	}
+
+	genMap := make(map[string]generator.FamilyGenerator, len(testCase.FamilyGens))
+	for _, gen := range testCase.FamilyGens {
+		genMap[gen.Name] = gen
+	}
+
+	for _, f := range metricFamilies {
+		var actualFamily metric.Family
+		f.Inspect(func(fam metric.Family) {
+			actualFamily = fam
+		})
+
+		gen, ok := genMap[actualFamily.Name]
+		if !ok {
+			return fmt.Errorf("metric %q emitted but has no corresponding generator in FamilyGens", actualFamily.Name)
+		}
+
+		if gen.StabilityLevel != basemetrics.STABLE {
+			continue
+		}
+
+		if err := validateFamilyLabels(actualFamily, gen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateFamilyLabels(family metric.Family, gen generator.FamilyGenerator) error {
+	for _, m := range family.Metrics {
+		for _, actualKey := range m.LabelKeys {
+			if slices.Contains(gen.Labels, actualKey) {
+				continue
+			}
+			if isDynamicLabelCompatible(actualKey, gen.Labels) {
+				continue
+			}
+			return fmt.Errorf("metric %q output undeclared label %q. Declared labels: %v", family.Name, actualKey, gen.Labels)
+		}
+	}
+	return nil
+}
+
+func isDynamicLabelCompatible(key string, declaredLabels []string) bool {
+	var prefix string
+	switch {
+	case strings.HasPrefix(key, "label_"):
+		prefix = "label_"
+	case strings.HasPrefix(key, "annotation_"):
+		prefix = "annotation_"
+	default:
+		return false
+	}
+
+	return slices.ContainsFunc(declaredLabels, func(l string) bool {
+		return strings.HasPrefix(l, prefix)
+	})
 }

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -196,26 +196,46 @@ func createPrometheusLabelKeysValues(prefix string, allKubeData map[string]strin
 	return kubeMapToPrometheusLabels(prefix, allowedKubeData)
 }
 
+func mergeKeys(keys ...[]string) []string {
+	capacity := 0
+	for _, keySet := range keys {
+		capacity += len(keySet)
+	}
+
+	mergedKeys := make([]string, 0, capacity)
+	for _, keySet := range keys {
+		mergedKeys = append(mergedKeys, keySet...)
+	}
+
+	return mergedKeys
+}
+
+func mergeValues(values ...[]string) []string {
+	capacity := 0
+	for _, valueSet := range values {
+		capacity += len(valueSet)
+	}
+
+	mergedValues := make([]string, 0, capacity)
+	for _, valueSet := range values {
+		mergedValues = append(mergedValues, valueSet...)
+	}
+
+	return mergedValues
+}
+
 // mergeKeyValues merges label keys and values slice pairs into a single slice pair.
 // Arguments are passed as equal-length pairs of slices, where the first slice contains keys and second contains values.
 // Example: mergeKeyValues(keys1, values1, keys2, values2) => (keys1+keys2, values1+values2)
 func mergeKeyValues(keyValues ...[]string) (keys, values []string) {
-	capacity := 0
-	for i := 0; i < len(keyValues); i += 2 {
-		capacity += len(keyValues[i])
-	}
-
-	// Allocate one contiguous block, then split it up to keys and values zero'd slices.
-	keysValues := make([]string, 0, capacity*2)
-	keys = (keysValues[0:capacity:capacity])[:0]
-	values = (keysValues[capacity : capacity*2])[:0]
+	var keySets, valueSets [][]string
 
 	for i := 0; i+1 < len(keyValues); i += 2 {
-		keys = append(keys, keyValues[i]...)
-		values = append(values, keyValues[i+1]...)
+		keySets = append(keySets, keyValues[i])
+		valueSets = append(valueSets, keyValues[i+1])
 	}
 
-	return keys, values
+	return mergeKeys(keySets...), mergeValues(valueSets...)
 }
 
 // convertValueToFloat64 converts a resource.Quantity to a float64 and checks for a possible overflow in the value.

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -228,14 +228,22 @@ func mergeValues(values ...[]string) []string {
 // Arguments are passed as equal-length pairs of slices, where the first slice contains keys and second contains values.
 // Example: mergeKeyValues(keys1, values1, keys2, values2) => (keys1+keys2, values1+values2)
 func mergeKeyValues(keyValues ...[]string) (keys, values []string) {
-	var keySets, valueSets [][]string
-
-	for i := 0; i+1 < len(keyValues); i += 2 {
-		keySets = append(keySets, keyValues[i])
-		valueSets = append(valueSets, keyValues[i+1])
+	capacity := 0
+	for i := 0; i < len(keyValues); i += 2 {
+		capacity += len(keyValues[i])
 	}
 
-	return mergeKeys(keySets...), mergeValues(valueSets...)
+	// Allocate one contiguous block, then split it up to keys and values zero'd slices.
+	keysValues := make([]string, 0, capacity*2)
+	keys = (keysValues[0:capacity:capacity])[:0]
+	values = (keysValues[capacity : capacity*2])[:0]
+
+	for i := 0; i+1 < len(keyValues); i += 2 {
+		keys = append(keys, keyValues[i]...)
+		values = append(values, keyValues[i+1]...)
+	}
+
+	return keys, values
 }
 
 // convertValueToFloat64 converts a resource.Quantity to a float64 and checks for a possible overflow in the value.

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -308,14 +308,22 @@ func mergeValues(values ...[]string) []string {
 // Arguments are passed as equal-length pairs of slices, where the first slice contains keys and second contains values.
 // Example: mergeKeyValues(keys1, values1, keys2, values2) => (keys1+keys2, values1+values2)
 func mergeKeyValues(keyValues ...[]string) (keys, values []string) {
-	var keySets, valueSets [][]string
-
-	for i := 0; i+1 < len(keyValues); i += 2 {
-		keySets = append(keySets, keyValues[i])
-		valueSets = append(valueSets, keyValues[i+1])
+	capacity := 0
+	for i := 0; i < len(keyValues); i += 2 {
+		capacity += len(keyValues[i])
 	}
 
-	return mergeKeys(keySets...), mergeValues(valueSets...)
+	// Allocate one contiguous block, then split it up to keys and values zero'd slices.
+	keysValues := make([]string, 0, capacity*2)
+	keys = (keysValues[0:capacity:capacity])[:0]
+	values = (keysValues[capacity : capacity*2])[:0]
+
+	for i := 0; i+1 < len(keyValues); i += 2 {
+		keys = append(keys, keyValues[i]...)
+		values = append(values, keyValues[i+1]...)
+	}
+
+	return keys, values
 }
 
 // convertValueToFloat64 converts a resource.Quantity to a float64 and checks for a possible overflow in the value.

--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -276,26 +276,46 @@ func cachedCompileAllowListPattern(pattern string) *regexp.Regexp {
 	return re
 }
 
+func mergeKeys(keys ...[]string) []string {
+	capacity := 0
+	for _, keySet := range keys {
+		capacity += len(keySet)
+	}
+
+	mergedKeys := make([]string, 0, capacity)
+	for _, keySet := range keys {
+		mergedKeys = append(mergedKeys, keySet...)
+	}
+
+	return mergedKeys
+}
+
+func mergeValues(values ...[]string) []string {
+	capacity := 0
+	for _, valueSet := range values {
+		capacity += len(valueSet)
+	}
+
+	mergedValues := make([]string, 0, capacity)
+	for _, valueSet := range values {
+		mergedValues = append(mergedValues, valueSet...)
+	}
+
+	return mergedValues
+}
+
 // mergeKeyValues merges label keys and values slice pairs into a single slice pair.
 // Arguments are passed as equal-length pairs of slices, where the first slice contains keys and second contains values.
 // Example: mergeKeyValues(keys1, values1, keys2, values2) => (keys1+keys2, values1+values2)
 func mergeKeyValues(keyValues ...[]string) (keys, values []string) {
-	capacity := 0
-	for i := 0; i < len(keyValues); i += 2 {
-		capacity += len(keyValues[i])
-	}
-
-	// Allocate one contiguous block, then split it up to keys and values zero'd slices.
-	keysValues := make([]string, 0, capacity*2)
-	keys = (keysValues[0:capacity:capacity])[:0]
-	values = (keysValues[capacity : capacity*2])[:0]
+	var keySets, valueSets [][]string
 
 	for i := 0; i+1 < len(keyValues); i += 2 {
-		keys = append(keys, keyValues[i]...)
-		values = append(values, keyValues[i+1]...)
+		keySets = append(keySets, keyValues[i])
+		valueSets = append(valueSets, keyValues[i+1])
 	}
 
-	return keys, values
+	return mergeKeys(keySets...), mergeValues(valueSets...)
 }
 
 // convertValueToFloat64 converts a resource.Quantity to a float64 and checks for a possible overflow in the value.

--- a/internal/store/utils_test.go
+++ b/internal/store/utils_test.go
@@ -319,3 +319,27 @@ func TestMergeKeyValues(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeKeys(t *testing.T) {
+	got := mergeKeys(
+		[]string{"keyA", "keyB"},
+		nil,
+		[]string{"keyC"},
+	)
+	want := []string{"keyA", "keyB", "keyC"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mergeKeys() got = %v, want %v", got, want)
+	}
+}
+
+func TestMergeValues(t *testing.T) {
+	got := mergeValues(
+		[]string{"valueA", "valueB"},
+		nil,
+		[]string{"valueC"},
+	)
+	want := []string{"valueA", "valueB", "valueC"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mergeValues() got = %v, want %v", got, want)
+	}
+}

--- a/internal/store/utils_test.go
+++ b/internal/store/utils_test.go
@@ -583,3 +583,27 @@ func BenchmarkMapToPrometheusLabels(b *testing.B) {
 		}
 	})
 }
+
+func TestMergeKeys(t *testing.T) {
+	got := mergeKeys(
+		[]string{"keyA", "keyB"},
+		nil,
+		[]string{"keyC"},
+	)
+	want := []string{"keyA", "keyB", "keyC"}
+	if !slices.Equal(got, want) {
+		t.Errorf("mergeKeys() got = %v, want %v", got, want)
+	}
+}
+
+func TestMergeValues(t *testing.T) {
+	got := mergeValues(
+		[]string{"valueA", "valueB"},
+		nil,
+		[]string{"valueC"},
+	)
+	want := []string{"valueA", "valueB", "valueC"}
+	if !slices.Equal(got, want) {
+		t.Errorf("mergeValues() got = %v, want %v", got, want)
+	}
+}

--- a/internal/store/validatingadmissionpolicy_test.go
+++ b/internal/store/validatingadmissionpolicy_test.go
@@ -80,6 +80,7 @@ func TestValidatingAdmissionPolicyStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(validatingAdmissionPolicyMetricFamilies)
 		c.Headers = generator.ExtractMetricFamilyHeaders(validatingAdmissionPolicyMetricFamilies)
+		c.FamilyGens = validatingAdmissionPolicyMetricFamilies
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/validatingadmissionpolicybinding_test.go
+++ b/internal/store/validatingadmissionpolicybinding_test.go
@@ -88,6 +88,7 @@ func TestValidatingAdmissionPolicyBindingStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(validatingAdmissionPolicyBindingMetricFamilies)
 		c.Headers = generator.ExtractMetricFamilyHeaders(validatingAdmissionPolicyBindingMetricFamilies)
+		c.FamilyGens = validatingAdmissionPolicyBindingMetricFamilies
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/validatingwebhookconfiguration_test.go
+++ b/internal/store/validatingwebhookconfiguration_test.go
@@ -105,6 +105,7 @@ func TestValidatingWebhookConfigurationStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(validatingWebhookConfigurationMetricFamilies)
 		c.Headers = generator.ExtractMetricFamilyHeaders(validatingWebhookConfigurationMetricFamilies)
+		c.FamilyGens = validatingWebhookConfigurationMetricFamilies
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/internal/store/volumeattachment_test.go
+++ b/internal/store/volumeattachment_test.go
@@ -89,6 +89,7 @@ func TestVolumeAttachmentStore(t *testing.T) {
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(volumeAttachmentMetricFamilies)
 		c.Headers = generator.ExtractMetricFamilyHeaders(volumeAttachmentMetricFamilies)
+		c.FamilyGens = volumeAttachmentMetricFamilies
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}

--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -34,6 +34,7 @@ type FamilyGenerator struct {
 	Name              string
 	Help              string
 	Type              metric.Type
+	Labels            []string
 	DeprecatedVersion string
 	StabilityLevel    basemetrics.StabilityLevel
 	OptIn             bool
@@ -42,10 +43,17 @@ type FamilyGenerator struct {
 // NewFamilyGeneratorWithStability creates new FamilyGenerator instances with metric
 // stabilityLevel.
 func NewFamilyGeneratorWithStability(name string, help string, metricType metric.Type, stabilityLevel basemetrics.StabilityLevel, deprecatedVersion string, generateFunc func(obj interface{}) *metric.Family) *FamilyGenerator {
+	return NewFamilyGeneratorWithLabels(name, help, metricType, stabilityLevel, deprecatedVersion, nil, generateFunc)
+}
+
+// NewFamilyGeneratorWithLabels creates new FamilyGenerator instances with metric
+// stabilityLevel and the complete set of label names emitted by the metric.
+func NewFamilyGeneratorWithLabels(name string, help string, metricType metric.Type, stabilityLevel basemetrics.StabilityLevel, deprecatedVersion string, labels []string, generateFunc func(obj interface{}) *metric.Family) *FamilyGenerator {
 	f := &FamilyGenerator{
 		Name:              name,
 		Type:              metricType,
 		Help:              help,
+		Labels:            labels,
 		OptIn:             false,
 		StabilityLevel:    stabilityLevel,
 		DeprecatedVersion: deprecatedVersion,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**

<!-- If you are adding a new metric, provide the use case of that metric. -->

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Fixes #1833


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and predictability of metric label schemas across Kubernetes resources.

* **Tests**
  * Added regression coverage against a stable-metrics reference list.
  * Added validation to ensure emitted labels match their declared schemas.
  * Added unit tests for label merging behavior.

* **Chores**
  * Added tools to update and verify the stable-metrics reference list.
  * Extended continuous integration to enforce stable-metrics consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->