### PR TITLE
fix(endpointslice): build each hint's labels independently

### DIFF
--- a/internal/store/endpointslice.go
+++ b/internal/store/endpointslice.go
@@ -102,26 +102,32 @@ func createEndpointsSliceHints() generator.FamilyGenerator {
 			for _, ep := range e.Endpoints {
 				// Hint is populated when the endpoint is configured to be zone aware and preferentially route requests to its local zone.
 				// If there is no hint, skip this metric
-				if ep.Hints != nil && len(ep.Hints.ForZones) > 0 {
-					var (
-						labelKeys,
-						labelValues []string
-					)
+				if ep.Hints == nil || len(ep.Hints.ForZones) == 0 {
+					continue
+				}
 
-					// Per Docs.
-					// This must contain at least one address but no more than
-					// 100. These are all assumed to be fungible and clients may choose to only
-					// use the first element. Refer to: https://issue.k8s.io/106267
-					labelKeys = append(labelKeys, "address")
-					labelValues = append(labelValues, ep.Addresses[0])
+				// Per Docs.
+				// This must contain at least one address but no more than
+				// 100. These are all assumed to be fungible and clients may choose to only
+				// use the first element. Refer to: https://issue.k8s.io/106267
+				// Validation enforces the lower bound today, but indexing on the
+				// strength of a comment is one relaxation away from a panic on the
+				// reflector goroutine.
+				if len(ep.Addresses) == 0 {
+					continue
+				}
+				address := ep.Addresses[0]
 
-					for _, zone := range ep.Hints.ForZones {
-						m = append(m, &metric.Metric{
-							LabelKeys:   append(labelKeys, "for_zone"),
-							LabelValues: append(labelValues, zone.Name),
-							Value:       1,
-						})
-					}
+				for _, zone := range ep.Hints.ForZones {
+					// Built per zone rather than appended onto a slice shared by
+					// the loop: if that slice ever had spare capacity, every zone
+					// would write into the same backing array and report the last
+					// one.
+					m = append(m, &metric.Metric{
+						LabelKeys:   []string{"address", "for_zone"},
+						LabelValues: []string{address, zone.Name},
+						Value:       1,
+					})
 				}
 			}
 			return &metric.Family{

--- a/internal/store/endpointslice_test.go
+++ b/internal/store/endpointslice_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package store
 
 import (
+	"slices"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -205,5 +206,65 @@ func TestEndpointSliceStore(t *testing.T) {
 		if err := c.run(); err != nil {
 			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
 		}
+	}
+}
+
+// Each hint gets its own label slices. Building them by appending onto a slice
+// shared across the loop works only while that slice has no spare capacity; with
+// any slack every zone writes into the same backing array and they all report
+// the last one.
+func TestEndpointSliceHintsPerZone(t *testing.T) {
+	es := &discoveryv1.EndpointSlice{
+		ObjectMeta:  metav1.ObjectMeta{Name: "es", Namespace: "ns"},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses: []string{"10.0.0.1"},
+			Hints: &discoveryv1.EndpointHints{
+				ForZones: []discoveryv1.ForZone{{Name: "zone-a"}, {Name: "zone-b"}, {Name: "zone-c"}},
+			},
+		}},
+	}
+
+	g := createEndpointsSliceHints()
+	family := g.Generate(es)
+
+	got := []string{}
+	for _, m := range family.Metrics {
+		if len(m.LabelKeys) != len(m.LabelValues) {
+			t.Fatalf("label keys and values differ in length: %v vs %v", m.LabelKeys, m.LabelValues)
+		}
+		for i, k := range m.LabelKeys {
+			if k == "for_zone" {
+				got = append(got, m.LabelValues[i])
+			}
+		}
+	}
+
+	want := []string{"zone-a", "zone-b", "zone-c"}
+	if !slices.Equal(got, want) {
+		t.Errorf("for_zone values: got %v, want %v", got, want)
+	}
+}
+
+// Validation requires at least one address today, so this is defence against a
+// future relaxation rather than a reachable panic.
+func TestEndpointSliceHintsWithoutAddresses(t *testing.T) {
+	es := &discoveryv1.EndpointSlice{
+		ObjectMeta:  metav1.ObjectMeta{Name: "es", Namespace: "ns"},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{{
+			Hints: &discoveryv1.EndpointHints{ForZones: []discoveryv1.ForZone{{Name: "zone-a"}}},
+		}},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panic on an endpoint with no addresses: %v", r)
+		}
+	}()
+
+	g := createEndpointsSliceHints()
+	if family := g.Generate(es); len(family.Metrics) != 0 {
+		t.Errorf("expected the endpoint to be skipped, got %d metrics", len(family.Metrics))
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

`kube_endpointslice_endpoints_hints` builds one metric per zone by appending onto label slices shared across the loop:

```go
labelKeys = append(labelKeys, "address")
labelValues = append(labelValues, ep.Addresses[0])

for _, zone := range ep.Hints.ForZones {
    m = append(m, &metric.Metric{
        LabelKeys:   append(labelKeys, "for_zone"),
        LabelValues: append(labelValues, zone.Name),
        Value:       1,
    })
}
```

Every iteration appends to the *same* base slice. That is correct today only by accident of allocation: the base is built with a single `append` onto a nil slice, which yields `cap == len == 1`, so each `append` in the loop is forced to reallocate. Give the base any spare capacity — a second base label, or someone switching to `make([]string, 0, n)` — and all zones share one backing array and report the last value:

```
for_zone values: got [zone-c zone-c zone-c], want [zone-a zone-b zone-c]
```

That is the output of the new test against the same code with a `make([]string, 0, 4)` base, so the failure mode is one edit away rather than hypothetical.

Building the two slices per zone removes the hazard and is shorter than the append dance it replaces.

**Also in here:** the same block indexed `ep.Addresses[0]` on the strength of a comment quoting the API docs ("This must contain at least one address"). Validation does enforce that today, so it is not reachable — but it is one relaxation away from a panic on the reflector goroutine, which nothing recovers, so it now skips such an endpoint.

Two tests: one asserting each zone keeps its own value, one asserting an endpoint with no addresses is skipped rather than panicking. Existing `kube_endpointslice_endpoints_hints` output is unchanged.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EndpointSlice topology-hint metrics by skipping endpoints without addresses or routing hints.
  * Ensured zone-specific metrics retain the correct labels and avoid incorrect data sharing.
  * Prevented errors when processing endpoints that have no addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->