### PR TITLE
fix(hpa): guard the spec metric source the way the status one is

### DIFF
--- a/internal/store/horizontalpodautoscaler.go
+++ b/internal/store/horizontalpodautoscaler.go
@@ -205,21 +205,42 @@ func createHPASpecTargetMetric() generator.FamilyGenerator {
 				// The variable maps the type of metric to the corresponding value
 				metricMap := make(map[metricTargetType]float64)
 
+				// validateMetricSpec requires the source named by Type to be set,
+				// so an object that reached etcd through the API server has it.
+				// Guard anyway: the cost is one comparison, and the alternative
+				// is a nil deref on the reflector goroutine, which takes down
+				// every metric the exporter serves rather than this one HPA.
+				// Mirrors createHPAStatusTargetMetric.
 				switch m.Type {
 				case autoscaling.ObjectMetricSourceType:
+					if m.Object == nil {
+						continue
+					}
 					metricName = m.Object.Metric.Name
 					metricTarget = m.Object.Target
 				case autoscaling.PodsMetricSourceType:
+					if m.Pods == nil {
+						continue
+					}
 					metricName = m.Pods.Metric.Name
 					metricTarget = m.Pods.Target
 				case autoscaling.ResourceMetricSourceType:
+					if m.Resource == nil {
+						continue
+					}
 					metricName = string(m.Resource.Name)
 					metricTarget = m.Resource.Target
 				case autoscaling.ContainerResourceMetricSourceType:
+					if m.ContainerResource == nil {
+						continue
+					}
 					metricName = string(m.ContainerResource.Name)
 					metricTarget = m.ContainerResource.Target
 					containerName = m.ContainerResource.Container
 				case autoscaling.ExternalMetricSourceType:
+					if m.External == nil {
+						continue
+					}
 					metricName = m.External.Metric.Name
 					metricTarget = m.External.Target
 				default:

--- a/internal/store/horizontalpodautoscaler_test.go
+++ b/internal/store/horizontalpodautoscaler_test.go
@@ -685,3 +685,39 @@ func TestHPAStatusTargetMetricWithNilSource(t *testing.T) {
 		})
 	}
 }
+
+// spec.metrics is validated by validateMetricSpec, so the source matching Type
+// is populated for anything the API server accepted. The generator still must
+// not depend on that: it runs against whatever the reflector hands it, and a
+// nil deref there takes down every metric the exporter serves.
+func TestHPASpecTargetMetricWithNilSource(t *testing.T) {
+	for _, metricType := range []autoscaling.MetricSourceType{
+		autoscaling.ObjectMetricSourceType,
+		autoscaling.PodsMetricSourceType,
+		autoscaling.ResourceMetricSourceType,
+		autoscaling.ContainerResourceMetricSourceType,
+		autoscaling.ExternalMetricSourceType,
+	} {
+		t.Run(string(metricType), func(t *testing.T) {
+			hpa := &autoscaling.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "hpa", Namespace: "ns"},
+				Spec: autoscaling.HorizontalPodAutoscalerSpec{
+					// Type is set, but the matching source is not.
+					Metrics: []autoscaling.MetricSpec{{Type: metricType}},
+				},
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panic generating metrics for a %s spec with no source: %v", metricType, r)
+				}
+			}()
+
+			g := createHPASpecTargetMetric()
+			family := g.Generate(hpa)
+			if len(family.Metrics) != 0 {
+				t.Errorf("expected the entry to be skipped, got %d metrics", len(family.Metrics))
+			}
+		})
+	}
+}


### PR DESCRIPTION
#3071 added nil guards to `createHPAStatusTargetMetric` because
`status.currentMetrics` is not validated. `createHPASpecTargetMetric`, ten
lines above it in the same file, still dereferences unconditionally:

```go
switch m.Type {
case autoscaling.ObjectMetricSourceType:
	metricName = m.Object.Metric.Name        // <- m.Object may be nil
	metricTarget = m.Object.Target
case autoscaling.PodsMetricSourceType:
	metricName = m.Pods.Metric.Name          // <- and so on, for all five
	...
```

`validateMetricSpec` does require the field named by `Type` to be populated,
so this is better protected than the status path -- I could not construct a
spec the API server accepts that trips it. But the generator does not run
against the API server, it runs against whatever the reflector hands it, and
the failure mode is not proportional to the cause: a nil deref on the
reflector goroutine ends the process, so every metric for every resource
disappears because of one malformed HPA.

The guard costs one comparison per metric spec. Make the two halves of the
file agree.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented failures when autoscaling configurations contain incomplete metric definitions.
  * Invalid metric entries are now safely skipped, while valid metrics continue to be processed normally.

* **Tests**
  * Added coverage to verify safe handling across all supported metric source types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->