### PR TITLE
fix(options): validate flags that are currently accepted at any value

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -206,13 +206,14 @@ func (o *Options) Usage() {
 
 // Validate validates arguments
 func (o *Options) Validate() error {
-	shardableResource := "pods"
-	if o.Node == "" {
-		return nil
-	}
-	for _, x := range o.Resources.AsSlice() {
-		if x != shardableResource {
-			return fmt.Errorf("resource %s can't be sharded by field selector spec.nodeName", x)
+	// Only node-scoped runs are restricted to the shardable resource; the checks
+	// below apply to every run, so they must not sit behind this condition.
+	if o.Node != "" {
+		shardableResource := "pods"
+		for _, x := range o.Resources.AsSlice() {
+			if x != shardableResource {
+				return fmt.Errorf("resource %s can't be sharded by field selector spec.nodeName", x)
+			}
 		}
 	}
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -225,5 +225,17 @@ func (o *Options) Validate() error {
 		return fmt.Errorf("value for --object-limit=%d must be equal or greater than 0", o.ObjectLimit)
 	}
 
+	// The shard an object belongs to is jump.Hash(hash(uid), totalShards). That
+	// returns -1 for a non-positive bucket count, and no shard index can match an
+	// out-of-range one, so either mistake filters out every object and serves an
+	// empty /metrics with no error anywhere.
+	if o.TotalShards < 1 {
+		return fmt.Errorf("value for --total-shards=%d must be greater than 0", o.TotalShards)
+	}
+
+	if o.Shard < 0 || int(o.Shard) >= o.TotalShards {
+		return fmt.Errorf("value for --shard=%d must be between 0 and --total-shards=%d minus 1", o.Shard, o.TotalShards)
+	}
+
 	return nil
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -217,7 +218,9 @@ func (o *Options) Validate() error {
 		}
 	}
 
-	if o.AutoGoMemlimitRatio <= 0.0 || o.AutoGoMemlimitRatio > 1.0 {
+	// NaN parses as a valid float64 and compares false against every bound, so it
+	// has to be rejected explicitly rather than by the range check alone.
+	if math.IsNaN(o.AutoGoMemlimitRatio) || o.AutoGoMemlimitRatio <= 0.0 || o.AutoGoMemlimitRatio > 1.0 {
 		return fmt.Errorf("value for --auto-gomemlimit-ratio=%f must be greater than 0 and less than or equal to 1", o.AutoGoMemlimitRatio)
 	}
 

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
@@ -93,4 +95,64 @@ func TestCustomResourceConfigFileDeprecatedAlias(t *testing.T) {
 			t.Fatalf("expected deprecated field to retain its value, got %q", opts.CustomResourceConfigFileDeprecated)
 		}
 	})
+}
+
+// The node check used to return early, which left every validation below it
+// unreachable for the ordinary cluster-wide deployment.
+func TestValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*Options)
+		wantErr bool
+	}{
+		{
+			name:   "defaults are valid",
+			mutate: func(_ *Options) {},
+		},
+		{
+			name:    "gomemlimit ratio above 1 without node",
+			mutate:  func(o *Options) { o.AutoGoMemlimitRatio = 5.0 },
+			wantErr: true,
+		},
+		{
+			name:    "gomemlimit ratio of 0 without node",
+			mutate:  func(o *Options) { o.AutoGoMemlimitRatio = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "negative object limit without node",
+			mutate:  func(o *Options) { o.ObjectLimit = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "gomemlimit ratio above 1 with node",
+			mutate:  func(o *Options) { o.Node = "node-1"; o.AutoGoMemlimitRatio = 5.0 },
+			wantErr: true,
+		},
+		{
+			name:    "node scoped run with an unshardable resource",
+			mutate:  func(o *Options) { o.Node = "node-1"; o.Resources = ResourceSet{"deployments": struct{}{}} },
+			wantErr: true,
+		},
+		{
+			name:   "node scoped run with pods",
+			mutate: func(o *Options) { o.Node = "node-1"; o.Resources = ResourceSet{"pods": struct{}{}} },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := NewOptions()
+			// A fresh command per case: AddFlags panics if the same command has
+			// the flags registered twice, and it is what applies the defaults.
+			opts.AddFlags(&cobra.Command{})
+			tc.mutate(opts)
+
+			err := opts.Validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("expected Validate() to fail, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected Validate() to pass, got %v", err)
+			}
+		})
+	}
 }

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -138,6 +138,30 @@ func TestValidate(t *testing.T) {
 			name:   "node scoped run with pods",
 			mutate: func(o *Options) { o.Node = "node-1"; o.Resources = ResourceSet{"pods": struct{}{}} },
 		},
