### PR TITLE
fix(store): never emit the same label name twice

### DIFF
--- a/internal/store/utils.go
+++ b/internal/store/utils.go
@@ -92,51 +92,52 @@ func mapToPrometheusLabels(labels map[string]string, prefix string) ([]string, [
 	}
 	slices.Sort(sortedKeys)
 
-	// conflictDesc holds some metadata for resolving potential label conflicts
-	type conflictDesc struct {
-		// the number of conflicting label keys we saw so far
-		count int
+	// used maps an emitted label name to its offset in labelKeys, so that the
+	// first time a name collides the entry already emitted under it can be
+	// renamed. conflicts counts the suffixes handed out per sanitized name.
+	// Prometheus rejects a sample carrying the same label name twice, so a
+	// generated "_conflictN" name must be checked against used as well: it can
+	// collide with a name some other key sanitized to.
+	used := make(map[string]int, len(labels))
+	conflicts := make(map[string]int)
 
-		// the offset of the initial conflicting label key, so we could
-		// later go back and rename "label_foo" to "label_foo_conflict1"
-		initial int
-	}
-
-	var conflicts map[string]*conflictDesc
 	for _, k := range sortedKeys {
-		labelKey := labelName(prefix, k)
-		var conflict *conflictDesc
-		if conflicts != nil {
-			conflict = conflicts[labelKey]
+		base := labelName(prefix, k)
+		name := base
+		if count, seen := conflicts[base]; seen {
+			// This name has collided before, so the unsuffixed form is no longer
+			// in use and every further occurrence just takes the next suffix.
+			name = nextFreeLabelName(base, &count, used)
+			conflicts[base] = count
+		} else if idx, taken := used[name]; taken {
+			// First collision for this name: the entry already emitted is still
+			// unsuffixed, so rename it to "_conflict1" and take "_conflict2".
+			count := 0
+			renamed := nextFreeLabelName(base, &count, used)
+			delete(used, name)
+			labelKeys[idx] = renamed
+			used[renamed] = idx
+
+			name = nextFreeLabelName(base, &count, used)
+			conflicts[base] = count
 		}
-		if conflict != nil {
-			conflict.count++
-			labelKey = labelConflictSuffix(labelKey, conflict.count)
-		} else {
-			initialIdx := -1
-			for i, lk := range labelKeys {
-				if lk == labelKey {
-					initialIdx = i
-					break
-				}
-			}
-			if initialIdx != -1 {
-				if conflicts == nil {
-					conflicts = make(map[string]*conflictDesc)
-				}
-				labelKeys[initialIdx] = labelConflictSuffix(labelKeys[initialIdx], 1)
-				conflict = &conflictDesc{
-					count:   2,
-					initial: initialIdx,
-				}
-				conflicts[labelKey] = conflict
-				labelKey = labelConflictSuffix(labelKey, 2)
-			}
-		}
-		labelKeys = append(labelKeys, labelKey)
+		used[name] = len(labelKeys)
+		labelKeys = append(labelKeys, name)
 		labelValues = append(labelValues, labels[k])
 	}
 	return labelKeys, labelValues
+}
+
+// nextFreeLabelName advances count until base with that conflict suffix is a
+// name no label is using yet, and returns it.
+func nextFreeLabelName(base string, count *int, used map[string]int) string {
+	for {
+		*count++
+		candidate := labelConflictSuffix(base, *count)
+		if _, taken := used[candidate]; !taken {
+			return candidate
+		}
+	}
 }
 
 func labelName(prefix, labelName string) string {

--- a/internal/store/utils_test.go
+++ b/internal/store/utils_test.go
@@ -245,6 +245,26 @@ func TestKubeLabelsToPrometheusLabels(t *testing.T) {
 				"snake_case",
 			},
 		},
+		{
+			// A key that sanitizes straight onto the name the conflict suffix
+			// would generate. Prometheus rejects a sample carrying the same
+			// label name twice, so the suffix has to skip past it.
+			kubeLabels: map[string]string{
+				"A.b.conflict1": "already_taken",
+				"a-b":           "dash",
+				"a.b":           "dot",
+			},
+			expectKeys: []string{
+				"label_a_b_conflict1",
+				"label_a_b_conflict2",
+				"label_a_b_conflict3",
+			},
+			expectValues: []string{
+				"already_taken",
+				"dash",
+				"dot",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it:**

`mapToPrometheusLabels` resolves colliding sanitized label names by renaming them to `<name>_conflictN`, but it never checks whether the generated name is itself already in use. A key that sanitizes directly onto that name collides with it:

```
{"A.b.conflict1": "v0", "a-b": "v1", "a.b": "v2"}     // all valid Kubernetes label keys
=> keys [label_a_b_conflict1  label_a_b_conflict1  label_a_b_conflict2]
```

`A.b.conflict1` sanitizes to `label_a_b_conflict1` and sorts first; the later `a-b`/`a.b` collision then renames the second entry onto that same name. `pkg/metric/metric.go` writes label keys verbatim with no dedup, so the exposed sample carries `label_a_b_conflict1` twice.

**Prometheus rejects a sample with a duplicate label name, and it fails the entire scrape rather than the individual series** — so one object carrying such a label pair suppresses every metric from the target, not just its own. The keys are reachable through `--metric-labels-allowlist` (or the annotations equivalent) for any label a tenant controls on their own namespaces, deployments, pods, and so on.

This PR tracks the names already handed out and advances the conflict suffix past any that are taken, so the output is `_conflict1`/`_conflict2`/`_conflict3` and every emitted name is unique.

Existing conflict behaviour is unchanged — the two current conflict test cases pass untouched. Added a case for the collision above; it fails on `main` with the duplicate shown and passes here.

Incidentally this replaces the linear rescan of `labelKeys` with a map lookup, so conflict resolution is no longer O(n²) in the number of labels on an object.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Prometheus label handling when label names conflict with generated suffixes.
  * Ensured all labels remain unique while preserving their associated values.

* **Tests**
  * Added coverage for conflicting label names and suffix progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->