### PR TITLE
fix(proc): start the reaper only once

### DIFF
--- a/pkg/util/proc/reaper.go
+++ b/pkg/util/proc/reaper.go
@@ -21,33 +21,54 @@ package proc
 import (
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"k8s.io/klog/v2"
 )
 
+var (
+	reaperOnce = new(sync.Once)
+
+	// Indirected so the guard can be tested without the test binary running as
+	// pid 1 or registering a real SIGCHLD handler.
+	getpid = os.Getpid
+	launch = func() { go reapChildren() }
+)
+
 // StartReaper starts a goroutine to reap processes if called from a process
 // that has pid 1.
+//
+// It is safe to call more than once: the reaper runs for the lifetime of the
+// process and has no stop path, and RunKubeStateMetrics -- which calls this --
+// is restarted by the config file watchers on every reload. Without the guard
+// each reload would strand another goroutine blocked on its own signal channel,
+// which the signal package keeps a reference to, so it is never collected.
 func StartReaper() {
-	if os.Getpid() == 1 {
+	if getpid() != 1 {
+		return
+	}
+	reaperOnce.Do(func() {
 		klog.V(4).InfoS("Launching reaper")
-		go func() {
-			sigs := make(chan os.Signal, 1)
-			signal.Notify(sigs, syscall.SIGCHLD)
-			for {
-				// Wait for a child to terminate
-				sig := <-sigs
-				klog.V(4).InfoS("Signal received", "signal", sig)
-				for {
-					// Reap processes
-					cpid, _ := syscall.Wait4(-1, nil, syscall.WNOHANG, nil)
-					if cpid < 1 {
-						break
-					}
+		launch()
+	})
+}
 
-					klog.V(4).InfoS("Reaped process with pid", "cpid", cpid)
-				}
+func reapChildren() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGCHLD)
+	for {
+		// Wait for a child to terminate
+		sig := <-sigs
+		klog.V(4).InfoS("Signal received", "signal", sig)
+		for {
+			// Reap processes
+			cpid, _ := syscall.Wait4(-1, nil, syscall.WNOHANG, nil)
+			if cpid < 1 {
+				break
 			}
-		}()
+
+			klog.V(4).InfoS("Reaped process with pid", "cpid", cpid)
+		}
 	}
 }

--- a/pkg/util/proc/reaper_test.go
+++ b/pkg/util/proc/reaper_test.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proc
+
+import (
+	"sync"
+	"testing"
+)
+
+// withStubs points the package at a fake pid and a launcher that only counts, so
+// the test neither has to run as pid 1 nor registers a real SIGCHLD handler in
+// the test binary.
+func withStubs(t *testing.T, pid int) *int {
+	t.Helper()
+
+	origOnce, origGetpid, origLaunch := reaperOnce, getpid, launch
+	t.Cleanup(func() {
+		reaperOnce, getpid, launch = origOnce, origGetpid, origLaunch
+	})
+
+	launched := 0
+	reaperOnce = new(sync.Once)
+	getpid = func() int { return pid }
+	launch = func() { launched++ }
+	return &launched
+}
+
+// RunKubeStateMetrics calls StartReaper and the config file watchers restart it
+// on every reload, so repeated calls must not each strand a reaper goroutine.
+func TestStartReaperLaunchesOnce(t *testing.T) {
+	launched := withStubs(t, 1)
+
+	for i := 0; i < 5; i++ {
+		StartReaper()
+	}
+
+	if *launched != 1 {
+		t.Errorf("reaper launched %d times, want 1", *launched)
+	}
+}
+
+// Reaping is only the responsibility of the init process.
+func TestStartReaperSkippedWhenNotPID1(t *testing.T) {
+	launched := withStubs(t, 4242)
+
+	StartReaper()
+
+	if *launched != 0 {
+		t.Errorf("reaper launched %d times off pid 1, want 0", *launched)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

`StartReaper` spawns a goroutine that runs for the lifetime of the process and has no stop path:

```go
func StartReaper() {
	if os.Getpid() == 1 {
		go func() {
			sigs := make(chan os.Signal, 1)
			signal.Notify(sigs, syscall.SIGCHLD)
			for { ... }        // never returns
		}()
	}
}
```

It is called from `RunKubeStateMetrics` (`pkg/app/server.go:275`), and `internal/wrapper.go` restarts `RunKubeStateMetrics` on **every config reload**. So each reload leaves another reaper behind, blocked on its own signal channel — which the `signal` package holds a reference to, so it is never collected. Reproduced with the same goroutine body:

```
after 5 calls: goroutines grew by 5
```

It only applies when the exporter runs as pid 1, which is the ordinary case for a container without an init system. And duplicate reapers are otherwise harmless — `Wait4` uses `WNOHANG`, so they race to reap and the losers simply find no children — which is exactly why this leaks quietly instead of breaking something visible. The cost is a goroutine and a channel per reload, so it matters for deployments whose configuration changes regularly.

Guarded with a `sync.Once`. The pid lookup and the goroutine launch are indirected through package variables so the guard can be tested without the test binary having to run as pid 1 or registering a real `SIGCHLD` handler in the test process — the latter matters, because a live handler calling `Wait4(-1, ...)` in a test binary could reap children belonging to other tests.

Two tests: repeated calls launch exactly one reaper (5 launches on `main`, 1 here), and nothing is launched when the process is not pid 1. Both are `//go:build linux`, matching the file they cover.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved child-process cleanup when running as the system’s initial process.
  * Prevented duplicate reaper processes, signal handlers, and background tasks when initialization is requested repeatedly.
  * Ensured child-process reaping continues reliably without blocking.

* **Tests**
  * Added coverage for initialization behavior under different process IDs.
  * Added verification that repeated initialization starts only one reaper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->