### PR TITLE
feat(customresourcestate): add valueType field for explicit duration parsing

### DIFF
--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -634,7 +634,6 @@ By default, kube-state-metrics automatically detects and converts values using t
 The `valueType` field in gauge configuration accepts the following values:
 
 * `duration` - Explicitly parse Go duration strings (e.g., "1h", "30m", "1h30m45s") and convert them to seconds
-* `quantity` - Explicitly parse Kubernetes resource quantities (e.g., "250m", "5Gi")
 * (empty/omitted) - Use automatic type detection (default behavior)
 
 ###### Duration Value Type
@@ -703,10 +702,7 @@ Use `valueType: duration` when:
 * Auto-detection fails because the string isn't recognized as a number
 * You want explicit, predictable parsing behavior
 
-Use `valueType: quantity` when:
-
-* You want to ensure Kubernetes quantity parsing (even if auto-detection would work)
-* You want to make the parsing behavior explicit in configuration
+Kubernetes quantities like "250m" or "5Gi" need no explicit valueType; automatic detection already parses them.
 
 ###### valueType with valueFrom
 

--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -191,7 +191,7 @@ spec:
               # if path targets an object, the object key will be used as label value
               # This is not supported for StateSet type as all values will be truthy, which is redundant.
               labelFromKey: type
-              # label values can be resolved specific to this path 
+              # label values can be resolved specific to this path
               labelsFromPath:
                 active: [active]
               # The actual field to use as metric value. Should be a number, boolean or RFC3339 timestamp string.
@@ -205,7 +205,7 @@ spec:
             # a prefix before the asterisk will be used as a label prefix
             "lorem_*": [metadata, annotations]
             "**": [metadata, annotations]
-            
+
             # or specific fields may be copied. these fields will always override values from *s
             name: [metadata, name]
             foo: [metadata, labels, foo]
@@ -214,10 +214,10 @@ spec:
 Produces the following metrics:
 
 ```prometheus
-kube_customresource_ready_count{customresource_group="myteam.io", customresource_kind="Foo", 
+kube_customresource_ready_count{customresource_group="myteam.io", customresource_kind="Foo",
 customresource_version="v1", active="1",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-a",
 lorem_bar="baz",lorem_qux="quxx",} 2
-kube_customresource_ready_count{customresource_group="myteam.io", customresource_kind="Foo", 
+kube_customresource_ready_count{customresource_group="myteam.io", customresource_kind="Foo",
 customresource_version="v1", active="3",custom_metric="yes",foo="bar",name="foo",bar="baz",qux="quxx",type="type-b",
 lorem_bar="baz",lorem_qux="quxx",} 4
 ```
@@ -620,10 +620,112 @@ Supported types are:
 * for bool `true` is mapped to `1.0` and `false` is mapped to `0.0`
 * for string the following logic applies
   * `"true"` and `"yes"` are mapped to `1.0`, `"false"`, `"no"` and `"unknown"` are mapped to `0.0` (all case-insensitive)
-  * RFC3339 times are parsed to float timestamp  
+  * RFC3339 times are parsed to float timestamp
   * Quantities like "250m" or "512Gi" are parsed to float using <https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go>
   * Percentages ending with a "%" are parsed to float
   * finally the string is parsed to float using <https://pkg.go.dev/strconv#ParseFloat> which should support all common number formats. If that fails an error is yielded
