### PR TITLE
perf: reduce allocations in metric generation and header sanitization

### DIFF
--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -86,7 +86,7 @@ func mapToPrometheusLabels(labels map[string]string, prefix string) ([]string, [
 	labelKeys := make([]string, 0, len(labels))
 	labelValues := make([]string, 0, len(labels))
 
-	sortedKeys := make([]string, 0)
+	sortedKeys := make([]string, 0, len(labels))
 	for key := range labels {
 		sortedKeys = append(sortedKeys, key)
 	}
@@ -102,23 +102,35 @@ func mapToPrometheusLabels(labels map[string]string, prefix string) ([]string, [
 		initial int
 	}
 
-	conflicts := make(map[string]*conflictDesc)
+	var conflicts map[string]*conflictDesc
 	for _, k := range sortedKeys {
 		labelKey := labelName(prefix, k)
-		if conflict, ok := conflicts[labelKey]; ok {
-			if conflict.count == 1 {
-				// this is the first conflict for the label,
-				// so we have to go back and rename the initial label that we've already added
-				labelKeys[conflict.initial] = labelConflictSuffix(labelKeys[conflict.initial], conflict.count)
-			}
-
+		var conflict *conflictDesc
+		if conflicts != nil {
+			conflict = conflicts[labelKey]
+		}
+		if conflict != nil {
 			conflict.count++
 			labelKey = labelConflictSuffix(labelKey, conflict.count)
 		} else {
-			// we'll need this info later in case there are conflicts
-			conflicts[labelKey] = &conflictDesc{
-				count:   1,
-				initial: len(labelKeys),
+			initialIdx := -1
+			for i, lk := range labelKeys {
+				if lk == labelKey {
+					initialIdx = i
+					break
+				}
+			}
+			if initialIdx != -1 {
+				if conflicts == nil {
+					conflicts = make(map[string]*conflictDesc)
+				}
+				labelKeys[initialIdx] = labelConflictSuffix(labelKeys[initialIdx], 1)
+				conflict = &conflictDesc{
+					count:   2,
+					initial: initialIdx,
+				}
+				conflicts[labelKey] = conflict
+				labelKey = labelConflictSuffix(labelKey, 2)
 			}
 		}
 		labelKeys = append(labelKeys, labelKey)

--- a/internal/store/utils_test.go
+++ b/internal/store/utils_test.go
@@ -538,3 +538,28 @@ func TestExpandWildcard(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkMapToPrometheusLabels(b *testing.B) {
+	for _, n := range []int{4, 8, 32} {
+		labels := make(map[string]string, n)
+		for i := 0; i < n; i++ {
+			labels[fmt.Sprintf("app.kubernetes.io/component-%d", i)] = fmt.Sprintf("value-%d", i)
+		}
+
+		b.Run(fmt.Sprintf("labels-%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = mapToPrometheusLabels(labels, "label")
+			}
+		})
+	}
+
+	// Keys that sanitize to the same Prometheus label name exercise the conflict path.
+	conflicting := map[string]string{"foo.bar": "a", "foo_bar": "b", "foo-bar": "c", "other": "d"}
+	b.Run("conflicts", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, _ = mapToPrometheusLabels(conflicting, "label")
+		}
+	})
+}

--- a/pkg/metric/family.go
+++ b/pkg/metric/family.go
@@ -40,11 +40,48 @@ func (f Family) Inspect(inspect func(Family)) {
 
 // ByteSlice returns the given Family in its string representation.
 func (f Family) ByteSlice() []byte {
-	b := bytes.Buffer{}
-	for _, m := range f.Metrics {
-		b.WriteString(f.Name)
-		m.Write(&b)
+	return f.AppendBytes(nil)
+}
+
+// AppendBytes appends the family in its string representation to b and returns
+// the extended slice. Callers rendering many families for the same object can
+// share a single buffer instead of allocating one per family.
+func (f Family) AppendBytes(b []byte) []byte {
+	// Nothing to render. Returning early also avoids bytes.Buffer.Grow's minimum
+	// allocation, which empty families would otherwise pay on every event.
+	if len(f.Metrics) == 0 {
+		return b
 	}
 
-	return b.Bytes()
+	buf := bytes.NewBuffer(b)
+	buf.Grow(f.SizeHint())
+	for _, m := range f.Metrics {
+		buf.WriteString(f.Name)
+		m.Write(buf)
+	}
+
+	return buf.Bytes()
+}
+
+// valueSizeHint is the assumed rendered length of a metric value plus the
+// separating space and trailing newline.
+const valueSizeHint = 16
+
+// SizeHint estimates the rendered size of the family so callers can size their
+// buffer up front instead of growing (and copying) it repeatedly. It is an
+// estimate, not a bound: the value length is assumed rather than computed.
+func (f Family) SizeHint() int {
+	size := 0
+	for _, m := range f.Metrics {
+		// name, '{', '}', the value, the space before it and the newline after
+		size += len(f.Name) + 2 + valueSizeHint
+		for i, k := range m.LabelKeys {
+			// key, '=', '"', value, '"' and the separating ',' or '{'
+			size += len(k) + 4
+			if i < len(m.LabelValues) {
+				size += len(m.LabelValues[i])
+			}
+		}
+	}
+	return size
 }

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -104,7 +104,14 @@ var (
 // '\"'.
 // Taken from github.com/prometheus/common/expfmt/text_create.go.
 func escapeString(m *bytes.Buffer, v string) {
-	escapeWithDoubleQuote.WriteString(m, v)
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if c == '\\' || c == '\n' || c == '"' {
+			escapeWithDoubleQuote.WriteString(m, v)
+			return
+		}
+	}
+	m.WriteString(v)
 }
 
 // writeFloat is equivalent to fmt.Fprint with a float64 argument but hardcodes

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -46,18 +46,40 @@ type MetricsStore struct {
 	// later on zipped with with their corresponding metric families in
 	// MetricStore.WriteAll().
 	headers []string
+
+	headersOpenMetrics []string
+	headersTextPlain   []string
+	metricNames        []string
 }
 
 // NewMetricsStore returns a new MetricsStore
 func NewMetricsStore(headers []string, generateFunc func(interface{}) []metric.FamilyInterface) *MetricsStore {
 	rv := ""
+	headersOpenMetrics, headersTextPlain, metricNames := precomputeHeaders(headers)
 	return &MetricsStore{
 		generateMetricsFunc:   generateFunc,
 		headers:               headers,
+		headersOpenMetrics:    headersOpenMetrics,
+		headersTextPlain:      headersTextPlain,
+		metricNames:           metricNames,
 		metrics:               &sync.Map{},
 		lastResourceVersion:   &rv,
 		lastResourceVersionMu: &sync.RWMutex{},
 	}
+}
+
+func precomputeHeaders(headers []string) (headersOpenMetrics, headersTextPlain, metricNames []string) {
+	headersOpenMetrics = make([]string, len(headers))
+	headersTextPlain = make([]string, len(headers))
+	metricNames = make([]string, len(headers))
+	for i, h := range headers {
+		mName, rHeaderOM := parseHeaderStatic(h, false)
+		_, rHeaderText := parseHeaderStatic(h, true)
+		headersOpenMetrics[i] = rHeaderOM
+		headersTextPlain[i] = rHeaderText
+		metricNames[i] = mName
+	}
+	return headersOpenMetrics, headersTextPlain, metricNames
 }
 
 // Implementing k8s.io/client-go/tools/cache.Store interface

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -68,6 +68,10 @@ func NewMetricsStore(headers []string, generateFunc func(interface{}) []metric.F
 	}
 }
 
+// precomputeHeaders parses each header once at store construction, returning the
+// rewritten header for both exposition formats plus the metric name it declares.
+// SanitizeHeaders runs on every scrape and would otherwise redo this work per
+// header, per store, per request.
 func precomputeHeaders(headers []string) (headersOpenMetrics, headersTextPlain, metricNames []string) {
 	headersOpenMetrics = make([]string, len(headers))
 	headersTextPlain = make([]string, len(headers))

--- a/pkg/metrics_store/metrics_store.go
+++ b/pkg/metrics_store/metrics_store.go
@@ -95,15 +95,62 @@ func (s *MetricsStore) Add(obj interface{}) error {
 	s.setLastResourceVersion(o.GetResourceVersion())
 
 	families := s.generateMetricsFunc(obj)
-	familyStrings := make([][]byte, len(families))
 
-	for i, f := range families {
-		familyStrings[i] = f.ByteSlice()
-	}
-
-	s.metrics.Store(o.GetUID(), familyStrings)
+	s.metrics.Store(o.GetUID(), renderFamilies(families))
 
 	return nil
+}
+
+// byteAppender is implemented by families that can render themselves into a
+// caller-provided buffer, letting all families of one object share a single
+// allocation.
+type byteAppender interface {
+	AppendBytes(b []byte) []byte
+	SizeHint() int
+}
+
+// renderFamilies renders every family of an object into one contiguous buffer
+// and returns per-family views into it. One allocation per object beats one per
+// family, both for allocation count and for the size-class rounding that a few
+// dozen small slices would otherwise waste.
+func renderFamilies(families []metric.FamilyInterface) [][]byte {
+	familyStrings := make([][]byte, len(families))
+	ends := make([]int, len(families))
+
+	// Size the shared buffer from the families themselves, so appending does not
+	// grow it geometrically and overshoot; the result is retained for the
+	// lifetime of the object, so slack is memory we would never reclaim.
+	hint := 0
+	for _, f := range families {
+		if a, ok := f.(byteAppender); ok {
+			hint += a.SizeHint()
+		}
+	}
+
+	buf := make([]byte, 0, hint)
+	for i, f := range families {
+		if a, ok := f.(byteAppender); ok {
+			buf = a.AppendBytes(buf)
+		} else {
+			buf = append(buf, f.ByteSlice()...)
+		}
+		ends[i] = len(buf)
+	}
+
+	// SizeHint over-estimates the value length, so trim the remaining slack
+	// rather than retain it for every object in the store.
+	if cap(buf)-len(buf) > len(buf)/8 {
+		buf = append(make([]byte, 0, len(buf)), buf...)
+	}
+
+	start := 0
+	for i, end := range ends {
+		// Full slice expression: a later append must not write into the next family.
+		familyStrings[i] = buf[start:end:end]
+		start = end
+	}
+
+	return familyStrings
 }
 
 // Update updates the existing entry in the MetricsStore.

--- a/pkg/metrics_store/metrics_store_test.go
+++ b/pkg/metrics_store/metrics_store_test.go
@@ -142,3 +142,43 @@ func TestMetricsStoreResourceVersion(t *testing.T) {
 		t.Fatalf("expected resource version 127, got %v", rv)
 	}
 }
+
+func BenchmarkAdd(b *testing.B) {
+	const nFamilies = 50
+
+	headers := make([]string, nFamilies)
+	genFunc := func(obj interface{}) []metric.FamilyInterface {
+		o, _ := meta.Accessor(obj)
+		families := make([]metric.FamilyInterface, nFamilies)
+		for j := 0; j < nFamilies; j++ {
+			families[j] = &metric.Family{
+				Name: fmt.Sprintf("kube_bench_metric_%d", j),
+				Metrics: []*metric.Metric{
+					{
+						LabelKeys:   []string{"namespace", "service", "uid"},
+						LabelValues: []string{o.GetNamespace(), o.GetName(), string(o.GetUID())},
+						Value:       float64(j),
+					},
+				},
+			}
+		}
+		return families
+	}
+
+	store := NewMetricsStore(headers, genFunc)
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID("uid-0"),
+			Name:      "svc-0",
+			Namespace: "default",
+		},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := store.Add(svc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/metrics_store/metrics_writer.go
+++ b/pkg/metrics_store/metrics_writer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/prometheus/common/expfmt"
 
@@ -39,6 +40,12 @@ var (
 	// Pre-computing it reduces rewriteTypeLine to a 2-string concat (concatstring2),
 	// avoiding the overhead of a 3-string concat (concatstring3) on every rewrite.
 	gaugeNewline = gaugeTypeString + "\n"
+
+	seenPool = sync.Pool{
+		New: func() interface{} {
+			return make(map[string]struct{})
+		},
+	}
 )
 
 // MetricsWriterList represent a list of MetricsWriter
@@ -116,39 +123,34 @@ func (m MetricsWriter) WriteAll(w io.Writer) error {
 	return nil
 }
 
-// scanHeader inspects a header string and returns deduplication/modification metadata.
-// It does not mutate seen — callers must update that map themselves.
-// Headers are expected to have the form "# HELP <name> <desc>\n# TYPE <name> <type>\n".
-// typeLastSpace is the byte offset of the space before the type suffix in header, or -1.
-func scanHeader(header string, seen map[string]struct{}, isTextPlain bool) (shouldRemove, needsModification bool, metricName string, typeLastSpace int) {
+// parseHeaderStatic parses and potentially rewrites a header string.
+// It returns the extracted metricName (if any) and the normalized/rewritten header string.
+func parseHeaderStatic(header string, isTextPlain bool) (metricName string, rewrittenHeader string) {
 	rest := header
-	typeLastSpace = -1
-
 	// Parse HELP line.
 	if len(rest) > len(helpPrefix) && rest[:len(helpPrefix)] == helpPrefix {
 		rest = rest[len(helpPrefix):]
 		if spaceIdx := strings.IndexByte(rest, ' '); spaceIdx > 0 {
 			metricName = rest[:spaceIdx]
-			if _, isSeen := seen[metricName]; isSeen {
-				return true, false, metricName, -1
-			}
 		}
 		// Advance past the rest of the HELP line.
 		nl := strings.IndexByte(rest, '\n')
 		if nl == -1 {
-			return false, false, metricName, -1
+			rewrittenHeader = header
+			if len(rewrittenHeader) > 0 && rewrittenHeader[len(rewrittenHeader)-1] != '\n' {
+				rewrittenHeader += "\n"
+			}
+			return metricName, rewrittenHeader
 		}
 		rest = rest[nl+1:]
 	}
 
+	needsModification := false
+	typeLastSpace := -1
 	// Parse TYPE line.
 	if len(rest) > len(typePrefix) && rest[:len(typePrefix)] == typePrefix {
 		rest = rest[len(typePrefix):]
 		if spaceIdx := strings.IndexByte(rest, ' '); spaceIdx > 0 {
-			typeName := rest[:spaceIdx]
-			if _, isSeen := seen[typeName]; isSeen {
-				return true, false, metricName, -1
-			}
 			// Record the position of the space before the type suffix within the
 			// original header string so rewriteTypeLine can avoid recomputing it.
 			typeLastSpace = len(header) - len(rest) + spaceIdx
@@ -162,7 +164,21 @@ func scanHeader(header string, seen map[string]struct{}, isTextPlain bool) (shou
 		}
 	}
 
-	return false, needsModification, metricName, typeLastSpace
+	if !needsModification {
+		rewrittenHeader = header
+	} else {
+		if rewritten := rewriteTypeLine(header, typeLastSpace); rewritten != "" {
+			rewrittenHeader = rewritten
+		} else {
+			rewrittenHeader = header
+		}
+	}
+
+	if len(rewrittenHeader) > 0 && rewrittenHeader[len(rewrittenHeader)-1] != '\n' {
+		rewrittenHeader += "\n"
+	}
+
+	return metricName, rewrittenHeader
 }
 
 // rewriteTypeLine replaces an OpenMetrics-only type suffix (info/stateset) with "gauge"
@@ -177,18 +193,14 @@ func rewriteTypeLine(header string, lastSpace int) string {
 
 // SanitizeHeaders sanitizes the headers of the given MetricsWriterList.
 func SanitizeHeaders(contentType expfmt.Format, writers MetricsWriterList) MetricsWriterList {
-	// Pre-count total headers to size the seen map accurately upfront.
-	capHint := 0
-	for _, writer := range writers {
-		if len(writer.stores) > 0 {
-			capHint += len(writer.stores[0].headers)
-		}
-	}
-
 	isTextPlain := contentType.FormatType() == expfmt.TypeTextPlain
 	// A single map replaces the former seenHELP+seenTYPE pair: HELP and TYPE lines
 	// always share the same metric name, so one lookup per header suffices.
-	seen := make(map[string]struct{}, capHint)
+	seen := seenPool.Get().(map[string]struct{})
+	defer func() {
+		clear(seen)
+		seenPool.Put(seen)
+	}()
 
 	clonedWriters := make(MetricsWriterList, 0, len(writers))
 	for _, writer := range writers {
@@ -201,7 +213,11 @@ func SanitizeHeaders(contentType expfmt.Format, writers MetricsWriterList) Metri
 			}
 			if i == 0 {
 				clonedHeaders := make([]string, len(store.headers))
-				copy(clonedHeaders, store.headers)
+				if isTextPlain {
+					copy(clonedHeaders, store.headersTextPlain)
+				} else {
+					copy(clonedHeaders, store.headersOpenMetrics)
+				}
 				clonedStore.headers = clonedHeaders
 			}
 			clonedStores = append(clonedStores, clonedStore)
@@ -210,34 +226,17 @@ func SanitizeHeaders(contentType expfmt.Format, writers MetricsWriterList) Metri
 		// Deduplicate and rewrite headers on the cloned store in the same pass.
 		if len(clonedStores) > 0 {
 			headers := clonedStores[0].headers
-			for i, header := range headers {
-				if header == "" {
+			metricNames := writer.stores[0].metricNames
+			for i, mName := range metricNames {
+				if headers[i] == "" {
 					continue
 				}
-
-				shouldRemove, needsModification, metricName, lastSpace := scanHeader(header, seen, isTextPlain)
-
-				if shouldRemove {
-					headers[i] = ""
-					continue
-				}
-
-				if metricName != "" {
-					seen[metricName] = struct{}{}
-				}
-
-				if !needsModification {
-					if header[len(header)-1] != '\n' {
-						headers[i] = header + "\n"
+				if mName != "" {
+					if _, isSeen := seen[mName]; isSeen {
+						headers[i] = ""
+						continue
 					}
-					continue
-				}
-
-				// Surgical replacement: only modify the TYPE line suffix.
-				if rewritten := rewriteTypeLine(header, lastSpace); rewritten != "" {
-					headers[i] = rewritten
-				} else if header[len(header)-1] != '\n' {
-					headers[i] = header + "\n"
+					seen[mName] = struct{}{}
 				}
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it:**

Three independent allocation reductions on the per-event and per-scrape paths, each measured with `benchstat` (6 runs).

**1. `SanitizeHeaders`: precompute per-store headers** — headers were re-parsed and rewritten on every scrape. They are now parsed once in `NewMetricsStore`, for both exposition formats.

```
SanitizeHeaders/text-format_unique_headers     16.03m -> 4.55m    -71.60%
                                           B/op 10.82Mi -> 1.56Mi -85.60%
                                     allocs/op 100265  -> 10      -99.99%
```

`escapeString` also gained a fast path that skips the `strings.Replacer` when nothing needs escaping (`MetricWrite`: -7 to -11% time, same allocs).

**2. `mapToPrometheusLabels`** — pre-sizes the sorted-keys slice and only allocates the conflict map when two Kubernetes keys actually sanitize to the same Prometheus label name (the uncommon case). Runs per object whenever a labels/annotations allowlist is configured:

```
labels-8    allocs/op  84 -> 75   -10.71%    B/op 2.41Ki -> 2.22Ki  -8.16%
labels-32   allocs/op 333 -> 291  -12.61%    B/op 13.0Ki -> 8.87Ki -31.95%   sec/op -38.83%
```

A `BenchmarkMapToPrometheusLabels` covering both the plain and the conflict path is included.

**3. `MetricsStore.Add`: one buffer per object, not per family** — every family allocated its own `bytes.Buffer`, which then grew geometrically as metrics were written into it (~59 buffers per pod). All families of an object now render into a single buffer sized up front from `Family.SizeHint()`, and each family gets a view into it. Empty families no longer pay `bytes.Buffer.Grow`s minimum allocation, and trailing slack is trimmed so the retained buffer is not larger than the per-family slices it replaces:

```
BenchmarkPodStoreAdd  sec/op 38.37µ -> 30.36µ  -20.89%
                        B/op 34.07Ki -> 25.00Ki -26.62%
                   allocs/op    380 -> 282      -25.79%
```

`Family.AppendBytes` and `Family.SizeHint` are additive; `FamilyInterface` is unchanged and anything not implementing them falls back to `ByteSlice()`. The scrape path (`WriteAll`) is unaffected.

**How does this change affect the cardinality of KSM:** does not change cardinality.

Split out of #2916.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved metric rendering with reusable buffers and size estimation, reducing allocations during output generation.
  * Optimized label conversion, string escaping, and metric-store updates.
  * Streamlined header processing and reuse for faster metrics responses.
* **Compatibility**
  * Preserved existing metric output and escaping behavior.
  * Continued consistent normalization of OpenMetrics metadata and label names.
* **Testing**
  * Added performance benchmarks covering metric rendering, label conversion, and metric-store updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->