### PR TITLE
fix(discovery): check the CRD fields instead of asserting them

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -95,12 +95,22 @@ func extractGVKPs(obj interface{}) []groupVersionKindPlural {
 			klog.ErrorS(nil, "CRD version has no name", "crd", u.GetName())
 			continue
 		}
-		// Versions that are not served by the API server cannot be listed or watched,
-		// so any reflector started for them would fail indefinitely. `served` is a
-		// required field on apiextensions.k8s.io/v1, treat it as served if absent.
-		if served, ok := versionSpec["served"].(bool); ok && !served {
-			klog.V(1).InfoS("skipping CRD version that is not served by the API server", "group", g, "version", v, "kind", k)
-			continue
+		// Versions that are not served by the API server cannot be listed or
+		// watched, so any reflector started for them would fail indefinitely.
+		// `served` is a required field on apiextensions.k8s.io/v1, so treat it as
+		// served when absent, but skip the version when it is present and not a
+		// bool: the point of this check is to avoid starting a reflector that can
+		// never succeed, and a value we cannot read is not a reason to start one.
+		if rawServed, present := versionSpec["served"]; present {
+			served, ok := rawServed.(bool)
+			if !ok {
+				klog.ErrorS(nil, "CRD version has a non-boolean served field", "crd", u.GetName(), "version", v)
+				continue
+			}
+			if !served {
+				klog.V(1).InfoS("skipping CRD version that is not served by the API server", "group", g, "version", v, "kind", k)
+				continue
+			}
 		}
 		gvkps = append(gvkps, groupVersionKindPlural{
 			GroupVersionKind: schema.GroupVersionKind{

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -48,17 +48,57 @@ func extractGVKPs(obj interface{}) []groupVersionKindPlural {
 		klog.ErrorS(nil, "expected *unstructured.Unstructured", "got", fmt.Sprintf("%T", obj))
 		return nil
 	}
-	objSpec := u.Object["spec"].(map[string]interface{})
-	g := objSpec["group"].(string)
-	k := objSpec["names"].(map[string]interface{})["kind"].(string)
-	p := objSpec["names"].(map[string]interface{})["plural"].(string)
+	// Every field read below is required on apiextensions.k8s.io/v1, so a CRD the
+	// API server accepted has them. They are still checked rather than asserted:
+	// this runs on the informer goroutine, where a failed assertion is an
+	// unrecovered panic that takes the process down, and the cost of being wrong
+	// about the shape of one object should be that object being skipped.
+	objSpec, ok := u.Object["spec"].(map[string]interface{})
+	if !ok {
+		klog.ErrorS(nil, "CRD has no spec object", "crd", u.GetName())
+		return nil
+	}
+	g, ok := objSpec["group"].(string)
+	if !ok {
+		klog.ErrorS(nil, "CRD spec has no group", "crd", u.GetName())
+		return nil
+	}
+	names, ok := objSpec["names"].(map[string]interface{})
+	if !ok {
+		klog.ErrorS(nil, "CRD spec has no names object", "crd", u.GetName())
+		return nil
+	}
+	k, ok := names["kind"].(string)
+	if !ok {
+		klog.ErrorS(nil, "CRD spec has no kind", "crd", u.GetName())
+		return nil
+	}
+	p, ok := names["plural"].(string)
+	if !ok {
+		klog.ErrorS(nil, "CRD spec has no plural", "crd", u.GetName())
+		return nil
+	}
+	versions, ok := objSpec["versions"].([]interface{})
+	if !ok {
+		klog.ErrorS(nil, "CRD spec has no versions list", "crd", u.GetName())
+		return nil
+	}
 	var gvkps []groupVersionKindPlural
-	for _, version := range objSpec["versions"].([]interface{}) {
-		v := version.(map[string]interface{})["name"].(string)
+	for _, version := range versions {
+		versionSpec, ok := version.(map[string]interface{})
+		if !ok {
+			klog.ErrorS(nil, "CRD version is not an object", "crd", u.GetName())
+			continue
+		}
+		v, ok := versionSpec["name"].(string)
+		if !ok {
+			klog.ErrorS(nil, "CRD version has no name", "crd", u.GetName())
+			continue
+		}
 		// Versions that are not served by the API server cannot be listed or watched,
 		// so any reflector started for them would fail indefinitely. `served` is a
 		// required field on apiextensions.k8s.io/v1, treat it as served if absent.
-		if served, ok := version.(map[string]interface{})["served"].(bool); ok && !served {
+		if served, ok := versionSpec["served"].(bool); ok && !served {
 			klog.V(1).InfoS("skipping CRD version that is not served by the API server", "group", g, "version", v, "kind", k)
 			continue
 		}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -304,6 +304,59 @@ func TestExtractGVKPs(t *testing.T) {
 			obj:  "not-a-crd",
 			want: nil,
 		},
+		// Every field below is required on apiextensions.k8s.io/v1, so the API
+		// server would reject these. They are covered because extractGVKPs runs
+		// on the informer goroutine, where a failed type assertion is an
+		// unrecovered panic rather than a skipped object.
+		{
+			desc: "no spec",
+			obj:  &unstructured.Unstructured{Object: map[string]interface{}{}},
+			want: nil,
+		},
+		{
+			desc: "spec is not an object",
+			obj:  &unstructured.Unstructured{Object: map[string]interface{}{"spec": "nope"}},
+			want: nil,
+		},
+		{
+			desc: "no group",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{"names": map[string]interface{}{"kind": "K", "plural": "ks"}},
+			}},
+			want: nil,
+		},
+		{
+			desc: "no names",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{"group": "g"},
+			}},
+			want: nil,
+		},
+		{
+			desc: "no versions",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"group": "g",
+					"names": map[string]interface{}{"kind": "K", "plural": "ks"},
+				},
+			}},
+			want: nil,
+		},
+		{
+			desc: "a malformed version is skipped, the rest are kept",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"group": "testgroup",
+					"names": map[string]interface{}{"kind": "TestObject", "plural": "testobjects"},
+					"versions": []interface{}{
+						"not-an-object",
+						map[string]interface{}{"served": true},
+						map[string]interface{}{"name": "v1", "served": true},
+					},
+				},
+			}},
+			want: []groupVersionKindPlural{gvkp("v1")},
+		},
 	}
 	for _, tc := range testcases {
 		got := extractGVKPs(tc.obj)

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -295,6 +295,14 @@ func TestExtractGVKPs(t *testing.T) {
 			want: []groupVersionKindPlural{gvkp("v1")},
 		},
 		{
+			// served is present but unreadable, so whether the API server would
+			// serve this version is unknown. Skip it rather than start a
+			// reflector that may never succeed.
+			desc: "non-boolean served field is skipped",
+			obj:  crd(version("v1", "false"), version("v2", true)),
+			want: []groupVersionKindPlural{gvkp("v2")},
+		},
+		{
 			desc: "tombstoned object is unwrapped",
 			obj:  cache.DeletedFinalStateUnknown{Key: "testobjects.testgroup", Obj: crd(version("v1", true), version("v1beta1", false))},
 			want: []groupVersionKindPlural{gvkp("v1")},


### PR DESCRIPTION
**What this PR does / why we need it:**

`extractGVKPs` reads the CRD spec with bare type assertions:

```go
objSpec := u.Object["spec"].(map[string]interface{})
g := objSpec["group"].(string)
k := objSpec["names"].(map[string]interface{})["kind"].(string)
p := objSpec["names"].(map[string]interface{})["plural"].(string)
for _, version := range objSpec["versions"].([]interface{}) {
	v := version.(map[string]interface{})["name"].(string)
```

Seven assertions, any of which panics on an object shaped differently than expected. Every field is required on `apiextensions.k8s.io/v1`, so a CRD the API server accepted does have them — I could not construct a realistic response that trips this, and I am **not** claiming a reachable bug.

The reason to fix it anyway is the blast radius. `extractGVKPs` runs from the CRD informer's event handlers, on the informer goroutine, where nothing recovers: a failed assertion is not a skipped object, it is the exporter exiting. The cost of being wrong about the shape of one object should be that object being skipped, not the process dying — the same reasoning that already applies to the `DeletedFinalStateUnknown` and `*unstructured.Unstructured` checks immediately above these lines.

Each field is now checked, with the failure logged and scoped: an unusable spec skips the whole CRD, a malformed single version skips just that version and keeps the rest.

Six new cases in `TestExtractGVKPs` cover a missing spec, a non-object spec, missing group, names and versions, and a versions list mixing a non-object, a nameless entry and a valid one. They panic on `main` (`interface conversion: interface {} is nil, not map[string]interface {}`) and pass here.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed or incomplete custom resource definitions.
  - Invalid definitions and version entries are now safely skipped instead of causing failures.
  - Valid versions continue to be processed as expected.

- **Tests**
  - Added coverage for missing fields, incorrect data types, and malformed version entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->