### PR TITLE
fix(metricshandler): scope the scrape lock to reading the writers

### DIFF
--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -192,8 +192,16 @@ func (m *MetricsHandler) Run(ctx context.Context) error {
 // ServeHTTP implements the http.Handler interface. It writes all generated metrics to the response body.
 // Note that all operations defined within this procedure are performed at every request.
 func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Snapshot the writers instead of holding the lock for the whole response.
+	// BuildWriters and ConfigureSharding need the write lock, so a slow client
+	// would otherwise delay a re-shard -- and since a waiting writer blocks new
+	// readers, every scrape queued behind it too. Writers are replaced wholesale
+	// rather than mutated, so a snapshot stays readable and self-consistent even
+	// if it is rebuilt mid-response.
 	m.mtx.RLock()
-	defer m.mtx.RUnlock()
+	writers := m.metricsWriters
+	m.mtx.RUnlock()
+
 	resHeader := w.Header()
 	var writer io.Writer = w
 
@@ -228,16 +236,19 @@ func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Sanitizing first can suppress HELP/TYPE headers for metrics whose
 	// only active writer is later in the list but its earlier same-named
 	// counterpart was filtered out.
-	activeWriters := m.metricsWriters
-	if requestedResources != nil || excludedResources != nil {
-		activeWriters = make(metricsstore.MetricsWriterList, 0, len(m.metricsWriters))
-		for _, mw := range m.metricsWriters {
-			if requestedResources != nil {
+	// Compare on length, not against nil: "?resources=" parses to an empty set,
+	// which names no resource and so is a request for no filtering rather than a
+	// request for nothing.
+	activeWriters := writers
+	if len(requestedResources) > 0 || len(excludedResources) > 0 {
+		activeWriters = make(metricsstore.MetricsWriterList, 0, len(writers))
+		for _, mw := range writers {
+			if len(requestedResources) > 0 {
 				if _, ok := requestedResources[mw.ResourceName]; !ok {
 					continue
 				}
 			}
-			if excludedResources != nil {
+			if len(excludedResources) > 0 {
 				if _, ok := excludedResources[mw.ResourceName]; ok {
 					continue
 				}

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -236,19 +236,16 @@ func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Sanitizing first can suppress HELP/TYPE headers for metrics whose
 	// only active writer is later in the list but its earlier same-named
 	// counterpart was filtered out.
-	// Compare on length, not against nil: "?resources=" parses to an empty set,
-	// which names no resource and so is a request for no filtering rather than a
-	// request for nothing.
 	activeWriters := writers
-	if len(requestedResources) > 0 || len(excludedResources) > 0 {
+	if requestedResources != nil || excludedResources != nil {
 		activeWriters = make(metricsstore.MetricsWriterList, 0, len(writers))
 		for _, mw := range writers {
-			if len(requestedResources) > 0 {
+			if requestedResources != nil {
 				if _, ok := requestedResources[mw.ResourceName]; !ok {
 					continue
 				}
 			}
-			if len(excludedResources) > 0 {
+			if excludedResources != nil {
 				if _, ok := excludedResources[mw.ResourceName]; ok {
 					continue
 				}

--- a/pkg/metricshandler/metrics_handler_test.go
+++ b/pkg/metricshandler/metrics_handler_test.go
@@ -17,8 +17,19 @@ limitations under the License.
 package metricshandler
 
 import (
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"k8s.io/kube-state-metrics/v2/internal/store"
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
+	"k8s.io/kube-state-metrics/v2/pkg/options"
 )
 
 func TestParseResources(t *testing.T) {
@@ -77,4 +88,62 @@ func TestParseResources(t *testing.T) {
 			}
 		})
 	}
+}
+
+// "?resources=" names no resource, so it is a request for no filtering rather
+// than a request for nothing. Same for its exclude counterpart, and for the
+// combination where one is empty and the other is not.
+func TestServeHTTPEmptyResourceFilter(t *testing.T) {
+	handler := New(&options.Options{}, fake.NewSimpleClientset(), store.NewBuilder(), false)
+	handler.metricsWriters = metricsstore.MetricsWriterList{
+		metricsstore.NewMetricsWriter("pods", newStoreWithOneMetric(t, "kube_pod_test")),
+		metricsstore.NewMetricsWriter("nodes", newStoreWithOneMetric(t, "kube_node_test")),
+	}
+
+	for _, tc := range []struct {
+		query string
+		want  []string
+		gone  []string
+	}{
+		{query: "", want: []string{"kube_pod_test", "kube_node_test"}},
+		{query: "?resources=", want: []string{"kube_pod_test", "kube_node_test"}},
+		{query: "?exclude_resources=", want: []string{"kube_pod_test", "kube_node_test"}},
+		{query: "?resources=&exclude_resources=nodes", want: []string{"kube_pod_test"}, gone: []string{"kube_node_test"}},
+		{query: "?resources=pods", want: []string{"kube_pod_test"}, gone: []string{"kube_node_test"}},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/metrics"+tc.query, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			body := w.Body.String()
+			for _, want := range tc.want {
+				if !strings.Contains(body, want) {
+					t.Errorf("expected %q in the response, got %q", want, body)
+				}
+			}
+			for _, gone := range tc.gone {
+				if strings.Contains(body, gone) {
+					t.Errorf("did not expect %q in the response, got %q", gone, body)
+				}
+			}
+		})
+	}
+}
+
+func newStoreWithOneMetric(t *testing.T, name string) *metricsstore.MetricsStore {
+	t.Helper()
+	s := metricsstore.NewMetricsStore(
+		[]string{"# HELP " + name + " help\n# TYPE " + name + " gauge"},
+		func(interface{}) []metric.FamilyInterface {
+			return []metric.FamilyInterface{&metric.Family{
+				Name:    name,
+				Metrics: []*metric.Metric{{Value: 1}},
+			}}
+		},
+	)
+	if err := s.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "uid"}}); err != nil {
+		t.Fatalf("adding to store: %v", err)
+	}
+	return s
 }

--- a/pkg/metricshandler/metrics_handler_test.go
+++ b/pkg/metricshandler/metrics_handler_test.go
@@ -17,19 +17,8 @@ limitations under the License.
 package metricshandler
 
 import (
-	"net/http/httptest"
 	"reflect"
-	"strings"
 	"testing"
-
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
-
-	"k8s.io/kube-state-metrics/v2/internal/store"
-	"k8s.io/kube-state-metrics/v2/pkg/metric"
-	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
-	"k8s.io/kube-state-metrics/v2/pkg/options"
 )
 
 func TestParseResources(t *testing.T) {
@@ -88,62 +77,4 @@ func TestParseResources(t *testing.T) {
 			}
 		})
 	}
-}
-
-// "?resources=" names no resource, so it is a request for no filtering rather
-// than a request for nothing. Same for its exclude counterpart, and for the
-// combination where one is empty and the other is not.
-func TestServeHTTPEmptyResourceFilter(t *testing.T) {
-	handler := New(&options.Options{}, fake.NewSimpleClientset(), store.NewBuilder(), false)
-	handler.metricsWriters = metricsstore.MetricsWriterList{
-		metricsstore.NewMetricsWriter("pods", newStoreWithOneMetric(t, "kube_pod_test")),
-		metricsstore.NewMetricsWriter("nodes", newStoreWithOneMetric(t, "kube_node_test")),
-	}
-
-	for _, tc := range []struct {
-		query string
-		want  []string
-		gone  []string
-	}{
-		{query: "", want: []string{"kube_pod_test", "kube_node_test"}},
-		{query: "?resources=", want: []string{"kube_pod_test", "kube_node_test"}},
-		{query: "?exclude_resources=", want: []string{"kube_pod_test", "kube_node_test"}},
-		{query: "?resources=&exclude_resources=nodes", want: []string{"kube_pod_test"}, gone: []string{"kube_node_test"}},
-		{query: "?resources=pods", want: []string{"kube_pod_test"}, gone: []string{"kube_node_test"}},
-	} {
-		t.Run(tc.query, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/metrics"+tc.query, nil)
-			w := httptest.NewRecorder()
-			handler.ServeHTTP(w, req)
-
-			body := w.Body.String()
-			for _, want := range tc.want {
-				if !strings.Contains(body, want) {
-					t.Errorf("expected %q in the response, got %q", want, body)
-				}
-			}
-			for _, gone := range tc.gone {
-				if strings.Contains(body, gone) {
-					t.Errorf("did not expect %q in the response, got %q", gone, body)
-				}
-			}
-		})
-	}
-}
-
-func newStoreWithOneMetric(t *testing.T, name string) *metricsstore.MetricsStore {
-	t.Helper()
-	s := metricsstore.NewMetricsStore(
-		[]string{"# HELP " + name + " help\n# TYPE " + name + " gauge"},
-		func(interface{}) []metric.FamilyInterface {
-			return []metric.FamilyInterface{&metric.Family{
-				Name:    name,
-				Metrics: []*metric.Metric{{Value: 1}},
-			}}
-		},
-	)
-	if err := s.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "uid"}}); err != nil {
-		t.Fatalf("adding to store: %v", err)
-	}
-	return s
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

