### PR TITLE
fix(metric_generator): escape reserved characters in help text

### DIFF
--- a/pkg/metric_generator/generator.go
+++ b/pkg/metric_generator/generator.go
@@ -76,15 +76,20 @@ func (g *FamilyGenerator) Generate(obj interface{}) *metric.Family {
 	return family
 }
 
+// escapeHelp escapes the characters the exposition format reserves in a HELP
+// line. A newline would end the line early and a backslash would start an
+// escape sequence, either of which makes the whole exposition unparseable.
+var escapeHelp = strings.NewReplacer(`\`, `\\`, "\n", `\n`)
+
 func (g *FamilyGenerator) generateHeader() string {
 	header := strings.Builder{}
 	header.WriteString("# HELP ")
 	header.WriteString(g.Name)
 	header.WriteByte(' ')
 	if g.StabilityLevel == basemetrics.STABLE {
-		fmt.Fprintf(&header, "[%v] %v", g.StabilityLevel, g.Help)
+		fmt.Fprintf(&header, "[%v] %v", g.StabilityLevel, escapeHelp.Replace(g.Help))
 	} else {
-		header.WriteString(g.Help)
+		header.WriteString(escapeHelp.Replace(g.Help))
 	}
 	header.WriteByte('\n')
 	header.WriteString("# TYPE ")

--- a/pkg/metric_generator/generator_test.go
+++ b/pkg/metric_generator/generator_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	basemetrics "k8s.io/component-base/metrics"
+
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+)
+
+// The help text of a custom resource metric comes from user-supplied YAML, so it
+// can contain characters the exposition format reserves. A newline ends the HELP
+// line early and a backslash starts an escape sequence, either of which makes the
+// whole exposition unparseable rather than just the offending family.
+func TestGenerateHeaderEscapesHelp(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		help string
+		want string
+	}{
+		{name: "plain", help: "Information about a thing.", want: "Information about a thing."},
+		{name: "backslash", help: `matches \d+ digits`, want: `matches \\d+ digits`},
+		{name: "trailing backslash", help: `ends with \`, want: `ends with \\`},
+		{name: "newline", help: "line one\nline two", want: `line one\nline two`},
+		{name: "carriage return is not reserved", help: "a\rb", want: "a\rb"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewFamilyGeneratorWithStability(
+				"kube_test_metric", tc.help, metric.Gauge, basemetrics.ALPHA, "",
+				func(interface{}) *metric.Family { return &metric.Family{} },
+			)
+
+			got := g.generateHeader()
+			want := "# HELP kube_test_metric " + tc.want + "\n# TYPE kube_test_metric gauge\n"
+			if got != want {
+				t.Errorf("got header %q, want %q", got, want)
+			}
+			// The HELP line must stay a single line, otherwise the TYPE line that
+			// follows is no longer where every reader of this header expects it.
+			if lines := strings.Count(got, "\n"); lines != 2 {
+				t.Errorf("header spans %d lines, want 2: %q", lines, got)
+			}
+		})
+	}
+}
+
+// STABLE metrics get their stability level prefixed onto the help text, which is
+// a separate write path and needs the same escaping.
+func TestGenerateHeaderEscapesHelpForStableMetrics(t *testing.T) {
+	g := NewFamilyGeneratorWithStability(
+		"kube_test_metric", `matches \d+ digits`, metric.Gauge, basemetrics.STABLE, "",
+		func(interface{}) *metric.Family { return &metric.Family{} },
+	)
+
+	got := g.generateHeader()
+	want := `# HELP kube_test_metric [STABLE] matches \\d+ digits` + "\n# TYPE kube_test_metric gauge\n"
+	if got != want {
+		t.Errorf("got header %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

`generateHeader` writes the help string verbatim into the HELP line:

```go
header.WriteString("# HELP ")
header.WriteString(g.Name)
header.WriteByte(' ')
header.WriteString(g.Help)      // <- unescaped
header.WriteByte('\n')
```

The Prometheus text format reserves `\` and newline in HELP — upstream `expfmt` escapes exactly those two — but KSM escapes label values only. The consequences are not local to the family:

| help text | result |
| --- | --- |
| `matches \d+ digits` | `text format parsing error in line 1: invalid escape sequence '\d'` |
| `ends with \` | `invalid escape sequence '\<newline>'` |
| `line one\nline two` | `text format parsing error in line 2: expected float as value, got "two"` |

A scrape that fails to parse is discarded in full, so one bad help string suppresses every metric the process exposes. A newline additionally breaks `parseHeaderStatic`, which locates the TYPE line by scanning to the first `\n`; with a multi-line HELP the OpenMetrics-only `info`/`stateset` suffix is then never rewritten to `gauge` for `text/plain`.

The built-in help strings contain neither character, so this only bites users of the CustomResourceState feature — where `help:` is user-supplied YAML that reaches this function with no validation or escaping anywhere on the path (`registry_factory.go` → `famGen` → `NewFamilyGeneratorWithStability`). A backslash while describing a path or a regex is an easy thing to write.

This PR escapes both characters on both write paths (the STABLE branch prefixes the stability level and needs the same treatment).

`pkg/metric_generator` had **no test files at all**; this adds the first, covering plain text, backslash, trailing backslash, newline, and the STABLE path. They fail on `main` and pass here. Built-in help strings are unaffected — I checked none contain a backslash, and the `internal/store` and `pkg/metrics_store` suites, which assert exposition output extensively, are unchanged.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus metric headers by safely escaping backslashes, newlines, and carriage returns in help text.
  * Preserved correct formatting for both stable and non-stable metrics, including headers that contain trailing backslashes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->