### PR TITLE
fix(sharding): preserve pagination metadata when filtering a list

### DIFF
--- a/pkg/sharding/listwatch.go
+++ b/pkg/sharding/listwatch.go
@@ -149,6 +149,11 @@ func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, err
 		}
 	}
 	res.ResourceVersion = metaObj.GetResourceVersion()
+	// The reflector pages through large lists. Dropping the continue token would
+	// end the pager after the first page and silently truncate the relist, so it
+	// has to survive the shard filtering along with the resource version.
+	res.Continue = metaObj.GetContinue()
+	res.RemainingItemCount = metaObj.GetRemainingItemCount()
 
 	return res, nil
 }

--- a/pkg/sharding/listwatch_test.go
+++ b/pkg/sharding/listwatch_test.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -318,4 +319,46 @@ func (w *countingWatch) closeResult() {
 
 func (w *countingWatch) ResultChan() <-chan watch.Event {
 	return w.result
+}
+
+// The reflector pages through large lists, so the continue token has to survive
+// the shard filtering: without it the pager stops after the first page and the
+// relist is silently truncated.
+func TestShardedListWatchPreservesPaginationMetadata(t *testing.T) {
+	remaining := int64(7)
+	upstream := &cache.ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			return &v1.ConfigMapList{
+				ListMeta: metav1.ListMeta{
+					ResourceVersion:    "123",
+					Continue:           "next-page-token",
+					RemainingItemCount: &remaining,
+				},
+				Items: []v1.ConfigMap{
+					{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: "ns1", UID: types.UID("test_uid")}},
+				},
+			}, nil
+		},
+	}
+
+	slw := NewShardedListWatch(0, 2, upstream)
+	// shardedListWatch implements only the deprecated List method.
+	list, err := slw.List(metav1.ListOptions{}) //nolint:staticcheck
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	m, err := meta.ListAccessor(list)
+	if err != nil {
+		t.Fatalf("ListAccessor: %v", err)
+	}
+	if got := m.GetResourceVersion(); got != "123" {
+		t.Errorf("resource version: got %q, want %q", got, "123")
+	}
+	if got := m.GetContinue(); got != "next-page-token" {
+		t.Errorf("continue token: got %q, want %q", got, "next-page-token")
+	}
+	if got := m.GetRemainingItemCount(); got == nil || *got != remaining {
+		t.Errorf("remaining item count: got %v, want %d", got, remaining)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

`shardedListWatch.List` rebuilds the upstream result as a fresh `metav1.List` containing only the objects belonging to this shard, and copies just the resource version onto it:

```go
res := &metav1.List{Items: []runtime.RawExtension{}}
for _, item := range items { if s.sharding.keep(a) { ... } }
res.ResourceVersion = metaObj.GetResourceVersion()
```

`ListMeta.Continue` is never propagated, so the reflector cannot page.

client-go's reflector lists through `pager.ListPager`, which defaults to `PageSize=500` and only disables paging when the requested `ResourceVersion` is set and non-zero. After a `410 Gone` or an expired watch, `relistResourceVersion()` returns `""`, so the relist *is* paginated: the API server returns page one plus a continue token, the sharded wrapper strips the token, and `pager.list` sees `len(m.GetContinue()) == 0` and returns after a single page.

The reflector then `Replace()`s the store with only this shard's share of the first 500 objects and resumes watching from that resource version. **Everything past the first page is silently missing** until some later full relist, with no error logged anywhere. The same applies to the initial list on clusters running with the watch cache disabled. Instances using `--use-apiserver-cache` are unaffected, since that forces `RV=0` and the watch cache ignores `Limit`.

This PR carries the continue token — and the remaining item count, for the same reason — through the filtering alongside the resource version.

Added `TestShardedListWatchPreservesPaginationMetadata`; it fails on `main` with `continue token: got "", want "next-page-token"` and passes here. No existing sharding test sets `Continue`, which is why this went unnoticed.

**How does this change affect the cardinality of KSM:** does not change cardinality — it restores series that were being dropped on sharded instances

### Interaction with `--object-limit`

Worth flagging for reviewers: `pkg/watch` sets `options.Limit` from `--object-limit`, which is a **page size**, not a total. Today the dropped continue token makes the pager stop after one page, so on a paginated list `--object-limit` accidentally behaves like a hard cap on the number of objects listed. With this fix the pager walks all pages, so it goes back to being a page size and the object count is no longer capped.

That is the correct behaviour — the flag's help says "total number of objects to list per resource", which it never actually implemented, and capping by silently dropping data is not a reasonable way to provide it. But anyone using `--object-limit` (experimental) to bound memory should know their object counts may rise after this merges. Note the whole interaction only arises when paging is active at all: with the watch cache enabled the initial `ResourceVersion=0` list ignores `Limit` entirely, per client-go's own comment in `reflector.go`.

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sharded list results now preserve pagination details, including resource versions, continuation tokens, and remaining-item counts.
  * Improves consistency when retrieving results across paginated lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
