### PR TITLE
docs: mark custom-resource-state as feature-frozen

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ are deleted they are no longer visible on the `/metrics` endpoint.
   * [Resource group version compatibility](#resource-group-version-compatibility)
   * [Container Image](#container-image)
 * [Metrics Documentation](#metrics-documentation)
+  * [Custom Resource State Metrics](#custom-resource-state-metrics)
   * [ECMAScript regular expression support for allow and deny lists](#ecmascript-regular-expression-support-for-allow-and-deny-lists)
   * [Conflict resolution in label names](#conflict-resolution-in-label-names)
 * [Kube-state-metrics self metrics](#kube-state-metrics-self-metrics)
@@ -106,6 +107,11 @@ Any resources and metrics based on alpha Kubernetes APIs are excluded from any s
 which may be changed at any given release.
 
 See the [`docs`](docs) directory for more information on the exposed metrics.
+
+#### Custom Resource State Metrics
+
+> [!NOTE]
+> `custom-resource-state` is feature-frozen in favor of [resource-state-metrics](https://github.com/kubernetes-sigs/resource-state-metrics). Once `resource-state-metrics` is stable, `custom-resource-state` will be deprecated.
 
 #### Conflict resolution in label names
 

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -41,6 +41,7 @@ are deleted they are no longer visible on the `/metrics` endpoint.
   * [Resource group version compatibility](#resource-group-version-compatibility)
   * [Container Image](#container-image)
 * [Metrics Documentation](#metrics-documentation)
+  * [Custom Resource State Metrics](#custom-resource-state-metrics)
   * [ECMAScript regular expression support for allow and deny lists](#ecmascript-regular-expression-support-for-allow-and-deny-lists)
   * [Conflict resolution in label names](#conflict-resolution-in-label-names)
 * [Kube-state-metrics self metrics](#kube-state-metrics-self-metrics)
@@ -107,6 +108,11 @@ Any resources and metrics based on alpha Kubernetes APIs are excluded from any s
 which may be changed at any given release.
 
 See the [`docs`](docs) directory for more information on the exposed metrics.
+
+#### Custom Resource State Metrics
+
+> [!NOTE]
+> `custom-resource-state` is feature-frozen in favor of [resource-state-metrics](https://github.com/kubernetes-sigs/resource-state-metrics). Once `resource-state-metrics` is stable, `custom-resource-state` will be deprecated.
 
 #### Conflict resolution in label names
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,9 @@ sum(kube_pod_container_resource_requests{resource="memory"}) by (namespace, pod,
 
 ## Metrics from Custom Resources
 
+> [!NOTE]
+> `custom-resource-state` is feature-frozen in favor of [resource-state-metrics](https://github.com/kubernetes-sigs/resource-state-metrics). Once `resource-state-metrics` is stable, `custom-resource-state` will be deprecated.
+
 See [Custom Resource State Metrics](metrics/extend/customresourcestate-metrics.md) for experimental support for custom resources.
 
 ## CLI Arguments

--- a/docs/metrics/extend/customresourcestate-metrics.md
+++ b/docs/metrics/extend/customresourcestate-metrics.md
@@ -1,5 +1,8 @@
 # Custom Resource State Metrics
 
+> [!NOTE]
+> `custom-resource-state` is feature-frozen in favor of [resource-state-metrics](https://github.com/kubernetes-sigs/resource-state-metrics). Once `resource-state-metrics` is stable, `custom-resource-state` will be deprecated.
+
 This section describes how to add metrics based on the state of a custom resource without writing a custom resource
 registry and running your own build of KSM.
 


### PR DESCRIPTION
**What this PR does / why we need it:**
Updates the README and documentation to mention that custom-resource-state is feature-frozen in favor of [resource-state-metrics](https://github.com/kubernetes-sigs/resource-state-metrics), and will be deprecated once resource-state-metrics is stable.

**How does this change affect the cardinality of KSM:**
does not change cardinality

**Which issue(s) this PR fixes:**
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Custom Resource State Metrics” documentation section and table-of-contents entry.
  * Included a note that `custom-resource-state` is feature-frozen in favor of `resource-state-metrics`.
  * Clarified that `custom-resource-state` will be deprecated once `resource-state-metrics` becomes stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->