### PR TITLE
fix(deployment): emit default rolling update metrics

### DIFF
--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -39,6 +39,10 @@ var (
 	descDeploymentLabelsName          = "kube_deployment_labels"
 	descDeploymentLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
 	descDeploymentLabelsDefaultLabels = []string{"namespace", "deployment"}
+	defaultDeploymentRollingUpdate    = v1.RollingUpdateDeployment{
+		MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+		MaxSurge:       &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+	}
 )
 
 // Reasons copied from kubernetes/pkg/controller/deployment/deployment_utils.go.
@@ -307,11 +311,17 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				if d.Spec.Strategy.RollingUpdate == nil || d.Spec.Replicas == nil {
+				rollingUpdate := resolveDeploymentRollingUpdate(d)
+				if rollingUpdate == nil || d.Spec.Replicas == nil {
 					return &metric.Family{}
 				}
 
-				maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*d.Spec.Replicas), false)
+				maxUnavailable := rollingUpdate.MaxUnavailable
+				if maxUnavailable == nil {
+					maxUnavailable = defaultDeploymentRollingUpdate.MaxUnavailable
+				}
+
+				maxUnavailableValue, err := intstr.GetScaledValueFromIntOrPercent(maxUnavailable, int(*d.Spec.Replicas), false)
 				if err != nil {
 					panic(err)
 				}
@@ -319,7 +329,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							Value: float64(maxUnavailable),
+							Value: float64(maxUnavailableValue),
 						},
 					},
 				}
@@ -332,11 +342,17 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 			basemetrics.STABLE,
 			"",
 			wrapDeploymentFunc(func(d *v1.Deployment) *metric.Family {
-				if d.Spec.Strategy.RollingUpdate == nil || d.Spec.Replicas == nil {
+				rollingUpdate := resolveDeploymentRollingUpdate(d)
+				if rollingUpdate == nil || d.Spec.Replicas == nil {
 					return &metric.Family{}
 				}
 
-				maxSurge, err := intstr.GetScaledValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxSurge, int(*d.Spec.Replicas), true)
+				maxSurge := rollingUpdate.MaxSurge
+				if maxSurge == nil {
+					maxSurge = defaultDeploymentRollingUpdate.MaxSurge
+				}
+
+				maxSurgeValue, err := intstr.GetScaledValueFromIntOrPercent(maxSurge, int(*d.Spec.Replicas), true)
 				if err != nil {
 					panic(err)
 				}
@@ -344,7 +360,7 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
-							Value: float64(maxSurge),
+							Value: float64(maxSurgeValue),
 						},
 					},
 				}
@@ -458,4 +474,16 @@ func createDeploymentListWatch(kubeClient clientset.Interface, ns string, fieldS
 			return kubeClient.AppsV1().Deployments(ns).Watch(context.TODO(), opts)
 		},
 	}
+}
+
+func resolveDeploymentRollingUpdate(d *v1.Deployment) *v1.RollingUpdateDeployment {
+	if d.Spec.Strategy.Type == v1.RecreateDeploymentStrategyType {
+		return nil
+	}
+
+	if d.Spec.Strategy.RollingUpdate != nil {
+		return d.Spec.Strategy.RollingUpdate
+	}
+
+	return &defaultDeploymentRollingUpdate
 }

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -226,6 +226,8 @@ func TestDeploymentStore(t *testing.T) {
         kube_deployment_owner{deployment="depl3",namespace="ns3",owner_kind="",owner_name=""} 1
         kube_deployment_spec_paused{deployment="depl3",namespace="ns3"} 0
         kube_deployment_spec_replicas{deployment="depl3",namespace="ns3"} 1
+        kube_deployment_spec_strategy_rollingupdate_max_surge{deployment="depl3",namespace="ns3"} 1
+        kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="depl3",namespace="ns3"} 0
         kube_deployment_status_condition{condition="Available",deployment="depl3",namespace="ns3",reason="unknown",status="true"} 0
         kube_deployment_status_condition{condition="Available",deployment="depl3",namespace="ns3",reason="unknown",status="false"} 1
         kube_deployment_status_condition{condition="Available",deployment="depl3",namespace="ns3",reason="unknown",status="unknown"} 0
