### PR TITLE
fix(discovery): avoid no-op CRD updates forcing writer rebuilds

### DIFF
--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -82,6 +82,7 @@ Flags:
       --skip_headers                                         If true, avoid header prefixes in the log messages
       --skip_log_headers                                     If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity                             logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
+      --store-sync-timeout duration                          Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild. (default 2m0s)
       --telemetry-host string                                Host to expose kube-state-metrics self metrics on. (default "::")
       --telemetry-port int                                   Port to expose kube-state-metrics self metrics on. (default 8081)
       --tls-config string                                    Path to the TLS configuration file

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -84,7 +84,7 @@ Flags:
       --stderrthreshold severity                             logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
       --store-sync-timeout duration                          Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild. (default 2m0s)
       --telemetry-host string                                Host to expose kube-state-metrics self metrics on. (default "::")
-      --telemetry-port int                                   Port to expose kube-state-metrics self metrics on. Readiness is reported at /readyz on this port. (default 8081)
+      --telemetry-port int                                   Port to expose kube-state-metrics self metrics on. (default 8081)
       --tls-config string                                    Path to the TLS configuration file
       --total-shards int                                     The total number of shards. Sharding is disabled when total shards is set to 1. (default 1)
       --track-unscheduled-pods                               This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.

--- a/docs/developer/cli-arguments.md
+++ b/docs/developer/cli-arguments.md
@@ -84,7 +84,7 @@ Flags:
       --stderrthreshold severity                             logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
       --store-sync-timeout duration                          Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild. (default 2m0s)
       --telemetry-host string                                Host to expose kube-state-metrics self metrics on. (default "::")
-      --telemetry-port int                                   Port to expose kube-state-metrics self metrics on. (default 8081)
+      --telemetry-port int                                   Port to expose kube-state-metrics self metrics on. Readiness is reported at /readyz on this port. (default 8081)
       --tls-config string                                    Path to the TLS configuration file
       --total-shards int                                     The total number of shards. Sharding is disabled when total shards is set to 1. (default 1)
       --track-unscheduled-pods                               This configuration is used in conjunction with node configuration. When this configuration is true, node configuration is empty and the metric of unscheduled pods is fetched from the Kubernetes API Server. This is experimental.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -344,14 +344,20 @@ func (r *CRDiscoverer) PollForCacheUpdates(
 		}
 		// Apply builder config under the same lock Build() uses, then rebuild.
 		// Mutating the shared builder directly would race async rebuilds.
+		var configErr error
 		m.ConfigureStore(ctx, func(b ksmtypes.BuilderInterface) {
 			b.WithCustomResourceClients(discoveredCustomResourceClients)
 			b.WithCustomResourceStoreFactories(customFactories...)
 			if err := b.WithEnabledResources(enabledCustomResources); err != nil {
 				klog.ErrorS(err, "failed to update custom resource stores")
+				configErr = err
 			}
 			b.WithGenerateCustomResourceStoresFunc(b.DefaultGenerateCustomResourceStoresFunc())
 		})
