### PR TITLE
fix(metrics_store): write headers when only a later store has metrics

### DIFF
--- a/pkg/metrics_store/metrics_writer.go
+++ b/pkg/metrics_store/metrics_writer.go
@@ -80,28 +80,41 @@ func (m MetricsWriter) WriteAll(w io.Writer) error {
 		return nil
 	}
 
+	// Headers describe the families written below, so they are emitted only when
+	// there is at least one object to describe. That has to consider every store,
+	// not just the first: there is one store per namespace, so the first can be
+	// empty while a later one holds objects whose families are still written.
+	// The answer is the same for every header, so determine it once.
+	hasMetrics := false
+	for _, s := range m.stores {
+		s.metrics.Range(func(_ interface{}, _ interface{}) bool {
+			hasMetrics = true
+			return false
+		})
+		if hasMetrics {
+			break
+		}
+	}
+
 	for i, help := range m.stores[0].headers {
 		var err error
 
 		// SanitizeHeaders blanks duplicate headers to preserve header/family
 		// index alignment. An empty header means suppress the header text but
 		// still emit the metric family bytes at this index.
-		if help != "" {
+		if help != "" && hasMetrics {
 			// Avoid allocating a new string if the header lacks a trailing newline:
 			// check once and emit "\n" as a second write if needed.
 			needsNewline := help[len(help)-1] != '\n'
-			m.stores[0].metrics.Range(func(_ interface{}, _ interface{}) bool {
-				_, err = io.WriteString(w, help)
-				if err != nil {
-					return false
-				}
-				if needsNewline {
-					_, err = io.WriteString(w, "\n")
-				}
-				return false
-			})
+			_, err = io.WriteString(w, help)
 			if err != nil {
 				return fmt.Errorf("failed to write help text: %w", err)
+			}
+			if needsNewline {
+				_, err = io.WriteString(w, "\n")
+				if err != nil {
+					return fmt.Errorf("failed to write help text: %w", err)
+				}
 			}
 		}
 

--- a/pkg/metrics_store/metrics_writer_test.go
+++ b/pkg/metrics_store/metrics_writer_test.go
@@ -268,6 +268,57 @@ func TestWriteAllWithEmptyStores(t *testing.T) {
 	}
 }
 
+// There is one store per namespace, so the first store can be empty while a
+// later one holds objects. The headers describe the families of every store, so
+// they must still be written in that case.
+func TestWriteAllWithEmptyFirstStore(t *testing.T) {
+	genFunc := func(obj interface{}) []metric.FamilyInterface {
+		o, err := meta.Accessor(obj)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mf := metric.Family{
+			Name: "kube_service_info_1",
+			Metrics: []*metric.Metric{
+				{
+					LabelKeys:   []string{"namespace", "uid"},
+					LabelValues: []string{o.GetNamespace(), string(o.GetUID())},
+					Value:       float64(1),
+				},
+			},
+		}
+
+		return []metric.FamilyInterface{&mf}
+	}
+
+	headers := []string{"# HELP kube_service_info_1 Info 1 about services\n# TYPE kube_service_info_1 gauge"}
+	emptyStore := NewMetricsStore(headers, genFunc)
+	populatedStore := NewMetricsStore(headers, genFunc)
+
+	svc := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "b1",
+			Name:      "service",
+			Namespace: "b",
+		},
+	}
+	if err := populatedStore.Add(&svc); err != nil {
+		t.Fatal(err)
+	}
+
+	multiNsWriter := NewMetricsWriter("test", emptyStore, populatedStore)
+	w := strings.Builder{}
+	if err := multiNsWriter.WriteAll(&w); err != nil {
+		t.Fatalf("failed to write metrics: %v", err)
+	}
+
+	expected := "# HELP kube_service_info_1 Info 1 about services\n# TYPE kube_service_info_1 gauge\nkube_service_info_1{namespace=\"b\",uid=\"b1\"} 1\n"
+	if w.String() != expected {
+		t.Fatalf("Unexpected output, got %q, want %q", w.String(), expected)
+	}
+}
+
 func TestWriteAllWithSanitizedDuplicateHeadersPreservesFamilyOrder(t *testing.T) {
 	genFunc := func(obj interface{}) []metric.FamilyInterface {
 		o, err := meta.Accessor(obj)


### PR DESCRIPTION
**What this PR does / why we need it:**

`WriteAll` emits each `# HELP`/`# TYPE` header from inside a `Range` over `m.stores[0]`, so the header is skipped whenever the first store holds no objects. The metric families underneath are written from *every* store:

```go
if help != "" {
    m.stores[0].metrics.Range(func(...) bool { io.WriteString(w, help); return false })
}
for _, s := range m.stores {           // <- every store
    s.metrics.Range(... w.Write(metricFamilies[i]) ...)
}
```

`buildStores` creates one store per namespace, so a deployment scoped to several namespaces (`--namespaces=a,b`) emits bare metric lines whenever the first namespace happens to hold no objects of that type. The type metadata is silently lost, and it comes back as soon as that namespace gains an object, so the exposition flaps with cluster contents rather than staying stable.

Before, with an empty first store:

```
kube_service_info_1{namespace="b",uid="b1"} 1
```

After:

```
# HELP kube_service_info_1 Info 1 about services
# TYPE kube_service_info_1 gauge
kube_service_info_1{namespace="b",uid="b1"} 1
```

This PR determines once, across all stores, whether there is anything to describe, and keeps the existing behaviour of writing no headers at all when every store is empty (covered by `TestWriteAllWithEmptyStores`). As a side effect it replaces a `Range` per header with a single pass.

Added `TestWriteAllWithEmptyFirstStore`, which fails on `main` with exactly the output above and passes with the fix.

This is long-standing rather than a recent regression — the pattern predates the current header-sanitization code.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metrics output when the first store is empty but later stores contain data.
  * Metric help headers are now emitted correctly for all available metric families.
  * Preserved proper newline handling and error reporting during metrics output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->