### PR TITLE
fix(cronjob): log and skip next schedule on unparseable schedules

### DIFF
--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -30,6 +30,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	basemetrics "k8s.io/component-base/metrics"
+	"k8s.io/klog/v2"
 
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -247,10 +248,12 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				// If the cron job is suspended, don't track the next scheduled time
 				nextScheduledTime, err := getNextScheduledTime(j.Spec.Schedule, j.Status.LastScheduleTime, j.CreationTimestamp, j.Spec.TimeZone)
 				// A single CronJob with an unparseable schedule must not crash the
-				// whole exporter. Skip its next-schedule metric and keep going, the
-				// same way the Kubernetes CronJob controller tolerates such schedules.
+				// whole exporter. Log and skip its next-schedule metric, the same way
+				// the Kubernetes CronJob controller tolerates such schedules.
 				// kube_cronjob_schedule_invalid surfaces the parse failure as a metric.
-				if err == nil && (j.Spec.Suspend == nil || !*j.Spec.Suspend) {
+				if err != nil {
+					klog.ErrorS(err, "Failed to parse CronJob schedule; skipping next schedule time metric", "namespace", j.Namespace, "cronjob", j.Name)
+				} else if j.Spec.Suspend == nil || !*j.Spec.Suspend {
 					ms = append(ms, &metric.Metric{
 						LabelKeys:   []string{},
 						LabelValues: []string{},

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -619,6 +619,21 @@ func TestCronJobStoreScheduleParsing(t *testing.T) {
 			MetricNames: []string{"kube_cronjob_next_schedule_time", "kube_cronjob_schedule_invalid", "kube_cronjob_status_last_schedule_time"},
 		},
 		{
+			// Unparseable schedule from issue #2988 (step == range size): next_schedule_time omitted, schedule_invalid emitted, no panic.
+			Obj: newCronJob("UnparseableScheduleCronJob", "*/60 * * * *"),
+			Want: `
+				# HELP kube_cronjob_next_schedule_time [STABLE] Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.
+				# TYPE kube_cronjob_next_schedule_time gauge
+				# HELP kube_cronjob_status_last_schedule_time [STABLE] LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
+				# TYPE kube_cronjob_status_last_schedule_time gauge
+				kube_cronjob_status_last_schedule_time{cronjob="UnparseableScheduleCronJob",namespace="ns1"} 1.520742896e+09
+				# HELP kube_cronjob_schedule_invalid Emitted with value 1 for cronjobs whose schedule, in its configured timezone, cannot be parsed.
+				# TYPE kube_cronjob_schedule_invalid gauge
+				kube_cronjob_schedule_invalid{cronjob="UnparseableScheduleCronJob",namespace="ns1"} 1
+`,
+			MetricNames: []string{"kube_cronjob_next_schedule_time", "kube_cronjob_schedule_invalid", "kube_cronjob_status_last_schedule_time"},
+		},
+		{
 			// Unparseable schedule (list with out-of-range step): next_schedule_time omitted, schedule_invalid emitted, no panic.
 			Obj: newCronJob("UnparseableScheduleCronJob", "0 1 */32,1-7 * 3"),
 			Want: `


### PR DESCRIPTION
## Summary
- Log and skip `kube_cronjob_next_schedule_time` when a CronJob schedule cannot be parsed (for example `*/60 * * * *`), instead of failing silently after the panic was removed in #2978.
- Add a unit-test case for the #2988 reproducer schedule so the log-and-skip path stays covered.

Panic crash itself was addressed by #2978 / #2967; this completes the log-and-skip behavior described in #2988.

## Test plan
- [x] `go test ./internal/store/ -run TestCronJobStoreScheduleParsing`
- [ ] Confirm a CronJob with an unparseable step schedule no longer risks exporter crash and emits `kube_cronjob_schedule_invalid`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid CronJob schedules by recording an error and omitting only the affected schedule metric.
  * Preserved existing behavior for suspended CronJobs and valid schedules.

* **Tests**
  * Updated monitoring output expectations for invalid schedule scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->