+
+##### Value Type Specification
+
+By default, kube-state-metrics automatically detects and converts values using the logic described above. However, you can **explicitly specify the value type** for more predictable parsing, especially for duration strings that would otherwise fail float parsing.
+
+###### Available Value Types
+
+The `valueType` field in gauge configuration accepts the following values:
+
+* `duration` - Explicitly parse Go duration strings (e.g., "1h", "30m", "1h30m45s") and convert them to seconds
+* `quantity` - Explicitly parse Kubernetes resource quantities (e.g., "250m", "5Gi")
+* (empty/omitted) - Use automatic type detection (default behavior)
+
+###### Duration Value Type
+
+The `duration` value type is particularly useful for custom resources that store time values as Go duration strings, such as cert-manager Certificates.
+
+###### Example: cert-manager Certificate Duration
+
+```yaml
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: cert-manager.io
+        version: v1
+        kind: Certificate
+      labelsFromPath:
+        name: [metadata, name]
+        namespace: [metadata, namespace]
+      metrics:
+        - name: "certificate_duration_seconds"
+          help: "Certificate validity duration in seconds"
+          each:
+            type: Gauge
+            gauge:
+              path: [spec, duration]
+              valueType: duration  # Explicitly parse as duration
+
+        - name: "certificate_renew_before_seconds"
+          help: "Time before expiration when certificate should be renewed"
+          each:
+            type: Gauge
+            gauge:
+              path: [spec, renewBefore]
+              valueType: duration  # Explicitly parse as duration
+```
+
+###### Supported Duration Formats
+
+The `duration` value type uses Go's `time.ParseDuration` format and supports:
+
+* Hours: `"1h"`, `"24h"`, `"2160h"` (90 days)
+* Minutes: `"30m"`, `"90m"`
+* Seconds: `"45s"`
+* Milliseconds: `"500ms"`
+* Microseconds: `"100us"`, `"1000µs"`
+* Nanoseconds: `"1000ns"`
+* Combined: `"1h30m45s"`, `"2h15m30s"`
+
+All durations are converted to **seconds as float64** for Prometheus compatibility.
+
+###### Example Metrics Output
+
+For a cert-manager Certificate with `spec.duration: "2160h"` and `spec.renewBefore: "720h"`:
+
+```prometheus
+kube_customresource_certificate_duration_seconds{customresource_group="cert-manager.io", customresource_kind="Certificate", customresource_version="v1", name="example-cert", namespace="default"} 7776000
+kube_customresource_certificate_renew_before_seconds{customresource_group="cert-manager.io", customresource_kind="Certificate", customresource_version="v1", name="example-cert", namespace="default"} 2592000
+```
+
+###### When to Use valueType
+
+Use `valueType: duration` when:
+
+* The resource field contains Go duration strings (e.g., "72h", "30m")
+* Auto-detection fails because the string isn't recognized as a number
+* You want explicit, predictable parsing behavior
+
+Use `valueType: quantity` when:
+
+* You want to ensure Kubernetes quantity parsing (even if auto-detection would work)
+* You want to make the parsing behavior explicit in configuration
+
+###### valueType with valueFrom
+
+The `valueType` field works with both direct `path` and `valueFrom` configurations:
+
+```yaml
+# Direct path
+gauge:
+  path: [spec, duration]
+  valueType: duration
+
+# With valueFrom (nested extraction)
+gauge:
+  path: [spec]
+  valueFrom: [duration]
+  valueType: duration
+  labelsFromPath:
+    name: [name]
+```
 
 ##### Example for status conditions on Kubernetes Controllers
 
@@ -805,10 +907,10 @@ Examples:
 # indexing an array
 [spec, order, "0", value]                # spec.order[0].value = true
 
-# finding an element in a list by key=value  
+# finding an element in a list by key=value
 [status, conditions, "[name=a]", value]  # status.conditions[0].value = 45
 
-# if the value to be matched is a number or boolean, the value is compared as a number or boolean  
+# if the value to be matched is a number or boolean, the value is compared as a number or boolean
 [status, conditions, "[value=66]", name]  # status.conditions[1].name = "b"
 
 # For generally matching against a field in an object schema, use the following syntax:

--- a/pkg/customresourcestate/config_metrics_types.go
+++ b/pkg/customresourcestate/config_metrics_types.go
@@ -16,6 +16,20 @@ limitations under the License.
 
 package customresourcestate
 
