### PR TITLE
fix(metricshandler): wait for store sync before swapping writers on rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main / unreleased
+
+* [BUGFIX] Wait for reflector initial list before swapping metrics writers on custom resource state rebuild
+
 ## v2.19.1 / 2026-06-10
 
 * This release builds with Go `v1.26.4`

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -82,6 +82,7 @@ Flags:
       --skip_headers                                         If true, avoid header prefixes in the log messages
       --skip_log_headers                                     If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity                             logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
+      --store-sync-timeout duration                          Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild. (default 2m0s)
       --telemetry-host string                                Host to expose kube-state-metrics self metrics on. (default "::")
       --telemetry-port int                                   Port to expose kube-state-metrics self metrics on. (default 8081)
       --tls-config string                                    Path to the TLS configuration file

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -84,7 +84,7 @@ Flags:
       --stderrthreshold severity                             logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
       --store-sync-timeout duration                          Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild. (default 2m0s)
       --telemetry-host string                                Host to expose kube-state-metrics self metrics on. (default "::")
-      --telemetry-port int                                   Port to expose kube-state-metrics self metrics on. Readiness is reported at /readyz on this port. (default 8081)
+      --telemetry-port int                                   Port to expose kube-state-metrics self metrics on. (default 8081)
       --tls-config string                                    Path to the TLS configuration file
       --total-shards int                                     The total number of shards. Sharding is disabled when total shards is set to 1. (default 1)
       --track-unscheduled-pods                               This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -84,7 +84,7 @@ Flags:
       --stderrthreshold severity                             logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
       --store-sync-timeout duration                          Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild. (default 2m0s)
       --telemetry-host string                                Host to expose kube-state-metrics self metrics on. (default "::")
-      --telemetry-port int                                   Port to expose kube-state-metrics self metrics on. (default 8081)
+      --telemetry-port int                                   Port to expose kube-state-metrics self metrics on. Readiness is reported at /readyz on this port. (default 8081)
       --tls-config string                                    Path to the TLS configuration file
       --total-shards int                                     The total number of shards. Sharding is disabled when total shards is set to 1. (default 1)
       --track-unscheduled-pods                               This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -40,6 +40,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -92,6 +93,11 @@ type Builder struct {
 	objectLimit        int64
 
 	GetGVKStopChan func(gvk string) chan struct{}
+
+	// reflectorsMu guards reflectors, which Build() replaces while
+	// WaitForStoresSync() reads it outside the caller's own lock.
+	reflectorsMu sync.Mutex
+	reflectors   []*cache.Reflector
 }
 
 // NewBuilder returns a new builder.
