### PR TITLE
fix: three fixes in the server request and shutdown paths

### DIFF
--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -379,7 +379,10 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 			klog.InfoS("Started kube-state-metrics self metrics server", "telemetryAddress", telemetryListenAddress)
 			return web.ListenAndServe(&telemetryServer, &telemetryFlags, sLogger)
 		}, func(error) {
-			ctxShutDown, cancel := context.WithTimeout(ctx, 3*time.Second)
+			// Not derived from ctx: the interrupt handler runs because ctx was
+			// cancelled, so a child of it is already done and Shutdown would
+			// return immediately instead of draining in-flight scrapes.
+			ctxShutDown, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancel()
 			telemetryServer.Shutdown(ctxShutDown)
 		})
@@ -390,7 +393,10 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 			klog.InfoS("Started metrics server", "metricsServerAddress", metricsServerListenAddress)
 			return web.ListenAndServe(&metricsServer, &metricsFlags, sLogger)
 		}, func(error) {
-			ctxShutDown, cancel := context.WithTimeout(ctx, 3*time.Second)
+			// Not derived from ctx: the interrupt handler runs because ctx was
+			// cancelled, so a child of it is already done and Shutdown would
+			// return immediately instead of draining in-flight scrapes.
+			ctxShutDown, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancel()
 			metricsServer.Shutdown(ctxShutDown)
 		})
@@ -557,8 +563,12 @@ func registerLandingPage(mux *http.ServeMux, landingConfig web.LandingConfig, ne
 }
 
 func handleClusterDelegationForProber(client kubernetes.Interface, probeType string) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
-		got := client.CoreV1().RESTClient().Get().AbsPath(probeType).Do(context.Background())
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Tie the upstream call to the probe request. With context.Background()
+		// an API server that accepts the connection but never answers would pin
+		// this goroutine until the TCP keepalive gave up, long after the prober
+		// stopped waiting.
+		got := client.CoreV1().RESTClient().Get().AbsPath(probeType).Do(r.Context())
 		if got.Error() != nil {
 			var statusCode int
 			got.StatusCode(&statusCode)

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -216,6 +216,10 @@ func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if part == "gzip" || strings.HasPrefix(part, "gzip;") {
 				writer = gzip.NewWriter(writer)
 				resHeader.Set("Content-Encoding", "gzip")
+				// Stop at the first match, as the upstream implementation does.
+				// Wrapping twice would leave the inner writer unclosed, so its
+				// stream would never be finalised and the body would be unusable.
+				break
 			}
 		}
 	}

--- a/pkg/metricshandler/metrics_handler_test.go
+++ b/pkg/metricshandler/metrics_handler_test.go
@@ -17,8 +17,16 @@ limitations under the License.
 package metricshandler
 
 import (
+	"compress/gzip"
+	"io"
+	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	"k8s.io/kube-state-metrics/v2/internal/store"
+	"k8s.io/kube-state-metrics/v2/pkg/options"
 )
 
 func TestParseResources(t *testing.T) {
@@ -74,6 +82,39 @@ func TestParseResources(t *testing.T) {
 			got := parseResources(tt.params)
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("parseResources() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// A client may send more than one gzip token in Accept-Encoding. Wrapping the
+// response writer once per token would leave every inner writer unclosed, so its
+// deflate stream is never finalised and the body cannot be decompressed.
+func TestServeHTTPGzipWrapsOnce(t *testing.T) {
+	// No writers are needed: the response is wrapped before any are consulted,
+	// and an empty gzip stream is still a valid one.
+	handler := New(&options.Options{}, fake.NewSimpleClientset(), store.NewBuilder(), true)
+
+	for _, acceptEncoding := range []string{"gzip", "gzip, gzip", "gzip;q=1.0, gzip"} {
+		t.Run(acceptEncoding, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/metrics", nil)
+			req.Header.Set("Accept-Encoding", acceptEncoding)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			if got := res.Header.Get("Content-Encoding"); got != "gzip" {
+				t.Fatalf("Content-Encoding: got %q, want %q", got, "gzip")
+			}
+
+			zr, err := gzip.NewReader(res.Body)
+			if err != nil {
+				t.Fatalf("response is not readable gzip: %v", err)
+			}
+			defer zr.Close()
+			if _, err := io.ReadAll(zr); err != nil {
+				t.Fatalf("decompressing response: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**

Three small, independent fixes in the serving path. Grouped because each is a couple of lines; happy to split if preferred.

### 1. Gzip negotiation wraps the response writer once per token

`pkg/metricshandler/metrics_handler.go` — the loop over `Accept-Encoding` has no `break`, unlike `promhttp.decorateWriter` which the comment says it was taken from:

```go
for _, part := range parts {
	if part == "gzip" || strings.HasPrefix(part, "gzip;") {
		writer = gzip.NewWriter(writer)      // <- once per matching token
		resHeader.Set("Content-Encoding", "gzip")
	}
}
```

Only the outermost writer is closed at the end of the handler, so with a duplicated token the inner `gzip.Writer` is never flushed or finalised and its trailer never reaches the response. The client gets `Content-Encoding: gzip` and a **zero-length body**, failing with `gzip: unexpected EOF`.

Requires `--enable-gzip-encoding` plus a client or intermediary that emits the token twice — Prometheus itself does not — so the blast radius is small, but the fix is a single `break`.

Covered by a new test over `gzip`, `gzip, gzip` and `gzip;q=1.0, gzip`; the duplicate cases fail on `main` with `unexpected EOF` and the single-token case is unaffected either way.

### 2. The shutdown grace period was always zero

`pkg/app/server.go` — both server interrupt handlers did:

```go
ctxShutDown, cancel := context.WithTimeout(ctx, 3*time.Second)
```

`ctx` is precisely the context whose cancellation triggered the shutdown, so the derived context is already `Done` and `Shutdown` closes the listeners and returns `ctx.Err()` immediately, without draining in-flight scrapes. Derived from `context.Background()` now, so the intended three seconds actually apply.

### 3. The `/healthz` and `/livez` delegation had no deadline

`handleClusterDelegationForProber` issued its upstream request with `context.Background()`, and the shared `rest.Config` sets no client `Timeout`. Against an API server that accepts the connection but never responds — packets dropped rather than refused — each probe pins a handler goroutine and a connection for the TCP keepalive duration, minutes after the kubelet has given up. The server's `WriteTimeout` closes the client connection but does not unblock the goroutine. It now uses the request context, so it is cancelled when the prober disconnects.

Fixes 2 and 3 are not unit-tested: both need a real shutdown sequence or a blackholed API server to observe, and neither seemed worth the harness. They are visible by inspection.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A