### PR TITLE
fix(store): guard the builder state shared with discovery

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -80,11 +81,15 @@ type Builder struct {
 	// namespaceFilter is inside fieldSelectorFilter
 	fieldSelectorFilter string
 	namespaces          options.NamespaceList
-	enabledResources    []string
-	totalShards         int
-	shard               int32
-	useAPIServerCache   bool
-	objectLimit         int64
+	// enabledResourcesMu guards enabledResources, which WithEnabledResources
+	// appends to from the custom resource discovery goroutine while Build reads
+	// it from the goroutine driving the rebuild.
+	enabledResourcesMu sync.RWMutex
+	enabledResources   []string
+	totalShards        int
+	shard              int32
+	useAPIServerCache  bool
+	objectLimit        int64
 
 	GetGVKStopChan func(gvk string) chan struct{}
 }
@@ -116,6 +121,9 @@ func (b *Builder) WithEnabledResources(r []string) error {
 			return fmt.Errorf("resource %s does not exist. Available resources: %s", resource, strings.Join(availableResources(), ","))
 		}
 	}
+
+	b.enabledResourcesMu.Lock()
+	defer b.enabledResourcesMu.Unlock()
 
 	b.enabledResources = append(b.enabledResources, r...)
 	slices.Sort(b.enabledResources)
@@ -215,10 +223,7 @@ func (b *Builder) WithCustomResourceStoreFactories(fs ...customresource.Registry
 		} else {
 			gvrString = f.Name()
 		}
-		if _, ok := availableStores[gvrString]; ok {
-			klog.InfoS("Updating store", "GVR", gvrString)
-		}
-		availableStores[gvrString] = func(b *Builder) []cache.Store {
+		replaced := registerStore(gvrString, func(b *Builder) []cache.Store {
 			return b.buildCustomResourceStoresFunc(
 				f.Name(),
 				f.MetricFamilyGenerators(),
@@ -227,6 +232,9 @@ func (b *Builder) WithCustomResourceStoreFactories(fs ...customresource.Registry
 				b.useAPIServerCache,
 				b.objectLimit,
 			)
+		})
+		if replaced {
+			klog.InfoS("Updating store", "GVR", gvrString)
 		}
 	}
 }
@@ -250,7 +258,7 @@ func (b *Builder) allowList(list map[string][]string) (map[string][]string, erro
 		return list, nil
 	}
 	m := make(map[string][]string)
