### PR TITLE
fix: fix issues with wrong labels being applied to endpointslices metric

### DIFF
--- a/internal/store/endpointslice.go
+++ b/internal/store/endpointslice.go
@@ -153,7 +153,7 @@ func createEndpointsSliceEndpoints() generator.FamilyGenerator {
 				}
 
 				if ep.Conditions.Terminating != nil {
-					serving = strconv.FormatBool(*ep.Conditions.Terminating)
+					terminating = strconv.FormatBool(*ep.Conditions.Terminating)
 				}
 				if ep.Hostname != nil {
 					hostname = *ep.Hostname
@@ -174,7 +174,7 @@ func createEndpointsSliceEndpoints() generator.FamilyGenerator {
 				}
 
 				labelKeys := []string{"ready", "serving", "hostname", "terminating", "targetref_kind", "targetref_name", "targetref_namespace", "endpoint_nodename", "endpoint_zone", "address"}
-				labelValues := []string{ready, serving, terminating, hostname, targetrefKind, targetrefName, targetrefNamespace, endpointNodename, endpointZone}
+				labelValues := []string{ready, serving, hostname, terminating, targetrefKind, targetrefName, targetrefNamespace, endpointNodename, endpointZone}
 
 				for _, address := range ep.Addresses {
 					newlabelValues := make([]string, len(labelValues))

--- a/internal/store/endpointslice_test.go
+++ b/internal/store/endpointslice_test.go
@@ -33,6 +33,7 @@ func TestEndpointSliceStore(t *testing.T) {
 	hostname := "host"
 	zone := "west"
 	ready := true
+	serving := true
 	terminating := false
 	addresses := []string{"10.0.0.1", "192.168.1.10"}
 
@@ -108,6 +109,7 @@ func TestEndpointSliceStore(t *testing.T) {
 						Conditions: discoveryv1.EndpointConditions{
 							Ready:       &ready,
 							Terminating: &terminating,
+							Serving:     &serving,
 						},
 						Hostname:  &hostname,
 						Zone:      &zone,
@@ -120,8 +122,8 @@ func TestEndpointSliceStore(t *testing.T) {
 					# HELP kube_endpointslice_endpoints_hints Topology routing hints attached to endpoints
 					# TYPE kube_endpointslice_endpoints gauge
 					# TYPE kube_endpointslice_endpoints_hints gauge
-					kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="",namespace="test",ready="true",serving="false",targetref_kind="",targetref_name="",targetref_namespace="",terminating="host"} 1
-					kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="",namespace="test",ready="true",serving="false",targetref_kind="",targetref_name="",targetref_namespace="",terminating="host"} 1
+					kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",namespace="test",ready="true",serving="true",targetref_kind="",targetref_name="",targetref_namespace="",terminating="false"} 1
+					kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",namespace="test",ready="true",serving="true",targetref_kind="",targetref_name="",targetref_namespace="",terminating="false"} 1
 				  `,
 
 			MetricNames: []string{
@@ -141,6 +143,7 @@ func TestEndpointSliceStore(t *testing.T) {
 						Conditions: discoveryv1.EndpointConditions{
 							Ready:       &ready,
 							Terminating: &terminating,
+							Serving:     &serving,
 						},
 						Hostname:  &hostname,
 						Zone:      &zone,
@@ -159,8 +162,8 @@ func TestEndpointSliceStore(t *testing.T) {
 					# TYPE kube_endpointslice_endpoints gauge
         			# TYPE kube_endpointslice_endpoints_hints gauge
          			kube_endpointslice_endpoints_hints{address="10.0.0.1",endpointslice="test_endpointslice-endpoints",for_zone="zone1",namespace="test"} 1
-        			kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="",namespace="test",ready="true",serving="false",targetref_kind="",targetref_name="",targetref_namespace="",terminating="host"} 1
-					kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="",namespace="test",ready="true",serving="false",targetref_kind="",targetref_name="",targetref_namespace="",terminating="host"} 1
+         			kube_endpointslice_endpoints{address="10.0.0.1",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",namespace="test",ready="true",serving="true",targetref_kind="",targetref_name="",targetref_namespace="",terminating="false"} 1
+					kube_endpointslice_endpoints{address="192.168.1.10",endpoint_nodename="node",endpoint_zone="west",endpointslice="test_endpointslice-endpoints",hostname="host",namespace="test",ready="true",serving="true",targetref_kind="",targetref_name="",targetref_namespace="",terminating="false"} 1
 				`,
 
 			MetricNames: []string{


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->

**What this PR does / why we need it:**

This fixes the ordering between terminating and hostname labels for endpointslice metrics, where they are swapped causing kube-state-metrics to emit strange metrics. This also ensures we don't overrwrite serving with terminating, and that terminating actually gets a value.

This means it fixes these three labels that have been broken
- serving, was set to the 'terminating' value
- terminating, was set to the 'hostname' value
- hostname, was set to the terminating value that was always an empty string

Fixes: 75e7841 ("endpointslices: Expose empty labels")

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected endpoint metrics to accurately report serving and terminating conditions.
  * Restored the correct hostname and label ordering in endpoint metrics.
  * Ensured endpoint metrics remain accurate when topology hints are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->