### PR TITLE
fix(customresourcestate): do not write GVK labels into the shared config

### DIFF
--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -19,6 +19,7 @@ package customresourcestate
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -38,12 +39,18 @@ import (
 func compile(resource Resource) ([]compiledFamily, error) {
 	var families []compiledFamily
 	// Explicitly add GVK labels to all CR metrics.
-	if resource.CommonLabels == nil {
-		resource.CommonLabels = map[string]string{}
-	}
-	resource.CommonLabels[customResourceState+"_group"] = resource.GroupVersionKind.Group
-	resource.CommonLabels[customResourceState+"_version"] = resource.GroupVersionKind.Version
-	resource.CommonLabels[customResourceState+"_kind"] = resource.GroupVersionKind.Kind
+	//
+	// resource is a copy, but CommonLabels is a map, so it is shared with the
+	// configured resource and with every other copy made from it -- wildcard
+	// resolution produces one per discovered GVK. Writing the GVK labels in
+	// place would have each copy overwrite the last one's values in a map they
+	// all point at. Build a new map instead.
+	commonLabels := make(map[string]string, len(resource.CommonLabels)+3)
+	maps.Copy(commonLabels, resource.CommonLabels)
+	commonLabels[customResourceState+"_group"] = resource.GroupVersionKind.Group
+	commonLabels[customResourceState+"_version"] = resource.GroupVersionKind.Version
+	commonLabels[customResourceState+"_kind"] = resource.GroupVersionKind.Kind
+	resource.CommonLabels = commonLabels
 	for _, f := range resource.Metrics {
 		family, err := compileFamily(f, resource)
 		if err != nil {

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -594,3 +594,37 @@ func mustCompilePath(t *testing.T, path ...string) valuePath {
 	}
 	return out
 }
+
+// Wildcard resolution produces one Resource copy per discovered GVK, all sharing
+// the CommonLabels map of the configured resource. Writing the GVK labels into
+// that shared map would have each copy overwrite the last one's values, and
+// would leak them back into the caller's configuration.
+func Test_compile_doesNotShareCommonLabels(t *testing.T) {
+	configured := map[string]string{"team": "myteam"}
+	base := Resource{
+		Labels: Labels{CommonLabels: configured},
+		Metrics: []Generator{{
+			Name: "foo",
+			Each: Metric{Type: metric.Gauge, Gauge: &MetricGauge{MetricMeta: MetricMeta{Path: []string{"status"}}}},
+		}},
+	}
+
+	v1 := base
+	v1.GroupVersionKind = GroupVersionKind{Group: "myteam.io", Version: "v1", Kind: "Foo"}
+	familiesV1, err := compile(v1)
+	assert.NoError(t, err)
+
+	v2 := base
+	v2.GroupVersionKind = GroupVersionKind{Group: "myteam.io", Version: "v2", Kind: "Bar"}
+	familiesV2, err := compile(v2)
+	assert.NoError(t, err)
+
+	// The first resolution must not have been rewritten by the second.
+	assert.Equal(t, "v1", familiesV1[0].Labels[customResourceState+"_version"])
+	assert.Equal(t, "Foo", familiesV1[0].Labels[customResourceState+"_kind"])
+	assert.Equal(t, "v2", familiesV2[0].Labels[customResourceState+"_version"])
+	assert.Equal(t, "Bar", familiesV2[0].Labels[customResourceState+"_kind"])
+
+	// And the configured map must be left as the user wrote it.
+	assert.Equal(t, map[string]string{"team": "myteam"}, configured)
+}

--- a/pkg/customresourcestate/registry_factory_test.go
+++ b/pkg/customresourcestate/registry_factory_test.go
@@ -595,10 +595,8 @@ func mustCompilePath(t *testing.T, path ...string) valuePath {
 	return out
 }
 
-// Wildcard resolution produces one Resource copy per discovered GVK, all sharing
-// the CommonLabels map of the configured resource. Writing the GVK labels into
-// that shared map would have each copy overwrite the last one's values, and
-// would leak them back into the caller's configuration.
+// Wildcard resolution compiles one Resource copy per GVK off a shared
+// CommonLabels map, so writing GVK labels into it would clobber every copy.
 func Test_compile_doesNotShareCommonLabels(t *testing.T) {
 	configured := map[string]string{"team": "myteam"}
 	base := Resource{
@@ -619,12 +617,10 @@ func Test_compile_doesNotShareCommonLabels(t *testing.T) {
 	familiesV2, err := compile(v2)
 	assert.NoError(t, err)
 
-	// The first resolution must not have been rewritten by the second.
 	assert.Equal(t, "v1", familiesV1[0].Labels[customResourceState+"_version"])
 	assert.Equal(t, "Foo", familiesV1[0].Labels[customResourceState+"_kind"])
 	assert.Equal(t, "v2", familiesV2[0].Labels[customResourceState+"_version"])
 	assert.Equal(t, "Bar", familiesV2[0].Labels[customResourceState+"_kind"])
 
-	// And the configured map must be left as the user wrote it.
 	assert.Equal(t, map[string]string{"team": "myteam"}, configured)
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

`compile` takes `Resource` by value, but `CommonLabels` is a map, so the copy shares it with the configured resource and with every other copy made from it — and wildcard resolution produces one copy per discovered GVK:

```go
if resource.CommonLabels == nil {
	resource.CommonLabels = map[string]string{}
}
resource.CommonLabels[customResourceState+"_group"] = resource.GroupVersionKind.Group
resource.CommonLabels[customResourceState+"_version"] = resource.GroupVersionKind.Version
resource.CommonLabels[customResourceState+"_kind"] = resource.GroupVersionKind.Kind
```

Those three writes go into a map every copy points at, and into the user's configuration. Compiling `myteam.io/v1 Foo` and then `myteam.io/v2 Bar` from one configured resource leaves the caller's map as:

```
expected: map[string]string{"team":"myteam"}
actual:   map[string]string{"customresource_group":"myteam.io",
                            "customresource_kind":"Bar",
                            "customresource_version":"v2",
                            "team":"myteam"}
```

**To be clear about severity:** the emitted metrics are correct today. Each `compile` overwrites all three keys before `Merge` copies them into the family, and factories are built one at a time, so no family ends up with another GVK's labels. This is a hazard rather than a live bug — but it is one concurrent or partially-overwriting compile away from being one, and mutating configuration the caller owns is wrong regardless.

Building a new map removes the sharing. The test asserts both that each resolution keeps its own GVK labels and that the configured map is left as the user wrote it; the second assertion fails on `main` with the output above.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where resources resolved from wildcards could share or overwrite labels.
  * Common labels now remain unchanged when resource-specific labels are added.
  * Resources with different group, version, and kind values retain independent labels, improving label accuracy and consistency.

* **Tests**
  * Added regression coverage for label isolation and preservation of configured common labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->