+		if configErr != nil {
+			// Preserve WasUpdated so the next tick retries.
+			return false
+		}
 		lastAppliedEnabledKey = enabledKey
 		lastAppliedRevision = observedRevision
 		// Clear only the revision we applied. If discovery changed while clients

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -345,9 +345,13 @@ func (r *CRDiscoverer) PollForCacheUpdates(
 		// Apply builder config under the same lock Build() uses, then rebuild.
 		// Mutating the shared builder directly would race async rebuilds.
 		if err := m.ConfigureStore(ctx, func(b ksmtypes.BuilderInterface) error {
+			replacer, ok := b.(ksmtypes.CustomResourceReplacer)
+			if !ok {
+				return fmt.Errorf("builder does not support replacing custom resources")
+			}
 			b.WithCustomResourceClients(discoveredCustomResourceClients)
 			b.WithCustomResourceStoreFactories(customFactories...)
-			if err := b.ReplaceEnabledCustomResources(enabledCustomResources); err != nil {
+			if err := replacer.ReplaceEnabledCustomResources(enabledCustomResources); err != nil {
 				klog.ErrorS(err, "failed to update custom resource stores")
 				return err
 			}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -17,6 +17,8 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -27,7 +29,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	"k8s.io/kube-state-metrics/v2/internal/store"
+	ksmtypes "k8s.io/kube-state-metrics/v2/pkg/builder/types"
 	"k8s.io/kube-state-metrics/v2/pkg/customresource"
 	"k8s.io/kube-state-metrics/v2/pkg/metricshandler"
 	"k8s.io/kube-state-metrics/v2/pkg/options"
@@ -139,8 +141,11 @@ func (r *CRDiscoverer) StartDiscovery(ctx context.Context, config *rest.Config) 
 		AddFunc: func(obj interface{}) {
 			gvkps := extractGVKPs(obj)
 			r.SafeWrite(func() {
-				r.AppendToMap(gvkps...)
-				r.WasUpdated = true
+				// Only flag a store rebuild when the cache gains a new GVK/plural.
+				// Re-adds of an already-known CRD are no-ops for metrics writers.
+				if r.AppendToMap(gvkps...) {
+					r.WasUpdated = true
+				}
 			})
 			r.SafeWrite(func() {
 				r.CRDsAddEventsCounter.Inc()
@@ -150,20 +155,21 @@ func (r *CRDiscoverer) StartDiscovery(ctx context.Context, config *rest.Config) 
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			oldGVKPs := extractGVKPs(oldObj)
 			newGVKPs := extractGVKPs(newObj)
+			// CRD status/metadata churn is common and does not change the
+			// discoverable GVK/plural set. Applying Remove+Append for those
+			// events previously closed active reflector stop channels and
+			// forced full metrics rebuilds for unchanged stores.
 			r.SafeWrite(func() {
-				r.RemoveFromMap(oldGVKPs...)
-				r.AppendToMap(newGVKPs...)
-				r.WasUpdated = true
-			})
-			r.SafeWrite(func() {
+				r.applyCRDUpdate(oldGVKPs, newGVKPs)
 				r.CRDsUpdateEventsCounter.Inc()
 			})
 		},
 		DeleteFunc: func(obj interface{}) {
 			gvkps := extractGVKPs(obj)
 			r.SafeWrite(func() {
-				r.RemoveFromMap(gvkps...)
-				r.WasUpdated = true
+				if r.RemoveFromMap(gvkps...) {
+					r.WasUpdated = true
+				}
 			})
 			r.SafeWrite(func() {
 				r.CRDsDeleteEventsCounter.Inc()
@@ -280,17 +286,27 @@ func (r *CRDiscoverer) ResolveGVKToGVKPs(gvk schema.GroupVersionKind) (resolvedG
 func (r *CRDiscoverer) PollForCacheUpdates(
 	ctx context.Context,
 	opts *options.Options,
-	storeBuilder *store.Builder,
 	m *metricshandler.MetricsHandler,
 	factoryGenerator func() ([]customresource.RegistryFactory, error),
 ) {
 	// The interval at which we will check the cache for updates.
 	t := time.NewTicker(Interval)
-	generateMetrics := func() {
+	// The key and cache revision jointly skip no-op rebuilds. The revision is
+	// needed because a CRD can be deleted and re-added between ticks with the
+	// same GVR while its reflector stop channel changes identity.
+	var lastAppliedEnabledKey string
+	var lastAppliedRevision uint64
+	generateMetrics := func() (applied bool) {
+		var observedRevision uint64
+		r.SafeRead(func() {
+			observedRevision = r.cacheRevision
+		})
 		// Get families for discovered factories.
 		customFactories, err := factoryGenerator()
 		if err != nil {
 			klog.ErrorS(err, "failed to update custom resource stores")
+			// Preserve WasUpdated so the next tick retries.
+			return false
 		}
 		// Update the list of enabled custom resources.
 		var enabledCustomResources []string
@@ -307,28 +323,45 @@ func (r *CRDiscoverer) PollForCacheUpdates(
 			}
 			enabledCustomResources = append(enabledCustomResources, gvrString)
 		}
-		// Create clients for discovered factories.
+		sort.Strings(enabledCustomResources)
+		enabledKey := strings.Join(enabledCustomResources, ",")
+		if enabledKey == lastAppliedEnabledKey && observedRevision == lastAppliedRevision {
+			r.SafeWrite(func() {
+				if r.cacheRevision == observedRevision {
+					r.WasUpdated = false
+				}
+			})
+			klog.V(2).InfoS("discovery cache changed but enabled custom resources are unchanged; skipping store rebuild")
+			return false
+		}
+		// Create clients for discovered factories. Keep this outside ConfigureStore:
+		// client construction is slow and must not hold the metrics handler lock.
 		discoveredCustomResourceClients, err := util.CreateCustomResourceClients(opts.Apiserver, opts.Kubeconfig, customFactories...)
 		if err != nil {
 			klog.ErrorS(err, "failed to update custom resource stores")
+			// Preserve WasUpdated so the next tick retries.
+			return false
 		}
-		// Update the store builder with the new clients.
-		storeBuilder.WithCustomResourceClients(discoveredCustomResourceClients)
-		// Inject families' constructors to the existing set of stores.
-		storeBuilder.WithCustomResourceStoreFactories(customFactories...)
-		// Update the store builder with the new custom resources.
-		if err := storeBuilder.WithEnabledResources(enabledCustomResources); err != nil {
-			klog.ErrorS(err, "failed to update custom resource stores")
-		}
-		// Configure the generation function for the custom resource stores.
-		storeBuilder.WithGenerateCustomResourceStoresFunc(storeBuilder.DefaultGenerateCustomResourceStoresFunc())
-		// Reset the flag, if there were no errors. Else, we'll try again on the next tick.
-		// Keep retrying if there were errors.
-		r.SafeWrite(func() {
-			r.WasUpdated = false
+		// Apply builder config under the same lock Build() uses, then rebuild.
+		// Mutating the shared builder directly would race async rebuilds.
+		m.ConfigureStore(ctx, func(b ksmtypes.BuilderInterface) {
+			b.WithCustomResourceClients(discoveredCustomResourceClients)
+			b.WithCustomResourceStoreFactories(customFactories...)
+			if err := b.WithEnabledResources(enabledCustomResources); err != nil {
+				klog.ErrorS(err, "failed to update custom resource stores")
+			}
+			b.WithGenerateCustomResourceStoresFunc(b.DefaultGenerateCustomResourceStoresFunc())
 		})
-		// Update metric handler with the new configs.
-		m.BuildWriters(ctx)
+		lastAppliedEnabledKey = enabledKey
+		lastAppliedRevision = observedRevision
+		// Clear only the revision we applied. If discovery changed while clients
+		// were being created, leave the flag set for another reconciliation.
+		r.SafeWrite(func() {
+			if r.cacheRevision == observedRevision {
+				r.WasUpdated = false
+			}
+		})
+		return true
 	}
 	go func() {
 		for range t.C {
@@ -344,8 +377,9 @@ func (r *CRDiscoverer) PollForCacheUpdates(
 					shouldGenerateMetrics = r.WasUpdated
 				})
 				if shouldGenerateMetrics {
-					generateMetrics()
-					klog.InfoS("discovery finished, cache updated")
+					if generateMetrics() {
+						klog.InfoS("discovery finished, cache updated")
+					}
 				}
 			}
 		}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -344,17 +344,16 @@ func (r *CRDiscoverer) PollForCacheUpdates(
 		}
 		// Apply builder config under the same lock Build() uses, then rebuild.
 		// Mutating the shared builder directly would race async rebuilds.
-		var configErr error
-		m.ConfigureStore(ctx, func(b ksmtypes.BuilderInterface) {
+		if err := m.ConfigureStore(ctx, func(b ksmtypes.BuilderInterface) error {
 			b.WithCustomResourceClients(discoveredCustomResourceClients)
 			b.WithCustomResourceStoreFactories(customFactories...)
-			if err := b.WithEnabledResources(enabledCustomResources); err != nil {
+			if err := b.ReplaceEnabledCustomResources(enabledCustomResources); err != nil {
 				klog.ErrorS(err, "failed to update custom resource stores")
-				configErr = err
+				return err
 			}
 			b.WithGenerateCustomResourceStoresFunc(b.DefaultGenerateCustomResourceStoresFunc())
-		})
-		if configErr != nil {
+			return nil
+		}); err != nil {
 			// Preserve WasUpdated so the next tick retries.
 			return false
 		}

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -30,6 +30,10 @@ func (g groupVersionKindPlural) String() string {
 	return fmt.Sprintf("%s/%s, Kind=%s, Plural=%s", g.Group, g.Version, g.Kind, g.Plural)
 }
 
+func gvkpKey(gvkp groupVersionKindPlural) string {
+	return gvkp.GroupVersionKind.String() + "\x00" + gvkp.Plural
+}
+
 type kindPlural struct {
 	Kind   string
 	Plural string
@@ -128,9 +132,13 @@ func (r *CRDiscoverer) AppendToMap(gvkps ...groupVersionKindPlural) bool {
 			r.Map[gvkp.Group][gvkp.Version] = []kindPlural{}
 		}
 		alreadyExists := false
-		for _, existing := range r.Map[gvkp.Group][gvkp.Version] {
+		for i, existing := range r.Map[gvkp.Group][gvkp.Version] {
 			if existing.Kind == gvkp.Kind {
 				alreadyExists = true
+				if existing.Plural != gvkp.Plural {
+					r.Map[gvkp.Group][gvkp.Version][i].Plural = gvkp.Plural
+					changed = true
+				}
 				break
 			}
 		}
@@ -220,10 +228,10 @@ func equalGVKPSet(a, b []groupVersionKindPlural) bool {
 	}
 	counts := make(map[string]int, len(a))
 	for _, gvkp := range a {
-		counts[gvkp.String()]++
+		counts[gvkpKey(gvkp)]++
 	}
 	for _, gvkp := range b {
-		key := gvkp.String()
+		key := gvkpKey(gvkp)
 		if counts[key] == 0 {
 			return false
 		}
@@ -237,10 +245,10 @@ func diffGVKPs(oldGVKPs, newGVKPs []groupVersionKindPlural) (removed, added []gr
 	oldSet := make(map[string]groupVersionKindPlural, len(oldGVKPs))
 	newSet := make(map[string]groupVersionKindPlural, len(newGVKPs))
 	for _, gvkp := range oldGVKPs {
-		oldSet[gvkp.String()] = gvkp
+		oldSet[gvkpKey(gvkp)] = gvkp
 	}
 	for _, gvkp := range newGVKPs {
-		newSet[gvkp.String()] = gvkp
+		newSet[gvkpKey(gvkp)] = gvkp
 	}
 	for key, gvkp := range oldSet {
 		if _, ok := newSet[key]; !ok {

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -57,6 +57,10 @@ type CRDiscoverer struct {
 	m sync.RWMutex
 	// ShouldUpdate is a flag that indicates whether the cache was updated.
 	WasUpdated bool
+	// cacheRevision changes whenever the discoverable GVK set changes. It lets
+	// reconciliation distinguish delete/re-add cycles that resolve to the same
+	// GVR strings but replace reflector stop channels.
+	cacheRevision uint64
 }
 
 // SafeRead executes the given function while holding a read lock.
@@ -107,7 +111,9 @@ func (r *CRDiscoverer) clearMissingGVKWarningLocked(gvk schema.GroupVersionKind)
 }
 
 // AppendToMap appends the given GVKs to the cache.
-func (r *CRDiscoverer) AppendToMap(gvkps ...groupVersionKindPlural) {
+// It returns true when at least one new kind entry was added.
+func (r *CRDiscoverer) AppendToMap(gvkps ...groupVersionKindPlural) bool {
+	changed := false
 	if r.Map == nil {
 		r.Map = map[string]map[string][]kindPlural{}
 	}
@@ -130,11 +136,16 @@ func (r *CRDiscoverer) AppendToMap(gvkps ...groupVersionKindPlural) {
 		}
 		if !alreadyExists {
 			r.Map[gvkp.Group][gvkp.Version] = append(r.Map[gvkp.Group][gvkp.Version], kindPlural{Kind: gvkp.Kind, Plural: gvkp.Plural})
+			changed = true
 		}
 		if _, exists := r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()]; !exists {
 			r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()] = make(chan struct{})
 		}
 	}
+	if changed {
+		r.cacheRevision++
+	}
+	return changed
 }
 
 // GetStopChanForGVK returns the stop channel for the given GVK under the read lock.
@@ -147,7 +158,10 @@ func (r *CRDiscoverer) GetStopChanForGVK(gvk string) chan struct{} {
 }
 
 // RemoveFromMap removes the given GVKs from the cache.
-func (r *CRDiscoverer) RemoveFromMap(gvkps ...groupVersionKindPlural) {
+// It returns true when at least one kind entry was removed. Stop channels are
+// closed only for GVKs that were actually present.
+func (r *CRDiscoverer) RemoveFromMap(gvkps ...groupVersionKindPlural) bool {
+	changed := false
 	for _, gvkp := range gvkps {
 		if _, ok := r.Map[gvkp.Group]; !ok {
 			continue
@@ -161,6 +175,7 @@ func (r *CRDiscoverer) RemoveFromMap(gvkps ...groupVersionKindPlural) {
 					close(r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()])
 					delete(r.GVKToReflectorStopChanMap, gvkp.GroupVersionKind.String())
 				}
+				changed = true
 				if len(r.Map[gvkp.Group][gvkp.Version]) == 1 {
 					delete(r.Map[gvkp.Group], gvkp.Version)
 					if len(r.Map[gvkp.Group]) == 0 {
@@ -173,4 +188,69 @@ func (r *CRDiscoverer) RemoveFromMap(gvkps ...groupVersionKindPlural) {
 			}
 		}
 	}
+	if changed {
+		r.cacheRevision++
+	}
+	return changed
+}
+
+// applyCRDUpdate applies only the changed GVKs from a CRD update. Status-only
+// or metadata-only updates preserve existing reflector stop channels.
+// The caller must hold r.m for writing.
+func (r *CRDiscoverer) applyCRDUpdate(oldGVKPs, newGVKPs []groupVersionKindPlural) bool {
+	if equalGVKPSet(oldGVKPs, newGVKPs) {
+		return false
+	}
+	removed, added := diffGVKPs(oldGVKPs, newGVKPs)
+	changed := r.RemoveFromMap(removed...)
+	if r.AppendToMap(added...) {
+		changed = true
+	}
+	if changed {
+		r.WasUpdated = true
+	}
+	return changed
+}
+
+// equalGVKPSet reports whether a and b contain the same GVK+plural entries,
+// ignoring order.
+func equalGVKPSet(a, b []groupVersionKindPlural) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, gvkp := range a {
+		counts[gvkp.String()]++
+	}
+	for _, gvkp := range b {
+		key := gvkp.String()
+		if counts[key] == 0 {
+			return false
+		}
+		counts[key]--
+	}
+	return true
+}
+
+// diffGVKPs returns entries present only in old and only in new.
+func diffGVKPs(oldGVKPs, newGVKPs []groupVersionKindPlural) (removed, added []groupVersionKindPlural) {
+	oldSet := make(map[string]groupVersionKindPlural, len(oldGVKPs))
+	newSet := make(map[string]groupVersionKindPlural, len(newGVKPs))
+	for _, gvkp := range oldGVKPs {
+		oldSet[gvkp.String()] = gvkp
+	}
+	for _, gvkp := range newGVKPs {
+		newSet[gvkp.String()] = gvkp
+	}
+	for key, gvkp := range oldSet {
+		if _, ok := newSet[key]; !ok {
+			removed = append(removed, gvkp)
+		}
+	}
+	for key, gvkp := range newSet {
+		if _, ok := oldSet[key]; !ok {
+			added = append(added, gvkp)
+		}
+	}
+	return removed, added
 }

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -206,6 +206,12 @@ func (r *CRDiscoverer) RemoveFromMap(gvkps ...groupVersionKindPlural) bool {
 // or metadata-only updates preserve existing reflector stop channels.
 // The caller must hold r.m for writing.
 func (r *CRDiscoverer) applyCRDUpdate(oldGVKPs, newGVKPs []groupVersionKindPlural) bool {
+	// extractGVKPs returns nil for objects it cannot read. Treating that as
+	// "all versions removed" would close live reflector channels for a CRD
+	// that still exists, so skip the event instead.
+	if len(newGVKPs) == 0 {
+		return false
+	}
 	if equalGVKPSet(oldGVKPs, newGVKPs) {
 		return false
 	}

--- a/internal/discovery/types_test.go
+++ b/internal/discovery/types_test.go
@@ -250,6 +250,29 @@ func TestAppendToMapReturnsWhetherChanged(t *testing.T) {
 	}
 }
 
+func TestAppendToMapRefreshesPlural(t *testing.T) {
+	gvkp := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
+		Plural:           "foos",
+	}
+	updated := gvkp
+	updated.Plural = "fooes"
+
+	r := &CRDiscoverer{}
+	r.AppendToMap(gvkp)
+	revision := r.cacheRevision
+
+	if !r.AppendToMap(updated) {
+		t.Fatal("plural refresh should report change")
+	}
+	if got := r.Map[gvkp.Group][gvkp.Version][0].Plural; got != "fooes" {
+		t.Fatalf("expected refreshed plural, got %q", got)
+	}
+	if r.cacheRevision <= revision {
+		t.Fatalf("expected revision to advance on plural refresh: before=%d after=%d", revision, r.cacheRevision)
+	}
+}
+
 func TestRemoveFromMapReturnsWhetherChanged(t *testing.T) {
 	gvkp := groupVersionKindPlural{
 		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},

--- a/internal/discovery/types_test.go
+++ b/internal/discovery/types_test.go
@@ -177,6 +177,34 @@ func TestCRDUpdateNoopDoesNotCloseStopChannel(t *testing.T) {
 	}
 }
 
+func TestCRDUpdateSkipsUnreadableNewGVKPs(t *testing.T) {
+	gvkp := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
+		Plural:           "foos",
+	}
+	r := &CRDiscoverer{
+		GVKToReflectorStopChanMap: make(map[string]chan struct{}),
+	}
+	if !r.AppendToMap(gvkp) {
+		t.Fatal("expected AppendToMap to register GVKP")
+	}
+	ch := r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()]
+	revision := r.cacheRevision
+
+	if r.applyCRDUpdate([]groupVersionKindPlural{gvkp}, nil) {
+		t.Fatal("expected unreadable new GVKP set to be ignored")
+	}
+	if r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()] != ch {
+		t.Fatal("stop channel changed on unreadable update")
+	}
+	if r.cacheRevision != revision {
+		t.Fatalf("cache revision changed on unreadable update: got %d, want %d", r.cacheRevision, revision)
+	}
+	if r.WasUpdated {
+		t.Fatal("WasUpdated set on unreadable update")
+	}
+}
+
 func TestCRDUpdateAddsVersionWithoutClosingKeptChannel(t *testing.T) {
 	v1 := groupVersionKindPlural{
 		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},

--- a/internal/discovery/types_test.go
+++ b/internal/discovery/types_test.go
@@ -94,3 +94,173 @@ func TestRemoveFromMapClosesChannel(t *testing.T) {
 		t.Error("stop channel map entry should be deleted after RemoveFromMap")
 	}
 }
+
+func TestEqualGVKPSet(t *testing.T) {
+	a := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
+		Plural:           "foos",
+	}
+	b := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Bar"},
+		Plural:           "bars",
+	}
+	a2 := a
+	if !equalGVKPSet([]groupVersionKindPlural{a, b}, []groupVersionKindPlural{b, a2}) {
+		t.Fatal("expected equal sets ignoring order")
+	}
+	if equalGVKPSet([]groupVersionKindPlural{a}, []groupVersionKindPlural{b}) {
+		t.Fatal("expected different kinds to be unequal")
+	}
+	aOtherPlural := a
+	aOtherPlural.Plural = "fooes"
+	if equalGVKPSet([]groupVersionKindPlural{a}, []groupVersionKindPlural{aOtherPlural}) {
+		t.Fatal("expected plural changes to be unequal")
+	}
+}
+
+func TestDiffGVKPsPreservesUnchanged(t *testing.T) {
+	keep := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Keep"},
+		Plural:           "keeps",
+	}
+	drop := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Drop"},
+		Plural:           "drops",
+	}
+	add := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v2", Kind: "Keep"},
+		Plural:           "keeps",
+	}
+
+	removed, added := diffGVKPs(
+		[]groupVersionKindPlural{keep, drop},
+		[]groupVersionKindPlural{keep, add},
+	)
+	if len(removed) != 1 || removed[0].Kind != "Drop" {
+		t.Fatalf("expected Drop removed, got %#v", removed)
+	}
+	if len(added) != 1 || added[0].Version != "v2" {
+		t.Fatalf("expected v2 Keep added, got %#v", added)
+	}
+}
+
+// TestCRDUpdateNoopDoesNotCloseStopChannel models the previous bug: status-only
+// CRD updates used Remove+Append for identical GVKPs and closed live stop channels.
+func TestCRDUpdateNoopDoesNotCloseStopChannel(t *testing.T) {
+	gvkp := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
+		Plural:           "foos",
+	}
+	r := &CRDiscoverer{}
+	if !r.AppendToMap(gvkp) {
+		t.Fatal("expected first AppendToMap to change the cache")
+	}
+	ch := r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()]
+
+	revision := r.cacheRevision
+	if r.applyCRDUpdate([]groupVersionKindPlural{gvkp}, []groupVersionKindPlural{gvkp}) {
+		t.Fatal("identical GVKPs should be a no-op")
+	}
+	if r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()] != ch {
+		t.Fatal("stop channel changed on no-op diff")
+	}
+	if r.cacheRevision != revision {
+		t.Fatalf("cache revision changed on no-op update: got %d, want %d", r.cacheRevision, revision)
+	}
+	if r.WasUpdated {
+		t.Fatal("WasUpdated set on no-op update")
+	}
+	select {
+	case <-ch:
+		t.Fatal("stop channel was closed on no-op update")
+	default:
+	}
+}
+
+func TestCRDUpdateAddsVersionWithoutClosingKeptChannel(t *testing.T) {
+	v1 := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
+		Plural:           "foos",
+	}
+	v2 := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v2", Kind: "Foo"},
+		Plural:           "foos",
+	}
+	r := &CRDiscoverer{}
+	r.AppendToMap(v1)
+	keepCh := r.GVKToReflectorStopChanMap[v1.GroupVersionKind.String()]
+
+	if !r.applyCRDUpdate([]groupVersionKindPlural{v1}, []groupVersionKindPlural{v1, v2}) {
+		t.Fatal("expected adding v2 to change the cache")
+	}
+
+	if r.GVKToReflectorStopChanMap[v1.GroupVersionKind.String()] != keepCh {
+		t.Fatal("v1 stop channel was replaced when adding v2")
+	}
+	select {
+	case <-keepCh:
+		t.Fatal("v1 stop channel was closed when adding v2")
+	default:
+	}
+	if r.GVKToReflectorStopChanMap[v2.GroupVersionKind.String()] == nil {
+		t.Fatal("expected stop channel for added v2")
+	}
+	if !r.WasUpdated {
+		t.Fatal("expected WasUpdated after real GVK change")
+	}
+}
+
+func TestCRDDeleteReAddChangesRevision(t *testing.T) {
+	gvkp := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
+		Plural:           "foos",
+	}
+	r := &CRDiscoverer{}
+	r.AppendToMap(gvkp)
+	firstRevision := r.cacheRevision
+	firstCh := r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()]
+
+	r.RemoveFromMap(gvkp)
+	r.AppendToMap(gvkp)
+
+	if r.cacheRevision <= firstRevision {
+		t.Fatalf("revision did not advance across delete/re-add: first=%d current=%d", firstRevision, r.cacheRevision)
+	}
+	if r.GVKToReflectorStopChanMap[gvkp.GroupVersionKind.String()] == firstCh {
+		t.Fatal("expected delete/re-add to replace stop channel")
+	}
+	select {
+	case <-firstCh:
+	default:
+		t.Fatal("expected original stop channel to be closed")
+	}
+}
+
+func TestAppendToMapReturnsWhetherChanged(t *testing.T) {
+	gvkp := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
+		Plural:           "foos",
+	}
+	r := &CRDiscoverer{}
+	if !r.AppendToMap(gvkp) {
+		t.Fatal("first append should report change")
+	}
+	if r.AppendToMap(gvkp) {
+		t.Fatal("duplicate append should not report change")
+	}
+}
+
+func TestRemoveFromMapReturnsWhetherChanged(t *testing.T) {
+	gvkp := groupVersionKindPlural{
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"},
+		Plural:           "foos",
+	}
+	r := &CRDiscoverer{}
+	r.AppendToMap(gvkp)
+	if !r.RemoveFromMap(gvkp) {
+		t.Fatal("removing present GVK should report change")
+	}
+	if r.RemoveFromMap(gvkp) {
+		t.Fatal("removing absent GVK should not report change")
+	}
+}

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -67,6 +67,8 @@ var _ ksmtypes.BuilderInterface = &Builder{}
 
 var _ ksmtypes.StoreSyncBuilder = &Builder{}
 
+var _ ksmtypes.CustomResourceReplacer = &Builder{}
+
 // Builder helps to build store. It follows the builder pattern
 // (https://en.wikipedia.org/wiki/Builder_pattern).
 type Builder struct {

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -40,6 +40,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -92,6 +93,11 @@ type Builder struct {
 	objectLimit        int64
 
 	GetGVKStopChan func(gvk string) chan struct{}
+
+	// reflectorsMu guards reflectors, which Build() replaces while
+	// WaitForStoresSync() reads it outside the caller's own lock.
+	reflectorsMu sync.Mutex
+	reflectors   []*cache.Reflector
 }
 
 // NewBuilder returns a new builder.
@@ -295,6 +301,10 @@ func (b *Builder) Build() metricsstore.MetricsWriterList {
 	if b.familyGeneratorFilter == nil {
 		panic("familyGeneratorFilter should not be nil")
 	}
+
+	b.reflectorsMu.Lock()
+	b.reflectors = nil
+	b.reflectorsMu.Unlock()
 
 	var metricsWriters metricsstore.MetricsWriterList
 	var activeStoreNames []string
@@ -723,12 +733,37 @@ func (b *Builder) startReflector(
 ) {
 	instrumentedListWatch := watch.NewInstrumentedListerWatcher(listWatcher, b.listWatchMetrics, reflect.TypeOf(expectedType).String(), useAPIServerCache, objectLimit, client)
 	reflector := cache.NewReflectorWithOptions(sharding.NewShardedListWatch(b.shard, b.totalShards, instrumentedListWatch), expectedType, store, cache.ReflectorOptions{ResyncPeriod: 0})
+	b.reflectorsMu.Lock()
+	b.reflectors = append(b.reflectors, reflector)
+	b.reflectorsMu.Unlock()
 	if cr, ok := expectedType.(*unstructured.Unstructured); ok {
 		gvkStopCh := b.GetGVKStopChan(cr.GroupVersionKind().String())
 		go reflector.Run(newCRReflectorStopCh(b.ctx, gvkStopCh))
 	} else {
 		go reflector.Run(b.ctx.Done())
 	}
+}
+
+// WaitForStoresSync blocks until every reflector started by the latest Build() has
+// completed its initial list, or until ctx/timeout elapses.
+func (b *Builder) WaitForStoresSync(ctx context.Context, timeout time.Duration) bool {
+	b.reflectorsMu.Lock()
+	reflectors := slices.Clone(b.reflectors)
+	b.reflectorsMu.Unlock()
+
+	if len(reflectors) == 0 {
+		return true
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, ResourceDiscoveryInterval, timeout, true, func(context.Context) (bool, error) {
+		for _, reflector := range reflectors {
+			if reflector.LastSyncResourceVersion() == "" {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	return err == nil
 }
 
 // cacheStoresToMetricStores converts []cache.Store into []*metricsstore.MetricsStore

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -65,6 +65,8 @@ const ResourceDiscoveryInterval = 100 * time.Millisecond
 // New Builder methods should be added to the public BuilderInterface.
 var _ ksmtypes.BuilderInterface = &Builder{}
 
+var _ ksmtypes.StoreSyncBuilder = &Builder{}
+
 // Builder helps to build store. It follows the builder pattern
 // (https://en.wikipedia.org/wiki/Builder_pattern).
 type Builder struct {

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -160,7 +160,8 @@ func (b *Builder) ReplaceEnabledCustomResources(r []string) error {
 			kept = append(kept, name)
 		}
 	}
-	b.enabledResources = append(kept, r...)
+	b.enabledResources = kept
+	b.enabledResources = append(b.enabledResources, r...)
 	slices.Sort(b.enabledResources)
 	b.enabledResources = slices.Compact(b.enabledResources)
 

--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -140,6 +140,35 @@ func (b *Builder) WithEnabledResources(r []string) error {
 	return nil
 }
 
+// ReplaceEnabledCustomResources enables exactly the given discovered custom
+// resources while preserving built-in enabled resource names.
+func (b *Builder) ReplaceEnabledCustomResources(r []string) error {
+	for _, resource := range r {
+		if !resourceExists(resource) {
+			return fmt.Errorf("resource %s does not exist. Available resources: %s", resource, strings.Join(availableResources(), ","))
+		}
+	}
+
+	b.enabledResourcesMu.Lock()
+	defer b.enabledResourcesMu.Unlock()
+
+	var kept []string
+	for _, name := range b.enabledResources {
+		if !isCustomResourceEnabledName(name) {
+			kept = append(kept, name)
+		}
+	}
+	b.enabledResources = append(kept, r...)
+	slices.Sort(b.enabledResources)
+	b.enabledResources = slices.Compact(b.enabledResources)
+
+	return nil
+}
+
+func isCustomResourceEnabledName(name string) bool {
+	return strings.Contains(name, "/") || strings.Contains(name, ", Resource=")
+}
+
 // WithFieldSelectorFilter sets the fieldSelector property of a Builder.
 func (b *Builder) WithFieldSelectorFilter(fieldSelectorFilter string) {
 	b.fieldSelectorFilter = fieldSelectorFilter

--- a/internal/store/builder_sync_test.go
+++ b/internal/store/builder_sync_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestWaitForStoresSync_NoReflectors(t *testing.T) {
+	b := NewBuilder()
+	if !b.WaitForStoresSync(context.Background(), time.Millisecond) {
+		t.Fatal("expected sync success with no reflectors")
+	}
+}
+
+func TestWaitForStoresSync_Timeout(t *testing.T) {
+	b := NewBuilder()
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	lw := &cache.ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			return &v1.PodList{}, nil
+		},
+	}
+	reflector := cache.NewReflectorWithOptions(lw, &v1.Pod{}, store, cache.ReflectorOptions{})
+	b.reflectors = []*cache.Reflector{reflector}
+
+	if b.WaitForStoresSync(context.Background(), 50*time.Millisecond) {
+		t.Fatal("expected sync to time out before reflector runs")
+	}
+}

--- a/internal/store/builder_test.go
+++ b/internal/store/builder_test.go
@@ -398,3 +398,35 @@ func TestBuilderSharedStateIsRaceFree(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestReplaceEnabledCustomResources(t *testing.T) {
+	b := NewBuilder()
+	if err := b.WithEnabledResources([]string{"pods", "deployments"}); err != nil {
+		t.Fatal(err)
+	}
+
+	customA := "example.com/v1, Resource=foos"
+	customB := "example.com/v1, Resource=bars"
+	registerStore(customA, func(b *Builder) []cache.Store { return nil })
+	registerStore(customB, func(b *Builder) []cache.Store { return nil })
+	t.Cleanup(func() {
+		availableStoresMu.Lock()
+		delete(availableStores, customA)
+		delete(availableStores, customB)
+		availableStoresMu.Unlock()
+	})
+
+	if err := b.ReplaceEnabledCustomResources([]string{customA, customB}); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(b.enabledResources, []string{"deployments", customB, customA, "pods"}) {
+		t.Fatalf("unexpected enabled resources after replace: %#v", b.enabledResources)
+	}
+
+	if err := b.ReplaceEnabledCustomResources([]string{customB}); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(b.enabledResources, []string{"deployments", customB, "pods"}) {
+		t.Fatalf("expected removed custom resource to be dropped: %#v", b.enabledResources)
+	}
+}

--- a/internal/store/builder_test.go
+++ b/internal/store/builder_test.go
@@ -407,8 +407,8 @@ func TestReplaceEnabledCustomResources(t *testing.T) {
 
 	customA := "example.com/v1, Resource=foos"
 	customB := "example.com/v1, Resource=bars"
-	registerStore(customA, func(b *Builder) []cache.Store { return nil })
-	registerStore(customB, func(b *Builder) []cache.Store { return nil })
+	registerStore(customA, func(*Builder) []cache.Store { return nil })
+	registerStore(customB, func(*Builder) []cache.Store { return nil })
 	t.Cleanup(func() {
 		availableStoresMu.Lock()
 		delete(availableStores, customA)

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -520,7 +520,8 @@ func buildTelemetryServer(registry prometheus.Gatherer, m *metricshandler.Metric
 		mux.Handle(path, h)
 	}
 
-	// Add readyzPath
+	// Add readyzPath on the telemetry server. Readiness probes must target
+	// opts.TelemetryPort (default 8081), not the main metrics port.
 	mux.Handle(readyzPath, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if !m.Ready() {
 			w.WriteHeader(http.StatusServiceUnavailable)

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -340,7 +340,6 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		discovererInstance.PollForCacheUpdates(
 			ctx,
 			opts,
-			storeBuilder,
 			m,
 			fn,
 		)

--- a/pkg/app/server.go
+++ b/pkg/app/server.go
@@ -346,7 +346,7 @@ func RunKubeStateMetrics(ctx context.Context, opts *options.Options) error {
 		)
 	}
 
-	telemetryMux := buildTelemetryServer(ksmMetricsRegistry, opts.AuthFilter, kubeConfig)
+	telemetryMux := buildTelemetryServer(ksmMetricsRegistry, m, opts.AuthFilter, kubeConfig)
 	telemetryListenAddress := net.JoinHostPort(opts.TelemetryHost, strconv.Itoa(opts.TelemetryPort))
 	telemetryServer := http.Server{
 		Handler:           telemetryMux,
@@ -463,7 +463,7 @@ func configureResourcesAndMetrics(opts *options.Options, configFile []byte) *opt
 	return opts
 }
 
-func buildTelemetryServer(registry prometheus.Gatherer, authFilter bool, kubeConfig *rest.Config) *http.ServeMux {
+func buildTelemetryServer(registry prometheus.Gatherer, m *metricshandler.MetricsHandler, authFilter bool, kubeConfig *rest.Config) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	loghandler := logr.ToSlogHandler(klog.Background())
@@ -522,6 +522,11 @@ func buildTelemetryServer(registry prometheus.Gatherer, authFilter bool, kubeCon
 
 	// Add readyzPath
 	mux.Handle(readyzPath, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if !m.Ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(http.StatusText(http.StatusServiceUnavailable)))
+			return
+		}
 		count, err := util.GatherAndCount(registry)
 		if err != nil || count == 0 {
 			w.WriteHeader(http.StatusServiceUnavailable)

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -108,14 +108,12 @@ func BenchmarkKubeStateMetrics(b *testing.B) {
 	builder.WithAllowAnnotations(map[string][]string{})
 	builder.WithAllowLabels(map[string][]string{})
 
-	// This test is not suitable to be compared in terms of time, as it includes
-	// a one second wait. Use for memory allocation comparisons, profiling, ...
+	// This test is not suitable to be compared in terms of time, as it waits for
+	// the initial writer generation. Use for memory allocation comparisons, profiling, ...
 	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
-	b.Run("GenerateMetrics", func(_ *testing.B) {
+	b.Run("GenerateMetrics", func(b *testing.B) {
 		handler.ConfigureSharding(ctx, 0, 1)
-
-		// Wait for caches to fill
-		time.Sleep(time.Second)
+		waitForHandlerReady(b, handler)
 	})
 
 	req := httptest.NewRequest("GET", "http://localhost:8080/metrics", nil)
@@ -144,6 +142,18 @@ func BenchmarkKubeStateMetrics(b *testing.B) {
 
 		b.SetBytes(int64(accumulatedContentLength))
 	})
+}
+
+// waitForHandlerReady blocks until the handler has installed a writer generation.
+func waitForHandlerReady(tb testing.TB, handler *metricshandler.MetricsHandler) {
+	tb.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for !handler.Ready() {
+		if time.Now().After(deadline) {
+			tb.Fatal("metrics handler did not become ready before deadline")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 // TestFullScrapeCycle is a simple smoke test covering the entire cycle from
@@ -197,8 +207,7 @@ func TestFullScrapeCycle(t *testing.T) {
 	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
 	handler.ConfigureSharding(ctx, 0, 1)
 
-	// Wait for caches to fill
-	time.Sleep(time.Second)
+	waitForHandlerReady(t, handler)
 
 	req := httptest.NewRequest("GET", "http://localhost:8080/metrics", nil)
 
@@ -570,8 +579,9 @@ func TestShardingEquivalenceScrapeCycle(t *testing.T) {
 	shardedHandler2 := metricshandler.New(&options.Options{}, kubeClient, shardedBuilder2, false)
 	shardedHandler2.ConfigureSharding(ctx, 1, 2)
 
-	// Wait for caches to fill
-	time.Sleep(time.Second)
+	waitForHandlerReady(t, unshardedHandler)
+	waitForHandlerReady(t, shardedHandler1)
+	waitForHandlerReady(t, shardedHandler2)
 
 	// unsharded request as the controlled environment
 	req := httptest.NewRequest("GET", "http://localhost:8080/metrics", nil)
@@ -724,8 +734,7 @@ func TestCustomResourceExtension(t *testing.T) {
 	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
 	handler.ConfigureSharding(ctx, 0, 1)
 
-	// Wait for caches to fill
-	time.Sleep(time.Second)
+	waitForHandlerReady(t, handler)
 
 	req := httptest.NewRequest("GET", "http://localhost:8080/metrics", nil)
 

--- a/pkg/app/server_test.go
+++ b/pkg/app/server_test.go
@@ -399,7 +399,7 @@ kube_pod_status_phase{namespace="default",pod="pod0",uid="abc-0",phase="Unknown"
 		}
 	}
 
-	telemetryMux := buildTelemetryServer(reg, false, nil)
+	telemetryMux := buildTelemetryServer(reg, handler, false, nil)
 
 	req2 := httptest.NewRequest("GET", "http://localhost:8081/metrics", nil)
 
@@ -473,7 +473,8 @@ func TestPprofRouting(t *testing.T) {
 		}
 
 		reg := prometheus.NewRegistry()
-		telemetryMux := buildTelemetryServer(reg, authEnabled, cfg)
+		telemetryHandler := metricshandler.New(options.NewOptions(), fake.NewSimpleClientset(), nil, false)
+		telemetryMux := buildTelemetryServer(reg, telemetryHandler, authEnabled, cfg)
 		for _, path := range pprofPaths {
 			req := httptest.NewRequest("GET", "http://localhost:8081"+path, nil)
 			_, pattern := telemetryMux.Handler(req)
@@ -1094,7 +1095,7 @@ func TestBuildServersServeLandingPage(t *testing.T) {
 	handler := metricshandler.New(&options.Options{}, kubeClient, builder, false)
 
 	for name, mux := range map[string]*http.ServeMux{
-		"telemetry": buildTelemetryServer(prometheus.NewRegistry(), false, nil),
+		"telemetry": buildTelemetryServer(prometheus.NewRegistry(), handler, false, nil),
 		"metrics":   buildMetricsServer(handler, durationVec, kubeClient, false, nil),
 	} {
 		req := httptest.NewRequest("GET", "/", nil)

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -139,7 +139,10 @@ func (b *Builder) Build() metricsstore.MetricsWriterList {
 
 // WaitForStoresSync blocks until reflectors from the latest Build() have listed once.
 func (b *Builder) WaitForStoresSync(ctx context.Context, timeout time.Duration) bool {
-	return b.internal.WaitForStoresSync(ctx, timeout)
+	if syncer, ok := b.internal.(ksmtypes.StoreSyncBuilder); ok {
+		return syncer.WaitForStoresSync(ctx, timeout)
+	}
+	return true
 }
 
 // BuildStores initializes and registers all enabled stores.

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -18,6 +18,7 @@ package builder
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -63,7 +64,11 @@ func (b *Builder) WithEnabledResources(c []string) error {
 // ReplaceEnabledCustomResources replaces discovered custom resources while
 // preserving built-in enabled resource names.
 func (b *Builder) ReplaceEnabledCustomResources(c []string) error {
-	return b.internal.ReplaceEnabledCustomResources(c)
+	replacer, ok := b.internal.(ksmtypes.CustomResourceReplacer)
+	if !ok {
+		return fmt.Errorf("builder does not support replacing custom resources")
+	}
+	return replacer.ReplaceEnabledCustomResources(c)
 }
 
 // WithNamespaces sets the namespaces property of a Builder.

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -60,6 +60,12 @@ func (b *Builder) WithEnabledResources(c []string) error {
 	return b.internal.WithEnabledResources(c)
 }
 
+// ReplaceEnabledCustomResources replaces discovered custom resources while
+// preserving built-in enabled resource names.
+func (b *Builder) ReplaceEnabledCustomResources(c []string) error {
+	return b.internal.ReplaceEnabledCustomResources(c)
+}
+
 // WithNamespaces sets the namespaces property of a Builder.
 func (b *Builder) WithNamespaces(n options.NamespaceList) {
 	b.internal.WithNamespaces(n)

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -18,6 +18,7 @@ package builder
 
 import (
 	"context"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	clientset "k8s.io/client-go/kubernetes"
@@ -134,6 +135,11 @@ func (b *Builder) WithCustomResourceStoreFactories(fs ...customresource.Registry
 // Returns metric writers.
 func (b *Builder) Build() metricsstore.MetricsWriterList {
 	return b.internal.Build()
+}
+
+// WaitForStoresSync blocks until reflectors from the latest Build() have listed once.
+func (b *Builder) WaitForStoresSync(ctx context.Context, timeout time.Duration) bool {
+	return b.internal.WaitForStoresSync(ctx, timeout)
 }
 
 // BuildStores initializes and registers all enabled stores.

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -35,6 +35,7 @@ import (
 type BuilderInterface interface {
 	WithMetrics(r prometheus.Registerer)
 	WithEnabledResources(c []string) error
+	ReplaceEnabledCustomResources(c []string) error
 	WithNamespaces(n options.NamespaceList)
 	WithFieldSelectorFilter(fieldSelectors string)
 	WithSharding(shard int32, totalShards int)

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"context"
+	"time"
 
 	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
 
@@ -49,6 +50,7 @@ type BuilderInterface interface {
 	DefaultGenerateCustomResourceStoresFunc() BuildCustomResourceStoresFunc
 	WithCustomResourceStoreFactories(fs ...customresource.RegistryFactory)
 	Build() metricsstore.MetricsWriterList
+	WaitForStoresSync(ctx context.Context, timeout time.Duration) bool
 	BuildStores() [][]cache.Store
 	WithGenerateCustomResourceStoresFunc(f BuildCustomResourceStoresFunc)
 }

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -50,9 +50,15 @@ type BuilderInterface interface {
 	DefaultGenerateCustomResourceStoresFunc() BuildCustomResourceStoresFunc
 	WithCustomResourceStoreFactories(fs ...customresource.RegistryFactory)
 	Build() metricsstore.MetricsWriterList
-	WaitForStoresSync(ctx context.Context, timeout time.Duration) bool
 	BuildStores() [][]cache.Store
 	WithGenerateCustomResourceStoresFunc(f BuildCustomResourceStoresFunc)
+}
+
+// StoreSyncBuilder can wait for reflector stores to sync after Build().
+// It is implemented by the internal store builder but is not part of the
+// stable BuilderInterface contract for downstream library users.
+type StoreSyncBuilder interface {
+	WaitForStoresSync(ctx context.Context, timeout time.Duration) bool
 }
 
 // BuildStoresFunc function signature that is used to return a list of cache.Store

--- a/pkg/builder/types/interfaces.go
+++ b/pkg/builder/types/interfaces.go
@@ -35,7 +35,6 @@ import (
 type BuilderInterface interface {
 	WithMetrics(r prometheus.Registerer)
 	WithEnabledResources(c []string) error
-	ReplaceEnabledCustomResources(c []string) error
 	WithNamespaces(n options.NamespaceList)
 	WithFieldSelectorFilter(fieldSelectors string)
 	WithSharding(shard int32, totalShards int)
@@ -53,6 +52,14 @@ type BuilderInterface interface {
 	Build() metricsstore.MetricsWriterList
 	BuildStores() [][]cache.Store
 	WithGenerateCustomResourceStoresFunc(f BuildCustomResourceStoresFunc)
+}
+
+// CustomResourceReplacer can replace the discovered custom resource set while
+// preserving built-in enabled resource names. It is implemented by the internal
+// store builder but is not part of the stable BuilderInterface contract for
+// downstream library users.
+type CustomResourceReplacer interface {
+	ReplaceEnabledCustomResources(c []string) error
 }
 
 // StoreSyncBuilder can wait for reflector stores to sync after Build().

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/prometheus/common/expfmt"
 
@@ -56,7 +57,20 @@ type MetricsHandler struct {
 	curTotalShards     int
 	curShard           int32
 	enableGZIPEncoding bool
+
+	rebuildMu        sync.Mutex
+	rebuildRunning   bool
+	pendingRebuild   bool
+	rebuildParentCtx context.Context
+	syncRetryDelay   time.Duration
 }
+
+// Backoff bounds for retrying a failed store sync while no metrics writers are
+// available. Declared as variables so tests can shorten them.
+var (
+	initialStoreSyncRetryDelay = 5 * time.Second
+	maxStoreSyncRetryDelay     = 2 * time.Minute
+)
 
 // New creates and returns a new MetricsHandler with the given options.
 func New(opts *options.Options, kubeClient kubernetes.Interface, storeBuilder ksmtypes.BuilderInterface, enableGZIPEncoding bool) *MetricsHandler {
@@ -69,18 +83,130 @@ func New(opts *options.Options, kubeClient kubernetes.Interface, storeBuilder ks
 	}
 }
 
-// BuildWriters builds the metrics writers, cancelling any previous context and passing a new one on every build.
-// Build can be used multiple times and concurrently.
+// BuildWriters rebuilds metrics writers after store configuration changes.
+// Rebuilds are coalesced and swap in the new writer set only after reflector stores sync.
 func (m *MetricsHandler) BuildWriters(ctx context.Context) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	if m.cancel != nil {
-		m.cancel()
+	m.rebuildMu.Lock()
+	m.rebuildParentCtx = ctx
+	if m.rebuildRunning {
+		m.pendingRebuild = true
+		m.rebuildMu.Unlock()
+		return
 	}
-	ctx, m.cancel = context.WithCancel(ctx)
-	m.storeBuilder.WithContext(ctx)
-	m.metricsWriters = m.storeBuilder.Build()
+	m.rebuildRunning = true
+	m.rebuildMu.Unlock()
+
+	go m.rebuildLoop(ctx)
+}
+
+func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
+	ctx := initialCtx
+	for {
+		synced := m.doRebuild(ctx)
+
+		m.mtx.RLock()
+		noWriters := len(m.metricsWriters) == 0
+		m.mtx.RUnlock()
+
+		m.rebuildMu.Lock()
+		if m.pendingRebuild {
+			m.pendingRebuild = false
+			ctx = m.rebuildParentCtx
+			m.rebuildMu.Unlock()
+			continue
+		}
+		m.rebuildRunning = false
+		var retryDelay time.Duration
+		if !synced && noWriters {
+			m.syncRetryDelay = nextStoreSyncRetryDelay(m.syncRetryDelay)
+			retryDelay = m.syncRetryDelay
+		} else {
+			m.syncRetryDelay = 0
+		}
+		m.rebuildMu.Unlock()
+
+		if retryDelay > 0 {
+			m.scheduleSyncRetry(ctx, retryDelay)
+		}
+		return
+	}
+}
+
+// scheduleSyncRetry re-runs a rebuild after delay. Without it, a store sync that
+// fails before any writer generation exists would leave the handler serving no
+// metrics until an unrelated event triggers another rebuild, which never happens
+// when autosharding is disabled.
+func (m *MetricsHandler) scheduleSyncRetry(ctx context.Context, delay time.Duration) {
+	klog.ErrorS(nil, "Store sync failed with no metrics writers available; scheduling rebuild retry", "retryDelay", delay)
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+		case <-timer.C:
+			m.BuildWriters(ctx)
+		}
+	}()
+}
+
+func nextStoreSyncRetryDelay(current time.Duration) time.Duration {
+	if current <= 0 {
+		return initialStoreSyncRetryDelay
+	}
+	if next := current * 2; next < maxStoreSyncRetryDelay {
+		return next
+	}
+	return maxStoreSyncRetryDelay
+}
+
+func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
+	m.mtx.Lock()
+	newCtx, newCancel := context.WithCancel(parentCtx)
+	m.storeBuilder.WithContext(newCtx)
+	newWriters := m.storeBuilder.Build()
+	m.mtx.Unlock()
+
+	syncTimeout := m.opts.StoreSyncTimeout
+	if syncTimeout <= 0 {
+		syncTimeout = options.DefaultStoreSyncTimeout
+	}
+	// mtx is deliberately released before waiting: ServeHTTP takes it for read on
+	// every scrape, so holding it for up to syncTimeout would stall all scrapes
+	// for the whole sync window. Rebuilds are already serialized by rebuildMu, so
+	// no other Build() can run concurrently with the wait.
+	syncStart := time.Now()
+	synced := m.storeBuilder.WaitForStoresSync(newCtx, syncTimeout)
+	syncWaitDuration := time.Since(syncStart)
+
+	if synced {
+		m.mtx.Lock()
+		oldCancel := m.cancel
+		m.metricsWriters = newWriters
+		m.cancel = newCancel
+		m.mtx.Unlock()
+		if oldCancel != nil {
+			oldCancel()
+		}
+		klog.InfoS("Swapped metrics writers after store sync", "writerCount", len(newWriters), "syncWaitDuration", syncWaitDuration)
+		return true
+	}
+
+	newCancel()
+	klog.ErrorS(nil, "Store sync timed out during metrics writer rebuild; keeping previous writers",
+		"syncWaitDuration", syncWaitDuration,
+		"syncTimeout", syncTimeout,
+		"writerCount", len(newWriters),
+	)
+	return false
+}
+
+// Ready reports whether at least one metrics writer generation has been swapped
+// in after a successful store sync. Until then /metrics may return HTTP 200 with
+// an empty body; /readyz uses this to withhold readiness.
+func (m *MetricsHandler) Ready() bool {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	return len(m.metricsWriters) > 0
 }
 
 // ConfigureSharding configures sharding. Configuration can be used multiple times and

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -33,6 +33,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -54,6 +55,7 @@ type MetricsHandler struct {
 	// mtx protects metricsWriters, curShard, and curTotalShards
 	mtx                *sync.RWMutex
 	metricsWriters     metricsstore.MetricsWriterList
+	writersInstalled   bool
 	curTotalShards     int
 	curShard           int32
 	enableGZIPEncoding bool
@@ -150,13 +152,19 @@ func (m *MetricsHandler) scheduleSyncRetry(ctx context.Context, delay time.Durat
 }
 
 func nextStoreSyncRetryDelay(current time.Duration) time.Duration {
+	var base time.Duration
 	if current <= 0 {
-		return initialStoreSyncRetryDelay
+		base = initialStoreSyncRetryDelay
+	} else if next := current * 2; next < maxStoreSyncRetryDelay {
+		base = next
+	} else {
+		base = maxStoreSyncRetryDelay
 	}
-	if next := current * 2; next < maxStoreSyncRetryDelay {
-		return next
+	jittered := wait.Jitter(base, 0.1)
+	if jittered > maxStoreSyncRetryDelay {
+		return maxStoreSyncRetryDelay
 	}
-	return maxStoreSyncRetryDelay
+	return jittered
 }
 
 func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
@@ -175,7 +183,10 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
 	// for the whole sync window. Rebuilds are already serialized by rebuildMu, so
 	// no other Build() can run concurrently with the wait.
 	syncStart := time.Now()
-	synced := m.storeBuilder.WaitForStoresSync(newCtx, syncTimeout)
+	synced := true
+	if syncer, ok := m.storeBuilder.(ksmtypes.StoreSyncBuilder); ok {
+		synced = syncer.WaitForStoresSync(newCtx, syncTimeout)
+	}
 	syncWaitDuration := time.Since(syncStart)
 
 	if synced {
@@ -183,6 +194,7 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
 		oldCancel := m.cancel
 		m.metricsWriters = newWriters
 		m.cancel = newCancel
+		m.writersInstalled = true
 		m.mtx.Unlock()
 		if oldCancel != nil {
 			oldCancel()
@@ -200,13 +212,13 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
 	return false
 }
 
-// Ready reports whether at least one metrics writer generation has been swapped
-// in after a successful store sync. Until then /metrics may return HTTP 200 with
-// an empty body; /readyz uses this to withhold readiness.
+// Ready reports whether a metrics writer generation has been swapped in after a
+// successful store sync. Until then /metrics may return HTTP 200 with an empty
+// body; /readyz on the telemetry port uses this to withhold readiness.
 func (m *MetricsHandler) Ready() bool {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
-	return len(m.metricsWriters) > 0
+	return m.writersInstalled
 }
 
 // ConfigureSharding configures sharding. Configuration can be used multiple times and

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -52,7 +52,9 @@ type MetricsHandler struct {
 
 	cancel func()
 
-	// mtx protects metricsWriters, curShard, and curTotalShards
+	// mtx protects metricsWriters, curShard, curTotalShards, and storeBuilder
+	// configuration (With* calls). Build() runs under this lock; WaitForStoresSync
+	// deliberately does not, so scrapes are not blocked for the sync timeout.
 	mtx                *sync.RWMutex
 	metricsWriters     metricsstore.MetricsWriterList
 	writersInstalled   bool
@@ -134,12 +136,10 @@ func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 	}
 }
 
-// scheduleSyncRetry re-runs a rebuild after delay. Without it, a store sync that
-// fails before any writer generation exists would leave the handler serving no
-// metrics until an unrelated event triggers another rebuild, which never happens
-// when autosharding is disabled.
+// scheduleSyncRetry re-runs a failed rebuild after a bounded backoff. Existing
+// writers remain active until a retry successfully synchronizes and swaps.
 func (m *MetricsHandler) scheduleSyncRetry(ctx context.Context, delay time.Duration) {
-	klog.ErrorS(nil, "Store sync failed with no metrics writers available; scheduling rebuild retry", "retryDelay", delay)
+	klog.ErrorS(nil, "Store sync failed; scheduling rebuild retry", "retryDelay", delay)
 	go func() {
 		timer := time.NewTimer(delay)
 		defer timer.Stop()
@@ -181,7 +181,9 @@ func (m *MetricsHandler) doRebuild(parentCtx context.Context) bool {
 	// mtx is deliberately released before waiting: ServeHTTP takes it for read on
 	// every scrape, so holding it for up to syncTimeout would stall all scrapes
 	// for the whole sync window. Rebuilds are already serialized by rebuildMu, so
-	// no other Build() can run concurrently with the wait.
+	// no other Build() can run concurrently with the wait. storeBuilder config
+	// may still change under mtx (ConfigureStore / ConfigureSharding); that only
+	// marks a pending rebuild and does not disturb the reflectors being waited on.
 	syncStart := time.Now()
 	synced := true
 	if syncer, ok := m.storeBuilder.(ksmtypes.StoreSyncBuilder); ok {
@@ -221,21 +223,32 @@ func (m *MetricsHandler) Ready() bool {
 	return m.writersInstalled
 }
 
+// ConfigureStore applies storeBuilder configuration under mtx, then rebuilds
+// writers. Runtime callers that mutate the shared builder (for example CR
+// discovery) must use this instead of calling builder With* methods directly,
+// so configuration cannot race with Build().
+func (m *MetricsHandler) ConfigureStore(ctx context.Context, configure func(ksmtypes.BuilderInterface)) {
+	if configure == nil {
+		m.BuildWriters(ctx)
+		return
+	}
+	m.mtx.Lock()
+	configure(m.storeBuilder)
+	m.mtx.Unlock()
+	m.BuildWriters(ctx)
+}
+
 // ConfigureSharding configures sharding. Configuration can be used multiple times and
 // concurrently.
 func (m *MetricsHandler) ConfigureSharding(ctx context.Context, shard int32, totalShards int) {
-	m.mtx.Lock()
-
 	if totalShards != 1 {
 		klog.InfoS("Configuring sharding of this instance to be shard index (zero-indexed) out of total shards", "shard", shard, "totalShards", totalShards)
 	}
-	m.curShard = shard
-	m.curTotalShards = totalShards
-	m.storeBuilder.WithSharding(shard, totalShards)
-
-	// unlock because BuildWriters will hold a lock again
-	m.mtx.Unlock()
-	m.BuildWriters(ctx)
+	m.ConfigureStore(ctx, func(b ksmtypes.BuilderInterface) {
+		m.curShard = shard
+		m.curTotalShards = totalShards
+		b.WithSharding(shard, totalShards)
+	})
 }
 
 // Run configures the MetricsHandler's sharding and if autosharding is enabled

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -226,16 +226,21 @@ func (m *MetricsHandler) Ready() bool {
 // ConfigureStore applies storeBuilder configuration under mtx, then rebuilds
 // writers. Runtime callers that mutate the shared builder (for example CR
 // discovery) must use this instead of calling builder With* methods directly,
-// so configuration cannot race with Build().
-func (m *MetricsHandler) ConfigureStore(ctx context.Context, configure func(ksmtypes.BuilderInterface)) {
+// so configuration cannot race with Build(). Returns an error without rebuilding
+// when configuration fails.
+func (m *MetricsHandler) ConfigureStore(ctx context.Context, configure func(ksmtypes.BuilderInterface) error) error {
 	if configure == nil {
 		m.BuildWriters(ctx)
-		return
+		return nil
 	}
 	m.mtx.Lock()
-	configure(m.storeBuilder)
+	err := configure(m.storeBuilder)
 	m.mtx.Unlock()
+	if err != nil {
+		return err
+	}
 	m.BuildWriters(ctx)
+	return nil
 }
 
 // ConfigureSharding configures sharding. Configuration can be used multiple times and
@@ -244,10 +249,11 @@ func (m *MetricsHandler) ConfigureSharding(ctx context.Context, shard int32, tot
 	if totalShards != 1 {
 		klog.InfoS("Configuring sharding of this instance to be shard index (zero-indexed) out of total shards", "shard", shard, "totalShards", totalShards)
 	}
-	m.ConfigureStore(ctx, func(b ksmtypes.BuilderInterface) {
+	m.ConfigureStore(ctx, func(b ksmtypes.BuilderInterface) error {
 		m.curShard = shard
 		m.curTotalShards = totalShards
 		b.WithSharding(shard, totalShards)
+		return nil
 	})
 }
 

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -108,10 +108,6 @@ func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 	for {
 		synced := m.doRebuild(ctx)
 
-		m.mtx.RLock()
-		noWriterGeneration := !m.writersInstalled
-		m.mtx.RUnlock()
-
 		m.rebuildMu.Lock()
 		if m.pendingRebuild {
 			m.pendingRebuild = false
@@ -121,7 +117,8 @@ func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 		}
 		m.rebuildRunning = false
 		var retryDelay time.Duration
-		if !synced && noWriterGeneration {
+		// Retry every failed sync. Previous writers stay active during backoff.
+		if !synced {
 			m.syncRetryDelay = nextStoreSyncRetryDelay(m.syncRetryDelay)
 			retryDelay = m.syncRetryDelay
 		} else {

--- a/pkg/metricshandler/metrics_handler.go
+++ b/pkg/metricshandler/metrics_handler.go
@@ -107,7 +107,7 @@ func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 		synced := m.doRebuild(ctx)
 
 		m.mtx.RLock()
-		noWriters := len(m.metricsWriters) == 0
+		noWriterGeneration := !m.writersInstalled
 		m.mtx.RUnlock()
 
 		m.rebuildMu.Lock()
@@ -119,7 +119,7 @@ func (m *MetricsHandler) rebuildLoop(initialCtx context.Context) {
 		}
 		m.rebuildRunning = false
 		var retryDelay time.Duration
-		if !synced && noWriters {
+		if !synced && noWriterGeneration {
 			m.syncRetryDelay = nextStoreSyncRetryDelay(m.syncRetryDelay)
 			retryDelay = m.syncRetryDelay
 		} else {

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -153,6 +153,22 @@ func TestBuildWriters_SwapsWritersWhenSyncSucceeds(t *testing.T) {
 	if len(got) != 1 || got[0].ResourceName != "next" {
 		t.Fatalf("expected writers to swap after successful sync, got %+v", got)
 	}
+	if !h.Ready() {
+		t.Fatal("expected handler to report ready after successful sync")
+	}
+}
+
+func TestBuildWriters_ReadyAfterEmptyGenerationSyncs(t *testing.T) {
+	stub := &stubStoreBuilder{buildWriters: metricsstore.MetricsWriterList{}}
+	stub.syncOK.Store(true)
+	h := New(options.NewOptions(), nil, stub, false)
+
+	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
+
+	if !h.Ready() {
+		t.Fatal("expected handler to report ready after a successful sync with zero writers")
+	}
 }
 
 func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -180,43 +180,6 @@ func TestBuildWriters_ReadyAfterEmptyGenerationSyncs(t *testing.T) {
 	}
 }
 
-func TestBuildWriters_DoesNotRetryFailedRebuildAfterEmptyGenerationInstalled(t *testing.T) {
-	restore := initialStoreSyncRetryDelay
-	initialStoreSyncRetryDelay = time.Millisecond
-	defer func() { initialStoreSyncRetryDelay = restore }()
-
-	syncGate := make(chan bool, 2)
-	stub := &stubStoreBuilder{
-		buildWriters: metricsstore.MetricsWriterList{},
-		syncGate:     syncGate,
-	}
-	h := New(options.NewOptions(), nil, stub, false)
-
-	syncGate <- true
-	h.BuildWriters(context.Background())
-	waitForRebuildIdle(t, h)
-	if !h.Ready() {
-		t.Fatal("expected ready after empty generation install")
-	}
-
-	firstBuild := stub.buildCount.Load()
-	firstSync := stub.syncCount.Load()
-
-	syncGate <- false
-	h.BuildWriters(context.Background())
-	waitForRebuildIdle(t, h)
-
-	time.Sleep(5 * time.Millisecond)
-	waitForRebuildIdle(t, h)
-
-	if stub.buildCount.Load() != firstBuild+1 {
-		t.Fatalf("expected only one failing rebuild after installed generation, buildCount=%d", stub.buildCount.Load())
-	}
-	if stub.syncCount.Load() != firstSync+1 {
-		t.Fatalf("expected only one failing sync after installed generation, syncCount=%d", stub.syncCount.Load())
-	}
-}
-
 func TestBuildWriters_RetriesFailedSyncWithExistingWriters(t *testing.T) {
 	restore := initialStoreSyncRetryDelay
 	initialStoreSyncRetryDelay = time.Millisecond

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -18,6 +18,7 @@ package metricshandler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -54,6 +55,7 @@ type stubStoreBuilder struct {
 
 func (s *stubStoreBuilder) WithMetrics(_ prometheus.Registerer)                         {}
 func (s *stubStoreBuilder) WithEnabledResources(_ []string) error                       { return nil }
+func (s *stubStoreBuilder) ReplaceEnabledCustomResources(_ []string) error              { return nil }
 func (s *stubStoreBuilder) WithNamespaces(_ options.NamespaceList)                      {}
 func (s *stubStoreBuilder) WithFieldSelectorFilter(_ string)                            {}
 func (s *stubStoreBuilder) WithSharding(_ int32, _ int)                                 {}
@@ -418,11 +420,12 @@ func TestConfigureStore_AppliesConfigUnderLockThenRebuilds(t *testing.T) {
 	h.mtx.Unlock()
 
 	var configured atomic.Bool
-	h.ConfigureStore(context.Background(), func(b ksmtypes.BuilderInterface) {
+	h.ConfigureStore(context.Background(), func(b ksmtypes.BuilderInterface) error {
 		if b != stub {
 			t.Fatalf("expected ConfigureStore to pass the handler store builder")
 		}
 		configured.Store(true)
+		return nil
 	})
 	waitForRebuildIdle(t, h)
 
@@ -468,8 +471,9 @@ func TestConfigureStore_CoalescesWithInFlightRebuild(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		h.ConfigureStore(context.Background(), func(ksmtypes.BuilderInterface) {
+		h.ConfigureStore(context.Background(), func(ksmtypes.BuilderInterface) error {
 			configDuringWait.Add(1)
+			return nil
 		})
 	}()
 
@@ -484,5 +488,23 @@ func TestConfigureStore_CoalescesWithInFlightRebuild(t *testing.T) {
 	}
 	if stub.buildCount.Load() < 2 {
 		t.Fatalf("expected coalesced rebuild after ConfigureStore during wait; buildCount=%d", stub.buildCount.Load())
+	}
+}
+
+func TestConfigureStore_SkipsRebuildOnConfigError(t *testing.T) {
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("next")},
+	}
+	stub.syncOK.Store(true)
+	h := New(options.NewOptions(), nil, stub, false)
+
+	err := h.ConfigureStore(context.Background(), func(ksmtypes.BuilderInterface) error {
+		return fmt.Errorf("config failed")
+	})
+	if err == nil {
+		t.Fatal("expected ConfigureStore to return configuration error")
+	}
+	if stub.buildCount.Load() != 0 {
+		t.Fatalf("expected no rebuild after configuration error; buildCount=%d", stub.buildCount.Load())
 	}
 }

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -48,7 +48,8 @@ type stubStoreBuilder struct {
 	syncCount    atomic.Int64
 	// syncGate, when set, makes WaitForStoresSync block until a result is sent.
 	// This lets tests assert mid-retry state without racing the retry timer.
-	syncGate chan bool
+	syncGate     chan bool
+	syncObserved chan bool
 }
 
 func (s *stubStoreBuilder) WithMetrics(_ prometheus.Registerer)                         {}
@@ -82,7 +83,11 @@ func (s *stubStoreBuilder) Build() metricsstore.MetricsWriterList {
 func (s *stubStoreBuilder) WaitForStoresSync(_ context.Context, _ time.Duration) bool {
 	s.syncCount.Add(1)
 	if s.syncGate != nil {
-		return <-s.syncGate
+		result := <-s.syncGate
+		if s.syncObserved != nil {
+			s.syncObserved <- result
+		}
+		return result
 	}
 	return s.syncOK.Load()
 }
@@ -116,7 +121,9 @@ func TestBuildWriters_KeepsPreviousWritersWhenSyncFails(t *testing.T) {
 	h.metricsWriters = existing
 	h.mtx.Unlock()
 
-	h.BuildWriters(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h.BuildWriters(ctx)
 	waitForRebuildIdle(t, h)
 
 	if stub.buildCount.Load() < 1 || stub.syncCount.Load() < 1 {
@@ -208,6 +215,57 @@ func TestBuildWriters_DoesNotRetryFailedRebuildAfterEmptyGenerationInstalled(t *
 	}
 }
 
+func TestBuildWriters_RetriesFailedSyncWithExistingWriters(t *testing.T) {
+	restore := initialStoreSyncRetryDelay
+	initialStoreSyncRetryDelay = time.Millisecond
+	defer func() { initialStoreSyncRetryDelay = restore }()
+
+	syncGate := make(chan bool, 1)
+	syncObserved := make(chan bool, 1)
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("next")},
+		syncGate:     syncGate,
+		syncObserved: syncObserved,
+	}
+	h := New(options.NewOptions(), nil, stub, false)
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("stable")}
+	h.mtx.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	syncGate <- false
+	h.BuildWriters(ctx)
+	if result := <-syncObserved; result {
+		t.Fatal("expected first sync attempt to fail")
+	}
+
+	h.mtx.RLock()
+	got := h.metricsWriters
+	h.mtx.RUnlock()
+	if len(got) != 1 || got[0].ResourceName != "stable" {
+		t.Fatalf("expected stable writers to remain active after failed sync, got %+v", got)
+	}
+
+	syncGate <- true
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mtx.RLock()
+		got = h.metricsWriters
+		h.mtx.RUnlock()
+		if len(got) == 1 && got[0].ResourceName == "next" {
+			waitForRebuildIdle(t, h)
+			if stub.syncCount.Load() < 2 {
+				t.Fatalf("expected retry sync attempt; syncCount=%d", stub.syncCount.Load())
+			}
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("expected retry to replace stable writers; buildCount=%d syncCount=%d",
+		stub.buildCount.Load(), stub.syncCount.Load())
+}
+
 func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
 	restore := initialStoreSyncRetryDelay
 	initialStoreSyncRetryDelay = time.Millisecond
@@ -256,6 +314,9 @@ func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
 			if stub.syncCount.Load() < 2 {
 				t.Fatalf("expected retry sync attempt; syncCount=%d", stub.syncCount.Load())
 			}
+			// The retry rebuild must leave rebuildLoop before the deferred
+			// initialStoreSyncRetryDelay restore runs.
+			waitForRebuildIdle(t, h)
 			return
 		}
 		time.Sleep(time.Millisecond)
@@ -343,4 +404,85 @@ func newTestWriter(name string) *metricsstore.MetricsWriter {
 		panic(err)
 	}
 	return metricsstore.NewMetricsWriter(name, store)
+}
+
+func TestConfigureStore_AppliesConfigUnderLockThenRebuilds(t *testing.T) {
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("configured")},
+	}
+	stub.syncOK.Store(true)
+	h := New(options.NewOptions(), nil, stub, false)
+
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("prev")}
+	h.mtx.Unlock()
+
+	var configured atomic.Bool
+	h.ConfigureStore(context.Background(), func(b ksmtypes.BuilderInterface) {
+		if b != stub {
+			t.Fatalf("expected ConfigureStore to pass the handler store builder")
+		}
+		configured.Store(true)
+	})
+	waitForRebuildIdle(t, h)
+
+	if !configured.Load() {
+		t.Fatal("expected ConfigureStore callback to run")
+	}
+	if stub.buildCount.Load() < 1 {
+		t.Fatalf("expected rebuild after ConfigureStore; buildCount=%d", stub.buildCount.Load())
+	}
+
+	h.mtx.RLock()
+	got := h.metricsWriters
+	h.mtx.RUnlock()
+	if len(got) != 1 || got[0].ResourceName != "configured" {
+		t.Fatalf("expected writers swapped after ConfigureStore rebuild, got %+v", got)
+	}
+}
+
+func TestConfigureStore_CoalescesWithInFlightRebuild(t *testing.T) {
+	syncGate := make(chan bool, 1)
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("next")},
+		syncGate:     syncGate,
+	}
+	h := New(options.NewOptions(), nil, stub, false)
+
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("prev")}
+	h.mtx.Unlock()
+
+	// Start an async rebuild that blocks in WaitForStoresSync.
+	h.BuildWriters(context.Background())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for stub.syncCount.Load() < 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("first rebuild did not reach WaitForStoresSync")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	var configDuringWait atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.ConfigureStore(context.Background(), func(ksmtypes.BuilderInterface) {
+			configDuringWait.Add(1)
+		})
+	}()
+
+	// Release the first sync as success; coalesced rebuild from ConfigureStore follows.
+	syncGate <- true
+	go func() { syncGate <- true }()
+	<-done
+	waitForRebuildIdle(t, h)
+
+	if configDuringWait.Load() != 1 {
+		t.Fatalf("expected ConfigureStore callback once, got %d", configDuringWait.Load())
+	}
+	if stub.buildCount.Load() < 2 {
+		t.Fatalf("expected coalesced rebuild after ConfigureStore during wait; buildCount=%d", stub.buildCount.Load())
+	}
 }

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricshandler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	ksmtypes "k8s.io/kube-state-metrics/v2/pkg/builder/types"
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	"k8s.io/kube-state-metrics/v2/pkg/metric"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+	metricsstore "k8s.io/kube-state-metrics/v2/pkg/metrics_store"
+	"k8s.io/kube-state-metrics/v2/pkg/options"
+)
+
+type stubStoreBuilder struct {
+	buildWriters metricsstore.MetricsWriterList
+	syncOK       atomic.Bool
+	buildCount   atomic.Int64
+	syncCount    atomic.Int64
+	// syncGate, when set, makes WaitForStoresSync block until a result is sent.
+	// This lets tests assert mid-retry state without racing the retry timer.
+	syncGate chan bool
+}
+
+func (s *stubStoreBuilder) WithMetrics(_ prometheus.Registerer)                         {}
+func (s *stubStoreBuilder) WithEnabledResources(_ []string) error                       { return nil }
+func (s *stubStoreBuilder) WithNamespaces(_ options.NamespaceList)                      {}
+func (s *stubStoreBuilder) WithFieldSelectorFilter(_ string)                            {}
+func (s *stubStoreBuilder) WithSharding(_ int32, _ int)                                 {}
+func (s *stubStoreBuilder) WithContext(_ context.Context)                               {}
+func (s *stubStoreBuilder) WithKubeClient(_ clientset.Interface)                        {}
+func (s *stubStoreBuilder) WithCustomResourceClients(_ map[string]interface{})          {}
+func (s *stubStoreBuilder) WithUsingAPIServerCache(_ bool)                              {}
+func (s *stubStoreBuilder) WithFamilyGeneratorFilter(_ generator.FamilyGeneratorFilter) {}
+func (s *stubStoreBuilder) WithAllowAnnotations(_ map[string][]string) error            { return nil }
+func (s *stubStoreBuilder) WithAllowLabels(_ map[string][]string) error                 { return nil }
+func (s *stubStoreBuilder) WithGenerateStoresFunc(_ ksmtypes.BuildStoresFunc)           {}
+func (s *stubStoreBuilder) DefaultGenerateStoresFunc() ksmtypes.BuildStoresFunc         { return nil }
+func (s *stubStoreBuilder) DefaultGenerateCustomResourceStoresFunc() ksmtypes.BuildCustomResourceStoresFunc {
+	return nil
+}
+func (s *stubStoreBuilder) WithCustomResourceStoreFactories(_ ...customresource.RegistryFactory) {
+}
+func (s *stubStoreBuilder) BuildStores() [][]cache.Store { return nil }
+func (s *stubStoreBuilder) WithGenerateCustomResourceStoresFunc(_ ksmtypes.BuildCustomResourceStoresFunc) {
+}
+
+func (s *stubStoreBuilder) Build() metricsstore.MetricsWriterList {
+	s.buildCount.Add(1)
+	return s.buildWriters
+}
+
+func (s *stubStoreBuilder) WaitForStoresSync(_ context.Context, _ time.Duration) bool {
+	s.syncCount.Add(1)
+	if s.syncGate != nil {
+		return <-s.syncGate
+	}
+	return s.syncOK.Load()
+}
+
+// waitForRebuildIdle blocks until no rebuild is in flight, so assertions do not
+// race an in-progress swap.
+func waitForRebuildIdle(t *testing.T, h *MetricsHandler) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.rebuildMu.Lock()
+		running := h.rebuildRunning
+		h.rebuildMu.Unlock()
+		if !running {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("rebuild did not finish before deadline")
+}
+
+func TestBuildWriters_KeepsPreviousWritersWhenSyncFails(t *testing.T) {
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("candidate")},
+	}
+	opts := options.NewOptions()
+	h := New(opts, nil, stub, false)
+
+	existing := metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("stable")}
+	h.mtx.Lock()
+	h.metricsWriters = existing
+	h.mtx.Unlock()
+
+	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
+
+	if stub.buildCount.Load() < 1 || stub.syncCount.Load() < 1 {
+		t.Fatalf("expected a build and a sync attempt; buildCount=%d syncCount=%d",
+			stub.buildCount.Load(), stub.syncCount.Load())
+	}
+
+	h.mtx.RLock()
+	got := h.metricsWriters
+	h.mtx.RUnlock()
+	if len(got) != 1 || got[0].ResourceName != "stable" {
+		t.Fatalf("expected stable writers to be kept after failed sync, got %+v", got)
+	}
+}
+
+func TestBuildWriters_SwapsWritersWhenSyncSucceeds(t *testing.T) {
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("next")},
+	}
+	stub.syncOK.Store(true)
+	opts := options.NewOptions()
+	h := New(opts, nil, stub, false)
+
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("prev")}
+	h.mtx.Unlock()
+
+	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
+
+	h.mtx.RLock()
+	got := h.metricsWriters
+	h.mtx.RUnlock()
+	if len(got) != 1 || got[0].ResourceName != "next" {
+		t.Fatalf("expected writers to swap after successful sync, got %+v", got)
+	}
+}
+
+func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
+	restore := initialStoreSyncRetryDelay
+	initialStoreSyncRetryDelay = time.Millisecond
+	defer func() { initialStoreSyncRetryDelay = restore }()
+
+	// Channel-gated sync: first attempt fails immediately; the retry blocks until
+	// the test releases a successful result, so mid-retry assertions cannot race
+	// the retry timer.
+	syncGate := make(chan bool)
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{metricsstore.NewMetricsWriter("first")},
+		syncGate:     syncGate,
+	}
+	h := New(options.NewOptions(), nil, stub, false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstSyncDone := make(chan struct{})
+	go func() {
+		syncGate <- false
+		close(firstSyncDone)
+	}()
+	h.BuildWriters(ctx)
+	<-firstSyncDone
+
+	// Writers stay empty until we release the retry, even if the retry timer has
+	// already fired and is blocked in WaitForStoresSync.
+	h.mtx.RLock()
+	got := len(h.metricsWriters)
+	h.mtx.RUnlock()
+	if got != 0 {
+		t.Fatalf("expected no writers after failed initial sync, got %d", got)
+	}
+
+	// Release the retry sync as success. Send in a goroutine so we do not block
+	// if the retry has not entered WaitForStoresSync yet.
+	go func() { syncGate <- true }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mtx.RLock()
+		writers := h.metricsWriters
+		h.mtx.RUnlock()
+		if len(writers) == 1 && writers[0].ResourceName == "first" {
+			if stub.syncCount.Load() < 2 {
+				t.Fatalf("expected retry sync attempt; syncCount=%d", stub.syncCount.Load())
+			}
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("expected retry to populate writers; buildCount=%d syncCount=%d",
+		stub.buildCount.Load(), stub.syncCount.Load())
+}
+
+func TestServeHTTP_WriterSnapshot(t *testing.T) {
+	h := New(options.NewOptions(), nil, &stubStoreBuilder{}, false)
+	h.mtx.Lock()
+	h.metricsWriters = metricsstore.MetricsWriterList{newTestWriter("first"), newTestWriter("second")}
+	h.mtx.Unlock()
+
+	// Replace the writer list while ServeHTTP is mid-response: the snapshot it
+	// took must still be written out in full.
+	rec := httptest.NewRecorder()
+	body := &blockingWriter{
+		ResponseWriter: rec,
+		onFirstWrite: func() {
+			h.mtx.Lock()
+			h.metricsWriters = metricsstore.MetricsWriterList{newTestWriter("replaced")}
+			h.mtx.Unlock()
+		},
+	}
+	// ServeHTTP must not hold mtx across the response body, or onFirstWrite would
+	// deadlock instead of failing.
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(body, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeHTTP did not complete while writers were replaced")
+	}
+
+	out := rec.Body.String()
+	for _, want := range []string{"kube_test_first", "kube_test_second"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in response, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "kube_test_replaced") {
+		t.Fatalf("response used writers swapped in mid-request:\n%s", out)
+	}
+}
+
+// blockingWriter runs onFirstWrite once, before the first byte of the response
+// body is written, to simulate a rebuild landing during a scrape.
+type blockingWriter struct {
+	http.ResponseWriter
+	onFirstWrite func()
+	written      bool
+}
+
+func (b *blockingWriter) Write(p []byte) (int, error) {
+	if !b.written {
+		b.written = true
+		b.onFirstWrite()
+	}
+	return b.ResponseWriter.Write(p)
+}
+
+func newTestWriter(name string) *metricsstore.MetricsWriter {
+	genFunc := func(obj interface{}) []metric.FamilyInterface {
+		o, err := meta.Accessor(obj)
+		if err != nil {
+			panic(err)
+		}
+		return []metric.FamilyInterface{&metric.Family{
+			Name: "kube_test_" + name,
+			Metrics: []*metric.Metric{{
+				LabelKeys:   []string{"namespace"},
+				LabelValues: []string{o.GetNamespace()},
+				Value:       1,
+			}},
+		}}
+	}
+	store := metricsstore.NewMetricsStore([]string{"# HELP kube_test_" + name + " test\n"}, genFunc)
+	if err := store.Add(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID(name), Name: name, Namespace: "ns"},
+	}); err != nil {
+		panic(err)
+	}
+	return metricsstore.NewMetricsWriter(name, store)
+}

--- a/pkg/metricshandler/rebuild_test.go
+++ b/pkg/metricshandler/rebuild_test.go
@@ -171,6 +171,43 @@ func TestBuildWriters_ReadyAfterEmptyGenerationSyncs(t *testing.T) {
 	}
 }
 
+func TestBuildWriters_DoesNotRetryFailedRebuildAfterEmptyGenerationInstalled(t *testing.T) {
+	restore := initialStoreSyncRetryDelay
+	initialStoreSyncRetryDelay = time.Millisecond
+	defer func() { initialStoreSyncRetryDelay = restore }()
+
+	syncGate := make(chan bool, 2)
+	stub := &stubStoreBuilder{
+		buildWriters: metricsstore.MetricsWriterList{},
+		syncGate:     syncGate,
+	}
+	h := New(options.NewOptions(), nil, stub, false)
+
+	syncGate <- true
+	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
+	if !h.Ready() {
+		t.Fatal("expected ready after empty generation install")
+	}
+
+	firstBuild := stub.buildCount.Load()
+	firstSync := stub.syncCount.Load()
+
+	syncGate <- false
+	h.BuildWriters(context.Background())
+	waitForRebuildIdle(t, h)
+
+	time.Sleep(5 * time.Millisecond)
+	waitForRebuildIdle(t, h)
+
+	if stub.buildCount.Load() != firstBuild+1 {
+		t.Fatalf("expected only one failing rebuild after installed generation, buildCount=%d", stub.buildCount.Load())
+	}
+	if stub.syncCount.Load() != firstSync+1 {
+		t.Fatalf("expected only one failing sync after installed generation, syncCount=%d", stub.syncCount.Load())
+	}
+}
+
 func TestBuildWriters_RetriesWhenInitialSyncFails(t *testing.T) {
 	restore := initialStoreSyncRetryDelay
 	initialStoreSyncRetryDelay = time.Millisecond

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -40,7 +40,7 @@ var (
 
 // DefaultStoreSyncTimeout is the default maximum time to wait for reflector
 // stores to complete their initial list before swapping metrics writers.
-var DefaultStoreSyncTimeout = 120 * time.Second
+const DefaultStoreSyncTimeout = 120 * time.Second
 
 // Options are the configurable parameters for kube-state-metrics.
 type Options struct {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -38,6 +38,10 @@ var (
 	defaultServerReadHeaderTimeout = 5 * time.Second
 )
 
+// DefaultStoreSyncTimeout is the default maximum time to wait for reflector
+// stores to complete their initial list before swapping metrics writers.
+var DefaultStoreSyncTimeout = 120 * time.Second
+
 // Options are the configurable parameters for kube-state-metrics.
 type Options struct {
 	AnnotationsAllowList LabelsAllowList `yaml:"annotations_allow_list"`
@@ -78,6 +82,7 @@ type Options struct {
 	ServerWriteTimeout      time.Duration `yaml:"server_write_timeout"`
 	ServerIdleTimeout       time.Duration `yaml:"server_idle_timeout"`
 	ServerReadHeaderTimeout time.Duration `yaml:"server_read_header_timeout"`
+	StoreSyncTimeout        time.Duration `yaml:"store_sync_timeout"`
 
 	Shard                int32 `yaml:"shard"`
 	AutoGoMemlimit       bool  `yaml:"auto-gomemlimit"`
@@ -191,6 +196,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	o.cmd.Flags().DurationVar(&o.ServerWriteTimeout, "server-write-timeout", defaultServerWriteTimeout, "The maximum duration before timing out writes of the response. Align with the scrape interval or timeout of scraping clients..")
 	o.cmd.Flags().DurationVar(&o.ServerIdleTimeout, "server-idle-timeout", defaultServerIdleTimeout, "The maximum amount of time to wait for the next request when keep-alives are enabled. Align with the idletimeout of your scrape clients.")
 	o.cmd.Flags().DurationVar(&o.ServerReadHeaderTimeout, "server-read-header-timeout", defaultServerReadHeaderTimeout, "The maximum duration for reading the header of requests.")
+	o.cmd.Flags().DurationVar(&o.StoreSyncTimeout, "store-sync-timeout", DefaultStoreSyncTimeout, "Maximum time to wait for reflector stores to complete their initial list before swapping metrics writers during a rebuild.")
 }
 
 // Parse parses the flag definitions from the argument list.

--- a/tests/e2e/discovery_test.go
+++ b/tests/e2e/discovery_test.go
@@ -133,6 +133,20 @@ func (rm *resourceManager) writeResourceFiles(t *testing.T) {
 	klog.InfoS("created initial and new CR and CRD manifests")
 }
 
+func waitForCRDEstablished(t *testing.T, name string) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(context.TODO(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		cmd := exec.CommandContext(ctx, "kubectl", "wait", "--for=condition=Established", "crd/"+name, "--timeout=1s") //nolint:gosec
+		if err := cmd.Run(); err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("timed out waiting for CRD %q to be established: %v", name, err)
+	}
+}
+
 func TestVariableVKsDiscoveryAndResolution(t *testing.T) {
 	// populateTimeout is the timeout on populating the cache for the first time.
 	const populateTimeout = 10 * time.Second
@@ -190,6 +204,7 @@ func TestVariableVKsDiscoveryAndResolution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to apply initial crd: %v", err)
 	}
+	waitForCRDEstablished(t, "myplatforms.contoso.com")
 	err = exec.Command("kubectl", "apply", "-f", rm.initCrFile.Name()).Run() //nolint:gosec
 	if err != nil {
 		t.Fatalf("failed to apply initial cr: %v", err)
@@ -234,6 +249,7 @@ func TestVariableVKsDiscoveryAndResolution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to apply new crd: %v", err)
 	}
+	waitForCRDEstablished(t, "updates.contoso.com")
 	err = exec.Command("kubectl", "apply", "-f", rm.newCrFile.Name()).Run() //nolint:gosec
 	if err != nil {
 		t.Fatalf("failed to apply new cr: %v", err)


### PR DESCRIPTION
## Summary

Second PR in a two-part split (see #3055 for store-sync-before-swap). **Merge #3055 first**, then merge this PR.

- Serialize `storeBuilder` updates through `MetricsHandler.ConfigureStore` so discovery cannot race async rebuilds
- Skip no-op CRD add/update/delete events that do not change the discoverable GVK/plural set
- Track `cacheRevision` so delete/re-add cycles with the same GVR still trigger rebuilds
- Preserve `WasUpdated` on factory/client/`WithEnabledResources` errors for retry on the next tick
- Run all writer rebuilds asynchronously (including the first CRS build) so discovery reconciliation does not block in `WaitForStoresSync`

Until #3055 lands, this PR's diff includes both changes. After #3055 merges, the diff should shrink to the two discovery commits below. A rebase onto `main` is only needed if GitHub shows a stale/duplicate diff (e.g. after a squash merge) or if there are merge conflicts.

Review the discovery commits:
- `fix(discovery): avoid no-op CRD updates forcing writer rebuilds`
- `fix(metricshandler): run all writer rebuilds asynchronously`

## Test plan

- [x] `go test ./internal/discovery/... ./pkg/metricshandler/...`
- [ ] Merge after #3055
- [ ] Internal cluster validation of full stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable store synchronization timeout through `--store-sync-timeout` and YAML settings, defaulting to two minutes.
  - Metrics rebuilds now wait for stores to synchronize before switching writers, with retries and fallback to the previous working metrics.
  - Readiness checks remain unavailable until metrics initialization is complete.
  - Added support for updating enabled custom resources without affecting built-in resources.

- **Bug Fixes**
  - Prevented unnecessary rebuilds when resource discovery has not changed.
  - Improved handling of discovery updates, removals, and synchronization failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->