### PR TITLE
test(discovery): add goleak lifecycle test for custom resource reflectors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	go.uber.org/goleak v1.3.0
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2

--- a/internal/discovery/reflector_lifecycle_test.go
+++ b/internal/discovery/reflector_lifecycle_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/goleak"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/kube-state-metrics/v2/internal/store"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+	"k8s.io/kube-state-metrics/v2/pkg/options"
+)
+
+type customWatch struct {
+	watch.Interface
+	onStop func()
+}
+
+func (w *customWatch) Stop() {
+	w.Interface.Stop()
+	w.onStop()
+}
+
+type dummyFactory struct {
+	gvk       schema.GroupVersionKind
+	watchOnce sync.Once
+	stopOnce  sync.Once
+	watchRun  chan struct{}
+	watchStop chan struct{}
+}
+
+func (f *dummyFactory) Name() string {
+	return "foos"
+}
+
+func (f *dummyFactory) CreateClient(_ *rest.Config) (interface{}, error) {
+	return nil, nil
+}
+
+func (f *dummyFactory) MetricFamilyGenerators() []generator.FamilyGenerator {
+	return nil
+}
+
+func (f *dummyFactory) ExpectedType() interface{} {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(f.gvk)
+	return u
+}
+
+func (f *dummyFactory) ListWatch(_ interface{}, _ string, _ string) cache.ListerWatcher {
+	return &cache.ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			return &unstructured.UnstructuredList{}, nil
+		},
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			f.watchOnce.Do(func() { close(f.watchRun) })
+			w := watch.NewFake()
+			return &customWatch{
+				Interface: w,
+				onStop: func() {
+					f.stopOnce.Do(func() { close(f.watchStop) })
+				},
+			}, nil
+		},
+	}
+}
+
+func TestCRReflectorLifecycleLeak(t *testing.T) {
+	// Call VerifyNone at the very start to establish baseline
+	defer goleak.VerifyNone(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	gvkp := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{
+			Group:   "example.com",
+			Version: "v1",
+			Kind:    "Foo",
+		},
+		Plural: "foos",
+	}
+
+	d := &CRDiscoverer{}
+
+	// 1. Initial GVK discovery
+	d.AppendToMap(gvkp)
+
+	b := store.NewBuilder()
+	b.WithContext(ctx)
+	b.WithNamespaces(options.NamespaceList{metav1.NamespaceAll})
+	b.WithFamilyGeneratorFilter(generator.NewCompositeFamilyGeneratorFilter())
+	b.WithMetrics(prometheus.NewRegistry())
+	// Wire the discoverer stop channels to the builder
+	b.GetGVKStopChan = d.GetStopChanForGVK
+
+	// Instantiate dummyFactory and wire sync channels
+	watchRun := make(chan struct{})
+	watchStop := make(chan struct{})
+	df := &dummyFactory{
+		gvk:       gvkp.GroupVersionKind,
+		watchRun:  watchRun,
+		watchStop: watchStop,
+	}
+
+	// Register factory and enable custom resource
+	b.WithCustomResourceStoreFactories(df)
+	b.WithCustomResourceClients(map[string]interface{}{"example.com/v1, Resource=foos": nil})
+	if err := b.WithEnabledResources([]string{"example.com/v1, Resource=foos"}); err != nil {
+		t.Fatal(err)
+	}
+	b.WithGenerateCustomResourceStoresFunc(b.DefaultGenerateCustomResourceStoresFunc())
+
+	// Build the stores to start the custom resource reflector
+	b.BuildStores()
+
+	// Wait until the reflector has actually started Watch
+	select {
+	case <-watchRun:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reflector watch did not start in time")
+	}
+
+	// Capture the initial stop channel
+	stopCh := d.GetStopChanForGVK(gvkp.GroupVersionKind.String())
+	if stopCh == nil {
+		t.Fatal("expected stop channel to exist for GVK")
+	}
+
+	// 2. Simulate repeated discovery event (the bug path)
+	d.AppendToMap(gvkp)
+
+	// Assert that the stop channel did not get replaced/overwritten on repeated discovery
+	gotCh := d.GetStopChanForGVK(gvkp.GroupVersionKind.String())
+	if gotCh != stopCh {
+		t.Fatal("stop channel was replaced on repeated AppendToMap calls")
+	}
+
+	// 3. Exercise deletion-driven stop-channel cleanup
+	d.RemoveFromMap(gvkp)
+
+	// Verify that the stop channel is closed
+	select {
+	case <-stopCh:
+		// Passed, channel is closed
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop channel was not closed on RemoveFromMap")
+	}
+
+	// Verify that the channel is removed from the discoverer map
+	if gotAfterRemove := d.GetStopChanForGVK(gvkp.GroupVersionKind.String()); gotAfterRemove != nil {
+		t.Fatal("expected stop channel to be nil in discoverer after RemoveFromMap")
+	}
+
+	// 4. Bounded wait for reflector teardown
+	select {
+	case <-watchStop:
+		// Passed, watch was stopped
+	case <-time.After(2 * time.Second):
+		t.Fatal("reflector watch did not stop in time")
+	}
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**
This PR adds a goroutine leak test for Custom Resource reflectors using `go.uber.org/goleak` to ensure reflector stop channels and goroutines are properly cleaned up during repeated discovery/deletion cycles and context cancellation.

The test also improves the integration test setup by:
- Configuring `store.Builder` with `WithNamespaces(options.NamespaceList{metav1.NamespaceAll})` so the reflector is created and started.
- Registering the composite family generator filter and a mock metrics registry to avoid nil pointer panics during startup.
- Using the correct GVR key format (`example.com/v1, Resource=foos`) so the mock client mapping correctly enables the Custom Resource.

The new `TestCRReflectorLifecycleLeak` verifies cleanup with `goleak.VerifyNone` and helps prevent future goroutine leak regressions.

<!-- If you are adding a new metric, provide the use case of that metric. -->

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*
Does not change cardinality.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle handling for custom resource discovery reflectors to ensure proper stop-channel cleanup and prevent goroutine leaks during repeated discovery and shutdown.

* **Tests**
  * Added coverage to validate reflector cleanup behavior, including stable stop-channel reuse for duplicate discovery and correct close/remove semantics when entries are removed or the context is canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->