### PR TITLE
fix(pod): do not emit nil metrics for unparseable pod IPs

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -18,11 +18,11 @@ package store
 
 import (
 	"context"
+	"net/netip"
 	"strconv"
 
 	basemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-helpers/storage/ephemeral"
-	"k8s.io/utils/net"
 
 	"k8s.io/kube-state-metrics/v2/pkg/constant"
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
@@ -39,6 +39,7 @@ import (
 var (
 	descPodLabelsDefaultLabels = []string{"namespace", "pod", "uid"}
 	podStatusReasons           = []string{"Evicted", "NodeAffinity", "NodeLost", "PreemptionByScheduler", "SchedulingGated", "Shutdown", "TerminationByKubelet", "UnexpectedAdmissionError"}
+	descPodIPsLabelKeys        = []string{"ip", "ip_family"}
 )
 
 func podMetricFamilies(allowAnnotationsList, allowLabelsList []string) []generator.FamilyGenerator {
@@ -730,25 +731,28 @@ func createPodIPFamilyGenerator() generator.FamilyGenerator {
 		basemetrics.ALPHA,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
-			ms := make([]*metric.Metric, len(p.Status.PodIPs))
-			labelKeys := []string{"ip", "ip_family"}
+			ms := make([]*metric.Metric, 0, len(p.Status.PodIPs))
 
-			for i, ip := range p.Status.PodIPs {
-				netIP := net.ParseIPSloppy(ip.IP)
-				var ipFamily net.IPFamily
+			for _, ip := range p.Status.PodIPs {
+				addr, err := netip.ParseAddr(ip.IP)
+				if err != nil {
+					continue // indicates failure to parse, so we don't include that in our metrics series
+				}
+				addr = addr.Unmap()
+				var ipFamily string
 				switch {
-				case net.IsIPv4(netIP):
-					ipFamily = net.IPv4
-				case net.IsIPv6(netIP):
-					ipFamily = net.IPv6
+				case addr.Is4():
+					ipFamily = "4"
+				case addr.Is6():
+					ipFamily = "6"
 				default:
-					continue // nil from ParseIPSloppy indicates failure to parse, so we don't include that in our metrics series
+					continue
 				}
-				ms[i] = &metric.Metric{
-					LabelKeys:   labelKeys,
-					LabelValues: []string{ip.IP, string(ipFamily)},
+				ms = append(ms, &metric.Metric{
+					LabelKeys:   descPodIPsLabelKeys,
+					LabelValues: []string{ip.IP, ipFamily},
 					Value:       1,
-				}
+				})
 			}
 
 			return &metric.Family{

--- a/internal/store/pod_test.go
+++ b/internal/store/pod_test.go
@@ -1080,6 +1080,9 @@ func TestPodStore(t *testing.T) {
 						{
 							IP: "fc00:1234:5678:90ab:cdef:cafe:f00d:d00d",
 						},
+						{
+							IP: "::ffff:1.2.3.4",
+						},
 					},
 					StartTime: &metav1StartTime,
 				},
@@ -1102,6 +1105,7 @@ func TestPodStore(t *testing.T) {
 				kube_pod_info{created_by_kind="",created_by_name="",host_ip="1.1.1.1",namespace="ns1",node="node1",pod="pod1",pod_ip="1.2.3.4",uid="abc-123-xxx",priority_class="system-node-critical",host_network="true"} 1
 				kube_pod_ips{namespace="ns1",pod="pod1",uid="abc-123-xxx",ip="1.2.3.4",ip_family="4"} 1
 				kube_pod_ips{namespace="ns1",pod="pod1",uid="abc-123-xxx",ip="fc00:1234:5678:90ab:cdef:cafe:f00d:d00d",ip_family="6"} 1
+				kube_pod_ips{namespace="ns1",pod="pod1",uid="abc-123-xxx",ip="::ffff:1.2.3.4",ip_family="4"} 1
 				kube_pod_start_time{namespace="ns1",pod="pod1",uid="abc-123-xxx"} 1.501569018e+09
 				kube_pod_owner{namespace="ns1",owner_is_controller="",owner_kind="",owner_name="",pod="pod1",uid="abc-123-xxx"} 1
 `,


### PR DESCRIPTION
**What this PR does / why we need it:**

`createPodIPFamilyGenerator` sized the metric slice with the number of pod IPs and assigned by index, but skipped entries whose IP failed to parse. Every skipped IP therefore left a `nil *metric.Metric` in the family, which `wrapPodFunc` then dereferences while merging the default labels — so a malformed `status.podIPs` entry crashes metric generation instead of producing one fewer series.

This appends the parsed entries instead, so skipped IPs leave no hole.

While here, the address is resolved with `net/netip` rather than the deprecated `ParseIPSloppy` helper from `k8s.io/utils/net`, and v4-in-v6 addresses are unmapped so they keep reporting `ip_family="4"` (covered by a new test case). Note that `netip.ParseAddr` is stricter than `ParseIPSloppy`: an address with leading zeros (`010.1.1.1`) is now skipped rather than reported. Kubelet-assigned IPs never use that form.

The label keys are hoisted into a package-level variable, matching `descPodLabelsDefaultLabels`, so they are not reallocated on every pod event.

**How does this change affect the cardinality of KSM:** does not change cardinality, except that a pod with an unparseable IP no longer crashes.

Split out of #2916.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod IP metric handling for invalid and IPv4-mapped addresses.
  * Invalid pod IPs are now excluded from metrics instead of producing empty entries.
  * IPv4-mapped IPv6 addresses are correctly reported as IPv4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->