### PR TITLE
fix(options): reject incomplete allowlist values

### DIFF
--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -301,6 +301,9 @@ func (l *LabelsAllowList) Set(value string) error {
 			firstWordPos = i + 1
 		}
 	}
+	if value != "" && !strings.HasSuffix(value, "]") {
+		return errLabelsAllowListFormat
+	}
 
 	// check amount of wildcards per label
 	for _, group := range m {

--- a/pkg/options/types_test.go
+++ b/pkg/options/types_test.go
@@ -314,6 +314,18 @@ func TestLabelsAllowListSet(t *testing.T) {
 			Wanted: LabelsAllowList(map[string][]string{}),
 			err:    errLabelsAllowListFormat,
 		},
+		{
+			Desc:   "[invalid] missing closing bracket",
+			Value:  "pods=[app",
+			Wanted: LabelsAllowList(map[string][]string{}),
+			err:    errLabelsAllowListFormat,
+		},
+		{
+			Desc:   "[invalid] unstructured value",
+			Value:  "pods",
+			Wanted: LabelsAllowList(map[string][]string{}),
+			err:    errLabelsAllowListFormat,
+		},
 
 		{
 			Desc:   "[invalid] no comma between metrics",


### PR DESCRIPTION
What this fixes

`LabelsAllowList.Set` accepts incomplete values like `pods=[app` and turns them into `pods=[]`. 
KSM starts normally, but requested labels never show up

This rejects non-empty allowlist values unless they close with `]`. 
Empty and valid values work as before

Repro

Set `metric-labels-allowlist` to `pods=[app`.

Before: startup continues with an empty pod allowlist.
After: startup fails with the existing invalid format error.

Tests

`make test-unit`
`make lint`
`make validate-modules`

Cardinality

No change.

Related: #3086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for label allowlist entries.
  * Incomplete or improperly structured expressions are now rejected instead of being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->