### PR TITLE
fix: negotiate OpenMetrics when protobuf is preferred in Accept header

### DIFF
--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -197,13 +197,7 @@ func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	resHeader := w.Header()
 	var writer io.Writer = w
 
-	contentType := expfmt.NegotiateIncludingOpenMetrics(r.Header)
-
-	// We do not support protobuf at the moment. Fall back to FmtText if the negotiated exposition format is not FmtOpenMetrics See: https://github.com/kubernetes/kube-state-metrics/issues/2022.
-
-	if contentType.FormatType() != expfmt.TypeOpenMetrics {
-		contentType = expfmt.NewFormat(expfmt.TypeTextPlain)
-	}
+	contentType := negotiateSupportedContentType(r.Header)
 	resHeader.Set("Content-Type", string(contentType))
 
 	if m.enableGZIPEncoding {
@@ -271,6 +265,49 @@ func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 }
+
+// negotiateSupportedContentType selects the highest-quality exposition format
+// kube-state-metrics can serve. Protobuf is skipped so clients that prefer it
+// (e.g. Prometheus scrapers) still receive OpenMetrics or text/plain.
+func negotiateSupportedContentType(h http.Header) expfmt.Format {
+	contentType := expfmt.NegotiateIncludingOpenMetrics(h)
+	if isProtoFormat(contentType) {
+		filtered := http.Header{}
+		filtered.Set(hdrAccept, filterProtoFromAccept(h.Get(hdrAccept)))
+		contentType = expfmt.NegotiateIncludingOpenMetrics(filtered)
+	}
+	if contentType.FormatType() != expfmt.TypeOpenMetrics && contentType.FormatType() != expfmt.TypeTextPlain {
+		contentType = expfmt.NewFormat(expfmt.TypeTextPlain)
+	}
+	return contentType
+}
+
+func isProtoFormat(contentType expfmt.Format) bool {
+	switch contentType.FormatType() {
+	case expfmt.TypeProtoDelim, expfmt.TypeProtoText, expfmt.TypeProtoCompact:
+		return true
+	default:
+		return false
+	}
+}
+
+func filterProtoFromAccept(accept string) string {
+	if accept == "" {
+		return accept
+	}
+	parts := strings.Split(accept, ",")
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if strings.HasPrefix(trimmed, expfmt.ProtoType) {
+			continue
+		}
+		filtered = append(filtered, trimmed)
+	}
+	return strings.Join(filtered, ",")
+}
+
+const hdrAccept = "Accept"
 
 func parseResources(params []string) map[string]struct{} {
 	if params == nil {

--- a/pkg/metricshandler/metrics_handler_test.go
+++ b/pkg/metricshandler/metrics_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 )
 
 func TestNegotiateSupportedContentType(t *testing.T) {
@@ -32,6 +33,18 @@ func TestNegotiateSupportedContentType(t *testing.T) {
 		"text/plain;version=0.0.4;q=0.2," +
 		"*/*;q=0.1"
 
+	allowUTF8, err := model.ToEscapingScheme("allow-utf-8")
+	if err != nil {
+		t.Fatalf("ToEscapingScheme(allow-utf-8): %v", err)
+	}
+	valuesEscaping, err := model.ToEscapingScheme("values")
+	if err != nil {
+		t.Fatalf("ToEscapingScheme(values): %v", err)
+	}
+	openMetricsAllowUTF8 := expfmt.NewFormat(expfmt.TypeOpenMetrics).WithEscapingScheme(allowUTF8)
+	openMetricsValues := expfmt.NewFormat(expfmt.TypeOpenMetrics).WithEscapingScheme(valuesEscaping)
+	textPlain := expfmt.NewFormat(expfmt.TypeTextPlain)
+
 	tests := []struct {
 		name     string
 		accept   string
@@ -40,27 +53,27 @@ func TestNegotiateSupportedContentType(t *testing.T) {
 		{
 			name:     "prometheus default accept prefers openmetrics over text/plain",
 			accept:   prometheusDefaultAccept,
-			expected: expfmt.FmtOpenMetrics_1_0_0 + "; escaping=allow-utf-8",
+			expected: openMetricsAllowUTF8,
 		},
 		{
 			name:     "openmetrics only",
 			accept:   "application/openmetrics-text;version=1.0.0",
-			expected: expfmt.FmtOpenMetrics_1_0_0 + "; escaping=values",
+			expected: openMetricsValues,
 		},
 		{
 			name:     "text plain only",
 			accept:   "text/plain;version=0.0.4",
-			expected: expfmt.FmtText,
+			expected: textPlain,
 		},
 		{
 			name:     "protobuf only falls back to text plain",
 			accept:   "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.6",
-			expected: expfmt.FmtText,
+			expected: textPlain,
 		},
 		{
 			name:     "empty accept falls back to text plain",
 			accept:   "",
-			expected: expfmt.FmtText,
+			expected: textPlain,
 		},
 	}
 

--- a/pkg/metricshandler/metrics_handler_test.go
+++ b/pkg/metricshandler/metrics_handler_test.go
@@ -17,9 +17,99 @@ limitations under the License.
 package metricshandler
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/prometheus/common/expfmt"
 )
+
+func TestNegotiateSupportedContentType(t *testing.T) {
+	prometheusDefaultAccept := "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.6," +
+		"application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5," +
+		"application/openmetrics-text;version=0.0.1;q=0.4," +
+		"text/plain;version=1.0.0;escaping=allow-utf-8;q=0.3," +
+		"text/plain;version=0.0.4;q=0.2," +
+		"*/*;q=0.1"
+
+	tests := []struct {
+		name     string
+		accept   string
+		expected expfmt.Format
+	}{
+		{
+			name:     "prometheus default accept prefers openmetrics over text/plain",
+			accept:   prometheusDefaultAccept,
+			expected: expfmt.FmtOpenMetrics_1_0_0 + "; escaping=allow-utf-8",
+		},
+		{
+			name:     "openmetrics only",
+			accept:   "application/openmetrics-text;version=1.0.0",
+			expected: expfmt.FmtOpenMetrics_1_0_0 + "; escaping=values",
+		},
+		{
+			name:     "text plain only",
+			accept:   "text/plain;version=0.0.4",
+			expected: expfmt.FmtText,
+		},
+		{
+			name:     "protobuf only falls back to text plain",
+			accept:   "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.6",
+			expected: expfmt.FmtText,
+		},
+		{
+			name:     "empty accept falls back to text plain",
+			accept:   "",
+			expected: expfmt.FmtText,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.Header{}
+			if tt.accept != "" {
+				h.Set("Accept", tt.accept)
+			}
+			got := negotiateSupportedContentType(h)
+			if got.FormatType() != tt.expected.FormatType() {
+				t.Errorf("negotiateSupportedContentType() format type = %v, want %v (got %q, want %q)", got.FormatType(), tt.expected.FormatType(), got, tt.expected)
+			}
+			if tt.name == "prometheus default accept prefers openmetrics over text/plain" {
+				if got != tt.expected {
+					t.Errorf("negotiateSupportedContentType() = %q, want %q", got, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterProtoFromAccept(t *testing.T) {
+	tests := []struct {
+		name   string
+		accept string
+		want   string
+	}{
+		{
+			name:   "removes protobuf entry",
+			accept: "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.6,text/plain;version=0.0.4;q=0.2",
+			want:   "text/plain;version=0.0.4;q=0.2",
+		},
+		{
+			name:   "empty accept",
+			accept: "",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterProtoFromAccept(tt.accept)
+			if got != tt.want {
+				t.Errorf("filterProtoFromAccept() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestParseResources(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What this PR does / why we need it:**

Fix content negotiation on `/metrics` so Prometheus scrapers receive OpenMetrics instead of falling back to legacy `text/plain; version=0.0.4`. When the Accept header lists protobuf with the highest q-value (Prometheus default), strip unsupported protobuf entries and re-negotiate against OpenMetrics and text/plain. Adds unit tests for the Prometheus default Accept header and protobuf-only fallback.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:**
Fixes #3010

```release-note
Fixed `/metrics` content negotiation to prefer OpenMetrics when Prometheus sends an Accept header that lists protobuf first.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics response `Content-Type` negotiation to more accurately follow client `Accept` headers.
  * When clients indicate protobuf preferences, those hints are ignored for the response, ensuring consistent output.
  * Responses now reliably fall back to OpenMetrics or plain text to avoid unexpected content-type selection.
* **Tests**
  * Added unit tests covering `Accept`-header negotiation and filtering of protobuf-related `Accept` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->