### PR TITLE
fix: prevent leaked goroutines on CRD updates

### DIFF
--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -51,7 +51,9 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 	if err != nil {
 		return nil, err
 	}
-	items, err := meta.ExtractList(list)
+	// Retained shard items outlive the source list. Allocate non-pointer items so
+	// they do not keep the source list's entire Items backing array reachable.
+	items, err := meta.ExtractListWithAlloc(list)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -19,6 +19,7 @@ package sharding
 import (
 	"fmt"
 	"hash/fnv"
+	"sync"
 
 	jump "github.com/dgryski/go-jump"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +33,79 @@ import (
 type shardedListWatch struct {
 	sharding *sharding
 	lw       cache.ListerWatcher
+}
+
+// shardedWatch filters events from an upstream watch while allowing Stop to
+// interrupt both receiving and forwarding. This is intentionally local to the
+// sharding implementation: once its consumer stops, an in-flight event may be
+// discarded so the forwarding goroutine can terminate promptly. This avoids
+// the blocked-send leak in watch.Filter documented in:
+// https://github.com/kubernetes/kubernetes/issues/113254.
+type shardedWatch struct {
+	incoming watch.Interface
+	result   chan watch.Event
+	filter   watch.FilterFunc
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+	stopOnce sync.Once
+}
+
+var _ watch.Interface = &shardedWatch{}
+
+func newShardedWatch(incoming watch.Interface, filter watch.FilterFunc) *shardedWatch {
+	w := &shardedWatch{
+		incoming: incoming,
+		result:   make(chan watch.Event),
+		filter:   filter,
+		stopCh:   make(chan struct{}),
+		doneCh:   make(chan struct{}),
+	}
+	go w.run()
+	return w
+}
+
+// ResultChan returns the filtered event stream.
+func (w *shardedWatch) ResultChan() <-chan watch.Event {
+	return w.result
+}
+
+// Stop stops the upstream watch and unblocks the forwarding goroutine.
+func (w *shardedWatch) Stop() {
+	w.stopOnce.Do(func() {
+		// Close stopCh first so forwarding can stop independently of upstream
+		// watcher shutdown.
+		close(w.stopCh)
+		w.incoming.Stop()
+	})
+}
+
+func (w *shardedWatch) run() {
+	defer close(w.doneCh)
+	defer close(w.result)
+	defer w.Stop()
+
+	incoming := w.incoming.ResultChan()
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case event, ok := <-incoming:
+			if !ok {
+				return
+			}
+
+			filtered, keep := w.filter(event)
+			if !keep {
+				continue
+			}
+
+			select {
+			case <-w.stopCh:
+				return
+			case w.result <- filtered:
+			}
+		}
+	}
 }
 
 // NewShardedListWatch returns a new shardedListWatch via the cache.ListerWatcher interface.
@@ -84,7 +158,7 @@ func (s *shardedListWatch) Watch(options metav1.ListOptions) (watch.Interface, e
 		return nil, err
 	}
 
-	return watch.Filter(w, s.filterWatchEvent), nil
+	return newShardedWatch(w, s.filterWatchEvent), nil
 }
 
 // filterWatchEvent shards resource state changes, passes control events through,

--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -125,8 +125,9 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 	if err != nil {
 		return nil, err
 	}
-	// Retained shard items outlive the source list. Allocate non-pointer items so
-	// they do not keep the source list's entire Items backing array reachable.
+	// Shard items outlive the source list. ExtractListWithAlloc shallow-copies
+	// non-pointer items so retained objects cannot keep the source Items backing
+	// array reachable.
 	items, err := meta.ExtractListWithAlloc(list)
 	if err != nil {
 		return nil, err

--- a/pkg/sharding/listwatch_test.go
+++ b/pkg/sharding/listwatch_test.go
@@ -205,19 +205,24 @@ func TestShardedListWatchPassesInitialEventsEndBookmarkToEveryShard(t *testing.T
 	}
 }
 
