### PR TITLE
fix(endpointslice): do not dereference an unset port number

### DIFF
--- a/internal/store/endpointslice.go
+++ b/internal/store/endpointslice.go
@@ -205,8 +205,25 @@ func createEndpointSlicePorts() generator.FamilyGenerator {
 		wrapEndpointSliceFunc(func(e *discoveryv1.EndpointSlice) *metric.Family {
 			m := []*metric.Metric{}
 			for _, port := range e.Ports {
+				// Every field of EndpointPort is optional. Name and Protocol are
+				// defaulted by the API server, but Port is not: an EndpointSlice
+				// used for something other than routing traffic is allowed to omit
+				// it. Expose the missing value as an empty label rather than
+				// dereferencing a nil pointer.
+				portName := ""
+				if port.Name != nil {
+					portName = *port.Name
+				}
+				portProtocol := ""
+				if port.Protocol != nil {
+					portProtocol = string(*port.Protocol)
+				}
+				portNumber := ""
+				if port.Port != nil {
+					portNumber = strconv.FormatInt(int64(*port.Port), 10)
+				}
 				m = append(m, &metric.Metric{
-					LabelValues: []string{*port.Name, string(*port.Protocol), strconv.FormatInt(int64(*port.Port), 10)},
+					LabelValues: []string{portName, portProtocol, portNumber},
 					LabelKeys:   []string{"port_name", "port_protocol", "port_number"},
 					Value:       1,
 				})

--- a/internal/store/endpointslice_test.go
+++ b/internal/store/endpointslice_test.go
@@ -97,6 +97,31 @@ func TestEndpointSliceStore(t *testing.T) {
 			},
 		},
 		{
+			// Port is optional and, unlike Name and Protocol, is not defaulted by
+			// the API server: an EndpointSlice that is not used for routing
+			// traffic may omit it.
+			Obj: &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test_endpointslice-ports-without-number",
+					Namespace: "test",
+				},
+				AddressType: "IPv4",
+				Ports: []discoveryv1.EndpointPort{
+					{Name: &portname,
+						Protocol: &portprotocol,
+					},
+				},
+			},
+			Want: `
+					# HELP kube_endpointslice_ports Ports attached to the endpointslice.
+					# TYPE kube_endpointslice_ports gauge
+					kube_endpointslice_ports{endpointslice="test_endpointslice-ports-without-number",port_name="http",port_protocol="TCP",port_number="",namespace="test"} 1
+				`,
+			MetricNames: []string{
+				"kube_endpointslice_ports",
+			},
+		},
+		{
 			Obj: &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test_endpointslice-endpoints",


### PR DESCRIPTION
**What this PR does / why we need it:**

`createEndpointSlicePorts` dereferences all three `EndpointPort` fields unconditionally:

```go
LabelValues: []string{*port.Name, string(*port.Protocol), strconv.FormatInt(int64(*port.Port), 10)},
```

`Name` and `Protocol` are safe because `SetDefaults_EndpointPort` fills them in, but **`Port` is not defaulted and not required**. `validatePorts` enforces neither, and the API documents that "EndpointSlices used for other purposes are not required to specify port numbers". So this is a valid object:

```yaml
apiVersion: discovery.k8s.io/v1
kind: EndpointSlice
metadata: {name: es, namespace: ns}
addressType: IPv4
ports: [{name: http, protocol: TCP}]   # no port number
endpoints: [{addresses: ["1.2.3.4"]}]
```

Generating metrics for it panics with `invalid memory address or nil pointer dereference`. That runs on the reflector goroutine and nothing in `pkg/` or `internal/` recovers, so the process dies and crashloops for as long as the object exists — i.e. anyone able to create an EndpointSlice can take the exporter down.

This PR exposes an unset value as an empty label, which matches how optional fields are handled elsewhere in the codebase, and keeps the series rather than dropping it. `Name` and `Protocol` get the same guard so a future change to their defaulting cannot reintroduce this.

Added a test case with a port that has no number; it panics on `main` and passes here. Existing `kube_endpointslice_ports` output for ports that do carry a number is unchanged.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of EndpointSlice ports with missing details.
  * Metrics are now emitted safely with empty label values instead of causing failures.
  * EndpointSlice metrics continue to be reported even when a port number is unavailable.

* **Tests**
  * Added coverage for EndpointSlice ports without port numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->