### PR TITLE
fix(options): index the allowlist value by rune, not by byte

### DIFF
--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -254,16 +254,21 @@ func (l *LabelsAllowList) Set(value string) error {
 		firstWordPos int
 		name         string
 	)
+	// Scan over runes, not bytes. `range` on a string yields byte offsets, which
+	// stop addressing []rune(value) as soon as the value holds a multi-byte
+	// character — indexing the rune slice with them reads the wrong character or
+	// runs off the end.
+	runes := []rune(value)
 	firstWordPos = 0
 
-	for i, v := range value {
-		if i+1 == len(value) {
+	for i, v := range runes {
+		if i+1 == len(runes) {
 			next = EOF
 		} else {
-			next = []rune(value)[i+1]
+			next = runes[i+1]
 		}
 		if i-1 >= 0 {
-			previous = []rune(value)[i-1]
+			previous = runes[i-1]
 		} else {
 			previous = v
 		}
@@ -273,7 +278,7 @@ func (l *LabelsAllowList) Set(value string) error {
 			if previous == ',' || next != '[' {
 				return errLabelsAllowListFormat
 			}
-			name = strings.TrimSpace(string(([]rune(value)[firstWordPos:i])))
+			name = strings.TrimSpace(string(runes[firstWordPos:i]))
 			m[name] = []string{}
 			firstWordPos = i + 1
 		case '[':
@@ -287,7 +292,7 @@ func (l *LabelsAllowList) Set(value string) error {
 				return errLabelsAllowListFormat
 			}
 			if previous != '[' {
-				m[name] = append(m[name], strings.TrimSpace(string(([]rune(value)[firstWordPos:i]))))
+				m[name] = append(m[name], strings.TrimSpace(string(runes[firstWordPos:i])))
 			}
 			firstWordPos = i + 1
 		case ',':
@@ -296,7 +301,7 @@ func (l *LabelsAllowList) Set(value string) error {
 				return errLabelsAllowListFormat
 			}
 			if previous != ']' {
-				m[name] = append(m[name], strings.TrimSpace(string(([]rune(value)[firstWordPos:i]))))
+				m[name] = append(m[name], strings.TrimSpace(string(runes[firstWordPos:i])))
 			}
 			firstWordPos = i + 1
 		}

--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -399,6 +399,51 @@ func TestLabelsAllowListSet(t *testing.T) {
 			Wanted: LabelsAllowList(map[string][]string{}),
 			err:    errLabelsAllowListMultipleWildcards,
 		},
+		{
+			// Used to panic: index out of range [12] with length 12.
+			Desc:  "multi-byte rune inside a label",
+			Value: "pods=[naïve]",
+			Wanted: LabelsAllowList(map[string][]string{
+				"pods": {
+					"naïve",
+				},
+			}),
+		},
+		{
+			// Used to yield "ö]" — the closing bracket was swallowed into the
+			// label because firstWordPos was a byte offset.
+			Desc:  "multi-byte rune in the last label",
+			Value: "pods=[a,ö]",
+			Wanted: LabelsAllowList(map[string][]string{
+				"pods": {
+					"a",
+					"ö",
+				},
+			}),
+		},
+		{
+			// Used to be rejected as malformed: the lookahead from '=' read one
+			// rune too far and saw 'a' instead of '['.
+			Desc:  "multi-byte rune in the resource name",
+			Value: "pöds=[a,b]",
+			Wanted: LabelsAllowList(map[string][]string{
+				"pöds": {
+					"a",
+					"b",
+				},
+			}),
+		},
+		{
+			// Same spurious rejection, triggered from the label side.
+			Desc:  "multi-byte rune in the first label",
+			Value: "pods=[ö,a]",
+			Wanted: LabelsAllowList(map[string][]string{
+				"pods": {
+					"ö",
+					"a",
+				},
+			}),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
`LabelsAllowList.Set` scans the flag value with `range`, which yields **byte**
offsets, and then uses those offsets to index `[]rune(value)`:

```go
for i, v := range value {
	if i+1 == len(value) {
		next = EOF
	} else {
		next = []rune(value)[i+1]      // <- byte offset into a rune slice
	}
	if i-1 >= 0 {
		previous = []rune(value)[i-1]  // <- same
	}
	...
	name = strings.TrimSpace(string(([]rune(value)[firstWordPos:i])))
```

The two agree only while every character is one byte. As soon as the value
contains a multi-byte rune, every offset after it is too large, and the three
uses fail in three different ways:

| value | before | after |
| --- | --- | --- |
| `pods=[naïve]` | `panic: index out of range [12] with length 12` | `{pods: [naïve]}` |
| `pods=[a,ö]` | `{pods: [a, "ö]"]}` — bracket swallowed | `{pods: [a, ö]}` |
| `pöds=[a,b]` | rejected as malformed | `{pöds: [a, b]}` |
| `pods=[ö,a]` | rejected as malformed | `{pods: [ö, a]}` |

The panic is the reachable one: it needs only a label whose last rune is
multi-byte, and it is an unrecovered panic during flag parsing, so
kube-state-metrics does not start and prints a stack trace instead of
`errLabelsAllowListFormat`.

This type backs both `--metric-labels-allowlist` and
`--metric-annotations-allowlist`; annotation keys and values are the more
likely place to meet a non-ASCII character.

Convert the value to `[]rune` once and index that throughout. As a side
effect this drops the repeated `[]rune(value)` conversions inside the loop,
which made parsing O(n^2).


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label allow-list parsing for names containing multi-byte Unicode characters.
  * Prevented incorrect parsing, malformed results, and potential crashes with Unicode labels, resource names, and label lists.

* **Tests**
  * Added regression coverage for Unicode parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->