+// ValueType specifies how to parse the value from the resource field.
+type ValueType string
+
+const (
+	// ValueTypeDefault uses automatic type detection (current behavior).
+	// This is the default when ValueType is not specified.
+	ValueTypeDefault ValueType = ""
+	// ValueTypeDuration parses duration strings (e.g., "1h", "30m", "1h30m45s") using time.ParseDuration.
+	// The parsed duration is converted to seconds as a float64 for Prometheus compatibility.
+	ValueTypeDuration ValueType = "duration"
+	// ValueTypeQuantity parses Kubernetes resource quantities (e.g., "250m" for millicores, "1Gi" for memory).
+	ValueTypeQuantity ValueType = "quantity"
+)
+
 // MetricMeta are variables which may used for any metric type.
 type MetricMeta struct {
 	// LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
@@ -32,7 +46,9 @@ type MetricGauge struct {
 	MetricMeta   `yaml:",inline" json:",inline"`
 
 	// ValueFrom is the path to a numeric field under Path that will be the metric value.
-	ValueFrom []string `yaml:"valueFrom" json:"valueFrom"`
+	ValueFrom []string  `yaml:"valueFrom" json:"valueFrom"`
+	ValueType ValueType `yaml:"valueType,omitempty" json:"valueType,omitempty"`
+
 	// NilIsZero indicates that if a value is nil it will be treated as zero value.
 	NilIsZero bool `yaml:"nilIsZero" json:"nilIsZero"`
 }

--- a/pkg/customresourcestate/config_metrics_types.go
+++ b/pkg/customresourcestate/config_metrics_types.go
@@ -46,7 +46,8 @@ type MetricGauge struct {
 	MetricMeta   `yaml:",inline" json:",inline"`
 
 	// ValueFrom is the path to a numeric field under Path that will be the metric value.
-	ValueFrom []string  `yaml:"valueFrom" json:"valueFrom"`
+	ValueFrom []string `yaml:"valueFrom" json:"valueFrom"`
+	// ValueType controls how the value at ValueFrom is parsed: "duration", "quantity", or empty for automatic detection.
 	ValueType ValueType `yaml:"valueType,omitempty" json:"valueType,omitempty"`
 
 	// NilIsZero indicates that if a value is nil it will be treated as zero value.

--- a/pkg/customresourcestate/config_metrics_types.go
+++ b/pkg/customresourcestate/config_metrics_types.go
@@ -26,8 +26,6 @@ const (
 	// ValueTypeDuration parses duration strings (e.g., "1h", "30m", "1h30m45s") using time.ParseDuration.
 	// The parsed duration is converted to seconds as a float64 for Prometheus compatibility.
 	ValueTypeDuration ValueType = "duration"
-	// ValueTypeQuantity parses Kubernetes resource quantities (e.g., "250m" for millicores, "1Gi" for memory).
-	ValueTypeQuantity ValueType = "quantity"
 )
 
 // MetricMeta are variables which may used for any metric type.
@@ -47,7 +45,7 @@ type MetricGauge struct {
 
 	// ValueFrom is the path to a numeric field under Path that will be the metric value.
 	ValueFrom []string `yaml:"valueFrom" json:"valueFrom"`
-	// ValueType controls how the value at ValueFrom is parsed: "duration", "quantity", or empty for automatic detection.
+	// ValueType controls how the value at ValueFrom is parsed: "duration", or empty for automatic detection.
 	ValueType ValueType `yaml:"valueType,omitempty" json:"valueType,omitempty"`
 
 	// NilIsZero indicates that if a value is nil it will be treated as zero value.

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -170,7 +170,7 @@ func newCompiledMetric(m Metric) (compiledMetric, error) {
 			return nil, fmt.Errorf("each.gauge.valueFrom: %w", err)
 		}
 		switch m.Gauge.ValueType {
-		case ValueTypeDefault, ValueTypeDuration, ValueTypeQuantity:
+		case ValueTypeDefault, ValueTypeDuration:
 		default:
 			return nil, fmt.Errorf("each.gauge.valueType: unknown valueType: %s", m.Gauge.ValueType)
 		}
@@ -249,9 +249,9 @@ func (c *compiledGauge) Values(v interface{}) (result []eachValue, errs []error)
 				len(sValueFrom) > 2 {
 				extractedValueFrom := sValueFrom[1 : len(sValueFrom)-1]
 				if key == extractedValueFrom {
-					gotFloat, err := parseGaugeValue(it, c.valueType, c.NilIsZero)
-					if err != nil {
-						onError(fmt.Errorf("[%s]: %w", key, err))
+					gotFloat, parseErr := parseGaugeValue(it, c.valueType, c.NilIsZero)
+					if parseErr != nil {
+						onError(fmt.Errorf("[%s]: %w", key, parseErr))
 						continue
 					}
 					labels := make(map[string]string)
@@ -464,7 +464,7 @@ func parseGaugeValue(value interface{}, valueType ValueType, nilIsZero bool) (fl
 			return 0, errors.New("expected duration but found nil value")
 		}
 		return parseDurationValue(value)
-	case ValueTypeQuantity, ValueTypeDefault:
+	case ValueTypeDefault:
 		return toFloat64(value, nilIsZero)
 	default:
 		return 0, fmt.Errorf("unknown valueType: %s", valueType)

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -250,7 +250,12 @@ func (c *compiledGauge) Values(v interface{}) (result []eachValue, errs []error)
 
 					switch c.valueType {
 					case ValueTypeDuration:
-						gotFloat, err = parseDurationValue(it)
+						if it == nil {
+							// Mirror value(): respect NilIsZero for nil values instead of failing duration parsing.
+							gotFloat, err = toFloat64(it, c.NilIsZero)
+						} else {
+							gotFloat, err = parseDurationValue(it)
+						}
 					case ValueTypeQuantity:
 						gotFloat, err = toFloat64(it, c.NilIsZero)
 					case ValueTypeDefault:

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -174,6 +174,7 @@ func newCompiledMetric(m Metric) (compiledMetric, error) {
 			ValueFrom:      valueFromPath,
 			NilIsZero:      m.Gauge.NilIsZero,
 			labelFromKey:   m.Gauge.LabelFromKey,
+			valueType:      m.Gauge.ValueType,
 		}, nil
 	case metric.Info:
 		if m.Info == nil {
@@ -217,6 +218,7 @@ type compiledGauge struct {
 	labelFromKey string
 	ValueFrom    valuePath
 	NilIsZero    bool
+	valueType    ValueType
 }
 
 func (c *compiledGauge) Values(v interface{}) (result []eachValue, errs []error) {
@@ -242,7 +244,21 @@ func (c *compiledGauge) Values(v interface{}) (result []eachValue, errs []error)
 				len(sValueFrom) > 2 {
 				extractedValueFrom := sValueFrom[1 : len(sValueFrom)-1]
 				if key == extractedValueFrom {
-					gotFloat, err := toFloat64(it, c.NilIsZero)
+					// Check if explicit valueType is specified
+					var gotFloat float64
+					var err error
+
+					switch c.valueType {
+					case ValueTypeDuration:
+						gotFloat, err = parseDurationValue(it)
+					case ValueTypeQuantity:
+						gotFloat, err = toFloat64(it, c.NilIsZero)
+					case ValueTypeDefault:
+						gotFloat, err = toFloat64(it, c.NilIsZero)
+					default:
+						err = fmt.Errorf("unknown valueType: %s", c.valueType)
+					}
+
 					if err != nil {
 						onError(fmt.Errorf("[%s]: %w", key, err))
 						continue
@@ -463,7 +479,23 @@ func (c compiledGauge) value(it interface{}) (*eachValue, error) {
 		// Don't error if there was not a type-casting issue (`toFloat64`).
 		return nil, nil
 	}
-	value, err := toFloat64(got, c.NilIsZero)
+
+	// Check if explicit valueType is specified
+	var value float64
+	var err error
+	switch c.valueType {
+	case ValueTypeDuration:
+		value, err = parseDurationValue(got)
+	case ValueTypeQuantity:
+		// Use existing quantity parsing from toFloat64
+		value, err = toFloat64(got, c.NilIsZero)
+	case ValueTypeDefault:
+		// Fall through to auto-detection (existing logic)
+		value, err = toFloat64(got, c.NilIsZero)
+	default:
+		return nil, fmt.Errorf("unknown valueType: %s", c.valueType)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", c.ValueFrom, err)
 	}
@@ -717,6 +749,35 @@ func scrapeValuesFor(e compiledEach, obj map[string]interface{}) ([]eachValue, [
 		return less(result[i].Labels, result[j].Labels)
 	})
 	return result, errs
+}
+
+// parseDurationValue converts a duration string to seconds as float64.
+// It uses time.ParseDuration to parse strings like "1h", "30m", "1h30m45s".
+// The result is converted to seconds for Prometheus compatibility.
+func parseDurationValue(value interface{}) (float64, error) {
+	var durationStr string
+
+	switch v := value.(type) {
+	case string:
+		durationStr = v
+	case nil:
+		return 0, fmt.Errorf("nil value cannot be parsed as duration")
+	default:
+		return 0, fmt.Errorf("value must be a string for duration parsing, got %T", value)
+	}
+
+	// Handle empty string
+	if durationStr == "" {
+		return 0, fmt.Errorf("empty string cannot be parsed as duration")
+	}
+
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse duration '%s': %w", durationStr, err)
+	}
+
+	// Convert to seconds as float64 for Prometheus compatibility
+	return duration.Seconds(), nil
 }
 
 // toFloat64 converts the value to a float64 which is the value type for any metric.

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -169,6 +169,11 @@ func newCompiledMetric(m Metric) (compiledMetric, error) {
 		if err != nil {
 			return nil, fmt.Errorf("each.gauge.valueFrom: %w", err)
 		}
+		switch m.Gauge.ValueType {
+		case ValueTypeDefault, ValueTypeDuration, ValueTypeQuantity:
+		default:
+			return nil, fmt.Errorf("each.gauge.valueType: unknown valueType: %s", m.Gauge.ValueType)
+		}
 		return &compiledGauge{
 			compiledCommon: *cc,
 			ValueFrom:      valueFromPath,
@@ -244,26 +249,7 @@ func (c *compiledGauge) Values(v interface{}) (result []eachValue, errs []error)
 				len(sValueFrom) > 2 {
 				extractedValueFrom := sValueFrom[1 : len(sValueFrom)-1]
 				if key == extractedValueFrom {
-					// Check if explicit valueType is specified
-					var gotFloat float64
-					var err error
-
-					switch c.valueType {
-					case ValueTypeDuration:
-						if it == nil {
-							// Mirror value(): respect NilIsZero for nil values instead of failing duration parsing.
-							gotFloat, err = toFloat64(it, c.NilIsZero)
-						} else {
-							gotFloat, err = parseDurationValue(it)
-						}
-					case ValueTypeQuantity:
-						gotFloat, err = toFloat64(it, c.NilIsZero)
-					case ValueTypeDefault:
-						gotFloat, err = toFloat64(it, c.NilIsZero)
-					default:
-						err = fmt.Errorf("unknown valueType: %s", c.valueType)
-					}
-
+					gotFloat, err := parseGaugeValue(it, c.valueType, c.NilIsZero)
 					if err != nil {
 						onError(fmt.Errorf("[%s]: %w", key, err))
 						continue
@@ -466,6 +452,25 @@ func less(a, b map[string]string) bool {
 	return len(aKeys) < len(bKeys)
 }
 
+// parseGaugeValue converts a resolved value into a float64 according to valueType.
+// Shared by the valueFrom fast path and value() so their parsing cannot drift.
+func parseGaugeValue(value interface{}, valueType ValueType, nilIsZero bool) (float64, error) {
+	switch valueType {
+	case ValueTypeDuration:
+		if value == nil {
+			if nilIsZero {
+				return 0, nil
+			}
+			return 0, errors.New("expected duration but found nil value")
+		}
+		return parseDurationValue(value)
+	case ValueTypeQuantity, ValueTypeDefault:
+		return toFloat64(value, nilIsZero)
+	default:
+		return 0, fmt.Errorf("unknown valueType: %s", valueType)
+	}
+}
+
 func (c compiledGauge) value(it interface{}) (*eachValue, error) {
 	labels := make(map[string]string)
 	got := c.ValueFrom.Get(it)
@@ -485,22 +490,7 @@ func (c compiledGauge) value(it interface{}) (*eachValue, error) {
 		return nil, nil
 	}
 
-	// Check if explicit valueType is specified
-	var value float64
-	var err error
-	switch c.valueType {
-	case ValueTypeDuration:
-		value, err = parseDurationValue(got)
-	case ValueTypeQuantity:
-		// Use existing quantity parsing from toFloat64
-		value, err = toFloat64(got, c.NilIsZero)
-	case ValueTypeDefault:
-		// Fall through to auto-detection (existing logic)
-		value, err = toFloat64(got, c.NilIsZero)
-	default:
-		return nil, fmt.Errorf("unknown valueType: %s", c.valueType)
-	}
-
+	value, err := parseGaugeValue(got, c.valueType, c.NilIsZero)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", c.ValueFrom, err)
 	}

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -726,6 +726,23 @@ func TestDurationValueType(t *testing.T) {
 			},
 			wantResult: []eachValue{newEachValue(t, 2592000.0, "name", "test-cert")},
 		},
+		{
+			name: "duration nil with NilIsZero in valueFrom fast path",
+			each: &compiledGauge{
+				compiledCommon: compiledCommon{
+					path: mustCompilePath(t, "spec"),
+				},
+				ValueFrom: mustCompilePath(t, "duration"),
+				valueType: ValueTypeDuration,
+				NilIsZero: true,
+			},
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"duration": nil,
+				},
+			},
+			wantResult: []eachValue{newEachValue(t, 0)},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -743,6 +743,24 @@ func TestDurationValueType(t *testing.T) {
 			},
 			wantResult: []eachValue{newEachValue(t, 0)},
 		},
+		{
+			name: "duration nil without NilIsZero in valueFrom fast path",
+			each: &compiledGauge{
+				compiledCommon: compiledCommon{
+					path: mustCompilePath(t, "spec"),
+				},
+				ValueFrom: mustCompilePath(t, "duration"),
+				valueType: ValueTypeDuration,
+			},
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"duration": nil,
+				},
+			},
+			wantErrors: []error{
+				errors.New("[spec]: [duration]: expected duration but found nil value"),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -752,6 +770,18 @@ func TestDurationValueType(t *testing.T) {
 			assert.Equal(t, tt.wantErrors, gotErrors)
 		})
 	}
+}
+
+func Test_newCompiledMetric_rejectsUnknownValueType(t *testing.T) {
+	_, err := newCompiledMetric(Metric{
+		Type: metric.Gauge,
+		Gauge: &MetricGauge{
+			MetricMeta: MetricMeta{Path: []string{"spec"}},
+			ValueFrom:  []string{"duration"},
+			ValueType:  "bogus",
+		},
+	})
+	assert.EqualError(t, err, "each.gauge.valueType: unknown valueType: bogus")
 }
 
 // TestValueTypeBackwardCompatibility tests that omitting valueType still works


### PR DESCRIPTION
Revives #2797 (closed as rotten when the original author went inactive) to implement the duration-parsing feature requested in #2625, which is `triage/accepted`. @mrueg suggested picking this up.

Adds a `valueType` field to the custom resource state gauge configuration. `valueType: duration` parses Go duration strings (for example `"2160h"`) with `time.ParseDuration` and converts them to seconds. This helps with resources such as cert-manager Certificates that store durations as strings and would otherwise fail float parsing.

Co-authored with the original author @SoumyaRaikwar.

Fixes #2625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `valueType` option for gauge metrics to control `valueFrom` parsing: default/auto behavior or `duration` (converted to seconds).
* **Documentation**
  * Refined Custom Resource State Metrics examples, expanded gauge `valueType` guidance (including duration semantics), and clarified `status.conditions` key=value matching.
* **Bug Fixes**
  * Enforced validation for unsupported `valueType` values with clear errors and ensured consistent gauge value parsing (including nil handling via `NilIsZero`).
* **Tests**
  * Added coverage for duration parsing, nil/empty/error cases, backward compatibility, and unknown `valueType` rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->