### PR TITLE
fix(discovery): read the GVK cache under the lock

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -144,74 +144,86 @@ func (r *CRDiscoverer) ResolveGVKToGVKPs(gvk schema.GroupVersionKind) (resolvedG
 	}
 	hasVersion := v != "" && v != "*"
 	hasKind := k != "" && k != "*"
-	// No need to resolve, return.
-	if hasVersion && hasKind {
-		for _, el := range r.Map[g][v] {
-			if el.Kind == k {
-				r.clearMissingGVKWarning(gvk)
-				return []groupVersionKindPlural{
-					{
-						GroupVersionKind: schema.GroupVersionKind{
-							Group:   g,
-							Version: v,
-							Kind:    k,
-						},
-						Plural: el.Plural,
-					},
-				}, nil
-			}
-		}
-		if r.markMissingGVKWarned(gvk) {
-			klog.InfoS("Configured custom resource was not found in the cluster, no metrics will be generated for it until a CRD serving this version is installed", "gvk", gvk)
-		}
-		return nil, nil
-	}
-	if hasVersion && !hasKind {
-		kinds := r.Map[g][v]
-		for _, el := range kinds {
-			resolvedGVKPs = append(resolvedGVKPs, groupVersionKindPlural{
-				GroupVersionKind: schema.GroupVersionKind{
-					Group:   g,
-					Version: v,
-					Kind:    el.Kind,
-				},
-				Plural: el.Plural,
-			})
-		}
-	}
-	if !hasVersion && hasKind {
-		versions := r.Map[g]
-		for version, kinds := range versions {
-			for _, el := range kinds {
+
+	// The cache is written by the CRD informer's event handlers, so reading it
+	// has to hold the lock. The whole body takes the lock once rather than
+	// locking each read: the warning bookkeeping writes to the cache as well,
+	// and sync.RWMutex is not reentrant, so a nested Safe* call from inside a
+	// held lock would deadlock. The logging is deliberately left outside.
+	warnMissing := false
+	r.SafeWrite(func() {
+		// No need to resolve, return.
+		if hasVersion && hasKind {
+			for _, el := range r.Map[g][v] {
 				if el.Kind == k {
-					resolvedGVKPs = append(resolvedGVKPs, groupVersionKindPlural{
-						GroupVersionKind: schema.GroupVersionKind{
-							Group:   g,
-							Version: version,
-							Kind:    k,
+					r.clearMissingGVKWarningLocked(gvk)
+					resolvedGVKPs = []groupVersionKindPlural{
+						{
+							GroupVersionKind: schema.GroupVersionKind{
+								Group:   g,
+								Version: v,
+								Kind:    k,
+							},
+							Plural: el.Plural,
 						},
-						Plural: el.Plural,
-					})
+					}
+					return
 				}
 			}
+			warnMissing = r.markMissingGVKWarnedLocked(gvk)
+			return
 		}
-	}
-	if !hasVersion && !hasKind {
-		versions := r.Map[g]
-		for version, kinds := range versions {
+		if hasVersion && !hasKind {
+			kinds := r.Map[g][v]
 			for _, el := range kinds {
 				resolvedGVKPs = append(resolvedGVKPs, groupVersionKindPlural{
 					GroupVersionKind: schema.GroupVersionKind{
 						Group:   g,
-						Version: version,
+						Version: v,
 						Kind:    el.Kind,
 					},
 					Plural: el.Plural,
 				})
 			}
 		}
+		if !hasVersion && hasKind {
+			versions := r.Map[g]
+			for version, kinds := range versions {
+				for _, el := range kinds {
+					if el.Kind == k {
+						resolvedGVKPs = append(resolvedGVKPs, groupVersionKindPlural{
+							GroupVersionKind: schema.GroupVersionKind{
+								Group:   g,
+								Version: version,
+								Kind:    k,
+							},
+							Plural: el.Plural,
+						})
+					}
+				}
+			}
+		}
+		if !hasVersion && !hasKind {
+			versions := r.Map[g]
+			for version, kinds := range versions {
+				for _, el := range kinds {
+					resolvedGVKPs = append(resolvedGVKPs, groupVersionKindPlural{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   g,
+							Version: version,
+							Kind:    el.Kind,
+						},
+						Plural: el.Plural,
+					})
+				}
+			}
+		}
+	})
+
+	if warnMissing {
+		klog.InfoS("Configured custom resource was not found in the cluster, no metrics will be generated for it until a CRD serving this version is installed", "gvk", gvk)
 	}
-	return
+	return resolvedGVKPs, nil
 }
 
 // PollForCacheUpdates polls the cache for updates and updates the stores accordingly.

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -16,6 +16,7 @@ package discovery
 import (
 	"cmp"
 	"slices"
+	"sync"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -311,4 +312,49 @@ func TestExtractGVKPs(t *testing.T) {
 			t.Errorf("testcase: %s: got %v, want %v", tc.desc, got, tc.want)
 		}
 	}
+}
+
+// The CRD informer's handlers write the cache while the discovery poll resolves
+// configured GVKs against it. Both must go through the lock: a concurrent map
+// read and write is a fatal runtime throw, not a recoverable panic. Run under
+// -race, which CI already does for unit tests.
+func TestResolveGVKToGVKPsIsRaceFree(t *testing.T) {
+	r := &CRDiscoverer{}
+	gvk := schema.GroupVersionKind{Group: "testgroup", Version: "v1", Kind: "TestObject"}
+	gvkp := groupVersionKindPlural{GroupVersionKind: gvk, Plural: "testobjects"}
+
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	// Stand in for the informer's event handlers.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			r.SafeWrite(func() { r.AppendToMap(gvkp) })
+			r.SafeWrite(func() { r.RemoveFromMap(gvkp) })
+		}
+	}()
+
+	// Stand in for the discovery poll resolving configured resources, covering
+	// the fixed lookup and all three wildcard paths.
+	for _, q := range []schema.GroupVersionKind{
+		{Group: "testgroup", Version: "v1", Kind: "TestObject"},
+		{Group: "testgroup", Version: "v1", Kind: "*"},
+		{Group: "testgroup", Version: "*", Kind: "TestObject"},
+		{Group: "testgroup", Version: "*", Kind: "*"},
+	} {
+		wg.Add(1)
+		go func(q schema.GroupVersionKind) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if _, err := r.ResolveGVKToGVKPs(q); err != nil {
+					t.Errorf("resolving %v: %v", q, err)
+					return
+				}
+			}
+		}(q)
+	}
+
+	wg.Wait()
 }

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -79,24 +79,31 @@ func (r *CRDiscoverer) SafeWrite(f func()) {
 func (r *CRDiscoverer) markMissingGVKWarned(gvk schema.GroupVersionKind) bool {
 	firstTime := false
 	r.SafeWrite(func() {
-		if r.warnedMissingGVKs == nil {
-			r.warnedMissingGVKs = map[string]struct{}{}
-		}
-		key := gvk.String()
-		if _, ok := r.warnedMissingGVKs[key]; !ok {
-			r.warnedMissingGVKs[key] = struct{}{}
-			firstTime = true
-		}
+		firstTime = r.markMissingGVKWarnedLocked(gvk)
 	})
 	return firstTime
 }
 
-// clearMissingGVKWarning forgets a previously recorded "missing" warning for the
-// given GVK so that a future disappearance is logged again.
-func (r *CRDiscoverer) clearMissingGVKWarning(gvk schema.GroupVersionKind) {
-	r.SafeWrite(func() {
-		delete(r.warnedMissingGVKs, gvk.String())
-	})
+// markMissingGVKWarnedLocked is markMissingGVKWarned for a caller that already
+// holds the cache lock. sync.RWMutex is not reentrant, so such a caller must not
+// go through SafeWrite.
+func (r *CRDiscoverer) markMissingGVKWarnedLocked(gvk schema.GroupVersionKind) bool {
+	if r.warnedMissingGVKs == nil {
+		r.warnedMissingGVKs = map[string]struct{}{}
+	}
+	key := gvk.String()
+	if _, ok := r.warnedMissingGVKs[key]; ok {
+		return false
+	}
+	r.warnedMissingGVKs[key] = struct{}{}
+	return true
+}
+
+// clearMissingGVKWarningLocked forgets a previously recorded "missing" warning
+// for the given GVK so that a future disappearance is logged again. The caller
+// must hold the cache lock.
+func (r *CRDiscoverer) clearMissingGVKWarningLocked(gvk schema.GroupVersionKind) {
+	delete(r.warnedMissingGVKs, gvk.String())
 }
 
 // AppendToMap appends the given GVKs to the cache.


### PR DESCRIPTION
**What this PR does / why we need it:**

`ResolveGVKToGVKPs` reads and range-iterates `r.Map` with no lock held — at four separate points, one per resolution path. Every other access to that map goes through `SafeRead`/`SafeWrite`, including the CRD informer's add, update and delete handlers, which write it from the informer goroutine.

`ResolveGVKToGVKPs` runs on the discovery poll goroutine, via the factory generator in `pkg/customresourcestate/config.go`. So any CRD add, update or delete that lands while a rebuild is resolving configured resources is a concurrent map read and write. That is a **fatal runtime throw** (`fatal error: concurrent map read and map write`), not a panic anything can recover from — the process dies. Installing an operator bundle with several CRDs, or ordinary CRD status churn, is enough.

**Why the obvious fix does not work:** wrapping the body in `SafeRead` deadlocks. The same function records and clears the "missing GVK" warning through `markMissingGVKWarned`/`clearMissingGVKWarning`, which take the write lock themselves, and `sync.RWMutex` is not reentrant — so the function would block against a lock it already holds.

Instead the body takes the lock once and uses lock-free `...Locked` variants of the warning helpers. One acquisition covers both the map reads and the warning bookkeeping, which is also what makes the read-then-mark sequence atomic rather than a check-then-act across two acquisitions. The `klog` call is deliberately left outside the critical section.

`clearMissingGVKWarning`'s locking wrapper became dead once the caller moved to the locked variant, so it is removed rather than kept behind a lint suppression; `markMissingGVKWarned` keeps its wrapper because the existing dedup test calls it.

### Testing

`TestResolveGVKToGVKPsIsRaceFree` drives the informer's append/remove against all four resolution paths concurrently. Against the current code it reports `WARNING: DATA RACE`; with this change it is clean. CI already runs unit tests with `-race`, so this stays covered.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent discovery resolution to prevent race conditions.
  * Stabilized exact and wildcard matching when mappings are updated simultaneously.
  * Improved handling and logging of missing-resource warnings during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->