### PR TITLE
fix(customresourcestate): do not panic on a metric that fails to compile

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -160,10 +160,12 @@ func newCompiledMetric(m Metric) (compiledMetric, error) {
 			return nil, errors.New("expected each.gauge to not be nil")
 		}
 		cc, err := compileCommon(m.Gauge.MetricMeta)
-		cc.t = metric.Gauge
 		if err != nil {
+			// compileCommon returns a nil *compiledCommon alongside its error,
+			// so nothing may be assigned through cc before this check.
 			return nil, fmt.Errorf("each.gauge: %w", err)
 		}
+		cc.t = metric.Gauge
 		valueFromPath, err := compilePath(m.Gauge.ValueFrom)
 		if err != nil {
 			return nil, fmt.Errorf("each.gauge.valueFrom: %w", err)
@@ -179,10 +181,12 @@ func newCompiledMetric(m Metric) (compiledMetric, error) {
 			return nil, errors.New("expected each.info to not be nil")
 		}
 		cc, err := compileCommon(m.Info.MetricMeta)
-		cc.t = metric.Info
 		if err != nil {
+			// compileCommon returns a nil *compiledCommon alongside its error,
+			// so nothing may be assigned through cc before this check.
 			return nil, fmt.Errorf("each.info: %w", err)
 		}
+		cc.t = metric.Info
 		return &compiledInfo{
 			compiledCommon: *cc,
 			labelFromKey:   m.Info.LabelFromKey,
@@ -192,10 +196,12 @@ func newCompiledMetric(m Metric) (compiledMetric, error) {
 			return nil, errors.New("expected each.stateSet to not be nil")
 		}
 		cc, err := compileCommon(m.StateSet.MetricMeta)
-		cc.t = metric.StateSet
 		if err != nil {
+			// compileCommon returns a nil *compiledCommon alongside its error,
+			// so nothing may be assigned through cc before this check.
 			return nil, fmt.Errorf("each.stateSet: %w", err)
 		}
+		cc.t = metric.StateSet
 		valueFromPath, err := compilePath(m.StateSet.ValueFrom)
 		if err != nil {
 			return nil, fmt.Errorf("each.stateSet.valueFrom: %w", err)
@@ -665,7 +671,12 @@ func compilePath(path []string) (out valuePath, _ error) {
 							i += len(s)
 						}
 						if i < 0 || i >= len(s) {
-							return fmt.Errorf("list index out of range: %s", part)
+							// The path does not resolve. Returning an error here
+							// would hand it back as the resolved *value*, which
+							// then surfaces as a label value or a "expected number
+							// but was ..." message, so report it the same way every
+							// other unresolvable path does.
+							return nil
 						}
 						return s[i]
 					}

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -155,6 +155,38 @@ func Test_addPathLabels(t *testing.T) {
 	}
 }
 
+// An index past the end of a list does not resolve, so it must be skipped like
+// any other unresolvable path rather than surfacing as a label value.
+func Test_addPathLabels_indexOutOfRange(t *testing.T) {
+	m := make(map[string]string)
+	addPathLabels(cr, map[string]valuePath{
+		"idx": mustCompilePath(t, "spec", "order", "5"),
+	}, m)
+	assert.Equal(t, map[string]string{}, m)
+}
+
+// compileCommon returns a nil *compiledCommon alongside its error, so a metric
+// whose path fails to compile must report the error rather than panic.
+func Test_newCompiledMetric_compileError(t *testing.T) {
+	// "[Ready]" is a list lookup with no "key=value", which compilePath rejects.
+	badMeta := MetricMeta{Path: []string{"status", "conditions", "[Ready]"}}
+
+	for _, tt := range []struct {
+		name string
+		m    Metric
+	}{
+		{name: "gauge", m: Metric{Type: metric.Gauge, Gauge: &MetricGauge{MetricMeta: badMeta}}},
+		{name: "info", m: Metric{Type: metric.Info, Info: &MetricInfo{MetricMeta: badMeta}}},
+		{name: "stateSet", m: Metric{Type: metric.StateSet, StateSet: &MetricStateSet{MetricMeta: badMeta}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newCompiledMetric(tt.m)
+			assert.Nil(t, got)
+			assert.ErrorContains(t, err, "invalid list lookup: [Ready]")
+		})
+	}
+}
+
 func Test_values(t *testing.T) {
 	type tc struct {
 		name       string

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -169,15 +169,22 @@ func Test_addPathLabels_indexOutOfRange(t *testing.T) {
 // whose path fails to compile must report the error rather than panic.
 func Test_newCompiledMetric_compileError(t *testing.T) {
 	// "[Ready]" is a list lookup with no "key=value", which compilePath rejects.
-	badMeta := MetricMeta{Path: []string{"status", "conditions", "[Ready]"}}
+	// compileCommon compiles both path and labelsFromPath, so either can fail.
+	badPath := MetricMeta{Path: []string{"status", "conditions", "[Ready]"}}
+	badLabels := MetricMeta{LabelsFromPath: map[string][]string{
+		"cond": {"status", "conditions", "[Ready]"},
+	}}
 
 	for _, tt := range []struct {
 		name string
 		m    Metric
 	}{
-		{name: "gauge", m: Metric{Type: metric.Gauge, Gauge: &MetricGauge{MetricMeta: badMeta}}},
-		{name: "info", m: Metric{Type: metric.Info, Info: &MetricInfo{MetricMeta: badMeta}}},
-		{name: "stateSet", m: Metric{Type: metric.StateSet, StateSet: &MetricStateSet{MetricMeta: badMeta}}},
+		{name: "gauge path", m: Metric{Type: metric.Gauge, Gauge: &MetricGauge{MetricMeta: badPath}}},
+		{name: "info path", m: Metric{Type: metric.Info, Info: &MetricInfo{MetricMeta: badPath}}},
+		{name: "stateSet path", m: Metric{Type: metric.StateSet, StateSet: &MetricStateSet{MetricMeta: badPath}}},
+		{name: "gauge labelsFromPath", m: Metric{Type: metric.Gauge, Gauge: &MetricGauge{MetricMeta: badLabels}}},
+		{name: "info labelsFromPath", m: Metric{Type: metric.Info, Info: &MetricInfo{MetricMeta: badLabels}}},
+		{name: "stateSet labelsFromPath", m: Metric{Type: metric.StateSet, StateSet: &MetricStateSet{MetricMeta: badLabels}}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newCompiledMetric(tt.m)


### PR DESCRIPTION
**What this PR does / why we need it:**

`compileCommon` returns a nil `*compiledCommon` alongside its error, but all three metric types assign through `cc` before checking `err`:

```go
cc, err := compileCommon(m.Gauge.MetricMeta)
cc.t = metric.Gauge                                  // <- nil deref when err != nil
if err != nil {
	return nil, fmt.Errorf("each.gauge: %w", err)
}
```

So any `path` or `labelsFromPath` that fails to compile panics instead of being reported. A plausible config typo is enough — a list lookup written without its `key=value`:

```yaml
metrics:
- name: bar
  each:
    type: Gauge
    gauge: {path: [status, conditions, "[Ready]"]}   # meant [type=Ready]
```

`newCompiledMetric` is reached from the factory generator running on the discovery poll goroutine, so nothing recovers and the process dies. Worse, it only fires once a *matching CRD is discovered*, so it presents as a random crash some time after startup rather than as the config error it is. All three types (`Gauge`, `Info`, `StateSet`) are affected.

This PR checks the error before touching `cc` at all three sites.

**Also in here** (same file, one line): `compilePath`'s list-index op returned `fmt.Errorf("list index out of range: %s", part)` as the resolved *value* rather than signalling non-resolution. Every other unresolvable path yields nil and is skipped, so an out-of-range index in the final path position surfaced as a label value:

```
idx="list index out of range: 5"
```

and through a gauge path as the misleading `expected number but was list index out of range: 5`. It now returns nil like its neighbours. Only a trailing index was affected — with a following path element the error object was consumed and turned into nil anyway, which is why this went unnoticed.

Both are covered by new tests that fail on `main` (the first with the nil-pointer panic, the second with the bogus label value) and pass here.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid list indexes are now treated as missing values instead of causing errors.
  * Metric configuration failures now return clear errors without causing crashes.
  * Prevented invalid metric definitions from attempting to write through unavailable results.

* **Tests**
  * Added coverage for invalid list indexes and metric compilation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->