@@ -295,6 +301,10 @@ func (b *Builder) Build() metricsstore.MetricsWriterList {
 	if b.familyGeneratorFilter == nil {
 		panic("familyGeneratorFilter should not be nil")
 	}
+
+	b.reflectorsMu.Lock()
+	b.reflectors = nil
+	b.reflectorsMu.Unlock()
 
 	var metricsWriters metricsstore.MetricsWriterList
 	var activeStoreNames []string
@@ -723,12 +733,37 @@ func (b *Builder) startReflector(
 ) {
 	instrumentedListWatch := watch.NewInstrumentedListerWatcher(listWatcher, b.listWatchMetrics, reflect.TypeOf(expectedType).String(), useAPIServerCache, objectLimit, client)
 	reflector := cache.NewReflectorWithOptions(sharding.NewShardedListWatch(b.shard, b.totalShards, instrumentedListWatch), expectedType, store, cache.ReflectorOptions{ResyncPeriod: 0})
+	b.reflectorsMu.Lock()
+	b.reflectors = append(b.reflectors, reflector)
+	b.reflectorsMu.Unlock()
 	if cr, ok := expectedType.(*unstructured.Unstructured); ok {
 		gvkStopCh := b.GetGVKStopChan(cr.GroupVersionKind().String())
 		go reflector.Run(newCRReflectorStopCh(b.ctx, gvkStopCh))
 	} else {
 		go reflector.Run(b.ctx.Done())
 	}
+}
+
+// WaitForStoresSync blocks until every reflector started by the latest Build() has
+// completed its initial list, or until ctx/timeout elapses.
+func (b *Builder) WaitForStoresSync(ctx context.Context, timeout time.Duration) bool {
+	b.reflectorsMu.Lock()
+	reflectors := slices.Clone(b.reflectors)
+	b.reflectorsMu.Unlock()
+
+	if len(reflectors) == 0 {
+		return true
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, ResourceDiscoveryInterval, timeout, true, func(context.Context) (bool, error) {
+		for _, reflector := range reflectors {
+			if reflector.LastSyncResourceVersion() == "" {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	return err == nil
 }
 
 // cacheStoresToMetricStores converts []cache.Store into []*metricsstore.MetricsStore

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -39,6 +39,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -87,6 +88,8 @@ type Builder struct {
 	objectLimit         int64
 
 	GetGVKStopChan func(gvk string) chan struct{}
+
+	reflectors []*cache.Reflector
 }
 
 // NewBuilder returns a new builder.
@@ -277,6 +280,8 @@ func (b *Builder) Build() metricsstore.MetricsWriterList {
 	if b.familyGeneratorFilter == nil {
 		panic("familyGeneratorFilter should not be nil")
 	}
+
+	b.reflectors = nil
 
 	var metricsWriters metricsstore.MetricsWriterList
 	var activeStoreNames []string
@@ -667,12 +672,34 @@ func (b *Builder) startReflector(
 ) {
 	instrumentedListWatch := watch.NewInstrumentedListerWatcher(listWatcher, b.listWatchMetrics, reflect.TypeOf(expectedType).String(), useAPIServerCache, objectLimit, client)
 	reflector := cache.NewReflectorWithOptions(sharding.NewShardedListWatch(b.shard, b.totalShards, instrumentedListWatch), expectedType, store, cache.ReflectorOptions{ResyncPeriod: 0})
+	b.reflectors = append(b.reflectors, reflector)
 	if cr, ok := expectedType.(*unstructured.Unstructured); ok {
 		gvkStopCh := b.GetGVKStopChan(cr.GroupVersionKind().String())
 		go reflector.Run(newCRReflectorStopCh(b.ctx, gvkStopCh))
 	} else {
 		go reflector.Run(b.ctx.Done())
 	}
+}
+
+// WaitForStoresSync blocks until every reflector started by the latest Build() has
+// completed its initial list, or until ctx/timeout elapses.
+func (b *Builder) WaitForStoresSync(ctx context.Context, timeout time.Duration) bool {
+	if len(b.reflectors) == 0 {
+		return true
+	}
+
+	syncCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	err := wait.PollUntilContextTimeout(syncCtx, ResourceDiscoveryInterval, timeout, true, func(context.Context) (bool, error) {
+		for _, reflector := range b.reflectors {
+			if reflector.LastSyncResourceVersion() == "" {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	return err == nil
 }
 
 // cacheStoresToMetricStores converts []cache.Store into []*metricsstore.MetricsStore

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -688,10 +688,7 @@ func (b *Builder) WaitForStoresSync(ctx context.Context, timeout time.Duration) 
 		return true
 	}
 
-	syncCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	err := wait.PollUntilContextTimeout(syncCtx, ResourceDiscoveryInterval, timeout, true, func(context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, ResourceDiscoveryInterval, timeout, true, func(context.Context) (bool, error) {
 		for _, reflector := range b.reflectors {
 			if reflector.LastSyncResourceVersion() == "" {
 				return false, nil

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -65,6 +65,8 @@ const ResourceDiscoveryInterval = 100 * time.Millisecond
 // New Builder methods should be added to the public BuilderInterface.
 var _ ksmtypes.BuilderInterface = &Builder{}
 
+var _ ksmtypes.StoreSyncBuilder = &Builder{}
+
 // Builder helps to build store. It follows the builder pattern
 // (https://en.wikipedia.org/wiki/Builder_pattern).
 type Builder struct {

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -89,7 +90,10 @@ type Builder struct {
 
 	GetGVKStopChan func(gvk string) chan struct{}
 
-	reflectors []*cache.Reflector
+	// reflectorsMu guards reflectors, which Build() replaces while
+	// WaitForStoresSync() reads it outside the caller's own lock.
+	reflectorsMu sync.Mutex
+	reflectors   []*cache.Reflector
 }
 
 // NewBuilder returns a new builder.
@@ -281,7 +285,9 @@ func (b *Builder) Build() metricsstore.MetricsWriterList {
 		panic("familyGeneratorFilter should not be nil")
 	}
 
+	b.reflectorsMu.Lock()
 	b.reflectors = nil
+	b.reflectorsMu.Unlock()
 
 	var metricsWriters metricsstore.MetricsWriterList
 	var activeStoreNames []string
@@ -672,7 +678,9 @@ func (b *Builder) startReflector(
 ) {
 	instrumentedListWatch := watch.NewInstrumentedListerWatcher(listWatcher, b.listWatchMetrics, reflect.TypeOf(expectedType).String(), useAPIServerCache, objectLimit, client)
 	reflector := cache.NewReflectorWithOptions(sharding.NewShardedListWatch(b.shard, b.totalShards, instrumentedListWatch), expectedType, store, cache.ReflectorOptions{ResyncPeriod: 0})
+	b.reflectorsMu.Lock()
 	b.reflectors = append(b.reflectors, reflector)
+	b.reflectorsMu.Unlock()
 	if cr, ok := expectedType.(*unstructured.Unstructured); ok {
 		gvkStopCh := b.GetGVKStopChan(cr.GroupVersionKind().String())
 		go reflector.Run(newCRReflectorStopCh(b.ctx, gvkStopCh))
@@ -684,12 +692,16 @@ func (b *Builder) startReflector(
 // WaitForStoresSync blocks until every reflector started by the latest Build() has
 // completed its initial list, or until ctx/timeout elapses.
 func (b *Builder) WaitForStoresSync(ctx context.Context, timeout time.Duration) bool {
-	if len(b.reflectors) == 0 {
+	b.reflectorsMu.Lock()
+	reflectors := slices.Clone(b.reflectors)
+	b.reflectorsMu.Unlock()
+
+	if len(reflectors) == 0 {
 		return true
 	}
 
 	err := wait.PollUntilContextTimeout(ctx, ResourceDiscoveryInterval, timeout, true, func(context.Context) (bool, error) {
-		for _, reflector := range b.reflectors {
+		for _, reflector := range reflectors {
 			if reflector.LastSyncResourceVersion() == "" {
 				return false, nil
 			}

--- a/internal/store/builder_sync_test.go
+++ b/internal/store/builder_sync_test.go
@@ -43,7 +43,9 @@ func TestWaitForStoresSync_Timeout(t *testing.T) {
 		},
 	}
 	reflector := cache.NewReflectorWithOptions(lw, &v1.Pod{}, store, cache.ReflectorOptions{})
+	b.reflectorsMu.Lock()
 	b.reflectors = []*cache.Reflector{reflector}
+	b.reflectorsMu.Unlock()
 
 	if b.WaitForStoresSync(context.Background(), 50*time.Millisecond) {
 		t.Fatal("expected sync to time out before reflector runs")

--- a/internal/store/builder_sync_test.go
+++ b/internal/store/builder_sync_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestWaitForStoresSync_NoReflectors(t *testing.T) {
+	b := NewBuilder()
+	if !b.WaitForStoresSync(context.Background(), time.Millisecond) {
+		t.Fatal("expected sync success with no reflectors")
+	}
+}
+
+func TestWaitForStoresSync_Timeout(t *testing.T) {
+	b := NewBuilder()
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	lw := &cache.ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			return &v1.PodList{}, nil
+		},
+	}
+	reflector := cache.NewReflectorWithOptions(lw, &v1.Pod{}, store, cache.ReflectorOptions{})
+	b.reflectors = []*cache.Reflector{reflector}
+
+	if b.WaitForStoresSync(context.Background(), 50*time.Millisecond) {
+		t.Fatal("expected sync to time out before reflector runs")
+	}
+}

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -520,7 +520,8 @@ func buildTelemetryServer(registry prometheus.Gatherer, m *metricshandler.Metric
 		mux.Handle(path, h)
 	}
 
-	// Add readyzPath
+	// Add readyzPath on the telemetry server. Readiness probes must target
+	// opts.TelemetryPort (default 8081), not the main metrics port.
 	mux.Handle(readyzPath, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if !m.Ready() {
 			w.WriteHeader(http.StatusServiceUnavailable)

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -346,7 +346,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		)
 	}
 
-	telemetryMux := buildTelemetryServer(ksmMetricsRegistry, opts.AuthFilter, kubeConfig)
+	telemetryMux := buildTelemetryServer(ksmMetricsRegistry, m, opts.AuthFilter, kubeConfig)
 	telemetryListenAddress := net.JoinHostPort(opts.TelemetryHost, strconv.Itoa(opts.TelemetryPort))
 	telemetryServer := http.Server{
 		Handler:           telemetryMux,
@@ -463,7 +463,7 @@ func configureResourcesAndMetrics(opts *options.Options, configFile []byte) *opt
 	return opts
 }
 
-func buildTelemetryServer(registry prometheus.Gatherer, authFilter bool, kubeConfig *rest.Config) *http.ServeMux {
+func buildTelemetryServer(registry prometheus.Gatherer, m *metricshandler.MetricsHandler, authFilter bool, kubeConfig *rest.Config) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	loghandler := logr.ToSlogHandler(klog.Background())
@@ -522,6 +522,11 @@ func buildTelemetryServer(registry prometheus.Gatherer, authFilter bool, kubeCon
 
 	// Add readyzPath
 	mux.Handle(readyzPath, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if !m.Ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(http.StatusText(http.StatusServiceUnavailable)))
+			return
+		}
 		count, err := util.GatherAndCount(registry)
 		if err != nil || count == 0 {
 			w.WriteHeader(http.StatusServiceUnavailable)

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -108,14 +108,12 @@ func BenchmarkKubeStateMetrics(b *testing.B) {
 	builder.WithAllowAnnotations(map[string][]string{})
 	builder.WithAllowLabels(map[string][]string{})
 
-	// This test is not suitable to be compared in terms of time, as it includes
-	// a one second wait. Use for memory allocation comparisons, profiling, ...
+	// This test is not suitable to be compared in terms of time, as it waits for
+	// the initial writer generation. Use for memory allocation comparisons, profiling, ...
 	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
-	b.Run("GenerateMetrics", func(_ *testing.B) {
+	b.Run("GenerateMetrics", func(b *testing.B) {
 		handler.ConfigureSharding(ctx, 0, 1)
-
-		// Wait for caches to fill
-		time.Sleep(time.Second)
+		waitForHandlerReady(b, handler)
 	})
 
 	req := httptest.NewRequest("GET", "http://localhost:8080/metrics", nil)
@@ -144,6 +142,18 @@ func BenchmarkKubeStateMetrics(b *testing.B) {
 
 		b.SetBytes(int64(accumulatedContentLength))
 	})
+}
+
+// waitForHandlerReady blocks until the handler has installed a writer generation.
+func waitForHandlerReady(tb testing.TB, handler *metricshandler.MetricsHandler) {
+	tb.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for !handler.Ready() {
+		if time.Now().After(deadline) {
+			tb.Fatal("metrics handler did not become ready before deadline")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 // TestFullScrapeCycle is a simple smoke test covering the entire cycle from
@@ -197,8 +207,7 @@ func TestFullScrapeCycle(t *testing.T) {
 	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
 	handler.ConfigureSharding(ctx, 0, 1)
 
-	// Wait for caches to fill
-	time.Sleep(time.Second)
+	waitForHandlerReady(t, handler)
 
 	req := httptest.NewRequest("GET", "http://localhost:8080/metrics", nil)
 
@@ -570,8 +579,9 @@ func TestShardingEquivalenceScrapeCycle(t *testing.T) {
 	shardedHandler2 := metricshandler.New(&options.Options{}, kubeClient, shardedBuilder2, false)
 	shardedHandler2.ConfigureSharding(ctx, 1, 2)
 
-	// Wait for caches to fill
-	time.Sleep(time.Second)
+	waitForHandlerReady(t, unshardedHandler)
+	waitForHandlerReady(t, shardedHandler1)
+	waitForHandlerReady(t, shardedHandler2)
 
 	// unsharded request as the controlled environment
 	req := httptest.NewRequest("GET", "http://localhost:8080/metrics", nil)
@@ -724,8 +734,7 @@ func TestCustomResourceExtension(t *testing.T) {
 	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
 	handler.ConfigureSharding(ctx, 0, 1)
 
-	// Wait for caches to fill
-	time.Sleep(time.Second)
+	waitForHandlerReady(t, handler)
 
 	req := httptest.NewRequest("GET", "http://localhost:8080/metrics", nil)
 

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -399,7 +399,7 @@ kube_pod_status_phase{namespace="default",pod="pod0",uid="abc-0",phase="Unknown"
 		}
 	}
 
-	telemetryMux := buildTelemetryServer(reg, false, nil)
+	telemetryMux := buildTelemetryServer(reg, handler, false, nil)
 
 	req2 := httptest.NewRequest("GET", "http://localhost:8081/metrics", nil)
 
@@ -473,7 +473,8 @@ func TestPprofRouting(t *testing.T) {
 		}
 
 		reg := prometheus.NewRegistry()
-		telemetryMux := buildTelemetryServer(reg, authEnabled, cfg)
+		telemetryHandler := metricshandler.New(options.NewOptions(), fake.NewSimpleClientset(), nil, false)
+		telemetryMux := buildTelemetryServer(reg, telemetryHandler, authEnabled, cfg)
 		for _, path := range pprofPaths {
 			req := httptest.NewRequest("GET", "http://localhost:8081"+path, nil)
 			_, pattern := telemetryMux.Handler(req)
@@ -1094,7 +1095,7 @@ func TestBuildServersServeLandingPage(t *testing.T) {
 	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
 
 	for name, mux := range map[string]*http.ServeMux{
-		"telemetry": buildTelemetryServer(prometheus.NewRegistry(), false, nil),
+		"telemetry": buildTelemetryServer(prometheus.NewRegistry(), handler, false, nil),
 		"metrics":   buildMetricsServer(handler, durationVec, kubeClient, false, nil),
 	} {
 		req := httptest.NewRequest("GET", "/", nil)

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -139,7 +139,10 @@ func (b *Builder) Build() metricsstore.MetricsWriterList {
 
 // WaitForStoresSync blocks until reflectors from the latest Build() have listed once.
 func (b *Builder) WaitForStoresSync(ctx context.Context, timeout time.Duration) bool {
-	return b.internal.WaitForStoresSync(ctx, timeout)
+	if syncer, ok := b.internal.(ksmtypes.StoreSyncBuilder); ok {
+		return syncer.WaitForStoresSync(ctx, timeout)
+	}
+	return true
 }
 
 // BuildStores initializes and registers all enabled stores.

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -18,6 +18,7 @@ package builder
 
 import (
 	"context"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	clientset "k8s.io/client-go/kubernetes"
@@ -134,6 +135,11 @@ func (b *Builder) WithCustomResourceStoreFactories(fs ...customresource.Registry
 // Returns metric writers.
 func (b *Builder) Build() metricsstore.MetricsWriterList {
 	return b.internal.Build()
+}
+
+// WaitForStoresSync blocks until reflectors from the latest Build() have listed once.
+func (b *Builder) WaitForStoresSync(ctx context.Context, timeout time.Duration) bool {
+	return b.internal.WaitForStoresSync(ctx, timeout)
 }
 
 // BuildStores initializes and registers all enabled stores.

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"context"
+	"time"
 
 	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
 
@@ -49,6 +50,7 @@ type BuilderInterface interface {
 	DefaultGenerateCustomResourceStoresFunc() BuildCustomResourceStoresFunc
 	WithCustomResourceStoreFactories(fs ...customresource.RegistryFactory)
 	Build() metricsstore.MetricsWriterList
+	WaitForStoresSync(ctx context.Context, timeout time.Duration) bool
 	BuildStores() [][]cache.Store
 	WithGenerateCustomResourceStoresFunc(f BuildCustomResourceStoresFunc)
 }

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -50,9 +50,15 @@ type BuilderInterface interface {
 	DefaultGenerateCustomResourceStoresFunc() BuildCustomResourceStoresFunc
 	WithCustomResourceStoreFactories(fs ...customresource.RegistryFactory)
 	Build() metricsstore.MetricsWriterList
-	WaitForStoresSync(ctx context.Context, timeout time.Duration) bool
 	BuildStores() [][]cache.Store
 	WithGenerateCustomResourceStoresFunc(f BuildCustomResourceStoresFunc)
+}
+
+// StoreSyncBuilder can wait for reflector stores to sync after Build().
+// It is implemented by the internal store builder but is not part of the
+// stable BuilderInterface contract for downstream library users.
+type StoreSyncBuilder interface {
+	WaitForStoresSync(ctx context.Context, timeout time.Duration) bool
 }
 
 // BuildStoresFunc function signature that is used to return a list of cache.Store

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/prometheus/common/expfmt"
 
@@ -56,7 +57,20 @@ type MetricsHandler struct {
 	curTotalShards     int
 	curShard           int32
 	enableGZIPEncoding bool
+
+	rebuildMu        sync.Mutex
+	rebuildRunning   bool
+	pendingRebuild   bool
+	rebuildParentCtx context.Context
+	syncRetryDelay   time.Duration
 }
+
+// Backoff bounds for retrying a failed store sync while no metrics writers are
+// available. Declared as variables so tests can shorten them.
+var (
+	initialStoreSyncRetryDelay = 5 * time.Second
+	maxStoreSyncRetryDelay     = 2 * time.Minute
+)
 
 // New creates and returns a new MetricsHandler with the given options.
 func New(opts *options.Options, kubeClient kubernetes.Interface, storeBuilder ksmtypes.BuilderInterface, enableGZIPEncoding bool) *MetricsHandler {
@@ -69,18 +83,130 @@ func New(opts *options.Options, kubeClient kubernetes.Interface, storeBuilder ks
 	}
 }
 
-// BuildWriters builds the metrics writers, cancelling any previous context and passing a new one on every build.
-// Build can be used multiple times and concurrently.
+// BuildWriters rebuilds metrics writers after store configuration changes.
+// Rebuilds are coalesced and swap in the new writer set only after reflector stores sync.
 func (m *MetricsHandler) BuildWriters(ctx context.Context) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	if m.cancel != nil {
-		m.cancel()
+	m.rebuildMu.Lock()
+	m.rebuildParentCtx = ctx
+	if m.rebuildRunning {
+		m.pendingRebuild = true
+		m.rebuildMu.Unlock()
+		return
 	}
-	ctx, m.cancel = context.WithCancel(ctx)
-	m.storeBuilder.WithContext(ctx)
-	m.metricsWriters = m.storeBuilder.Build()
+	m.rebuildRunning = true
+	m.rebuildMu.Unlock()
+
+	go m.rebuildLoop(ctx)
+}
+
+func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
+	ctx := initialCtx
+	for {
+		synced := m.doRebuild(ctx)
+
+		m.mtx.RLock()
+		noWriters := len(m.metricsWriters) == 0
+		m.mtx.RUnlock()
+
+		m.rebuildMu.Lock()
+		if m.pendingRebuild {
+			m.pendingRebuild = false
+			ctx = m.rebuildParentCtx
+			m.rebuildMu.Unlock()
+			continue
+		}
+		m.rebuildRunning = false
+		var retryDelay time.Duration
+		if !synced && noWriters {
+			m.syncRetryDelay = nextStoreSyncRetryDelay(m.syncRetryDelay)
+			retryDelay = m.syncRetryDelay
+		} else {
+			m.syncRetryDelay = 0
+		}
+		m.rebuildMu.Unlock()
+
+		if retryDelay > 0 {
+			m.scheduleSyncRetry(ctx, retryDelay)
+		}
+		return
+	}
+}
+
+// scheduleSyncRetry re-runs a rebuild after delay. Without it, a store sync that
+// fails before any writer generation exists would leave the handler serving no
+// metrics until an unrelated event triggers another rebuild, which never happens
+// when autosharding is disabled.
+func (m *MetricsHandler) scheduleSyncRetry(ctx context.Context, delay time.Duration) {
+	klog.ErrorS(nil, "Store sync failed with no metrics writers available; scheduling rebuild retry", "retryDelay", delay)
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+		case <-timer.C:
+			m.BuildWriters(ctx)
+		}
+	}()
+}
+
+func nextStoreSyncRetryDelay(current time.Duration) time.Duration {
+	if current <= 0 {
+		return initialStoreSyncRetryDelay
+	}
+	if next := current * 2; next < maxStoreSyncRetryDelay {
+		return next
+	}
+	return maxStoreSyncRetryDelay
+}
+
+func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
+	m.mtx.Lock()
+	newCtx, newCancel := context.WithCancel(parentCtx)
+	m.storeBuilder.WithContext(newCtx)
+	newWriters := m.storeBuilder.Build()
+	m.mtx.Unlock()
+
+	syncTimeout := m.opts.StoreSyncTimeout
+	if syncTimeout <= 0 {
+		syncTimeout = options.DefaultStoreSyncTimeout
+	}
+	// mtx is deliberately released before waiting: ServeHTTP takes it for read on
+	// every scrape, so holding it for up to syncTimeout would stall all scrapes
+	// for the whole sync window. Rebuilds are already serialized by rebuildMu, so
+	// no other Build() can run concurrently with the wait.
+	syncStart := time.Now()
+	synced := m.storeBuilder.WaitForStoresSync(newCtx, syncTimeout)
+	syncWaitDuration := time.Since(syncStart)
+
+	if synced {
+		m.mtx.Lock()
+		oldCancel := m.cancel
+		m.metricsWriters = newWriters
+		m.cancel = newCancel
+		m.mtx.Unlock()
+		if oldCancel != nil {
+			oldCancel()
+		}
+		klog.InfoS("Swapped metrics writers after store sync", "writerCount", len(newWriters), "syncWaitDuration", syncWaitDuration)
+		return true
+	}
+
+	newCancel()
+	klog.ErrorS(nil, "Store sync timed out during metrics writer rebuild; keeping previous writers",
+		"syncWaitDuration", syncWaitDuration,
+		"syncTimeout", syncTimeout,
+		"writerCount", len(newWriters),
+	)
+	return false
+}
+
+// Ready reports whether at least one metrics writer generation has been swapped
+// in after a successful store sync. Until then /metrics may return HTTP 200 with
+// an empty body; /readyz uses this to withhold readiness.
+func (m *MetricsHandler) Ready() bool {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	return len(m.metricsWriters) > 0
 }
 
 // ConfigureSharding configures sharding. Configuration can be used multiple times and

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -33,6 +33,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -54,6 +55,7 @@ type MetricsHandler struct {
 	// mtx protects metricsWriters, curShard, and curTotalShards
 	mtx                *sync.RWMutex
 	metricsWriters     metricsstore.MetricsWriterList
+	writersInstalled   bool
 	curTotalShards     int
 	curShard           int32
 	enableGZIPEncoding bool
@@ -150,13 +152,19 @@ func (m *MetricsHandler) scheduleSyncRetry(ctx context.Context, delay time.Durat
 }
 
 func nextStoreSyncRetryDelay(current time.Duration) time.Duration {
+	var base time.Duration
 	if current <= 0 {
-		return initialStoreSyncRetryDelay
+		base = initialStoreSyncRetryDelay
+	} else if next := current * 2; next < maxStoreSyncRetryDelay {
+		base = next
+	} else {
+		base = maxStoreSyncRetryDelay
 	}
-	if next := current * 2; next < maxStoreSyncRetryDelay {
-		return next
+	jittered := wait.Jitter(base, 0.1)
+	if jittered > maxStoreSyncRetryDelay {
+		return maxStoreSyncRetryDelay
 	}
-	return maxStoreSyncRetryDelay
+	return jittered
 }
 
 func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
@@ -175,7 +183,10 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
 	// for the whole sync window. Rebuilds are already serialized by rebuildMu, so
 	// no other Build() can run concurrently with the wait.
 	syncStart := time.Now()
-	synced := m.storeBuilder.WaitForStoresSync(newCtx, syncTimeout)
+	synced := true
+	if syncer, ok := m.storeBuilder.(ksmtypes.StoreSyncBuilder); ok {
+		synced = syncer.WaitForStoresSync(newCtx, syncTimeout)
+	}
 	syncWaitDuration := time.Since(syncStart)
 
 	if synced {
@@ -183,6 +194,7 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
 		oldCancel := m.cancel
 		m.metricsWriters = newWriters
 		m.cancel = newCancel
+		m.writersInstalled = true
 		m.mtx.Unlock()
 		if oldCancel != nil {
 			oldCancel()
@@ -200,13 +212,13 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
 	return false
 }
 
-// Ready reports whether at least one metrics writer generation has been swapped
-// in after a successful store sync. Until then /metrics may return HTTP 200 with
-// an empty body; /readyz uses this to withhold readiness.
+// Ready reports whether a metrics writer generation has been swapped in after a
+// successful store sync. Until then /metrics may return HTTP 200 with an empty
+// body; /readyz on the telemetry port uses this to withhold readiness.
 func (m *MetricsHandler) Ready() bool {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
-	return len(m.metricsWriters) > 0
+	return m.writersInstalled
 }
 
 // ConfigureSharding configures sharding. Configuration can be used multiple times and

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -178,6 +178,10 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
 	if syncTimeout <= 0 {
 		syncTimeout = options.DefaultStoreSyncTimeout
 	}
+	// mtx is deliberately released before waiting: ServeHTTP takes it for read on
+	// every scrape, so holding it for up to syncTimeout would stall all scrapes
+	// for the whole sync window. Rebuilds are already serialized by rebuildMu, so
+	// no other Build() can run concurrently with the wait.
 	syncStart := time.Now()
 	synced := m.storeBuilder.WaitForStoresSync(newCtx, syncTimeout)
 	syncWaitDuration := time.Since(syncStart)

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -52,7 +52,9 @@ type MetricsHandler struct {
 
 	cancel func()
 
-	// mtx protects metricsWriters, curShard, and curTotalShards
+	// mtx protects metricsWriters, curShard, curTotalShards, and storeBuilder
+	// configuration (With* calls). Build() runs under this lock; WaitForStoresSync
+	// deliberately does not, so scrapes are not blocked for the sync timeout.
 	mtx                *sync.RWMutex
 	metricsWriters     metricsstore.MetricsWriterList
 	writersInstalled   bool
@@ -106,10 +108,6 @@ func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 	for {
 		synced := m.doRebuild(ctx)
 
-		m.mtx.RLock()
-		noWriterGeneration := !m.writersInstalled
-		m.mtx.RUnlock()
-
 		m.rebuildMu.Lock()
 		if m.pendingRebuild {
 			m.pendingRebuild = false
@@ -119,7 +117,8 @@ func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 		}
 		m.rebuildRunning = false
 		var retryDelay time.Duration
-		if !synced && noWriterGeneration {
+		// Retry every failed sync. Previous writers stay active during backoff.
+		if !synced {
 			m.syncRetryDelay = nextStoreSyncRetryDelay(m.syncRetryDelay)
 			retryDelay = m.syncRetryDelay
 		} else {
@@ -134,12 +133,10 @@ func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 	}
 }
 
-// scheduleSyncRetry re-runs a rebuild after delay. Without it, a store sync that
-// fails before any writer generation exists would leave the handler serving no
-// metrics until an unrelated event triggers another rebuild, which never happens
-// when autosharding is disabled.
+// scheduleSyncRetry re-runs a failed rebuild after a bounded backoff. Existing
+// writers remain active until a retry successfully synchronizes and swaps.
 func (m *MetricsHandler) scheduleSyncRetry(ctx context.Context, delay time.Duration) {
-	klog.ErrorS(nil, "Store sync failed with no metrics writers available; scheduling rebuild retry", "retryDelay", delay)
+	klog.ErrorS(nil, "Store sync failed; scheduling rebuild retry", "retryDelay", delay)
 	go func() {
 		timer := time.NewTimer(delay)
 		defer timer.Stop()
@@ -181,7 +178,9 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
 	// mtx is deliberately released before waiting: ServeHTTP takes it for read on
 	// every scrape, so holding it for up to syncTimeout would stall all scrapes
 	// for the whole sync window. Rebuilds are already serialized by rebuildMu, so
-	// no other Build() can run concurrently with the wait.
+	// no other Build() can run concurrently with the wait. storeBuilder config
+	// may still change under mtx (ConfigureStore / ConfigureSharding); that only
+	// marks a pending rebuild and does not disturb the reflectors being waited on.
 	syncStart := time.Now()
 	synced := true
 	if syncer, ok := m.storeBuilder.(ksmtypes.StoreSyncBuilder); ok {
@@ -221,21 +220,38 @@ func (m *MetricsHandler) Ready() bool {
 	return m.writersInstalled
 }
 
+// ConfigureStore applies storeBuilder configuration under mtx, then rebuilds
+// writers. Runtime callers that mutate the shared builder (for example CR
+// discovery) must use this instead of calling builder With* methods directly,
+// so configuration cannot race with Build(). Returns an error without rebuilding
+// when configuration fails.
+func (m *MetricsHandler) ConfigureStore(ctx context.Context, configure func(ksmtypes.BuilderInterface) error) error {
+	if configure == nil {
+		m.BuildWriters(ctx)
+		return nil
+	}
+	m.mtx.Lock()
+	err := configure(m.storeBuilder)
+	m.mtx.Unlock()
+	if err != nil {
+		return err
+	}
+	m.BuildWriters(ctx)
+	return nil
+}
+
 // ConfigureSharding configures sharding. Configuration can be used multiple times and
 // concurrently.
 func (m *MetricsHandler) ConfigureSharding(ctx context.Context, shard int32, totalShards int) {
-	m.mtx.Lock()
-
 	if totalShards != 1 {
 		klog.InfoS("Configuring sharding of this instance to be shard index (zero-indexed) out of total shards", "shard", shard, "totalShards", totalShards)
 	}
-	m.curShard = shard
-	m.curTotalShards = totalShards
-	m.storeBuilder.WithSharding(shard, totalShards)
-
-	// unlock because BuildWriters will hold a lock again
-	m.mtx.Unlock()
-	m.BuildWriters(ctx)
+	m.ConfigureStore(ctx, func(b ksmtypes.BuilderInterface) error {
+		m.curShard = shard
+		m.curTotalShards = totalShards
+		b.WithSharding(shard, totalShards)
+		return nil
+	})
 }
 
 // Run configures the MetricsHandler's sharding and if autosharding is enabled

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -107,7 +107,7 @@ func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 		synced := m.doRebuild(ctx)
 
 		m.mtx.RLock()
-		noWriters := len(m.metricsWriters) == 0
+		noWriterGeneration := !m.writersInstalled
 		m.mtx.RUnlock()
 
 		m.rebuildMu.Lock()
@@ -119,7 +119,7 @@ func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 		}
 		m.rebuildRunning = false
 		var retryDelay time.Duration
-		if !synced && noWriters {
+		if !synced && noWriterGeneration {
 			m.syncRetryDelay = nextStoreSyncRetryDelay(m.syncRetryDelay)
 			retryDelay = m.syncRetryDelay
 		} else {

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -62,7 +62,15 @@ type MetricsHandler struct {
 	rebuildRunning   bool
 	pendingRebuild   bool
 	rebuildParentCtx context.Context
+	syncRetryDelay   time.Duration
 }
+
+// Backoff bounds for retrying a failed store sync while no metrics writers are
+// available. Declared as variables so tests can shorten them.
+var (
+	initialStoreSyncRetryDelay = 5 * time.Second
+	maxStoreSyncRetryDelay     = 2 * time.Minute
+)
 
 // New creates and returns a new MetricsHandler with the given options.
 func New(opts *options.Options, kubeClient kubernetes.Interface, storeBuilder ksmtypes.BuilderInterface, enableGZIPEncoding bool) *MetricsHandler {
@@ -78,9 +86,12 @@ func New(opts *options.Options, kubeClient kubernetes.Interface, storeBuilder ks
 // BuildWriters rebuilds metrics writers after store configuration changes.
 // Rebuilds are coalesced and swap in the new writer set only after reflector stores sync.
 func (m *MetricsHandler) BuildWriters(ctx context.Context) {
+	m.mtx.RLock()
+	syncFirst := len(m.metricsWriters) == 0
+	m.mtx.RUnlock()
+
 	m.rebuildMu.Lock()
 	m.rebuildParentCtx = ctx
-	syncFirst := len(m.metricsWriters) == 0
 	if m.rebuildRunning {
 		m.pendingRebuild = true
 		m.rebuildMu.Unlock()
@@ -99,20 +110,64 @@ func (m *MetricsHandler) BuildWriters(ctx context.Context) {
 func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 	ctx := initialCtx
 	for {
-		m.doRebuild(ctx)
+		synced := m.doRebuild(ctx)
+
+		m.mtx.RLock()
+		noWriters := len(m.metricsWriters) == 0
+		m.mtx.RUnlock()
+
 		m.rebuildMu.Lock()
-		if !m.pendingRebuild {
-			m.rebuildRunning = false
+		if m.pendingRebuild {
+			m.pendingRebuild = false
+			ctx = m.rebuildParentCtx
 			m.rebuildMu.Unlock()
-			return
+			continue
 		}
-		m.pendingRebuild = false
-		ctx = m.rebuildParentCtx
+		m.rebuildRunning = false
+		var retryDelay time.Duration
+		if !synced && noWriters {
+			m.syncRetryDelay = nextStoreSyncRetryDelay(m.syncRetryDelay)
+			retryDelay = m.syncRetryDelay
+		} else {
+			m.syncRetryDelay = 0
+		}
 		m.rebuildMu.Unlock()
+
+		if retryDelay > 0 {
+			m.scheduleSyncRetry(ctx, retryDelay)
+		}
+		return
 	}
 }
 
-func (m *MetricsHandler) doRebuild(parentCtx context.Context) {
+// scheduleSyncRetry re-runs a rebuild after delay. Without it, a store sync that
+// fails before any writer generation exists would leave the handler serving no
+// metrics until an unrelated event triggers another rebuild, which never happens
+// when autosharding is disabled.
+func (m *MetricsHandler) scheduleSyncRetry(ctx context.Context, delay time.Duration) {
+	klog.ErrorS(nil, "Store sync failed with no metrics writers available; scheduling rebuild retry", "retryDelay", delay)
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+		case <-timer.C:
+			m.BuildWriters(ctx)
+		}
+	}()
+}
+
+func nextStoreSyncRetryDelay(current time.Duration) time.Duration {
+	if current <= 0 {
+		return initialStoreSyncRetryDelay
+	}
+	if next := current * 2; next < maxStoreSyncRetryDelay {
+		return next
+	}
+	return maxStoreSyncRetryDelay
+}
+
+func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
 	m.mtx.Lock()
 	newCtx, newCancel := context.WithCancel(parentCtx)
 	m.storeBuilder.WithContext(newCtx)
@@ -121,7 +176,7 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) {
 
 	syncTimeout := m.opts.StoreSyncTimeout
 	if syncTimeout <= 0 {
-		syncTimeout = 120 * time.Second
+		syncTimeout = options.DefaultStoreSyncTimeout
 	}
 	syncStart := time.Now()
 	synced := m.storeBuilder.WaitForStoresSync(newCtx, syncTimeout)
@@ -137,7 +192,7 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) {
 			oldCancel()
 		}
 		klog.InfoS("Swapped metrics writers after store sync", "writerCount", len(newWriters), "syncWaitDuration", syncWaitDuration)
-		return
+		return true
 	}
 
 	newCancel()
@@ -146,6 +201,7 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) {
 		"syncTimeout", syncTimeout,
 		"writerCount", len(newWriters),
 	)
+	return false
 }
 
 // ConfigureSharding configures sharding. Configuration can be used multiple times and

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/prometheus/common/expfmt"
 
@@ -56,6 +57,11 @@ type MetricsHandler struct {
 	curTotalShards     int
 	curShard           int32
 	enableGZIPEncoding bool
+
+	rebuildMu        sync.Mutex
+	rebuildRunning   bool
+	pendingRebuild   bool
+	rebuildParentCtx context.Context
 }
 
 // New creates and returns a new MetricsHandler with the given options.
@@ -69,18 +75,77 @@ func New(opts *options.Options, kubeClient kubernetes.Interface, storeBuilder ks
 	}
 }
 
-// BuildWriters builds the metrics writers, cancelling any previous context and passing a new one on every build.
-// Build can be used multiple times and concurrently.
+// BuildWriters rebuilds metrics writers after store configuration changes.
+// Rebuilds are coalesced and swap in the new writer set only after reflector stores sync.
 func (m *MetricsHandler) BuildWriters(ctx context.Context) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	if m.cancel != nil {
-		m.cancel()
+	m.rebuildMu.Lock()
+	m.rebuildParentCtx = ctx
+	syncFirst := len(m.metricsWriters) == 0
+	if m.rebuildRunning {
+		m.pendingRebuild = true
+		m.rebuildMu.Unlock()
+		return
 	}
-	ctx, m.cancel = context.WithCancel(ctx)
-	m.storeBuilder.WithContext(ctx)
-	m.metricsWriters = m.storeBuilder.Build()
+	m.rebuildRunning = true
+	m.rebuildMu.Unlock()
+
+	if syncFirst {
+		m.rebuildLoop(ctx)
+		return
+	}
+	go m.rebuildLoop(ctx)
+}
+
+func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
+	ctx := initialCtx
+	for {
+		m.doRebuild(ctx)
+		m.rebuildMu.Lock()
+		if !m.pendingRebuild {
+			m.rebuildRunning = false
+			m.rebuildMu.Unlock()
+			return
+		}
+		m.pendingRebuild = false
+		ctx = m.rebuildParentCtx
+		m.rebuildMu.Unlock()
+	}
+}
+
+func (m *MetricsHandler) doRebuild(parentCtx context.Context) {
+	m.mtx.Lock()
+	newCtx, newCancel := context.WithCancel(parentCtx)
+	m.storeBuilder.WithContext(newCtx)
+	newWriters := m.storeBuilder.Build()
+	m.mtx.Unlock()
+
+	syncTimeout := m.opts.StoreSyncTimeout
+	if syncTimeout <= 0 {
+		syncTimeout = 120 * time.Second
+	}
+	syncStart := time.Now()
+	synced := m.storeBuilder.WaitForStoresSync(newCtx, syncTimeout)
+	syncWaitDuration := time.Since(syncStart)
+
+	if synced {
+		m.mtx.Lock()
+		oldCancel := m.cancel
+		m.metricsWriters = newWriters
+		m.cancel = newCancel
+		m.mtx.Unlock()
+		if oldCancel != nil {
+			oldCancel()
+		}
+		klog.InfoS("Swapped metrics writers after store sync", "writerCount", len(newWriters), "syncWaitDuration", syncWaitDuration)
+		return
+	}
+
+	newCancel()
+	klog.ErrorS(nil, "Store sync timed out during metrics writer rebuild; keeping previous writers",
+		"syncWaitDuration", syncWaitDuration,
+		"syncTimeout", syncTimeout,
+		"writerCount", len(newWriters),
+	)
 }
 
 // ConfigureSharding configures sharding. Configuration can be used multiple times and
@@ -193,7 +258,9 @@ func (m *MetricsHandler) Run(ctx context.Context) error {
 // Note that all operations defined within this procedure are performed at every request.
 func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.mtx.RLock()
-	defer m.mtx.RUnlock()
+	writers := append(metricsstore.MetricsWriterList(nil), m.metricsWriters...)
+	m.mtx.RUnlock()
+
 	resHeader := w.Header()
 	var writer io.Writer = w
 
@@ -228,10 +295,10 @@ func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Sanitizing first can suppress HELP/TYPE headers for metrics whose
 	// only active writer is later in the list but its earlier same-named
 	// counterpart was filtered out.
-	activeWriters := m.metricsWriters
+	activeWriters := writers
 	if requestedResources != nil || excludedResources != nil {
-		activeWriters = make(metricsstore.MetricsWriterList, 0, len(m.metricsWriters))
-		for _, mw := range m.metricsWriters {
+		activeWriters = make(metricsstore.MetricsWriterList, 0, len(writers))
+		for _, mw := range writers {
 			if requestedResources != nil {
 				if _, ok := requestedResources[mw.ResourceName]; !ok {
 					continue

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -46,9 +46,9 @@ type stubStoreBuilder struct {
 	syncOK       atomic.Bool
 	buildCount   atomic.Int64
 	syncCount    atomic.Int64
-	// failingSyncs is how many leading WaitForStoresSync calls report failure,
-	// regardless of syncOK, so tests can pin which attempt fails.
-	failingSyncs int64
+	// syncGate, when set, makes WaitForStoresSync block until a result is sent.
+	// This lets tests assert mid-retry state without racing the retry timer.
+	syncGate chan bool
 }
 
 func (s *stubStoreBuilder) WithMetrics(_ prometheus.Registerer)                         {}
@@ -80,8 +80,9 @@ func (s *stubStoreBuilder) Build() metricsstore.MetricsWriterList {
 }
 
 func (s *stubStoreBuilder) WaitForStoresSync(_ context.Context, _ time.Duration) bool {
-	if s.syncCount.Add(1) <= s.failingSyncs {
-		return false
+	s.syncCount.Add(1)
+	if s.syncGate != nil {
+		return <-s.syncGate
 	}
 	return s.syncOK.Load()
 }
@@ -156,25 +157,33 @@ func TestBuildWriters_SwapsWritersWhenSyncSucceeds(t *testing.T) {
 
 func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
 	restore := initialStoreSyncRetryDelay
-	initialStoreSyncRetryDelay = 10 * time.Millisecond
+	initialStoreSyncRetryDelay = time.Millisecond
 	defer func() { initialStoreSyncRetryDelay = restore }()
 
-	// Only the first sync attempt fails, so the retry is what populates writers.
+	// Channel-gated sync: first attempt fails immediately; the retry blocks until
+	// the test releases a successful result, so mid-retry assertions cannot race
+	// the retry timer.
+	syncGate := make(chan bool)
 	stub := &stubStoreBuilder{
 		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("first")},
-		failingSyncs: 1,
+		syncGate:     syncGate,
 	}
-	stub.syncOK.Store(true)
 	h := New(options.NewOptions(), nil, stub, false)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	firstSyncDone := make(chan struct{})
+	go func() {
+		syncGate <- false
+		close(firstSyncDone)
+	}()
 	// The first rebuild runs inline because no writers exist yet.
 	h.BuildWriters(ctx)
+	<-firstSyncDone
 
-	if got := stub.syncCount.Load(); got != 1 {
-		t.Fatalf("expected exactly one sync attempt before the retry, got %d", got)
-	}
+	// Writers stay empty until we release the retry, even if the retry timer has
+	// already fired and is blocked in WaitForStoresSync.
 	h.mtx.RLock()
 	got := len(h.metricsWriters)
 	h.mtx.RUnlock()
@@ -182,17 +191,25 @@ func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
 		t.Fatalf("expected no writers after failed initial sync, got %d", got)
 	}
 
+	// Release the retry sync as success. Send in a goroutine so we do not block
+	// if the retry has not entered WaitForStoresSync yet.
+	go func() { syncGate <- true }()
+
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		h.mtx.RLock()
 		writers := h.metricsWriters
 		h.mtx.RUnlock()
 		if len(writers) == 1 && writers[0].ResourceName == "first" {
+			if stub.syncCount.Load() < 2 {
+				t.Fatalf("expected retry sync attempt; syncCount=%d", stub.syncCount.Load())
+			}
 			return
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(time.Millisecond)
 	}
-	t.Fatalf("expected retry to populate writers; buildCount=%d", stub.buildCount.Load())
+	t.Fatalf("expected retry to populate writers; buildCount=%d syncCount=%d",
+		stub.buildCount.Load(), stub.syncCount.Load())
 }
 
 func TestServeHTTP_WriterSnapshot(t *testing.T) {

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricshandler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	ksmtypes "k8s.io/kube-state-metrics/v2/pkg/builder/types"
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
+	"k8s.io/kube-state-metrics/v2/pkg/options"
+)
+
+type stubStoreBuilder struct {
+	buildWriters metricsstore.MetricsWriterList
+	syncOK       bool
+	buildCount   int
+}
+
+func (s *stubStoreBuilder) WithMetrics(_ prometheus.Registerer)                         {}
+func (s *stubStoreBuilder) WithEnabledResources(_ []string) error                       { return nil }
+func (s *stubStoreBuilder) WithNamespaces(_ options.NamespaceList)                      {}
+func (s *stubStoreBuilder) WithFieldSelectorFilter(_ string)                            {}
+func (s *stubStoreBuilder) WithSharding(_ int32, _ int)                                 {}
+func (s *stubStoreBuilder) WithContext(_ context.Context)                               {}
+func (s *stubStoreBuilder) WithKubeClient(_ clientset.Interface)                        {}
+func (s *stubStoreBuilder) WithCustomResourceClients(_ map[string]interface{})          {}
+func (s *stubStoreBuilder) WithUsingAPIServerCache(_ bool)                              {}
+func (s *stubStoreBuilder) WithFamilyGeneratorFilter(_ generator.FamilyGeneratorFilter) {}
+func (s *stubStoreBuilder) WithAllowAnnotations(_ map[string][]string) error            { return nil }
+func (s *stubStoreBuilder) WithAllowLabels(_ map[string][]string) error                 { return nil }
+func (s *stubStoreBuilder) WithGenerateStoresFunc(_ ksmtypes.BuildStoresFunc)           {}
+func (s *stubStoreBuilder) DefaultGenerateStoresFunc() ksmtypes.BuildStoresFunc         { return nil }
+func (s *stubStoreBuilder) DefaultGenerateCustomResourceStoresFunc() ksmtypes.BuildCustomResourceStoresFunc {
+	return nil
+}
+func (s *stubStoreBuilder) WithCustomResourceStoreFactories(_ ...customresource.RegistryFactory) {
+}
+func (s *stubStoreBuilder) BuildStores() [][]cache.Store { return nil }
+func (s *stubStoreBuilder) WithGenerateCustomResourceStoresFunc(_ ksmtypes.BuildCustomResourceStoresFunc) {
+}
+
+func (s *stubStoreBuilder) Build() metricsstore.MetricsWriterList {
+	s.buildCount++
+	return s.buildWriters
+}
+
+func (s *stubStoreBuilder) WaitForStoresSync(_ context.Context, _ time.Duration) bool {
+	return s.syncOK
+}
+
+func TestBuildWriters_KeepsPreviousWritersWhenSyncFails(t *testing.T) {
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("candidate")},
+		syncOK:       false,
+	}
+	opts := options.NewOptions()
+	h := New(opts, nil, stub, false)
+
+	existing := metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("stable")}
+	h.mtx.Lock()
+	h.metricsWriters = existing
+	h.mtx.Unlock()
+
+	h.BuildWriters(context.Background())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mtx.RLock()
+		got := h.metricsWriters
+		h.mtx.RUnlock()
+		if stub.buildCount >= 1 && len(got) == 1 && got[0].ResourceName == "stable" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected stable writers after failed sync; buildCount=%d", stub.buildCount)
+}
+
+func TestBuildWriters_SwapsWritersWhenSyncSucceeds(t *testing.T) {
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("next")},
+		syncOK:       true,
+	}
+	opts := options.NewOptions()
+	h := New(opts, nil, stub, false)
+
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("prev")}
+	h.mtx.Unlock()
+
+	h.BuildWriters(context.Background())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mtx.RLock()
+		got := h.metricsWriters
+		h.mtx.RUnlock()
+		if len(got) == 1 && got[0].ResourceName == "next" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("expected writers to swap after successful sync")
+}
+
+func TestServeHTTP_WriterSnapshot(t *testing.T) {
+	h := New(options.NewOptions(), nil, &stubStoreBuilder{}, false)
+	w1 := metricsstore.NewMetricsWriter("first")
+	w2 := metricsstore.NewMetricsWriter("second")
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{w1, w2}
+	h.mtx.Unlock()
+
+	h.mtx.RLock()
+	snapshot := append(metricsstore.MetricsWriterList(nil), h.metricsWriters...)
+	h.mtx.RUnlock()
+
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("replaced")}
+	h.mtx.Unlock()
+
+	if len(snapshot) != 2 || snapshot[0].ResourceName != "first" || snapshot[1].ResourceName != "second" {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+}

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -153,6 +153,22 @@ func TestBuildWriters_SwapsWritersWhenSyncSucceeds(t *testing.T) {
 	if len(got) != 1 || got[0].ResourceName != "next" {
 		t.Fatalf("expected writers to swap after successful sync, got %+v", got)
 	}
+	if !h.Ready() {
+		t.Fatal("expected handler to report ready after successful sync")
+	}
+}
+
+func TestBuildWriters_ReadyAfterEmptyGenerationSyncs(t *testing.T) {
+	stub := &stubStoreBuilder{buildWriters: metricsstore.MetricsWriterList{}}
+	stub.syncOK.Store(true)
+	h := New(options.NewOptions(), nil, stub, false)
+
+	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
+
+	if !h.Ready() {
+		t.Fatal("expected handler to report ready after a successful sync with zero writers")
+	}
 }
 
 func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -18,6 +18,7 @@ package metricshandler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -48,11 +49,13 @@ type stubStoreBuilder struct {
 	syncCount    atomic.Int64
 	// syncGate, when set, makes WaitForStoresSync block until a result is sent.
 	// This lets tests assert mid-retry state without racing the retry timer.
-	syncGate chan bool
+	syncGate     chan bool
+	syncObserved chan bool
 }
 
 func (s *stubStoreBuilder) WithMetrics(_ prometheus.Registerer)                         {}
 func (s *stubStoreBuilder) WithEnabledResources(_ []string) error                       { return nil }
+func (s *stubStoreBuilder) ReplaceEnabledCustomResources(_ []string) error              { return nil }
 func (s *stubStoreBuilder) WithNamespaces(_ options.NamespaceList)                      {}
 func (s *stubStoreBuilder) WithFieldSelectorFilter(_ string)                            {}
 func (s *stubStoreBuilder) WithSharding(_ int32, _ int)                                 {}
@@ -82,7 +85,11 @@ func (s *stubStoreBuilder) Build() metricsstore.MetricsWriterList {
 func (s *stubStoreBuilder) WaitForStoresSync(_ context.Context, _ time.Duration) bool {
 	s.syncCount.Add(1)
 	if s.syncGate != nil {
-		return <-s.syncGate
+		result := <-s.syncGate
+		if s.syncObserved != nil {
+			s.syncObserved <- result
+		}
+		return result
 	}
 	return s.syncOK.Load()
 }
@@ -116,7 +123,9 @@ func TestBuildWriters_KeepsPreviousWritersWhenSyncFails(t *testing.T) {
 	h.metricsWriters = existing
 	h.mtx.Unlock()
 
-	h.BuildWriters(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h.BuildWriters(ctx)
 	waitForRebuildIdle(t, h)
 
 	if stub.buildCount.Load() < 1 || stub.syncCount.Load() < 1 {
@@ -171,41 +180,55 @@ func TestBuildWriters_ReadyAfterEmptyGenerationSyncs(t *testing.T) {
 	}
 }
 
-func TestBuildWriters_DoesNotRetryFailedRebuildAfterEmptyGenerationInstalled(t *testing.T) {
+func TestBuildWriters_RetriesFailedSyncWithExistingWriters(t *testing.T) {
 	restore := initialStoreSyncRetryDelay
 	initialStoreSyncRetryDelay = time.Millisecond
 	defer func() { initialStoreSyncRetryDelay = restore }()
 
-	syncGate := make(chan bool, 2)
+	syncGate := make(chan bool, 1)
+	syncObserved := make(chan bool, 1)
 	stub := &stubStoreBuilder{
-		buildWriters: metricsstore.MetricsWriterList{},
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("next")},
 		syncGate:     syncGate,
+		syncObserved: syncObserved,
 	}
 	h := New(options.NewOptions(), nil, stub, false)
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("stable")}
+	h.mtx.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	syncGate <- false
+	h.BuildWriters(ctx)
+	if result := <-syncObserved; result {
+		t.Fatal("expected first sync attempt to fail")
+	}
+
+	h.mtx.RLock()
+	got := h.metricsWriters
+	h.mtx.RUnlock()
+	if len(got) != 1 || got[0].ResourceName != "stable" {
+		t.Fatalf("expected stable writers to remain active after failed sync, got %+v", got)
+	}
 
 	syncGate <- true
-	h.BuildWriters(context.Background())
-	waitForRebuildIdle(t, h)
-	if !h.Ready() {
-		t.Fatal("expected ready after empty generation install")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mtx.RLock()
+		got = h.metricsWriters
+		h.mtx.RUnlock()
+		if len(got) == 1 && got[0].ResourceName == "next" {
+			waitForRebuildIdle(t, h)
+			if stub.syncCount.Load() < 2 {
+				t.Fatalf("expected retry sync attempt; syncCount=%d", stub.syncCount.Load())
+			}
+			return
+		}
+		time.Sleep(time.Millisecond)
 	}
-
-	firstBuild := stub.buildCount.Load()
-	firstSync := stub.syncCount.Load()
-
-	syncGate <- false
-	h.BuildWriters(context.Background())
-	waitForRebuildIdle(t, h)
-
-	time.Sleep(5 * time.Millisecond)
-	waitForRebuildIdle(t, h)
-
-	if stub.buildCount.Load() != firstBuild+1 {
-		t.Fatalf("expected only one failing rebuild after installed generation, buildCount=%d", stub.buildCount.Load())
-	}
-	if stub.syncCount.Load() != firstSync+1 {
-		t.Fatalf("expected only one failing sync after installed generation, syncCount=%d", stub.syncCount.Load())
-	}
+	t.Fatalf("expected retry to replace stable writers; buildCount=%d syncCount=%d",
+		stub.buildCount.Load(), stub.syncCount.Load())
 }
 
 func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
@@ -256,6 +279,9 @@ func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
 			if stub.syncCount.Load() < 2 {
 				t.Fatalf("expected retry sync attempt; syncCount=%d", stub.syncCount.Load())
 			}
+			// The retry rebuild must leave rebuildLoop before the deferred
+			// initialStoreSyncRetryDelay restore runs.
+			waitForRebuildIdle(t, h)
 			return
 		}
 		time.Sleep(time.Millisecond)
@@ -343,4 +369,105 @@ func newTestWriter(name string) *metricsstore.MetricsWriter {
 		panic(err)
 	}
 	return metricsstore.NewMetricsWriter(name, store)
+}
+
+func TestConfigureStore_AppliesConfigUnderLockThenRebuilds(t *testing.T) {
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("configured")},
+	}
+	stub.syncOK.Store(true)
+	h := New(options.NewOptions(), nil, stub, false)
+
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("prev")}
+	h.mtx.Unlock()
+
+	var configured atomic.Bool
+	h.ConfigureStore(context.Background(), func(b ksmtypes.BuilderInterface) error {
+		if b != stub {
+			t.Fatalf("expected ConfigureStore to pass the handler store builder")
+		}
+		configured.Store(true)
+		return nil
+	})
+	waitForRebuildIdle(t, h)
+
+	if !configured.Load() {
+		t.Fatal("expected ConfigureStore callback to run")
+	}
+	if stub.buildCount.Load() < 1 {
+		t.Fatalf("expected rebuild after ConfigureStore; buildCount=%d", stub.buildCount.Load())
+	}
+
+	h.mtx.RLock()
+	got := h.metricsWriters
+	h.mtx.RUnlock()
+	if len(got) != 1 || got[0].ResourceName != "configured" {
+		t.Fatalf("expected writers swapped after ConfigureStore rebuild, got %+v", got)
+	}
+}
+
+func TestConfigureStore_CoalescesWithInFlightRebuild(t *testing.T) {
+	syncGate := make(chan bool, 1)
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("next")},
+		syncGate:     syncGate,
+	}
+	h := New(options.NewOptions(), nil, stub, false)
+
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("prev")}
+	h.mtx.Unlock()
+
+	// Start an async rebuild that blocks in WaitForStoresSync.
+	h.BuildWriters(context.Background())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for stub.syncCount.Load() < 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("first rebuild did not reach WaitForStoresSync")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	var configDuringWait atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.ConfigureStore(context.Background(), func(ksmtypes.BuilderInterface) error {
+			configDuringWait.Add(1)
+			return nil
+		})
+	}()
+
+	// Release the first sync as success; coalesced rebuild from ConfigureStore follows.
+	syncGate <- true
+	go func() { syncGate <- true }()
+	<-done
+	waitForRebuildIdle(t, h)
+
+	if configDuringWait.Load() != 1 {
+		t.Fatalf("expected ConfigureStore callback once, got %d", configDuringWait.Load())
+	}
+	if stub.buildCount.Load() < 2 {
+		t.Fatalf("expected coalesced rebuild after ConfigureStore during wait; buildCount=%d", stub.buildCount.Load())
+	}
+}
+
+func TestConfigureStore_SkipsRebuildOnConfigError(t *testing.T) {
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("next")},
+	}
+	stub.syncOK.Store(true)
+	h := New(options.NewOptions(), nil, stub, false)
+
+	err := h.ConfigureStore(context.Background(), func(ksmtypes.BuilderInterface) error {
+		return fmt.Errorf("config failed")
+	})
+	if err == nil {
+		t.Fatal("expected ConfigureStore to return configuration error")
+	}
+	if stub.buildCount.Load() != 0 {
+		t.Fatalf("expected no rebuild after configuration error; buildCount=%d", stub.buildCount.Load())
+	}
 }

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricshandler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	ksmtypes "k8s.io/kube-state-metrics/v2/pkg/builder/types"
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
+	"k8s.io/kube-state-metrics/v2/pkg/options"
+)
+
+type stubStoreBuilder struct {
+	buildWriters metricsstore.MetricsWriterList
+	syncOK       atomic.Bool
+	buildCount   atomic.Int64
+	syncCount    atomic.Int64
+	// syncGate, when set, makes WaitForStoresSync block until a result is sent.
+	// This lets tests assert mid-retry state without racing the retry timer.
+	syncGate chan bool
+}
+
+func (s *stubStoreBuilder) WithMetrics(_ prometheus.Registerer)                         {}
+func (s *stubStoreBuilder) WithEnabledResources(_ []string) error                       { return nil }
+func (s *stubStoreBuilder) WithNamespaces(_ options.NamespaceList)                      {}
+func (s *stubStoreBuilder) WithFieldSelectorFilter(_ string)                            {}
+func (s *stubStoreBuilder) WithSharding(_ int32, _ int)                                 {}
+func (s *stubStoreBuilder) WithContext(_ context.Context)                               {}
+func (s *stubStoreBuilder) WithKubeClient(_ clientset.Interface)                        {}
+func (s *stubStoreBuilder) WithCustomResourceClients(_ map[string]interface{})          {}
+func (s *stubStoreBuilder) WithUsingAPIServerCache(_ bool)                              {}
+func (s *stubStoreBuilder) WithFamilyGeneratorFilter(_ generator.FamilyGeneratorFilter) {}
+func (s *stubStoreBuilder) WithAllowAnnotations(_ map[string][]string) error            { return nil }
+func (s *stubStoreBuilder) WithAllowLabels(_ map[string][]string) error                 { return nil }
+func (s *stubStoreBuilder) WithGenerateStoresFunc(_ ksmtypes.BuildStoresFunc)           {}
+func (s *stubStoreBuilder) DefaultGenerateStoresFunc() ksmtypes.BuildStoresFunc         { return nil }
+func (s *stubStoreBuilder) DefaultGenerateCustomResourceStoresFunc() ksmtypes.BuildCustomResourceStoresFunc {
+	return nil
+}
+func (s *stubStoreBuilder) WithCustomResourceStoreFactories(_ ...customresource.RegistryFactory) {
+}
+func (s *stubStoreBuilder) BuildStores() [][]cache.Store { return nil }
+func (s *stubStoreBuilder) WithGenerateCustomResourceStoresFunc(_ ksmtypes.BuildCustomResourceStoresFunc) {
+}
+
+func (s *stubStoreBuilder) Build() metricsstore.MetricsWriterList {
+	s.buildCount.Add(1)
+	return s.buildWriters
+}
+
+func (s *stubStoreBuilder) WaitForStoresSync(_ context.Context, _ time.Duration) bool {
+	s.syncCount.Add(1)
+	if s.syncGate != nil {
+		return <-s.syncGate
+	}
+	return s.syncOK.Load()
+}
+
+// waitForRebuildIdle blocks until no rebuild is in flight, so assertions do not
+// race an in-progress swap.
+func waitForRebuildIdle(t *testing.T, h *MetricsHandler) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.rebuildMu.Lock()
+		running := h.rebuildRunning
+		h.rebuildMu.Unlock()
+		if !running {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("rebuild did not finish before deadline")
+}
+
+func TestBuildWriters_KeepsPreviousWritersWhenSyncFails(t *testing.T) {
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("candidate")},
+	}
+	opts := options.NewOptions()
+	h := New(opts, nil, stub, false)
+
+	existing := metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("stable")}
+	h.mtx.Lock()
+	h.metricsWriters = existing
+	h.mtx.Unlock()
+
+	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
+
+	if stub.buildCount.Load() < 1 || stub.syncCount.Load() < 1 {
+		t.Fatalf("expected a build and a sync attempt; buildCount=%d syncCount=%d",
+			stub.buildCount.Load(), stub.syncCount.Load())
+	}
+
+	h.mtx.RLock()
+	got := h.metricsWriters
+	h.mtx.RUnlock()
+	if len(got) != 1 || got[0].ResourceName != "stable" {
+		t.Fatalf("expected stable writers to be kept after failed sync, got %+v", got)
+	}
+}
+
+func TestBuildWriters_SwapsWritersWhenSyncSucceeds(t *testing.T) {
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("next")},
+	}
+	stub.syncOK.Store(true)
+	opts := options.NewOptions()
+	h := New(opts, nil, stub, false)
+
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("prev")}
+	h.mtx.Unlock()
+
+	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
+
+	h.mtx.RLock()
+	got := h.metricsWriters
+	h.mtx.RUnlock()
+	if len(got) != 1 || got[0].ResourceName != "next" {
+		t.Fatalf("expected writers to swap after successful sync, got %+v", got)
+	}
+}
+
+func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
+	restore := initialStoreSyncRetryDelay
+	initialStoreSyncRetryDelay = time.Millisecond
+	defer func() { initialStoreSyncRetryDelay = restore }()
+
+	// Channel-gated sync: first attempt fails immediately; the retry blocks until
+	// the test releases a successful result, so mid-retry assertions cannot race
+	// the retry timer.
+	syncGate := make(chan bool)
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("first")},
+		syncGate:     syncGate,
+	}
+	h := New(options.NewOptions(), nil, stub, false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstSyncDone := make(chan struct{})
+	go func() {
+		syncGate <- false
+		close(firstSyncDone)
+	}()
+	h.BuildWriters(ctx)
+	<-firstSyncDone
+
+	// Writers stay empty until we release the retry, even if the retry timer has
+	// already fired and is blocked in WaitForStoresSync.
+	h.mtx.RLock()
+	got := len(h.metricsWriters)
+	h.mtx.RUnlock()
+	if got != 0 {
+		t.Fatalf("expected no writers after failed initial sync, got %d", got)
+	}
+
+	// Release the retry sync as success. Send in a goroutine so we do not block
+	// if the retry has not entered WaitForStoresSync yet.
+	go func() { syncGate <- true }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mtx.RLock()
+		writers := h.metricsWriters
+		h.mtx.RUnlock()
+		if len(writers) == 1 && writers[0].ResourceName == "first" {
+			if stub.syncCount.Load() < 2 {
+				t.Fatalf("expected retry sync attempt; syncCount=%d", stub.syncCount.Load())
+			}
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("expected retry to populate writers; buildCount=%d syncCount=%d",
+		stub.buildCount.Load(), stub.syncCount.Load())
+}
+
+func TestServeHTTP_WriterSnapshot(t *testing.T) {
+	h := New(options.NewOptions(), nil, &stubStoreBuilder{}, false)
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{newTestWriter("first"), newTestWriter("second")}
+	h.mtx.Unlock()
+
+	// Replace the writer list while ServeHTTP is mid-response: the snapshot it
+	// took must still be written out in full.
+	rec := httptest.NewRecorder()
+	body := &blockingWriter{
+		ResponseWriter: rec,
+		onFirstWrite: func() {
+			h.mtx.Lock()
+			h.metricsWriters = metricsstore.MetricsWriterList{newTestWriter("replaced")}
+			h.mtx.Unlock()
+		},
+	}
+	// ServeHTTP must not hold mtx across the response body, or onFirstWrite would
+	// deadlock instead of failing.
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(body, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeHTTP did not complete while writers were replaced")
+	}
+
+	out := rec.Body.String()
+	for _, want := range []string{"kube_test_first", "kube_test_second"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in response, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "kube_test_replaced") {
+		t.Fatalf("response used writers swapped in mid-request:\n%s", out)
+	}
+}
+
+// blockingWriter runs onFirstWrite once, before the first byte of the response
+// body is written, to simulate a rebuild landing during a scrape.
+type blockingWriter struct {
+	http.ResponseWriter
+	onFirstWrite func()
+	written      bool
+}
+
+func (b *blockingWriter) Write(p []byte) (int, error) {
+	if !b.written {
+		b.written = true
+		b.onFirstWrite()
+	}
+	return b.ResponseWriter.Write(p)
+}
+
+func newTestWriter(name string) *metricsstore.MetricsWriter {
+	genFunc := func(obj interface{}) []metric.FamilyInterface {
+		o, err := meta.Accessor(obj)
+		if err != nil {
+			panic(err)
+		}
+		return []metric.FamilyInterface{&metric.Family{
+			Name: "kube_test_" + name,
+			Metrics: []*metric.Metric{{
+				LabelKeys:   []string{"namespace"},
+				LabelValues: []string{o.GetNamespace()},
+				Value:       1,
+			}},
+		}}
+	}
+	store := metricsstore.NewMetricsStore([]string{"# HELP kube_test_" + name + " test\n"}, genFunc)
+	if err := store.Add(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID(name), Name: name, Namespace: "ns"},
+	}); err != nil {
+		panic(err)
+	}
+	return metricsstore.NewMetricsWriter(name, store)
+}

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -18,15 +18,24 @@ package metricshandler
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	ksmtypes "k8s.io/kube-state-metrics/v2/pkg/builder/types"
 	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
 	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
 	"k8s.io/kube-state-metrics/v2/pkg/options"
@@ -34,8 +43,8 @@ import (
 
 type stubStoreBuilder struct {
 	buildWriters metricsstore.MetricsWriterList
-	syncOK       bool
-	buildCount   int
+	syncOK       atomic.Bool
+	buildCount   atomic.Int64
 }
 
 func (s *stubStoreBuilder) WithMetrics(_ prometheus.Registerer)                         {}
@@ -62,18 +71,17 @@ func (s *stubStoreBuilder) WithGenerateCustomResourceStoresFunc(_ ksmtypes.Build
 }
 
 func (s *stubStoreBuilder) Build() metricsstore.MetricsWriterList {
-	s.buildCount++
+	s.buildCount.Add(1)
 	return s.buildWriters
 }
 
 func (s *stubStoreBuilder) WaitForStoresSync(_ context.Context, _ time.Duration) bool {
-	return s.syncOK
+	return s.syncOK.Load()
 }
 
 func TestBuildWriters_KeepsPreviousWritersWhenSyncFails(t *testing.T) {
 	stub := &stubStoreBuilder{
 		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("candidate")},
-		syncOK:       false,
 	}
 	opts := options.NewOptions()
 	h := New(opts, nil, stub, false)
@@ -90,19 +98,19 @@ func TestBuildWriters_KeepsPreviousWritersWhenSyncFails(t *testing.T) {
 		h.mtx.RLock()
 		got := h.metricsWriters
 		h.mtx.RUnlock()
-		if stub.buildCount >= 1 && len(got) == 1 && got[0].ResourceName == "stable" {
+		if stub.buildCount.Load() >= 1 && len(got) == 1 && got[0].ResourceName == "stable" {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("expected stable writers after failed sync; buildCount=%d", stub.buildCount)
+	t.Fatalf("expected stable writers after failed sync; buildCount=%d", stub.buildCount.Load())
 }
 
 func TestBuildWriters_SwapsWritersWhenSyncSucceeds(t *testing.T) {
 	stub := &stubStoreBuilder{
 		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("next")},
-		syncOK:       true,
 	}
+	stub.syncOK.Store(true)
 	opts := options.NewOptions()
 	h := New(opts, nil, stub, false)
 
@@ -125,23 +133,108 @@ func TestBuildWriters_SwapsWritersWhenSyncSucceeds(t *testing.T) {
 	t.Fatal("expected writers to swap after successful sync")
 }
 
-func TestServeHTTP_WriterSnapshot(t *testing.T) {
-	h := New(options.NewOptions(), nil, &stubStoreBuilder{}, false)
-	w1 := metricsstore.NewMetricsWriter("first")
-	w2 := metricsstore.NewMetricsWriter("second")
-	h.mtx.Lock()
-	h.metricsWriters = metricsstore.MetricsWriterList{w1, w2}
-	h.mtx.Unlock()
+func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
+	restore := initialStoreSyncRetryDelay
+	initialStoreSyncRetryDelay = 10 * time.Millisecond
+	defer func() { initialStoreSyncRetryDelay = restore }()
+
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("first")},
+	}
+	h := New(options.NewOptions(), nil, stub, false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h.BuildWriters(ctx)
 
 	h.mtx.RLock()
-	snapshot := append(metricsstore.MetricsWriterList(nil), h.metricsWriters...)
+	got := len(h.metricsWriters)
 	h.mtx.RUnlock()
+	if got != 0 {
+		t.Fatalf("expected no writers after failed initial sync, got %d", got)
+	}
 
+	stub.syncOK.Store(true)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mtx.RLock()
+		writers := h.metricsWriters
+		h.mtx.RUnlock()
+		if len(writers) == 1 && writers[0].ResourceName == "first" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected retry to populate writers; buildCount=%d", stub.buildCount.Load())
+}
+
+func TestServeHTTP_WriterSnapshot(t *testing.T) {
+	h := New(options.NewOptions(), nil, &stubStoreBuilder{}, false)
 	h.mtx.Lock()
-	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("replaced")}
+	h.metricsWriters = metricsstore.MetricsWriterList{newTestWriter("first"), newTestWriter("second")}
 	h.mtx.Unlock()
 
-	if len(snapshot) != 2 || snapshot[0].ResourceName != "first" || snapshot[1].ResourceName != "second" {
-		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	// Replace the writer list while ServeHTTP is mid-response: the snapshot it
+	// took must still be written out in full.
+	rec := httptest.NewRecorder()
+	body := &blockingWriter{
+		ResponseWriter: rec,
+		onFirstWrite: func() {
+			h.mtx.Lock()
+			h.metricsWriters = metricsstore.MetricsWriterList{newTestWriter("replaced")}
+			h.mtx.Unlock()
+		},
 	}
+	h.ServeHTTP(body, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	out := rec.Body.String()
+	for _, want := range []string{"kube_test_first", "kube_test_second"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in response, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "kube_test_replaced") {
+		t.Fatalf("response used writers swapped in mid-request:\n%s", out)
+	}
+}
+
+// blockingWriter runs onFirstWrite once, before the first byte of the response
+// body is written, to simulate a rebuild landing during a scrape.
+type blockingWriter struct {
+	http.ResponseWriter
+	onFirstWrite func()
+	written      bool
+}
+
+func (b *blockingWriter) Write(p []byte) (int, error) {
+	if !b.written {
+		b.written = true
+		b.onFirstWrite()
+	}
+	return b.ResponseWriter.Write(p)
+}
+
+func newTestWriter(name string) *metricsstore.MetricsWriter {
+	genFunc := func(obj interface{}) []metric.FamilyInterface {
+		o, err := meta.Accessor(obj)
+		if err != nil {
+			panic(err)
+		}
+		return []metric.FamilyInterface{&metric.Family{
+			Name: "kube_test_" + name,
+			Metrics: []*metric.Metric{{
+				LabelKeys:   []string{"namespace"},
+				LabelValues: []string{o.GetNamespace()},
+				Value:       1,
+			}},
+		}}
+	}
+	store := metricsstore.NewMetricsStore([]string{"# HELP kube_test_" + name + " test\n"}, genFunc)
+	if err := store.Add(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID(name), Name: name, Namespace: "ns"},
+	}); err != nil {
+		panic(err)
+	}
+	return metricsstore.NewMetricsWriter(name, store)
 }

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -45,6 +45,10 @@ type stubStoreBuilder struct {
 	buildWriters metricsstore.MetricsWriterList
 	syncOK       atomic.Bool
 	buildCount   atomic.Int64
+	syncCount    atomic.Int64
+	// failingSyncs is how many leading WaitForStoresSync calls report failure,
+	// regardless of syncOK, so tests can pin which attempt fails.
+	failingSyncs int64
 }
 
 func (s *stubStoreBuilder) WithMetrics(_ prometheus.Registerer)                         {}
@@ -76,7 +80,27 @@ func (s *stubStoreBuilder) Build() metricsstore.MetricsWriterList {
 }
 
 func (s *stubStoreBuilder) WaitForStoresSync(_ context.Context, _ time.Duration) bool {
+	if s.syncCount.Add(1) <= s.failingSyncs {
+		return false
+	}
 	return s.syncOK.Load()
+}
+
+// waitForRebuildIdle blocks until no rebuild is in flight, so assertions do not
+// race an in-progress swap.
+func waitForRebuildIdle(t *testing.T, h *MetricsHandler) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.rebuildMu.Lock()
+		running := h.rebuildRunning
+		h.rebuildMu.Unlock()
+		if !running {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("rebuild did not finish before deadline")
 }
 
 func TestBuildWriters_KeepsPreviousWritersWhenSyncFails(t *testing.T) {
@@ -92,18 +116,19 @@ func TestBuildWriters_KeepsPreviousWritersWhenSyncFails(t *testing.T) {
 	h.mtx.Unlock()
 
 	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		h.mtx.RLock()
-		got := h.metricsWriters
-		h.mtx.RUnlock()
-		if stub.buildCount.Load() >= 1 && len(got) == 1 && got[0].ResourceName == "stable" {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	if stub.buildCount.Load() < 1 || stub.syncCount.Load() < 1 {
+		t.Fatalf("expected a build and a sync attempt; buildCount=%d syncCount=%d",
+			stub.buildCount.Load(), stub.syncCount.Load())
 	}
-	t.Fatalf("expected stable writers after failed sync; buildCount=%d", stub.buildCount.Load())
+
+	h.mtx.RLock()
+	got := h.metricsWriters
+	h.mtx.RUnlock()
+	if len(got) != 1 || got[0].ResourceName != "stable" {
+		t.Fatalf("expected stable writers to be kept after failed sync, got %+v", got)
+	}
 }
 
 func TestBuildWriters_SwapsWritersWhenSyncSucceeds(t *testing.T) {
@@ -119,18 +144,14 @@ func TestBuildWriters_SwapsWritersWhenSyncSucceeds(t *testing.T) {
 	h.mtx.Unlock()
 
 	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		h.mtx.RLock()
-		got := h.metricsWriters
-		h.mtx.RUnlock()
-		if len(got) == 1 && got[0].ResourceName == "next" {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	h.mtx.RLock()
+	got := h.metricsWriters
+	h.mtx.RUnlock()
+	if len(got) != 1 || got[0].ResourceName != "next" {
+		t.Fatalf("expected writers to swap after successful sync, got %+v", got)
 	}
-	t.Fatal("expected writers to swap after successful sync")
 }
 
 func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
@@ -138,23 +159,28 @@ func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
 	initialStoreSyncRetryDelay = 10 * time.Millisecond
 	defer func() { initialStoreSyncRetryDelay = restore }()
 
+	// Only the first sync attempt fails, so the retry is what populates writers.
 	stub := &stubStoreBuilder{
 		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("first")},
+		failingSyncs: 1,
 	}
+	stub.syncOK.Store(true)
 	h := New(options.NewOptions(), nil, stub, false)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	// The first rebuild runs inline because no writers exist yet.
 	h.BuildWriters(ctx)
 
+	if got := stub.syncCount.Load(); got != 1 {
+		t.Fatalf("expected exactly one sync attempt before the retry, got %d", got)
+	}
 	h.mtx.RLock()
 	got := len(h.metricsWriters)
 	h.mtx.RUnlock()
 	if got != 0 {
 		t.Fatalf("expected no writers after failed initial sync, got %d", got)
 	}
-
-	stub.syncOK.Store(true)
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -186,7 +212,18 @@ func TestServeHTTP_WriterSnapshot(t *testing.T) {
 			h.mtx.Unlock()
 		},
 	}
-	h.ServeHTTP(body, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	// ServeHTTP must not hold mtx across the response body, or onFirstWrite would
+	// deadlock instead of failing.
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(body, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeHTTP did not complete while writers were replaced")
+	}
 
 	out := rec.Body.String()
 	for _, want := range []string{"kube_test_first", "kube_test_second"} {

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -171,6 +171,43 @@ func TestBuildWriters_ReadyAfterEmptyGenerationSyncs(t *testing.T) {
 	}
 }
 
+func TestBuildWriters_DoesNotRetryFailedRebuildAfterEmptyGenerationInstalled(t *testing.T) {
+	restore := initialStoreSyncRetryDelay
+	initialStoreSyncRetryDelay = time.Millisecond
+	defer func() { initialStoreSyncRetryDelay = restore }()
+
+	syncGate := make(chan bool, 2)
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{},
+		syncGate:     syncGate,
+	}
+	h := New(options.NewOptions(), nil, stub, false)
+
+	syncGate <- true
+	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
+	if !h.Ready() {
+		t.Fatal("expected ready after empty generation install")
+	}
+
+	firstBuild := stub.buildCount.Load()
+	firstSync := stub.syncCount.Load()
+
+	syncGate <- false
+	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
+
+	time.Sleep(5 * time.Millisecond)
+	waitForRebuildIdle(t, h)
+
+	if stub.buildCount.Load() != firstBuild+1 {
+		t.Fatalf("expected only one failing rebuild after installed generation, buildCount=%d", stub.buildCount.Load())
+	}
+	if stub.syncCount.Load() != firstSync+1 {
+		t.Fatalf("expected only one failing sync after installed generation, syncCount=%d", stub.syncCount.Load())
+	}
+}
+
 func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
 	restore := initialStoreSyncRetryDelay
 	initialStoreSyncRetryDelay = time.Millisecond

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -36,8 +36,11 @@ var (
 	// https://github.com/prometheus/common/blob/318309999517402ad522877ac7e55fa650a11114/config/http_config.go#L55
 	defaultServerIdleTimeout       = 5 * time.Minute
 	defaultServerReadHeaderTimeout = 5 * time.Second
-	defaultStoreSyncTimeout        = 120 * time.Second
 )
+
+// DefaultStoreSyncTimeout is the default maximum time to wait for reflector
+// stores to complete their initial list before swapping metrics writers.
+var DefaultStoreSyncTimeout = 120 * time.Second
 
 // Options are the configurable parameters for kube-state-metrics.
 type Options struct {
@@ -193,7 +196,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	o.cmd.Flags().DurationVar(&o.ServerWriteTimeout, "server-write-timeout", defaultServerWriteTimeout, "The maximum duration before timing out writes of the response. Align with the scrape interval or timeout of scraping clients..")
 	o.cmd.Flags().DurationVar(&o.ServerIdleTimeout, "server-idle-timeout", defaultServerIdleTimeout, "The maximum amount of time to wait for the next request when keep-alives are enabled. Align with the idletimeout of your scrape clients.")
 	o.cmd.Flags().DurationVar(&o.ServerReadHeaderTimeout, "server-read-header-timeout", defaultServerReadHeaderTimeout, "The maximum duration for reading the header of requests.")
-	o.cmd.Flags().DurationVar(&o.StoreSyncTimeout, "store-sync-timeout", defaultStoreSyncTimeout, "Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild.")
+	o.cmd.Flags().DurationVar(&o.StoreSyncTimeout, "store-sync-timeout", DefaultStoreSyncTimeout, "Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild.")
 }
 
 // Parse parses the flag definitions from the argument list.

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -36,6 +36,7 @@ var (
 	// https://github.com/prometheus/common/blob/318309999517402ad522877ac7e55fa650a11114/config/http_config.go#L55
 	defaultServerIdleTimeout       = 5 * time.Minute
 	defaultServerReadHeaderTimeout = 5 * time.Second
+	defaultStoreSyncTimeout        = 120 * time.Second
 )
 
 // Options are the configurable parameters for kube-state-metrics.
@@ -78,6 +79,7 @@ type Options struct {
 	ServerWriteTimeout      time.Duration `yaml:"server_write_timeout"`
 	ServerIdleTimeout       time.Duration `yaml:"server_idle_timeout"`
 	ServerReadHeaderTimeout time.Duration `yaml:"server_read_header_timeout"`
+	StoreSyncTimeout        time.Duration `yaml:"store_sync_timeout"`
 
 	Shard                int32 `yaml:"shard"`
 	AutoGoMemlimit       bool  `yaml:"auto-gomemlimit"`
@@ -191,6 +193,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	o.cmd.Flags().DurationVar(&o.ServerWriteTimeout, "server-write-timeout", defaultServerWriteTimeout, "The maximum duration before timing out writes of the response. Align with the scrape interval or timeout of scraping clients..")
 	o.cmd.Flags().DurationVar(&o.ServerIdleTimeout, "server-idle-timeout", defaultServerIdleTimeout, "The maximum amount of time to wait for the next request when keep-alives are enabled. Align with the idletimeout of your scrape clients.")
 	o.cmd.Flags().DurationVar(&o.ServerReadHeaderTimeout, "server-read-header-timeout", defaultServerReadHeaderTimeout, "The maximum duration for reading the header of requests.")
+	o.cmd.Flags().DurationVar(&o.StoreSyncTimeout, "store-sync-timeout", defaultStoreSyncTimeout, "Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild.")
 }
 
 // Parse parses the flag definitions from the argument list.

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -40,7 +40,7 @@ var (
 
 // DefaultStoreSyncTimeout is the default maximum time to wait for reflector
 // stores to complete their initial list before swapping metrics writers.
-var DefaultStoreSyncTimeout = 120 * time.Second
+const DefaultStoreSyncTimeout = 120 * time.Second
 
 // Options are the configurable parameters for kube-state-metrics.
 type Options struct {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -38,6 +38,10 @@ var (
 	defaultServerReadHeaderTimeout = 5 * time.Second
 )
 
+// DefaultStoreSyncTimeout is the default maximum time to wait for reflector
+// stores to complete their initial list before swapping metrics writers.
+var DefaultStoreSyncTimeout = 120 * time.Second
+
 // Options are the configurable parameters for kube-state-metrics.
 type Options struct {
 	AnnotationsAllowList LabelsAllowList `yaml:"annotations_allow_list"`
@@ -78,6 +82,7 @@ type Options struct {
 	ServerWriteTimeout      time.Duration `yaml:"server_write_timeout"`
 	ServerIdleTimeout       time.Duration `yaml:"server_idle_timeout"`
 	ServerReadHeaderTimeout time.Duration `yaml:"server_read_header_timeout"`
+	StoreSyncTimeout        time.Duration `yaml:"store_sync_timeout"`
 
 	Shard                int32 `yaml:"shard"`
 	AutoGoMemlimit       bool  `yaml:"auto-gomemlimit"`
@@ -191,6 +196,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	o.cmd.Flags().DurationVar(&o.ServerWriteTimeout, "server-write-timeout", defaultServerWriteTimeout, "The maximum duration before timing out writes of the response. Align with the scrape interval or timeout of scraping clients..")
 	o.cmd.Flags().DurationVar(&o.ServerIdleTimeout, "server-idle-timeout", defaultServerIdleTimeout, "The maximum amount of time to wait for the next request when keep-alives are enabled. Align with the idletimeout of your scrape clients.")
 	o.cmd.Flags().DurationVar(&o.ServerReadHeaderTimeout, "server-read-header-timeout", defaultServerReadHeaderTimeout, "The maximum duration for reading the header of requests.")
+	o.cmd.Flags().DurationVar(&o.StoreSyncTimeout, "store-sync-timeout", DefaultStoreSyncTimeout, "Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild.")
 }
 
 // Parse parses the flag definitions from the argument list.

--- a/tests/e2e/discovery_test.go
+++ b/tests/e2e/discovery_test.go
@@ -133,6 +133,20 @@ func (rm *resourceManager) writeResourceFiles(t *testing.T) {
 	klog.InfoS("created initial and new CR and CRD manifests")
 }
 
+func waitForCRDEstablished(t *testing.T, name string) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(context.TODO(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		cmd := exec.CommandContext(ctx, "kubectl", "wait", "--for=condition=Established", "crd/"+name, "--timeout=1s") //nolint:gosec
+		if err := cmd.Run(); err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("timed out waiting for CRD %q to be established: %v", name, err)
+	}
+}
+
 func TestVariableVKsDiscoveryAndResolution(t *testing.T) {
 	// populateTimeout is the timeout on populating the cache for the first time.
 	const populateTimeout = 10 * time.Second
@@ -190,6 +204,7 @@ func TestVariableVKsDiscoveryAndResolution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to apply initial crd: %v", err)
 	}
+	waitForCRDEstablished(t, "myplatforms.contoso.com")
 	err = exec.Command("kubectl", "apply", "-f", rm.initCrFile.Name()).Run() //nolint:gosec
 	if err != nil {
 		t.Fatalf("failed to apply initial cr: %v", err)
@@ -234,6 +249,7 @@ func TestVariableVKsDiscoveryAndResolution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to apply new crd: %v", err)
 	}
+	waitForCRDEstablished(t, "updates.contoso.com")
 	err = exec.Command("kubectl", "apply", "-f", rm.newCrFile.Name()).Run() //nolint:gosec
 	if err != nil {
 		t.Fatalf("failed to apply new cr: %v", err)


### PR DESCRIPTION
## What this PR does / why we need it

When custom resource state (CRS) discovery rebuilds metrics writers, kube-state-metrics starts new reflectors with **empty** stores and previously could swap those writers in before the initial list completed. Scrapes during that window returned HTTP 200 with an incomplete metric set (notably missing large families such as `kube_pod_*`), which looks like intermittent metrics gaps to Prometheus.

This change waits for the new reflector generation to sync (configurable via `--store-sync-timeout`), swaps writers only after a successful sync, and keeps serving the previous writer generation until then. Each scrape also snapshots the active writers under the read lock so a long `/metrics` response is not blocked by a concurrent rebuild.

## How does this change affect the users?

- Reduces empty/incomplete scrapes during CRS-driven writer rebuilds.
- Adds `--store-sync-timeout` (default matches existing store sync behavior) so operators can tune how long a rebuild waits for the new generation to become ready.
- During the sync window, memory may briefly hold two generations of stores (old + new). That is intentional for correctness; operators with very large CRS sets should be aware of peak memory during frequent rebuilds.

## Related Issues / PRs

Relates to #3093 (discovery-side `ConfigureStore` migration). This PR does not fully close the builder mutation race; that lands in #3093.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/kubernetes/kube-state-metrics/blob/main/CONTRIBUTING.md) and [Developer Guide](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/developer/guide.md)
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have updated CHANGELOG.md
- [x] I have added/updated unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric updates during resource state rebuilds by waiting for initial store synchronization.
  * Preserved existing metrics when synchronization fails or times out, with automatic retries.
  * Ensured consistent metric snapshots during concurrent updates.
  * Reduced unnecessary metric rebuilds when discovered resources have not changed.

* **New Features**
  * Added configurable store synchronization timeouts.
  * Added the `--store-sync-timeout` option, defaulting to 120 seconds.
  * Coalesced configuration changes during metric rebuilds.

* **Documentation**
  * Documented the store synchronization timeout option and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->