### PR TITLE
test(e2e): make the pod wait loop actually retry

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -103,8 +103,10 @@ function kube_pod_up() {
     is_pod_running="false"
 
     for _ in {1..90}; do # timeout for 3 minutes
-        kubectl get pods -A | grep "$1" 1>/dev/null 2>&1
-        if [[ $? -ne 1 ]]; then
+        # Test the pipeline inside the condition. As a bare statement it is
+        # subject to `set -e`, so the first poll that finds nothing ends the
+        # script before the retry below is ever reached.
+        if kubectl get pods -A | grep -q "$1"; then
             is_pod_running="true"
             break
         fi

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -106,7 +106,11 @@ function kube_pod_up() {
         # Test the pipeline inside the condition. As a bare statement it is
         # subject to `set -e`, so the first poll that finds nothing ends the
         # script before the retry below is ever reached.
-        if kubectl get pods -A | grep -q "$1"; then
+        #
+        # Not `grep -q`: it stops reading at the first match, so kubectl can be
+        # killed by SIGPIPE, and `set -o pipefail` then reports the whole
+        # pipeline as failed even though the pod was found.
+        if kubectl get pods -A | grep "$1" 1>/dev/null 2>&1; then
             is_pod_running="true"
             break
         fi


### PR DESCRIPTION
**What this PR does / why we need it:**

`ci-e2e-tests` fails intermittently. `kube_pod_up` polls with a bare pipeline and inspects `$?` on the next line:

```bash
for _ in {1..90}; do # timeout for 3 minutes
    kubectl get pods -A | grep "$1" 1>/dev/null 2>&1
    if [[ $? -ne 1 ]]; then
        is_pod_running="true"
        break
    fi
    echo "waiting for pod $1 to come up"
    sleep 2
done
```

`grep` exits 1 when it finds nothing, and as a bare statement that pipeline is subject to `set -e`, so the script ends there — the `if` that was meant to retry is never reached. The `set +e` region the function body is written inside does not help: `test_daemonset` is called at line 214, after `set -e` is restored at line 187, and what matters is where the function *runs*, not where it is defined.

The poll runs immediately after `kubectl apply` creates the deployments, so it only passes when the deployment controller has produced a Pod object within milliseconds. That is the flake.

Observed on a recent run — the loop produced no "waiting for pod" line at all before the script died:

```
+ kube_pod_up runningpod1
+ is_pod_running=false
+ for _ in {1..90}
+ kubectl get pods -A
+ grep runningpod1
make: *** [Makefile:147: e2e] Error 1
```

Testing the pipeline as the `if` condition instead makes it exempt from `set -e`, so the loop retries for its intended three minutes.

**Note on `grep -q`:** the obvious form, `if kubectl get pods -A | grep -q "$1"`, introduces a *different* failure. `grep -q` stops reading at the first match, so `kubectl` can be killed by `SIGPIPE`, and `set -o pipefail` then reports the whole pipeline as failed even though the pod was found — turning an instant failure into a three-minute timeout. Demonstrated under `pipefail` with a producer that matches on its first line:

```
grep -q        : pipeline=141 producer=141 grep=0   -> reported NO MATCH despite the line being present
grep >/dev/null: pipeline=0   producer=0   grep=0   -> MATCHED
```

So this keeps the original redirect form, which consumes the input to the end. Verified that a present pod is found on the first poll and an absent one retries rather than aborting. `shellcheck` passes.

**Not changed:** the same idiom at line 172 (`kubectl get po` while waiting for the cluster) executes at top level while `set +e` is in effect, so it is not affected today. It is fragile for the same reason, but changing it has no behavioural benefit and I kept the diff minimal.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A