+const shardedWatchTestTimeout = 5 * time.Second
+
 func TestShardedWatchStopUnblocksPendingSend(t *testing.T) {
 	// Regression test for https://github.com/kubernetes/kubernetes/issues/113254.
 	source := watch.NewRaceFreeFake()
 	filterCalled := make(chan struct{})
+	var filterCalledOnce sync.Once
 	filtered := newShardedWatch(source, func(event watch.Event) (watch.Event, bool) {
-		close(filterCalled)
+		filterCalledOnce.Do(func() {
+			close(filterCalled)
+		})
 		return event, true
 	})
 
 	source.Add(&v1.ConfigMap{})
 	select {
 	case <-filterCalled:
-	case <-time.After(time.Second):
+	case <-time.After(shardedWatchTestTimeout):
 		t.Fatal("timed out waiting for the event to reach the filter")
 	}
 
@@ -285,7 +290,7 @@ func waitForShardedWatchStop(t *testing.T, w *shardedWatch) {
 	t.Helper()
 	select {
 	case <-w.doneCh:
-	case <-time.After(time.Second):
+	case <-time.After(shardedWatchTestTimeout):
 		t.Fatal("timed out waiting for the sharded watch to stop")
 	}
 }

--- a/pkg/sharding/listwatch_test.go
+++ b/pkg/sharding/listwatch_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -201,4 +203,114 @@ func TestShardedListWatchPassesInitialEventsEndBookmarkToEveryShard(t *testing.T
 			}
 		})
 	}
+}
+
+func TestShardedWatchStopUnblocksPendingSend(t *testing.T) {
+	// Regression test for https://github.com/kubernetes/kubernetes/issues/113254.
+	source := watch.NewRaceFreeFake()
+	filterCalled := make(chan struct{})
+	filtered := newShardedWatch(source, func(event watch.Event) (watch.Event, bool) {
+		close(filterCalled)
+		return event, true
+	})
+
+	source.Add(&v1.ConfigMap{})
+	select {
+	case <-filterCalled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the event to reach the filter")
+	}
+
+	// Do not consume ResultChan. Stop must interrupt the pending send without
+	// relying on the consumer to drain the event.
+	filtered.Stop()
+	waitForShardedWatchStop(t, filtered)
+
+	select {
+	case _, ok := <-filtered.ResultChan():
+		if ok {
+			t.Fatal("got an event after the sharded watch stopped")
+		}
+	default:
+		t.Fatal("result channel is not closed after the sharded watch stopped")
+	}
+}
+
+func TestShardedWatchStopIsIdempotent(t *testing.T) {
+	source := newCountingWatch()
+	filtered := newShardedWatch(source, func(event watch.Event) (watch.Event, bool) {
+		return event, true
+	})
+
+	const callers = 10
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			filtered.Stop()
+		}()
+	}
+	wg.Wait()
+	waitForShardedWatchStop(t, filtered)
+
+	if got := source.stopCalls.Load(); got != 1 {
+		t.Fatalf("upstream Stop called %d times, want 1", got)
+	}
+}
+
+func TestShardedWatchClosesWhenUpstreamCloses(t *testing.T) {
+	source := newCountingWatch()
+	filtered := newShardedWatch(source, func(event watch.Event) (watch.Event, bool) {
+		return event, true
+	})
+
+	source.closeResult()
+	waitForShardedWatchStop(t, filtered)
+
+	select {
+	case _, ok := <-filtered.ResultChan():
+		if ok {
+			t.Fatal("got an event after the upstream watch closed")
+		}
+	default:
+		t.Fatal("result channel is not closed after the upstream watch closed")
+	}
+	if got := source.stopCalls.Load(); got != 1 {
+		t.Fatalf("upstream Stop called %d times after its result channel closed, want 1", got)
+	}
+}
+
+func waitForShardedWatchStop(t *testing.T, w *shardedWatch) {
+	t.Helper()
+	select {
+	case <-w.doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the sharded watch to stop")
+	}
+}
+
+type countingWatch struct {
+	result    chan watch.Event
+	stopCalls atomic.Int32
+	stopOnce  sync.Once
+}
+
+func newCountingWatch() *countingWatch {
+	return &countingWatch{result: make(chan watch.Event)}
+}
+
+func (w *countingWatch) Stop() {
+	w.stopCalls.Add(1)
+	w.closeResult()
+}
+
+func (w *countingWatch) closeResult() {
+	w.stopOnce.Do(func() {
+		close(w.result)
+	})
+}
+
+func (w *countingWatch) ResultChan() <-chan watch.Event {
+	return w.result
 }


### PR DESCRIPTION
This PR makes 2 changes to the KSM code:
### Use `meta.ExtractListWithAlloc` in `List` call for sharded code
The current `meta.ExtractList` call prevents the GC of the filtered objects until there is no reference left to any of the object in the list.
See https://github.com/kubernetes/apimachinery/blob/v0.35.4/pkg/api/meta/help.go#L200

### Prevent leaking go routines when rebuilding a reflector (for instance CRDs update event)
This is a manifestation of https://github.com/kubernetes/kubernetes/issues/113254
We need to drain the result channel to avoid ending with stuck watch.Filter goroutines (observed in live clusters).
In this case, we just drop the event which is acceptable since we'll rebuild the metrics afterward once the replacement watch is started
One example trigger for this is a CRD update event but anything that stops a watch can trigger it.