+		{
+			name:    "zero total shards",
+			mutate:  func(o *Options) { o.TotalShards = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "negative total shards",
+			mutate:  func(o *Options) { o.TotalShards = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "shard index beyond total shards",
+			mutate:  func(o *Options) { o.Shard = 3; o.TotalShards = 3 },
+			wantErr: true,
+		},
+		{
+			name:    "negative shard index",
+			mutate:  func(o *Options) { o.Shard = -1 },
+			wantErr: true,
+		},
+		{
+			name:   "last shard of a sharded set",
+			mutate: func(o *Options) { o.Shard = 2; o.TotalShards = 3 },
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := NewOptions()

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	"math"
 	"os"
 	"testing"
 
@@ -117,6 +118,13 @@ func TestValidate(t *testing.T) {
 		{
 			name:    "gomemlimit ratio of 0 without node",
 			mutate:  func(o *Options) { o.AutoGoMemlimitRatio = 0 },
+			wantErr: true,
+		},
+		{
+			// NaN parses as a valid float64 and compares false against every
+			// bound, so the range check alone lets it through.
+			name:    "gomemlimit ratio of NaN",
+			mutate:  func(o *Options) { o.AutoGoMemlimitRatio = math.NaN() },
 			wantErr: true,
 		},
 		{

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -147,6 +147,12 @@ func TestValidate(t *testing.T) {
 			mutate: func(o *Options) { o.Node = "node-1"; o.Resources = ResourceSet{"pods": struct{}{}} },
 		},
 		{
+			// The resource restriction exists because --node filters by
+			// spec.nodeName, so it must stay scoped to node-mode runs.
+			name:   "non-node run with an unshardable resource",
+			mutate: func(o *Options) { o.Resources = ResourceSet{"deployments": struct{}{}} },
+		},
+		{
 			name:    "zero total shards",
 			mutate:  func(o *Options) { o.TotalShards = 0 },
 			wantErr: true,


### PR DESCRIPTION
**What this PR does / why we need it:**

Three related gaps in `Options.Validate()`, each of which lets a misconfiguration through silently.

### 1. The general validations never ran without `--node`

`Validate()` returned early when `--node` was empty, leaving every check below that guard unreachable for the ordinary cluster-wide deployment:

```go
shardableResource := "pods"
if o.Node == "" {
	return nil            // <- everything below is skipped
}
...
if o.AutoGoMemlimitRatio <= 0.0 || o.AutoGoMemlimitRatio > 1.0 { ... }
if o.ObjectLimit < 0 { ... }
```

So `--auto-gomemlimit-ratio` and `--object-limit` were accepted at any value unless `--node` happened to be set, even though their flag help documents the bounds. The values are then used: the ratio reaches `memlimit.SetGoMemLimitWithOpts(memlimit.WithRatio(...))`, where anything above 1 sets `GOMEMLIMIT` above the detected container limit and defeats the flag; the object limit reaches the list options as `Limit`. Demonstrated on `main`: without `--node`, `AutoGoMemlimitRatio = 5.0` and `ObjectLimit = -1` both pass; setting `--node` makes the identical values fail.

The resource check is now scoped to the node case and the rest run on every path.

### 2. NaN passed the ratio range check

`--auto-gomemlimit-ratio=NaN` parses as a valid float64, and every comparison against NaN is false, so it satisfied both `<= 0.0` and `> 1.0` and reached `memlimit.WithRatio`. Rejected explicitly now. (Thanks to the review comment for catching this.)

### 3. A shard configuration matching no objects was accepted

The shard an object belongs to is `jump.Hash(fnv64a(uid), totalShards)` compared against the configured index. `jump.Hash` returns `-1` for a non-positive bucket count, and no index can equal an out-of-range one, so `--total-shards=0` (or negative) and `--shard >= --total-shards` both filter out **every** object. KSM starts normally, lists and watches everything at full cost, and serves an empty `/metrics` with HTTP 200 and nothing logged anywhere.

Autosharding is unaffected — it configures shards through `ConfigureSharding` at runtime rather than through the flags this validates.

### Testing

`TestValidate` covers all three, node and non-node paths, and the valid boundary cases. The new cases fail on `main` and pass here.

**Behaviour change worth noting:** a deployment currently passing an out-of-range `--auto-gomemlimit-ratio`, a negative `--object-limit`, or an unsatisfiable shard configuration starts today and will now fail fast with the documented error. That is what the existing validation intends, and the defaults are unaffected.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for memory-limit ratios, object limits, and shard configurations.
  * Rejected invalid values such as NaN, non-positive shard counts, and out-of-range shard indexes.
  * Applied node-specific resource checks only when node settings are configured.

* **Tests**
  * Added comprehensive validation coverage for valid and invalid configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->