### PR TITLE
fix(util): rebuild the clients from the current kubeconfig

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -105,15 +104,6 @@ func CreateCustomResourceClients(apiserver string, kubeconfig string, factories 
 		customResourceClients[gvrString] = customResourceClient
 	}
 	return customResourceClients, nil
-}
-
-// CreateDiscoveryClient creates a Kubernetes discovery client.
-func CreateDiscoveryClient(apiserver string, kubeconfig string) (*discovery.DiscoveryClient, error) {
-	config, err := buildConfig(apiserver, kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-	return discovery.NewDiscoveryClientForConfig(config)
 }
 
 // GVRFromType returns the GroupVersionResource for a given type.

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -36,28 +36,29 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/customresource"
 )
 
-var config *rest.Config
-var currentKubeClient clientset.Interface
-var currentDiscoveryClient *discovery.DiscoveryClient
-
-// CreateKubeClient creates a Kubernetes clientset and a custom resource clientset.
-func CreateKubeClient(apiserver string, kubeconfig string) (clientset.Interface, error) {
-	if currentKubeClient != nil {
-		return currentKubeClient, nil
-	}
-
-	var err error
-
-	if config == nil {
-		config, err = clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
-		if err != nil {
-			return nil, err
-		}
+// buildConfig reads the kubeconfig and applies the settings every client here
+// shares. It is deliberately not memoized: the kubeconfig is watched for
+// changes, and a rotation rewrites the file rather than changing its path, so a
+// cache keyed on the arguments would still hand back superseded credentials.
+func buildConfig(apiserver string, kubeconfig string) (*rest.Config, error) {
+	config, err := clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
+	if err != nil {
+		return nil, err
 	}
 
 	config.UserAgent = fmt.Sprintf("%s/%s (%s/%s) kubernetes/%s", "kube-state-metrics", version.Version, runtime.GOOS, runtime.GOARCH, version.Revision)
 	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
 	config.ContentType = "application/vnd.kubernetes.protobuf"
+
+	return config, nil
+}
+
+// CreateKubeClient creates a Kubernetes clientset and a custom resource clientset.
+func CreateKubeClient(apiserver string, kubeconfig string) (clientset.Interface, error) {
+	config, err := buildConfig(apiserver, kubeconfig)
+	if err != nil {
+		return nil, err
+	}
 
 	kubeClient, err := clientset.NewForConfig(config)
 	if err != nil {
@@ -75,19 +76,15 @@ func CreateKubeClient(apiserver string, kubeconfig string) (clientset.Interface,
 	klog.InfoS("Run with Kubernetes cluster version", "major", v.Major, "minor", v.Minor, "gitVersion", v.GitVersion, "gitTreeState", v.GitTreeState, "gitCommit", v.GitCommit, "platform", v.Platform)
 	klog.InfoS("Communication with server successful")
 
-	currentKubeClient = kubeClient
 	return kubeClient, nil
 }
 
 // CreateCustomResourceClients creates a custom resource clientset.
 func CreateCustomResourceClients(apiserver string, kubeconfig string, factories ...customresource.RegistryFactory) (map[string]interface{}, error) {
 	// Not relying on memoized clients here because the factories are subject to change.
-	var err error
-	if config == nil {
-		config, err = clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
-		if err != nil {
-			return nil, err
-		}
+	config, err := buildConfig(apiserver, kubeconfig)
+	if err != nil {
+		return nil, err
 	}
 	customResourceClients := make(map[string]interface{}, len(factories))
 	for _, f := range factories {
@@ -112,19 +109,11 @@ func CreateCustomResourceClients(apiserver string, kubeconfig string, factories 
 
 // CreateDiscoveryClient creates a Kubernetes discovery client.
 func CreateDiscoveryClient(apiserver string, kubeconfig string) (*discovery.DiscoveryClient, error) {
-	if currentDiscoveryClient != nil {
-		return currentDiscoveryClient, nil
+	config, err := buildConfig(apiserver, kubeconfig)
+	if err != nil {
+		return nil, err
 	}
-	var err error
-	if config == nil {
-		var err error
-		config, err = clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
-		if err != nil {
-			return nil, err
-		}
-	}
-	currentDiscoveryClient, err = discovery.NewDiscoveryClientForConfig(config)
-	return currentDiscoveryClient, err
+	return discovery.NewDiscoveryClientForConfig(config)
 }
 
 // GVRFromType returns the GroupVersionResource for a given type.

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+// writeKubeconfig writes a minimal kubeconfig pointing at server, and returns its
+// path. Rewriting the same path stands in for a credential rotation, which is
+// what the file watcher in internal/wrapper.go restarts KSM for.
+func writeKubeconfig(t *testing.T, path, server, token string) {
+	t.Helper()
+
+	contents := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: %s
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user:
+    token: %s
+`, server, token)
+
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("writing kubeconfig: %v", err)
+	}
+}
+
+// The kubeconfig path stays the same across a rotation while its contents
+// change, so nothing here may be memoized on the arguments -- or at all.
+func TestBuildConfigReflectsCurrentKubeconfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+
+	writeKubeconfig(t, path, "https://first.example.com", "token-one")
+	first, err := buildConfig("", path)
+	if err != nil {
+		t.Fatalf("building config: %v", err)
+	}
+
+	writeKubeconfig(t, path, "https://second.example.com", "token-two")
+	second, err := buildConfig("", path)
+	if err != nil {
+		t.Fatalf("rebuilding config: %v", err)
+	}
+
+	if first.Host != "https://first.example.com" {
+		t.Errorf("first host: got %q, want %q", first.Host, "https://first.example.com")
+	}
+	if second.Host != "https://second.example.com" {
+		t.Errorf("second host: got %q, want %q", second.Host, "https://second.example.com")
+	}
+	if second.BearerToken != "token-two" {
+		t.Errorf("second token: got %q, want %q", second.BearerToken, "token-two")
+	}
+}
+
+// The kubeconfig watcher restarts KSM so it picks up new credentials, which only
+// works if the client is rebuilt from the file as it stands at that moment.
+func TestCreateKubeClientRebuildsAfterRotation(t *testing.T) {
+	var firstHits, secondHits atomic.Int32
+
+	version := func(hits *atomic.Int32) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/version" {
+				hits.Add(1)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"major":"1","minor":"33","gitVersion":"v1.33.0"}`)
+		}
+	}
+
+	first := httptest.NewServer(version(&firstHits))
+	defer first.Close()
+	second := httptest.NewServer(version(&secondHits))
+	defer second.Close()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+
+	writeKubeconfig(t, path, first.URL, "token-one")
+	if _, err := CreateKubeClient("", path); err != nil {
+		t.Fatalf("creating the first client: %v", err)
+	}
+
+	// Stand in for a rotation: same path, new contents.
+	writeKubeconfig(t, path, second.URL, "token-two")
+	if _, err := CreateKubeClient("", path); err != nil {
+		t.Fatalf("creating the client after rotation: %v", err)
+	}
+
+	if got := firstHits.Load(); got != 1 {
+		t.Errorf("first server saw %d version requests, want 1", got)
+	}
+	if got := secondHits.Load(); got != 1 {
+		t.Errorf("second server saw %d version requests, want 1 -- the client was not rebuilt from the rotated kubeconfig", got)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

`CreateKubeClient` returns a memoized client and ignores its arguments entirely:

```go
func CreateKubeClient(apiserver string, kubeconfig string) (clientset.Interface, error) {
	if currentKubeClient != nil {
		return currentKubeClient, nil
	}
	...
	if config == nil {
		config, err = clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
```

and the `*rest.Config` behind it is built once into a package variable that `CreateCustomResourceClients` and `CreateDiscoveryClient` then reuse.

`internal/wrapper.go` watches the kubeconfig and restarts KSM when it changes, precisely so that new credentials take effect. But the restart calls `CreateKubeClient` again and gets the client built from the **superseded** file, while `pkg/app/server.go:186` builds its own fresh `rest.Config` for the CRD discoverer and the auth filter. So after a certificate or token rotation the two halves of the process are running on different credentials, and the store client keeps failing until the pod is actually restarted — which is the very thing the watcher exists to avoid.

`tests/e2e/hot-reload-kubeconfig_test.go` only asserts that port 8080 comes back up, so it does not catch this.

**Why not just key the cache on the arguments:** a rotation rewrites the kubeconfig and leaves its path alone, so `(apiserver, kubeconfig)` is unchanged across exactly the event we need to react to. Any cache keyed on the arguments would still hand back the old credentials. The memoization has to go.

Each call now builds from the file as it stands. The shared settings move into a `buildConfig` helper, so:

- the custom resource and discovery clients keep getting the user agent and content types that previously only `CreateKubeClient` applied — today they inherit them by side effect, and only if `CreateKubeClient` happened to run first;
- `CreateDiscoveryClient` and `CreateCustomResourceClients` stop depending on call ordering for their configuration.

The cost is re-reading the kubeconfig per call. `CreateKubeClient` runs once per KSM run; `CreateCustomResourceClients` runs per discovery rebuild, where it is negligible against the store reconstruction that follows.

### Testing

`pkg/util` had no test file. Two added, both failing on `main`:

- `TestBuildConfigReflectsCurrentKubeconfig` — rewrites the same path and asserts the second config carries the new host and token. On `main`: `second host: got "https://first.example.com", want "https://second.example.com"`.
- `TestCreateKubeClientRebuildsAfterRotation` — points the kubeconfig at one `httptest` server, rewrites it to a second, and asserts each server sees exactly one `/version` request. On `main` the second sees none.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:** N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Kubernetes and discovery connections now use the latest configuration whenever they are created.
  - Updated kubeconfig files, including rotated credentials and changed endpoints, are recognized automatically.
  - Improved reliability when configuration changes while the application is running.
  - Reduced the risk of stale connection details being used after configuration updates.
  - Added coverage for configuration refresh scenarios to help ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->