### PR TITLE
fix(options): validate the options before starting

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,11 +31,11 @@ func main() {
 		internal.RunKubeStateMetricsWrapper(opts)
 	}
 	opts.AddFlags(cmd)
+	// Parse blocks for the lifetime of the process: Execute runs cmd.Run, which
+	// only returns once kube-state-metrics is shutting down. Option validation
+	// therefore happens in the command's PreRunE, not here.
 	if err := opts.Parse(); err != nil {
-		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
-	}
-	if err := opts.Validate(); err != nil {
-		klog.ErrorS(err, "Validating options error")
+		klog.ErrorS(err, "Running kube-state-metrics failed")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 }

--- a/pkg/options/autoload.go
+++ b/pkg/options/autoload.go
@@ -140,4 +140,7 @@ var InitCommand = &cobra.Command{
 	Short: "Add-on agent to generate and expose cluster-level metrics.",
 	Long:  "kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.",
 	Args:  cobra.NoArgs,
+	// A rejected option is reported on its own; dumping the full flag usage
+	// after it buries the message.
+	SilenceUsage: true,
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -111,6 +111,14 @@ func NewOptions() *Options {
 func (o *Options) AddFlags(cmd *cobra.Command) {
 	o.cmd = cmd
 
+	// Validate from PreRunE rather than from the caller: cmd.Run blocks for the
+	// lifetime of the process, so anything the caller does after Execute() is
+	// unreachable. Returning here aborts before Run and surfaces the error
+	// through Execute().
+	o.cmd.PreRunE = func(_ *cobra.Command, _ []string) error {
+		return o.Validate()
+	}
+
 	completionCommand.SetHelpFunc(func(_ *cobra.Command, _ []string) {
 		if shellPath, ok := os.LookupEnv("SHELL"); ok {
 			shell := shellPath[strings.LastIndex(shellPath, "/")+1:]

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package options
 
 import (
+	"io"
 	"os"
 	"testing"
 
+	"github.com/spf13/cobra"
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
@@ -61,6 +63,65 @@ func TestOptionsParse(t *testing.T) {
 
 			if test.ExpectsError && err == nil {
 				t.Errorf("Expected error for test with description: %s", test.Desc)
+			}
+		})
+	}
+}
+
+// Validate used to be called by main after Parse returned, which never happens:
+// Parse runs cmd.Execute, and cmd.Run only returns once the process is shutting
+// down. It is wired into the command's PreRunE instead, so a rejected option
+// aborts before anything is started.
+func TestValidateRunsBeforeRun(t *testing.T) {
+	tests := []struct {
+		Desc         string
+		Args         []string
+		ExpectsError bool
+	}{
+		{
+			Desc:         "node sharding rejects a resource without a spec.nodeName field selector",
+			Args:         []string{"--node=node-1", "--resources=deployments"},
+			ExpectsError: true,
+		},
+		{
+			Desc:         "node sharding accepts pods",
+			Args:         []string{"--node=node-1", "--resources=pods"},
+			ExpectsError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Desc, func(t *testing.T) {
+			ran := false
+			cmd := &cobra.Command{
+				Use:          "kube-state-metrics",
+				Args:         cobra.NoArgs,
+				SilenceUsage: true,
+				Run:          func(_ *cobra.Command, _ []string) { ran = true },
+			}
+
+			opts := NewOptions()
+			opts.AddFlags(cmd)
+			cmd.SetArgs(test.Args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := opts.Parse()
+
+			if test.ExpectsError {
+				if err == nil {
+					t.Fatal("expected Parse to surface the validation error, got nil")
+				}
+				if ran {
+					t.Error("command ran despite failing validation")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !ran {
+				t.Error("command did not run")
 			}
 		})
 	}


### PR DESCRIPTION
`main` calls `Validate` after `Parse` returns:

```go
if err := opts.Parse(); err != nil {
	klog.FlushAndExit(klog.ExitFlushTimeout, 1)
}
if err := opts.Validate(); err != nil {      // <- unreachable
	klog.ErrorS(err, "Validating options error")
	klog.FlushAndExit(klog.ExitFlushTimeout, 1)
}
```

`Parse` is `o.cmd.Execute()`, which runs `cmd.Run`, which is
`internal.RunKubeStateMetricsWrapper`. That function ends in `select {}` and
never returns, so `Parse` only returns when the process is already shutting
down — and on the error path it exits before reaching the next statement
either way. `Validate` has therefore never run in any real invocation.

What that lets through today:

    --node=n --resources=deployments   accepted, then silently collects
                                       nothing (the field selector does not
                                       apply to deployments)

and, once the early `return nil` in `Validate` is removed (#3062):

    --auto-gomemlimit-ratio=7          GOMEMLIMIT set to 7x available memory
    --object-limit=-1                  accepted

Move the call into the command's `PreRunE`, which cobra runs after flag
parsing and before `Run`, and which propagates its error out through
`Execute`. A rejected option now aborts before any client, informer or
listener is created.

`SilenceUsage` is set on the root command so a one-line validation failure
is not buried under the full flag usage dump.

Note this is orthogonal to #3062: that PR fixes `Validate` returning early
when `--node` is empty, this one makes `Validate` run at all. The test uses
the `--node` check because it is the only one reachable before #3062 lands.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid command-line options are now rejected before execution begins.
  * Validation errors no longer trigger full command usage output.
  * Parsing failures continue to be logged and terminate the process appropriately.

* **Tests**
  * Added coverage confirming invalid options prevent command execution while valid options proceed normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->