### PR TITLE
fix: retry a failed rebuild instead of dropping it

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -225,9 +225,13 @@ func (r *CRDiscoverer) PollForCacheUpdates(
 	// The interval at which we will check the cache for updates.
 	t := time.NewTicker(Interval)
 	generateMetrics := func() {
+		// Tracks whether anything went wrong, so the update can be retried on the
+		// next tick instead of being dropped.
+		failed := false
 		// Get families for discovered factories.
 		customFactories, err := factoryGenerator()
 		if err != nil {
+			failed = true
 			klog.ErrorS(err, "failed to update custom resource stores")
 		}
 		// Update the list of enabled custom resources.
@@ -235,6 +239,7 @@ func (r *CRDiscoverer) PollForCacheUpdates(
 		for _, factory := range customFactories {
 			gvr, err := util.GVRFromType(factory.Name(), factory.ExpectedType())
 			if err != nil {
+				failed = true
 				klog.ErrorS(err, "failed to update custom resource stores")
 			}
 			var gvrString string
@@ -248,6 +253,7 @@ func (r *CRDiscoverer) PollForCacheUpdates(
 		// Create clients for discovered factories.
 		discoveredCustomResourceClients, err := util.CreateCustomResourceClients(opts.Apiserver, opts.Kubeconfig, customFactories...)
 		if err != nil {
+			failed = true
 			klog.ErrorS(err, "failed to update custom resource stores")
 		}
 		// Update the store builder with the new clients.
@@ -256,15 +262,19 @@ func (r *CRDiscoverer) PollForCacheUpdates(
 		storeBuilder.WithCustomResourceStoreFactories(customFactories...)
 		// Update the store builder with the new custom resources.
 		if err := storeBuilder.WithEnabledResources(enabledCustomResources); err != nil {
+			failed = true
 			klog.ErrorS(err, "failed to update custom resource stores")
 		}
 		// Configure the generation function for the custom resource stores.
 		storeBuilder.WithGenerateCustomResourceStoresFunc(storeBuilder.DefaultGenerateCustomResourceStoresFunc())
-		// Reset the flag, if there were no errors. Else, we'll try again on the next tick.
-		// Keep retrying if there were errors.
-		r.SafeWrite(func() {
-			r.WasUpdated = false
-		})
+		// Reset the flag only if there were no errors, so a failed update is
+		// retried on the next tick rather than waiting for an unrelated CRD event
+		// to set the flag again.
+		if !failed {
+			r.SafeWrite(func() {
+				r.WasUpdated = false
+			})
+		}
 		// Update metric handler with the new configs.
 		m.BuildWriters(ctx)
 	}

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -158,11 +158,8 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 				klog.InfoS("waiting for config to be fixed")
 				configSuccess.WithLabelValues("config", filepath.Clean(got)).Set(0)
 				<-ctx.Done()
-				// The wait ended because the watcher cancelled this run to start a
-				// fresh one with the corrected config. Returning hands over to it;
-				// carrying on would build a second, half-configured instance on a
-				// context that is already done, racing the new run for the listen
-				// ports and for the options this one shares with it.
+				// The watcher cancelled this run to start a fresh one; hand over
+				// rather than race it for the listen ports and the shared options.
 				return nil
 			}
 

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -158,12 +158,19 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 				klog.InfoS("waiting for config to be fixed")
 				configSuccess.WithLabelValues("config", filepath.Clean(got)).Set(0)
 				<-ctx.Done()
-			} else {
-				configSuccess.WithLabelValues("config", filepath.Clean(got)).Set(1)
-				configSuccessTime.WithLabelValues("config", filepath.Clean(got)).SetToCurrentTime()
-				hash := md5HashAsMetricValue(configFile)
-				configHash.WithLabelValues("config", filepath.Clean(got)).Set(hash)
+				// The wait ended because the watcher cancelled this run to start a
+				// fresh one with the corrected config. Returning hands over to it;
+				// carrying on would build a second, half-configured instance on a
+				// context that is already done, racing the new run for the listen
+				// ports and for the options this one shares with it.
+				return nil
 			}
+
+			configSuccess.WithLabelValues("config", filepath.Clean(got)).Set(1)
+			configSuccessTime.WithLabelValues("config", filepath.Clean(got)).SetToCurrentTime()
+			hash := md5HashAsMetricValue(configFile)
+			configHash.WithLabelValues("config", filepath.Clean(got)).Set(hash)
+
 			opts = configureResourcesAndMetrics(opts, configFile)
 			klog.InfoS("Using config file", "file", got)
 		}


### PR DESCRIPTION
**What this PR does / why we need it:**

Two places that record a failure and then carry on as though it had not happened.

### 1. `WasUpdated` was cleared even when the rebuild failed

`internal/discovery/discovery.go` — the comment states the intent plainly:

```go
// Reset the flag, if there were no errors. Else, we'll try again on the next tick.
// Keep retrying if there were errors.
r.SafeWrite(func() {
	r.WasUpdated = false
})
```

but the reset is unconditional, and all four error paths above it only `klog.ErrorS`. A transient failure in `factoryGenerator`, `util.GVRFromType`, `util.CreateCustomResourceClients` or `WithEnabledResources` — an API server blip during an operator install, say — therefore leaves the newly discovered CRD unbuilt *and* the flag clear. Its metrics stay missing until some unrelated CRD event happens to set the flag again, which may be never.

Now tracks whether anything failed and keeps the flag set, so the next tick retries, as the comment always said it would.

### 2. A bad config file fell through into a second startup

`pkg/app/server.go` — when the options config fails to unmarshal, the run deliberately does not exit, so the operator can fix the file and have KSM reload:

```go
klog.InfoS("waiting for config to be fixed")
configSuccess.WithLabelValues(...).Set(0)
<-ctx.Done()
```

It then falls through into the remainder of `RunKubeStateMetrics`. But that wait ends precisely *because* the file watcher cancelled this run in order to start a fresh one with the corrected config. Continuing builds a second, half-configured instance on an already-cancelled context: it re-unmarshals into the `*options.Options` the new run shares, starts the discovery goroutines, and binds the metrics and telemetry listeners. It tears itself down within milliseconds, so the three-second grace in the watcher usually hides it, but the sequence races the real run for the ports and for shared state.

Returns instead and lets the new run take over. (The `else` is outdented to satisfy `revive`'s `indent-error-flow`.)

Neither is unit-tested: the first needs a failing factory generator injected into the poll loop, the second a real watcher-driven restart. Both are visible by inspection, and the first is simply the behaviour its own comment describes.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of configuration updates by retrying failed resource refreshes automatically.
  * Prevented conflicting restart behavior when configuration processing is cancelled.
  * Ensured successful configuration reloads are recorded accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->