@@ -236,15 +238,40 @@ func TestDeploymentStore(t *testing.T) {
         kube_deployment_status_replicas_unavailable{deployment="depl3",namespace="ns3"} 0
         kube_deployment_status_replicas_updated{deployment="depl3",namespace="ns3"} 0
 	    kube_deployment_status_condition{condition="Progressing",deployment="depl3",namespace="ns3",reason="",status="false"} 0
-        kube_deployment_status_condition{condition="Progressing",deployment="depl3",namespace="ns3",reason="",status="true"} 1
+	    kube_deployment_status_condition{condition="Progressing",deployment="depl3",namespace="ns3",reason="",status="true"} 1
         kube_deployment_status_condition{condition="Progressing",deployment="depl3",namespace="ns3",reason="",status="unknown"} 0
 `,
 		},
 		{
 			Obj: &v1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "depl-default-rollingupdate",
+					Namespace: "ns4",
+				},
+				Spec: v1.DeploymentSpec{
+					Replicas: &depl4Replicas,
+				},
+			},
+			Want: metadata + `
+				kube_deployment_metadata_generation{deployment="depl-default-rollingupdate",namespace="ns4"} 0
+				kube_deployment_owner{deployment="depl-default-rollingupdate",namespace="ns4",owner_kind="",owner_name=""} 1
+				kube_deployment_spec_paused{deployment="depl-default-rollingupdate",namespace="ns4"} 0
+				kube_deployment_spec_replicas{deployment="depl-default-rollingupdate",namespace="ns4"} 10
+				kube_deployment_spec_strategy_rollingupdate_max_surge{deployment="depl-default-rollingupdate",namespace="ns4"} 3
+				kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="depl-default-rollingupdate",namespace="ns4"} 2
+				kube_deployment_status_observed_generation{deployment="depl-default-rollingupdate",namespace="ns4"} 0
+				kube_deployment_status_replicas{deployment="depl-default-rollingupdate",namespace="ns4"} 0
+				kube_deployment_status_replicas_available{deployment="depl-default-rollingupdate",namespace="ns4"} 0
+				kube_deployment_status_replicas_ready{deployment="depl-default-rollingupdate",namespace="ns4"} 0
+				kube_deployment_status_replicas_unavailable{deployment="depl-default-rollingupdate",namespace="ns4"} 0
+				kube_deployment_status_replicas_updated{deployment="depl-default-rollingupdate",namespace="ns4"} 0
+			`,
+		},
+		{
+			Obj: &v1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:              "deployment-terminating",
-					Namespace:         "ns4",
+					Namespace:         "ns5",
 					CreationTimestamp: metav1.Time{Time: time.Unix(1600000000, 0)},
 					DeletionTimestamp: &metav1.Time{Time: time.Unix(1800000000, 0)},
 					Labels: map[string]string{
@@ -260,7 +287,7 @@ func TestDeploymentStore(t *testing.T) {
 			Want: `
 			    # HELP kube_deployment_deletion_timestamp Unix deletion timestamp
 			    # TYPE kube_deployment_deletion_timestamp gauge
-					kube_deployment_deletion_timestamp{deployment="deployment-terminating",namespace="ns4"} 1.8e+09`,
+					kube_deployment_deletion_timestamp{deployment="deployment-terminating",namespace="ns5"} 1.8e+09`,
 			MetricNames: []string{"kube_deployment_deletion_timestamp"},
 		},
 		{
@@ -285,6 +312,8 @@ func TestDeploymentStore(t *testing.T) {
 				kube_deployment_metadata_generation{deployment="deployment-with-owner",namespace="ns5"} 0
 				kube_deployment_spec_paused{deployment="deployment-with-owner",namespace="ns5"} 0
 				kube_deployment_spec_replicas{deployment="deployment-with-owner",namespace="ns5"} 200
+				kube_deployment_spec_strategy_rollingupdate_max_surge{deployment="deployment-with-owner",namespace="ns5"} 50
+				kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="deployment-with-owner",namespace="ns5"} 50
 				kube_deployment_status_observed_generation{deployment="deployment-with-owner",namespace="ns5"} 0
 				kube_deployment_status_replicas{deployment="deployment-with-owner",namespace="ns5"} 0
 				kube_deployment_status_replicas_available{deployment="deployment-with-owner",namespace="ns5"} 0
@@ -308,6 +337,8 @@ func TestDeploymentStore(t *testing.T) {
 				kube_deployment_metadata_generation{deployment="deployment-without-owner",namespace="ns5"} 0
 				kube_deployment_spec_paused{deployment="deployment-without-owner",namespace="ns5"} 0
 				kube_deployment_spec_replicas{deployment="deployment-without-owner",namespace="ns5"} 200
+				kube_deployment_spec_strategy_rollingupdate_max_surge{deployment="deployment-without-owner",namespace="ns5"} 50
+				kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="deployment-without-owner",namespace="ns5"} 50
 				kube_deployment_status_observed_generation{deployment="deployment-without-owner",namespace="ns5"} 0
 				kube_deployment_status_replicas{deployment="deployment-without-owner",namespace="ns5"} 0
 				kube_deployment_status_replicas_available{deployment="deployment-without-owner",namespace="ns5"} 0


### PR DESCRIPTION
**What this PR does / why we need it:**

`kube_deployment_spec_strategy_rollingupdate_max_unavailable` and `kube_deployment_spec_strategy_rollingupdate_max_surge` are skipped when a Deployment leaves `spec.strategy.rollingUpdate` unset.

That case is pretty common. In `apps/v1`, Kubernetes defaults both fields to `25%`, so KSM was under-reporting these metrics for normal Deployments. This patch emits the defaulted values, and still skips `Recreate`.

Repro:
1. Apply a plain Deployment with `replicas: 10` and no `spec.strategy` / `spec.strategy.rollingUpdate`.
2. Scrape KSM before this patch.
3. `kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="demo",namespace="default"}` and `kube_deployment_spec_strategy_rollingupdate_max_surge{deployment="demo",namespace="default"}` are missing, which is kinda wrong.
4. After this patch they show up as `2` and `3`.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A
