### PR TITLE
fix(deployment): do not panic on an unset rollingUpdate value

### DIFF
--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -311,9 +311,13 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 					return &metric.Family{}
 				}
 
+				// GetScaledValueFromIntOrPercent also fails on a nil
+				// MaxUnavailable and on a percentage that does not parse, neither
+				// of which the guard above covers. A single such Deployment must
+				// not crash the exporter, so skip its metric instead.
 				maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*d.Spec.Replicas), false)
 				if err != nil {
-					panic(err)
+					return &metric.Family{}
 				}
 
 				return &metric.Family{
@@ -336,9 +340,11 @@ func deploymentMetricFamilies(allowAnnotationsList, allowLabelsList []string) []
 					return &metric.Family{}
 				}
 
+				// As above: a nil MaxSurge or an unparseable percentage is an
+				// error here, not a panic-worthy invariant violation.
 				maxSurge, err := intstr.GetScaledValueFromIntOrPercent(d.Spec.Strategy.RollingUpdate.MaxSurge, int(*d.Spec.Replicas), true)
 				if err != nil {
-					panic(err)
+					return &metric.Family{}
 				}
 
 				return &metric.Family{

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -345,6 +345,37 @@ func TestDeploymentStore(t *testing.T) {
 				"kube_deployment_spec_strategy_rollingupdate_max_surge",
 			},
 		},
+		{
+			// A non-nil RollingUpdate whose MaxUnavailable/MaxSurge are unset:
+			// GetScaledValueFromIntOrPercent returns an error, which used to be
+			// re-raised as a panic and took down the whole exporter.
+			Obj: &v1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment-nil-rollingupdate-values",
+					Namespace: "ns7",
+				},
+				Spec: v1.DeploymentSpec{
+					Replicas: &depl3Replicas,
+					Strategy: v1.DeploymentStrategy{
+						RollingUpdate: &v1.RollingUpdateDeployment{},
+					},
+				},
+			},
+			Want: `
+				# HELP kube_deployment_spec_replicas [STABLE] Number of desired pods for a deployment.
+				# TYPE kube_deployment_spec_replicas gauge
+				# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable [STABLE] Maximum number of unavailable replicas during a rolling update of a deployment.
+				# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
+				# HELP kube_deployment_spec_strategy_rollingupdate_max_surge [STABLE] Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
+				# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
+				kube_deployment_spec_replicas{deployment="deployment-nil-rollingupdate-values",namespace="ns7"} 1
+			`,
+			MetricNames: []string{
+				"kube_deployment_spec_replicas",
+				"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
+				"kube_deployment_spec_strategy_rollingupdate_max_surge",
+			},
+		},
 	}
 	for i, c := range cases {
 		c.Func = generator.ComposeMetricGenFuncs(deploymentMetricFamilies(c.AllowAnnotationsList, nil))

--- a/internal/store/deployment_test.go
+++ b/internal/store/deployment_test.go
@@ -40,6 +40,10 @@ var (
 
 	depl1MaxSurge = intstr.FromInt(10)
 	depl2MaxSurge = intstr.FromString("20%")
+
+	// Not a percentage, and a percentage whose number does not parse.
+	deplMalformedMaxUnavailable = intstr.FromString("not-a-percentage")
+	deplMalformedMaxSurge       = intstr.FromString("abc%")
 )
 
 func TestDeploymentStore(t *testing.T) {
@@ -369,6 +373,40 @@ func TestDeploymentStore(t *testing.T) {
 				# HELP kube_deployment_spec_strategy_rollingupdate_max_surge [STABLE] Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
 				# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
 				kube_deployment_spec_replicas{deployment="deployment-nil-rollingupdate-values",namespace="ns7"} 1
+			`,
+			MetricNames: []string{
+				"kube_deployment_spec_replicas",
+				"kube_deployment_spec_strategy_rollingupdate_max_unavailable",
+				"kube_deployment_spec_strategy_rollingupdate_max_surge",
+			},
+		},
+		{
+			// The other way GetScaledValueFromIntOrPercent fails: a string that
+			// is not a percentage at all, and a percentage whose number does not
+			// parse. Both used to panic.
+			Obj: &v1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment-malformed-rollingupdate-values",
+					Namespace: "ns8",
+				},
+				Spec: v1.DeploymentSpec{
+					Replicas: &depl3Replicas,
+					Strategy: v1.DeploymentStrategy{
+						RollingUpdate: &v1.RollingUpdateDeployment{
+							MaxUnavailable: &deplMalformedMaxUnavailable,
+							MaxSurge:       &deplMalformedMaxSurge,
+						},
+					},
+				},
+			},
+			Want: `
+				# HELP kube_deployment_spec_replicas [STABLE] Number of desired pods for a deployment.
+				# TYPE kube_deployment_spec_replicas gauge
+				# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable [STABLE] Maximum number of unavailable replicas during a rolling update of a deployment.
+				# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
+				# HELP kube_deployment_spec_strategy_rollingupdate_max_surge [STABLE] Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
+				# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
+				kube_deployment_spec_replicas{deployment="deployment-malformed-rollingupdate-values",namespace="ns8"} 1
 			`,
 			MetricNames: []string{
 				"kube_deployment_spec_replicas",


### PR DESCRIPTION
Both rolling-update generators guard the outer pointers and then re-raise any
error from the conversion as a panic:

```go
if d.Spec.Strategy.RollingUpdate == nil || d.Spec.Replicas == nil {
	return &metric.Family{}
}

maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(
	d.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*d.Spec.Replicas), false)
if err != nil {
	panic(err)
}
```

The guard does not cover what the helper actually rejects. It returns
`errors.New("nil value for IntOrString")` when the *inner* `MaxUnavailable` /
`MaxSurge` pointer is nil, and a parse error when a percentage string is
malformed. Neither is implied by `RollingUpdate != nil`:

```yaml
spec:
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: null
```

Defaulting fills these in for objects that go through the API server, but
nothing in kube-state-metrics depends on that, and the blast radius is the
whole process rather than the one Deployment: a panic on the reflector
goroutine takes down every metric for every resource.

Return an empty family instead, which is what the same generators already do
when the outer pointers are nil, and what `kube_cronjob_next_schedule_time`
does for an unparseable schedule.

Test added: a Deployment with `RollingUpdate: &v1.RollingUpdateDeployment{}`
panics with `nil value for IntOrString` before this change.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deployment metrics collection from crashing when rolling-update settings are missing, nil, malformed, or invalid.
  * Deployment replica metrics continue to be reported when rolling-update values cannot be converted.
  * Rolling-update metric families remain available even when they contain no sample values.

* **Tests**
  * Added coverage for unset, non-percentage, and unparsable rolling-update limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->