### PR TITLE
feat: reduce cache memory use to 1/n  in sharded mode when ClientListWatch is not available

### DIFF
--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -49,7 +49,9 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 	if err != nil {
 		return nil, err
 	}
-	items, err := meta.ExtractList(list)
+	// Retained shard items outlive the source list. Allocate non-pointer items so
+	// they do not keep the source list's entire Items backing array reachable.
+	items, err := meta.ExtractListWithAlloc(list)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sharding/listwatch_test.go
+++ b/pkg/sharding/listwatch_test.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
@@ -57,6 +58,69 @@ func TestSharding(t *testing.T) {
 
 	if s2.keep(cm) {
 		t.Fatal("Shard two should not pick up the object.")
+	}
+}
+
+func TestShardedListWatchListDoesNotRetainSourceItemsArray(t *testing.T) {
+	const (
+		totalShards     = 2
+		resourceVersion = "42"
+	)
+
+	source := &v1.ConfigMapList{
+		ListMeta: metav1.ListMeta{ResourceVersion: resourceVersion},
+		Items: []v1.ConfigMap{
+			configMapForShard(0, totalShards),
+			configMapForShard(1, totalShards),
+		},
+	}
+	lw := &cache.ListWatch{
+		ListFunc: func(metav1.ListOptions) (runtime.Object, error) {
+			return source, nil
+		},
+	}
+	shardedLister := cache.ToListerWithContext(NewShardedListWatch(0, totalShards, lw))
+
+	result, err := shardedLister.ListWithContext(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list shard: %v", err)
+	}
+	list, ok := result.(*metav1.List)
+	if !ok {
+		t.Fatalf("got result type %T, want *metav1.List", result)
+	}
+	if list.ResourceVersion != resourceVersion {
+		t.Errorf("got resource version %q, want %q", list.ResourceVersion, resourceVersion)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("got %d retained items, want 1", len(list.Items))
+	}
+	retained, ok := list.Items[0].Object.(*v1.ConfigMap)
+	if !ok {
+		t.Fatalf("got retained item type %T, want *v1.ConfigMap", list.Items[0].Object)
+	}
+	if retained.UID != source.Items[0].UID {
+		t.Errorf("got retained item UID %q, want %q", retained.UID, source.Items[0].UID)
+	}
+	for i := range source.Items {
+		if retained == &source.Items[i] {
+			t.Fatalf("retained item aliases source Items[%d]", i)
+		}
+	}
+}
+
+func configMapForShard(shard int32, totalShards int) v1.ConfigMap {
+	filter := &sharding{shard: shard, totalShards: totalShards}
+	for i := 0; ; i++ {
+		configMap := v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "configmap-" + strconv.Itoa(i),
+				UID:  types.UID(strconv.Itoa(i)),
+			},
+		}
+		if filter.keep(&configMap) {
+			return configMap
+		}
 	}
 }
 


### PR DESCRIPTION
In sharded mode, KSM uses `meta.ExtractList` which explicitly states 
https://github.com/kubernetes/apimachinery/blob/v0.35.4/pkg/api/meta/help.go#L200
```
// If items in the returned list are retained for different durations, and you want to avoid
// retaining all items in obj as long as any item is referenced, use ExtractListWithAlloc instead.
```
This results in KSM keeping in memory all the objects being sent by the API server, not just the ones for the shard.

Replace the `meta.ExtractList` call with `meta.ExtractListWithAlloc` (it does a shallow copy and avoids the previous issue).
This means there will be a slight increase in transient memory usage (for the shallow copies), but the steady state cache memory usage will finally be in the order of 1/n compared to single shard.

When ClientListWatch is available, there is no such problem because there is no List call, just Watch and the objects will be processed individually.

Ran a sample bench with 2048 32k configmaps / 4 shards

Implementation | Retained heap | Retained payload
-- | -- | --
ExtractList | 65.36 MiB | 64 MiB—all 2,048 payloads
ExtractListWithAlloc | 16.74 MiB | 16.31 MiB—522 payloads
Reduction | 3.9× | 3.92×

total allocation volume:
Old: 68,546,032 B/op
New: 69,125,016 B/op
Increase: about 579 KiB, or 0.84%

So we see a slight increase because of the shallow copy (would be more pronounced with small objects)
