### PR TITLE
feat: Add metric for configuration errors (`kube_state_metrics_config_errors_total`)

### DIFF
--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/kube-state-metrics/v2/internal/discovery"
 	"k8s.io/kube-state-metrics/v2/internal/store"
 	"k8s.io/kube-state-metrics/v2/pkg/allowdenylist"
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
 	"k8s.io/kube-state-metrics/v2/pkg/customresourcestate"
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
 	"k8s.io/kube-state-metrics/v2/pkg/metricshandler"
@@ -117,6 +118,13 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 			Name: "kube_state_metrics_last_config_reload_success_timestamp_seconds",
 			Help: "Timestamp of the last successful configuration reload.",
 		}, []string{"type", "filename"})
+	configErrors := promauto.With(ksmMetricsRegistry).NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kube_state_metrics_config_errors_total",
+			Help: "Total number of configuration error encountered.",
+		},
+		[]string{"type"},
+	)
 
 	// Register self-metrics to track the state of the cache.
 	crdsAddEventsCounter := promauto.With(ksmMetricsRegistry).NewCounter(prometheus.CounterOpts{
@@ -153,6 +161,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 				// DO NOT end the process.
 				// We want to allow the user to still be able to fix the misconfigured config (redeploy or edit the configmaps) and reload KSM automatically once that's done.
 				klog.ErrorS(err, "failed to unmarshal opts config file")
+				configErrors.WithLabelValues("config").Inc()
 				// Wait for the next reload.
 				klog.InfoS("misconfigured config detected, KSM will automatically reload on next write to the config")
 				klog.InfoS("waiting for config to be fixed")
@@ -334,7 +343,16 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		// FromConfig will return different behaviours when a G**-based config is supplied (since that is subject to change based on the resources present in the cluster).
 		fn, err := customresourcestate.FromConfig(config, discovererInstance)
 		if err != nil {
+			configErrors.WithLabelValues("customresourceconfig").Inc()
 			return err
+		}
+		instrumentedFn := func() ([]customresource.RegistryFactory, error) {
+			factories, err := fn()
+			if err != nil {
+				configErrors.WithLabelValues("customresourceconfig").Inc()
+				return nil, err
+			}
+			return factories, nil
 		}
 		// This starts a goroutine that will keep the cache up to date.
 		discovererInstance.PollForCacheUpdates(
@@ -342,7 +360,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 			opts,
 			storeBuilder,
 			m,
-			fn,
+			instrumentedFn,
 		)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**
This adds `kube_state_metrics_config_errors_total` to track errors encountered while processing kube-state-metrics configuration. The metric distinguishes between regular configuration and Custom Resource State configuration.

<!-- If you are adding a new metric, provide the use case of that metric. -->

**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes:** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*
Fixes #2472 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics for configuration processing errors.
  * Added separate tracking for general configuration and custom resource configuration failures.
  * Metrics now record failures during configuration loading, creation, and refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->