`ServeHTTP` holds `mtx.RLock` for the entire response:

```go
func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
	m.mtx.RLock()
	defer m.mtx.RUnlock()
```

That covers negotiation, gzip wrapping, header sanitisation and the write itself — i.e. as long as the slowest client takes to read the body. `BuildWriters` and `ConfigureSharding` need the write lock, so a single slow scraper delays a re-shard or a config rebuild for its whole duration. Worse, Go's `sync.RWMutex` blocks *new* readers once a writer is waiting, so one slow client plus one re-shard stalls every scrape queued behind them.

The lock is only needed to read `m.metricsWriters`. Writers are replaced wholesale by `BuildWriters` rather than mutated in place, so snapshotting the slice header under the lock and releasing it immediately gives the response a self-consistent view even if a rebuild lands mid-write: the old writers stay readable, they simply stop being updated.

No dedicated test — reproducing the stall needs a slow client racing a rebuild, which is timing-dependent and would be flaky. `go test -race` on the package is clean, and `TestResourceFiltering` in `pkg/app` continues to pass, which exercises `ServeHTTP` end to end.

**Previously in this PR, now reverted:** I had also changed the resource filters to compare on length rather than against nil, on the theory that `?resources=` (empty value) returning no metrics was an undocumented asymmetry. It is not — `TestResourceFiltering` already pins `?resources=,,,,` to return nothing and `?exclude_resources=,,,,` to return everything, which is coherent: `resources` is an allowlist, so an empty one allows nothing, and `exclude_resources` is a denylist, so an empty one denies nothing. CI caught it. Only the lock scoping remains.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved metrics response handling so configuration updates can continue while responses are being generated.
  * Ensured each metrics response uses a consistent set of configured writers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->