### PR TITLE
ci: give each job its own Go build cache and cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,26 @@ on:
 permissions:
   contents: read
 
+# Superseded runs on a pull request are pointless work; the org runner pool is
+# shared, so cancel them. Pushes to main/release branches and tags are never
+# cancelled - their runs are the record for that commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   E2E_SETUP_KIND: yes
   E2E_SETUP_KUBECTL: yes
   SUDO: sudo
   GOLANGCI_LINT_VERSION: "v2.11.3"
 
+# setup-go's own caching is off in every job below. It derives a single cache
+# key from OS + Go version + go.sum, so all jobs here collide on it: they start
+# together, all miss, all race to save, and one arbitrary winner takes the slot
+# - often a job that barely populates GOCACHE, which the rest then restore. The
+# steps below cache GOMODCACHE under a shared key (its contents are the same
+# everywhere) and GOCACHE under a per-job key. Jobs that compile little enough
+# not to earn a build cache entry take the module cache only.
 jobs:
   ci-go-lint:
     name: ci-go-lint
@@ -34,7 +48,24 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: '.go-version'
+        cache: false # see the caching note above `jobs`
       id: go
+
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gomod-${{ runner.os }}-
+
+    - name: Cache Go build output
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/.cache/golangci-lint
+        key: gobuild-${{ runner.os }}-lint-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gobuild-${{ runner.os }}-lint-
 
     - name: Lint
       run: |
@@ -52,7 +83,15 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: '.go-version'
+        cache: false # see the caching note above `jobs`
       id: go
+
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gomod-${{ runner.os }}-
 
     - name: Validate generated manifests
       run: |
@@ -69,7 +108,15 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: '.go-version'
+        cache: false # see the caching note above `jobs`
       id: go
+
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gomod-${{ runner.os }}-
 
     - name: Validate go modules
       run: |
@@ -86,7 +133,22 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: '.go-version'
+        cache: false # see the caching note above `jobs`
       id: go
+
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gomod-${{ runner.os }}-
+
+    - name: Cache Go build output
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/go-build
+        key: gobuild-${{ runner.os }}-docs-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gobuild-${{ runner.os }}-docs-
 
     - name: Check that all metrics are documented and templates have no delta
       run: |
@@ -103,7 +165,22 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: '.go-version'
+        cache: false # see the caching note above `jobs`
       id: go
+
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gomod-${{ runner.os }}-
+
+    - name: Cache Go build output
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/go-build
+        key: gobuild-${{ runner.os }}-unit-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gobuild-${{ runner.os }}-unit-
 
     - name: Unit tests
       run: |
@@ -135,7 +212,22 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: '.go-version'
+        cache: false # see the caching note above `jobs`
       id: go
+
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gomod-${{ runner.os }}-
+
+    - name: Cache Go build output
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/go-build
+        key: gobuild-${{ runner.os }}-benchmark-main-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gobuild-${{ runner.os }}-benchmark-main-
 
     - name: Benchmark tests
       run: |
@@ -166,7 +258,22 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: '.go-version'
+        cache: false # see the caching note above `jobs`
       id: go
+
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gomod-${{ runner.os }}-
+
+    - name: Cache Go build output
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/go-build
+        key: gobuild-${{ runner.os }}-benchmark-release-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gobuild-${{ runner.os }}-benchmark-release-
 
     - name: Benchmark tests
       run: |
@@ -194,7 +301,22 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: '.go-version'
+        cache: false # see the caching note above `jobs`
       id: go
+
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gomod-${{ runner.os }}-
+
+    - name: Cache Go build output
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/go-build
+        key: gobuild-${{ runner.os }}-build-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gobuild-${{ runner.os }}-build-
 
     - name: Build
       run: |
@@ -211,7 +333,22 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: '.go-version'
+        cache: false # see the caching note above `jobs`
       id: go
+
+    - name: Cache Go modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gomod-${{ runner.os }}-
+
+    - name: Cache Go build output
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/go-build
+        key: gobuild-${{ runner.os }}-e2e-${{ hashFiles('go.sum', '.go-version') }}
+        restore-keys: gobuild-${{ runner.os }}-e2e-
 
     - name: End-to-end tests
       run: |


### PR DESCRIPTION
**What this PR does / why we need it:**

Two independent CI speedups.

**1. The Go cache never hits.**

`setup-go` derives a single cache key from OS + Go version + `go.sum`, so all nine Go jobs in `ci.yml` collide on it. They start together, so all of them miss, all of them race to save, and one arbitrary winner takes the slot — often a ~20s job like `ci-validate-manifests` whose `GOCACHE` is nearly empty, which everyone else then restores.

Both of the last two runs show this in every Go job:

```
Cache is not found
Failed to save: Unable to reserve cache with key
setup-go-Linux-x64-ubuntu24-go-1.26.6-b048585…, another job may be creating this cache.
```

So nothing is reused and every job compiles the dependency graph from scratch. Measured on this module:

| scenario | `go test -race` compile |
|---|---|
| cold cache (what CI does today) | **2m35s** (13m29s CPU) |
| deps cached, sources changed (a typical PR) | **24s** |
| fully warm | 11s |

That penalty is currently paid nine times per run. It is also visible inside `ci-e2e-tests`, where the first `go test -race` takes 118s and the next one 12s.

This PR turns `setup-go`'s caching off and caches explicitly instead:

- `~/go/pkg/mod` under a key shared by all jobs, since its contents are identical everywhere.
- `~/.cache/go-build` under a per-job key, for the seven jobs that actually compile. `ci-validate-manifests` and `ci-validate-go-modules` compile little enough that a multi-hundred-MB entry is not worth it, so they take the module cache only. This also keeps total cache storage comfortably under the 10 GB repo limit.
- The lint entry additionally covers `~/.cache/golangci-lint`.

The keys deliberately exclude the commit SHA. Including it would write a fresh entry every run and thrash LRU eviction, and it buys little — per the table above, a key that only rolls when dependencies change already captures ~91% of the available win.

**2. No `concurrency` group.**

Force-pushes to a PR leave superseded runs burning slots in the shared org runner pool. Cancellation is gated to `pull_request`, so pushes to `main`/release branches and tag builds still run to completion — those runs are the record for the commit. The group keys on the PR number rather than the ref so a push and its PR don't cancel each other.

**Note on when the benefit appears:** the first run after merge is still a full miss, and GitHub scopes caches so PR branches can only read from the base branch. The caches must be populated by a run on `main` before PRs see any improvement — so this shouldn't be judged from the CI run on this PR itself.

Estimated effect once warm: wall clock ~10m → ~7m. Follow-ups I'd like to send separately: taking the release-tag benchmark comparison off the PR critical path (it's the longest job at ~10m and its base only changes when a tag lands), and `make build`, which pulls the 800MB `golang` image to run `git config` in a throwaway container and then builds on the host anyway because of where the `&&` binds.

`actionlint` is clean on the additions; the three findings it reports are pre-existing shellcheck issues in `run:` blocks this PR doesn't touch.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:**
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined automated checks by canceling outdated pull-request runs while preserving validation for pushes, tags, and releases.
  * Improved build and test performance through more effective reuse of downloaded modules and job-specific build results.
  * These updates help provide faster, more consistent feedback during development and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->