### PR TITLE
fix(cronjob): embed tzdata so named spec.timeZone values resolve

### DIFF
--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -22,6 +22,11 @@ import (
 	"fmt"
 	"time"
 
+	// Embed the IANA time zone database into the binary so that named time
+	// zones (e.g. a CronJob's spec.timeZone of "Asia/Singapore") resolve even
+	// when running from a minimal/distroless image that ships no tzdata.
+	_ "time/tzdata"
+
 	cron "github.com/netresearch/go-cron"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -44,38 +44,44 @@ var (
 )
 
 func calculateNextSchedule6h(timestamp time.Time, timezone string) time.Time {
-	loc, _ := time.LoadLocation(timezone)
-	hour := timestamp.In(loc).Hour()
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		panic(err)
+	}
+	// Extract the date components in the target zone, not the machine's local
+	// zone, so the result is correct regardless of where the test runs.
+	ts := timestamp.In(loc)
+	hour := ts.Hour()
 	switch {
 	case hour < 6:
 		return time.Date(
-			timestamp.Year(),
-			timestamp.Month(),
-			timestamp.Day(),
+			ts.Year(),
+			ts.Month(),
+			ts.Day(),
 			6,
 			0,
 			0, 0, loc)
 	case hour < 12:
 		return time.Date(
-			timestamp.Year(),
-			timestamp.Month(),
-			timestamp.Day(),
+			ts.Year(),
+			ts.Month(),
+			ts.Day(),
 			12,
 			0,
 			0, 0, loc)
 	case hour < 18:
 		return time.Date(
-			timestamp.Year(),
-			timestamp.Month(),
-			timestamp.Day(),
+			ts.Year(),
+			ts.Month(),
+			ts.Day(),
 			18,
 			0,
 			0, 0, loc)
 	default:
 		return time.Date(
-			timestamp.Year(),
-			timestamp.Month(),
-			timestamp.Day()+1,
+			ts.Year(),
+			ts.Month(),
+			ts.Day()+1,
 			0,
 			0,
 			0, 0, loc)
@@ -83,27 +89,30 @@ func calculateNextSchedule6h(timestamp time.Time, timezone string) time.Time {
 }
 
 func calculateNextSchedule25m(timestamp time.Time, timezone string) time.Time {
-	loc, _ := time.LoadLocation(timezone)
-	minute := timestamp.In(loc).Minute()
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		panic(err)
+	}
+	ts := timestamp.In(loc)
+	minute := ts.Minute()
 	switch {
 	case minute < 25:
 		return time.Date(
-			timestamp.Year(),
-			timestamp.Month(),
-			timestamp.Day(),
-			timestamp.Hour(),
+			ts.Year(),
+			ts.Month(),
+			ts.Day(),
+			ts.Hour(),
 			25,
 			0, 0, loc)
 	default:
 		return time.Date(
-			timestamp.Year(),
-			timestamp.Month(),
-			timestamp.Day(),
-			timestamp.Hour()+1,
+			ts.Year(),
+			ts.Month(),
+			ts.Day(),
+			ts.Hour()+1,
 			25,
 			0, 0, loc)
 	}
-
 }
 func TestCronJobStore(t *testing.T) {
 
@@ -587,6 +596,12 @@ func TestCronJobStoreScheduleParsing(t *testing.T) {
 	// next schedule time for a valid "0 */6 * * *" schedule relative to LastScheduleTime.
 	validNextScheduleTime := calculateNextSchedule6h(ActiveRunningCronJob1LastScheduleTime, "Local")
 
+	// next schedule time for the same schedule evaluated in a valid named time zone.
+	// This is the scenario from issue #2898: resolving "Asia/Singapore" requires the
+	// IANA tz database, which internal/store/cronjob.go embeds via `_ "time/tzdata"` so that named zones
+	// resolve even on minimal/distroless images that ship no tzdata.
+	namedTZNextScheduleTime := calculateNextSchedule6h(ActiveRunningCronJob1LastScheduleTime, "Asia/Singapore")
+
 	cases := []generateMetricsTestCase{
 		{
 			// Valid schedule: next_schedule_time is emitted, schedule_invalid is not.
@@ -651,6 +666,29 @@ func TestCronJobStoreScheduleParsing(t *testing.T) {
 				# TYPE kube_cronjob_schedule_invalid gauge
 				kube_cronjob_schedule_invalid{cronjob="InvalidTimeZoneCronJob",namespace="ns1"} 1
 `,
+			MetricNames: []string{"kube_cronjob_next_schedule_time", "kube_cronjob_schedule_invalid", "kube_cronjob_status_last_schedule_time"},
+		},
+		{
+			// Valid named time zone (regression for issue #2898): next_schedule_time is
+			// emitted, computed in that zone, and schedule_invalid is not. Before tzdata
+			// was embedded into the binary, a distroless image could not resolve
+			// "Asia/Singapore" and KSM wrongly flagged the schedule as invalid.
+			Obj: func() *batchv1.CronJob {
+				cj := newCronJob("NamedTimeZoneCronJob", "0 */6 * * *")
+				namedTimeZone := "Asia/Singapore"
+				cj.Spec.TimeZone = &namedTimeZone
+				return cj
+			}(),
+			Want: `
+				# HELP kube_cronjob_schedule_invalid Emitted with value 1 for cronjobs whose schedule, in its configured timezone, cannot be parsed.
+				# TYPE kube_cronjob_schedule_invalid gauge
+				# HELP kube_cronjob_status_last_schedule_time [STABLE] LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
+				# TYPE kube_cronjob_status_last_schedule_time gauge
+				kube_cronjob_status_last_schedule_time{cronjob="NamedTimeZoneCronJob",namespace="ns1"} 1.520742896e+09
+				# HELP kube_cronjob_next_schedule_time [STABLE] Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.
+				# TYPE kube_cronjob_next_schedule_time gauge
+` + fmt.Sprintf("kube_cronjob_next_schedule_time{cronjob=\"NamedTimeZoneCronJob\",namespace=\"ns1\"} %ve+09\n",
+				float64(namedTZNextScheduleTime.Unix())/math.Pow10(9)),
 			MetricNames: []string{"kube_cronjob_next_schedule_time", "kube_cronjob_schedule_invalid", "kube_cronjob_status_last_schedule_time"},
 		},
 	}


### PR DESCRIPTION
## What this PR does / why we need it:
Embeds Go's built-in IANA time zone database into the binary via a blank import of `time/tzdata` in `main.go`, so that named CronJob time zones(ex: `spec.timeZone: "Asia/Singapore"`) resolve at runtime even when kube-state-metrics runs from a minimal/distroless image that ships no tzdata.

## Why?
We added a scheduled batch job, simple nightly report CronJob, and set spec.timeZone: "Asia/Singapore" so itd fire at 4am local rather than 4am UTC.The CronJob itself ran fine.

A while later we noticed a gap on our dashboards: `kube_cronjob_next_schedule_time` was simply missing for that CronJob, even though the schedule (0 4 * * 1-5) is perfectly valid. Around the same time, an alert on `kube_cronjob_schedule_invalid` started firing for it, which made no sense, since the schedule parses fine and the job was clearly running on time.

The tell was that everything worked when we dropped spec.timeZone (falling back to UTC) and only broke with a named zone. That pointed at timezone resolution rather than the cron expression itself. We checked the KSM  pod, healthy, no crash, no restarts, but its logs showed it failing to compute the next schedule for that one CronJob:
```
  failed to parse cron job schedule 'CRON_TZ=Asia/Singapore 0 4 * * 1-5':
      provided bad location Asia/Singapore: unknown time zone Asia/Singapore

```

The image is built `FROM gcr.io/distroless/static-debian13`, which contains no time zone database. Without it, `time.LoadLocation` fails for any named zone, so a CronJob with `spec.timeZone` set has its `kube_cronjob_next_schedule_time` metric dropped and is wrongly flagged via `kube_cronjob_schedule_invalid`.

> Note: the panic described in #2898 was already fixed in 36cc81d4, this resolves the remaining half.

## Approach
Importing `time/tzdata` is the standard, base-image-agnostic way to make `time.LoadLocation` work on `distroless`/`scratch` images. It needs no Dockerfile change and survives a future switch to a smaller base image. The trade-off is ~450 KB of additional binary size.

## Tests
- Added a regression case to `TestCronJobStoreScheduleParsing` for the #2898 scenario: a CronJob with a valid named `spec.timeZone` (`Asia/Singapore`) emits `kube_cronjob_next_schedule_time` (computed in that zone) and does not emit `kube_cronjob_schedule_invalid`.
- Fixed a latent bug in the `calculateNextSchedule6h` test helper I found while testing my change, which read the hour in the target zone but the date in the machine's local zone, making the expected value off by a day on any non-UTC machine. It now reads all date components in the target zone. This is a no-op under the UTC-based CI but makes the suite correct regardless of the runner's local time zone.

`go test ./internal/store/`, `go vet`, and `gofmt` all pass. 
As well as testing a custom build of KSM in a throw away cluster, replicating my scenario, we do not see the invalid schedule. 


**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*
Does not change cardinality. No metrics or labels are added/removed.

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
fixes #2898 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CronJobs using named time zones now work reliably in environments without installed time zone data.
  * Improved schedule handling for time zone–specific dates and next-run calculations.
  * Invalid time zone names are detected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->