-	for _, resource := range b.enabledResources {
+	for _, resource := range b.enabledResourcesSnapshot() {
 		m[resource] = allowedList
 	}
 	return m, nil
@@ -270,6 +278,16 @@ func (b *Builder) WithAllowLabels(labels map[string][]string) error {
 	return err
 }
 
+// enabledResourcesSnapshot returns a copy of the enabled resources. Callers take
+// a copy rather than holding the lock for the whole build: the store
+// constructors mutate the builder as they run, so holding it across them would
+// be both a longer critical section than needed and a write under a read lock.
+func (b *Builder) enabledResourcesSnapshot() []string {
+	b.enabledResourcesMu.RLock()
+	defer b.enabledResourcesMu.RUnlock()
+	return slices.Clone(b.enabledResources)
+}
+
 // Build initializes and registers all enabled stores.
 // It returns metrics writers which can be used to write out
 // metrics from the stores.
@@ -281,8 +299,8 @@ func (b *Builder) Build() metricsstore.MetricsWriterList {
 	var metricsWriters metricsstore.MetricsWriterList
 	var activeStoreNames []string
 
-	for _, c := range b.enabledResources {
-		constructor, ok := availableStores[c]
+	for _, c := range b.enabledResourcesSnapshot() {
+		constructor, ok := lookupStore(c)
 		if ok {
 			stores := cacheStoresToMetricStores(constructor(b))
 			activeStoreNames = append(activeStoreNames, c)
@@ -308,8 +326,8 @@ func (b *Builder) BuildStores() [][]cache.Store {
 	var allStores [][]cache.Store
 	var activeStoreNames []string
 
-	for _, c := range b.enabledResources {
-		constructor, ok := availableStores[c]
+	for _, c := range b.enabledResourcesSnapshot() {
+		constructor, ok := lookupStore(c)
 		if ok {
 			stores := constructor(b)
 			activeStoreNames = append(activeStoreNames, c)
@@ -321,6 +339,14 @@ func (b *Builder) BuildStores() [][]cache.Store {
 
 	return allStores
 }
+
+// availableStoresMu guards availableStores. The map is package state seeded with
+// the built-in resources, but WithCustomResourceStoreFactories adds to it from
+// the custom resource discovery goroutine while Build reads it from whichever
+// goroutine triggered the rebuild -- the autosharding informer, for instance.
+// A concurrent map read and write is a fatal runtime throw, not a recoverable
+// panic, so every access goes through the helpers below.
+var availableStoresMu sync.RWMutex
 
 var availableStores = map[string]func(f *Builder) []cache.Store{
 	"certificatesigningrequests":        func(b *Builder) []cache.Store { return b.buildCsrStores() },
@@ -364,12 +390,32 @@ var availableStores = map[string]func(f *Builder) []cache.Store{
 	"volumeattachments":                 func(b *Builder) []cache.Store { return b.buildVolumeAttachmentStores() },
 }
 
+// lookupStore returns the store constructor registered for name.
+func lookupStore(name string) (func(*Builder) []cache.Store, bool) {
+	availableStoresMu.RLock()
+	defer availableStoresMu.RUnlock()
+	constructor, ok := availableStores[name]
+	return constructor, ok
+}
+
+// registerStore records the store constructor for name, replacing any previous
+// one, and reports whether it replaced an existing entry.
+func registerStore(name string, constructor func(*Builder) []cache.Store) bool {
+	availableStoresMu.Lock()
+	defer availableStoresMu.Unlock()
+	_, existed := availableStores[name]
+	availableStores[name] = constructor
+	return existed
+}
+
 func resourceExists(name string) bool {
-	_, ok := availableStores[name]
+	_, ok := lookupStore(name)
 	return ok
 }
 
 func availableResources() []string {
+	availableStoresMu.RLock()
+	defer availableStoresMu.RUnlock()
 	c := []string{}
 	for name := range availableStores {
 		c = append(c, name)

--- a/internal/store/builder_test.go
+++ b/internal/store/builder_test.go
@@ -18,13 +18,16 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/kube-state-metrics/v2/pkg/allowdenylist"
 	"k8s.io/kube-state-metrics/v2/pkg/options"
@@ -343,4 +346,55 @@ func TestClusterScopedStoresNotDuplicatedPerNamespace(t *testing.T) {
 	if got := len(b.buildPodStores()); got != 3 {
 		t.Errorf("namespaced pod stores across 3 namespaces: got %d, want 3", got)
 	}
+}
+
+// The custom resource discovery goroutine registers store factories and enabled
+// resources while a rebuild -- triggered from the autosharding informer, for
+// instance -- reads them. A concurrent map read and write on the package-level
+// store registry is a fatal runtime throw, not a recoverable panic. Run under
+// -race, which CI already does for unit tests.
+func TestBuilderSharedStateIsRaceFree(t *testing.T) {
+	const iterations = 200
+
+	b := NewBuilder()
+	b.WithMetrics(prometheus.NewRegistry())
+	b.WithEnabledResources([]string{"pods"}) //nolint:errcheck
+
+	var wg sync.WaitGroup
+
+	// Stand in for discovery registering factories for discovered CRDs.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			registerStore(fmt.Sprintf("testgroup/v1, Resource=test%d", i), func(*Builder) []cache.Store { return nil })
+		}
+	}()
+
+	// Stand in for discovery updating the enabled set.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if err := b.WithEnabledResources([]string{"pods"}); err != nil {
+				t.Errorf("enabling resources: %v", err)
+				return
+			}
+		}
+	}()
+
+	// Stand in for the rebuild reading both.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			for _, name := range b.enabledResourcesSnapshot() {
+				lookupStore(name) //nolint:errcheck
+			}
+			availableResources()
+			resourceExists("pods")
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

`availableStores` is package state, seeded with the built-in resources, and `WithCustomResourceStoreFactories` adds entries to it:

```go
if _, ok := availableStores[gvrString]; ok { ... }
availableStores[gvrString] = func(b *Builder) []cache.Store { ... }
```

Custom resource discovery calls that from its poll goroutine with no lock held (`internal/discovery/discovery.go`, before `BuildWriters`), while `Build` and `BuildStores` read the same map from whichever goroutine drove the rebuild — the autosharding informer, for instance, reacting to a StatefulSet replica change.

A concurrent map read and write is a **fatal runtime throw**, not a panic anything can recover from. So a CRD add, update or delete landing alongside a re-shard can kill the process. The window is short and no test drives both paths, which is why `-race` in CI has never seen it.

This puts the map behind a `sync.RWMutex`, reached through `lookupStore` and `registerStore` so no access can bypass it, and guards the `range` in `availableResources` too. `resourceExists` goes through `lookupStore`.

`b.enabledResources` has exactly the same pair of writers and readers — `WithEnabledResources` appends and sorts it from the discovery goroutine, `Build` ranges over it — so it gets a lock as well. `Build` takes a **copy** rather than holding the read lock for the whole build: the store constructors it invokes mutate the builder as they run (`buildStores` swaps `b.namespaces` and restores it via defer), so holding a read lock across them would mean a write under a read lock.

### Scope

The two remaining fields discovery writes, `customResourceClients` and `buildCustomResourceStoresFunc`, are whole-value assignments read later during the build. They are still races in the strict sense, but they are single-word writes rather than map mutation, so they cannot produce the fatal throw this PR is about. Fixing them properly means making `Build` stop mutating the builder mid-flight, which is a larger refactor and better kept separate.

### Testing

`TestBuilderSharedStateIsRaceFree` drives factory registration and resource enablement against the rebuild's reads. Against the current code the race detector reports three data races; with this change it is clean. CI already runs unit tests with `-race`.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when store configuration and enabled resources are accessed or updated concurrently.
  * Prevented inconsistent resource and store lookups during simultaneous operations.
  * Custom resource replacements now report their registration status accurately.

* **Tests**
  * Added concurrency coverage to verify race-free behavior across repeated parallel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->