### PR TITLE
fix: serialize config reloads so one does not strand the other

### DIFF
--- a/internal/wrapper.go
+++ b/internal/wrapper.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -45,6 +46,25 @@ func RunKubeStateMetricsWrapper(opts *options.Options) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Every watched file gets its own viper instance, and viper runs each
+	// OnConfigChange callback on its own goroutine. They all restart KSM through
+	// the same ctx and cancel, and a ConfigMap holding more than one watched file
+	// updates them together, so the callbacks have to take turns. Otherwise one
+	// cancel is overwritten before it is used, the instance it belonged to is
+	// never stopped, and two of them contend for the listen ports.
+	var reloadMu sync.Mutex
+	restart := func(e fsnotify.Event) {
+		reloadMu.Lock()
+		defer reloadMu.Unlock()
+
+		klog.InfoS("Changes detected", "name", e.Name)
+		cancel()
+		// Wait for the ports to be released.
+		<-time.After(3 * time.Second)
+		ctx, cancel = context.WithCancel(context.Background())
+		go KSMRunOrDie(ctx)
+	}
+
 	if file := options.GetConfigFile(*opts); file != "" {
 		cfgViper := viper.New()
 		cfgViper.SetConfigType("yaml")
@@ -64,14 +84,7 @@ func RunKubeStateMetricsWrapper(opts *options.Options) {
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
 		}
-		cfgViper.OnConfigChange(func(e fsnotify.Event) {
-			klog.InfoS("Changes detected", "name", e.Name)
-			cancel()
-			// Wait for the ports to be released.
-			<-time.After(3 * time.Second)
-			ctx, cancel = context.WithCancel(context.Background())
-			go KSMRunOrDie(ctx)
-		})
+		cfgViper.OnConfigChange(restart)
 		cfgViper.WatchConfig()
 
 		if cfgViperReadInConfigErr == nil {
@@ -116,14 +129,7 @@ func RunKubeStateMetricsWrapper(opts *options.Options) {
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
 		}
-		crcViper.OnConfigChange(func(e fsnotify.Event) {
-			klog.InfoS("Changes detected", "name", e.Name)
-			cancel()
-			// Wait for the ports to be released.
-			<-time.After(3 * time.Second)
-			ctx, cancel = context.WithCancel(context.Background())
-			go KSMRunOrDie(ctx)
-		})
+		crcViper.OnConfigChange(restart)
 		crcViper.WatchConfig()
 	}
 	if opts.Kubeconfig != "" {
@@ -138,14 +144,7 @@ func RunKubeStateMetricsWrapper(opts *options.Options) {
 			}
 			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
-		kubecfgViper.OnConfigChange(func(e fsnotify.Event) {
-			klog.InfoS("Changes detected", "name", e.Name)
-			cancel()
-			// Wait for the ports to be released.
-			<-time.After(3 * time.Second)
-			ctx, cancel = context.WithCancel(context.Background())
-			go KSMRunOrDie(ctx)
-		})
+		kubecfgViper.OnConfigChange(restart)
 		kubecfgViper.WatchConfig()
 	}
 	klog.InfoS("Starting kube-state-metrics")


### PR DESCRIPTION
**What this PR does / why we need it:**

`RunKubeStateMetricsWrapper` watches up to three files — the options config, the custom resource state config and the kubeconfig — and each gets its own `viper` instance. `WatchConfig` starts a goroutine per instance, so every `OnConfigChange` callback runs on its own goroutine. All three closed over the same `ctx` and `cancel` and wrote them with no synchronisation:

```go
cancel()
<-time.After(3 * time.Second)
ctx, cancel = context.WithCancel(context.Background())   // shared, unsynchronised
go KSMRunOrDie(ctx)
```

Two of them firing together is not an edge case: the options config and the custom resource state config are normally keys in the **same** ConfigMap, and kubelet updates the mounted files together, so one edit fires both watchers.

When that happens the second callback overwrites `cancel` before the first has used it. The instance the lost `cancel` belonged to is never stopped, so two instances end up contending for `:8080`; the loser's bind error propagates to `KSMRunOrDie`, which calls `klog.FlushAndExit(1)`. A routine config reload takes the process down.

The three callbacks were byte-identical, so this collapses them into a single `restart` function guarded by a mutex — reloads now queue instead of racing, and the duplication goes away with it.

Not unit-tested: the reload path has no test harness today, and exercising it means driving real `fsnotify` events against three watchers with controlled timing. `go test -race` would not have caught this for the same reason.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A