### PR TITLE
fix(hpa): skip a status metric whose source is not set

### DIFF
--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -266,21 +266,40 @@ func createHPAStatusTargetMetric() generator.FamilyGenerator {
 				// The variable maps the type of metric to the corresponding value
 				metricMap := make(map[metricTargetType]float64)
 
+				// Unlike spec.metrics, status.currentMetrics is not validated:
+				// ValidateHorizontalPodAutoscalerStatusUpdate checks only the
+				// replica counts and the conditions, so the source matching Type
+				// may be absent. Skip such an entry rather than dereferencing it.
 				switch m.Type {
 				case autoscaling.ObjectMetricSourceType:
+					if m.Object == nil {
+						continue
+					}
 					metricName = m.Object.Metric.Name
 					currentMetric = m.Object.Current
 				case autoscaling.PodsMetricSourceType:
+					if m.Pods == nil {
+						continue
+					}
 					metricName = m.Pods.Metric.Name
 					currentMetric = m.Pods.Current
 				case autoscaling.ResourceMetricSourceType:
+					if m.Resource == nil {
+						continue
+					}
 					metricName = string(m.Resource.Name)
 					currentMetric = m.Resource.Current
 				case autoscaling.ContainerResourceMetricSourceType:
+					if m.ContainerResource == nil {
+						continue
+					}
 					metricName = string(m.ContainerResource.Name)
 					currentMetric = m.ContainerResource.Current
 					containerName = m.ContainerResource.Container
 				case autoscaling.ExternalMetricSourceType:
+					if m.External == nil {
+						continue
+					}
 					metricName = m.External.Metric.Name
 					currentMetric = m.External.Current
 				default:

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -648,3 +648,40 @@ func int32ptr(value int32) *int32 {
 func resourcePtr(quantity resource.Quantity) *resource.Quantity {
 	return &quantity
 }
+
+// status.currentMetrics is not validated by the API server -- unlike
+// spec.metrics, ValidateHorizontalPodAutoscalerStatusUpdate checks only the
+// replica counts and the conditions -- so the source matching Type can be
+// absent. Generating metrics for such an entry must skip it rather than
+// dereference the nil source, which would panic on the reflector goroutine.
+func TestHPAStatusTargetMetricWithNilSource(t *testing.T) {
+	for _, metricType := range []autoscaling.MetricSourceType{
+		autoscaling.ObjectMetricSourceType,
+		autoscaling.PodsMetricSourceType,
+		autoscaling.ResourceMetricSourceType,
+		autoscaling.ContainerResourceMetricSourceType,
+		autoscaling.ExternalMetricSourceType,
+	} {
+		t.Run(string(metricType), func(t *testing.T) {
+			hpa := &autoscaling.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "hpa", Namespace: "ns"},
+				Status: autoscaling.HorizontalPodAutoscalerStatus{
+					// Type is set, but the matching source is not.
+					CurrentMetrics: []autoscaling.MetricStatus{{Type: metricType}},
+				},
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panic generating metrics for a %s status with no source: %v", metricType, r)
+				}
+			}()
+
+			g := createHPAStatusTargetMetric()
+			family := g.Generate(hpa)
+			if len(family.Metrics) != 0 {
+				t.Errorf("expected the entry to be skipped, got %d metrics", len(family.Metrics))
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

`createHPAStatusTargetMetric` switches on `MetricStatus.Type` and dereferences the matching source pointer with no nil check:

```go
switch m.Type {
case autoscaling.ObjectMetricSourceType:
	metricName = m.Object.Metric.Name        // <- m.Object may be nil
	currentMetric = m.Object.Current
...
```

The **spec** counterpart is safe because `validateMetricSpec` requires the field named by `Type` to be populated. The **status** counterpart is not: `ValidateHorizontalPodAutoscalerStatusUpdate` validates only `currentReplicas`, `desiredReplicas` and the conditions, and `autoscalerStatusStrategy.ValidateUpdate` is the only validation applied to the `/status` subresource. `status.currentMetrics` is entirely unchecked, so this is accepted:

```
PATCH hpa/status  {"status":{"currentMetrics":[{"type":"Resource"}]}}
```

Generating metrics for that object panics with a nil pointer dereference on the reflector goroutine, and nothing in `pkg/` or `internal/` recovers, so the process dies. Writing an HPA's status requires privileges the HPA controller normally holds — the controller itself always writes a well-formed status — so this is a robustness gap rather than an unprivileged DoS, but the fix is cheap and mirrors what the switch already does for an unrecognised type.

Added `TestHPAStatusTargetMetricWithNilSource` covering all five source types; each panics on `main` and passes here.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A