### PR TITLE
test: repeat the backtracking test input 1024 times, not 8

### DIFF
--- a/pkg/allowdenylist/allowdenylist_test.go
+++ b/pkg/allowdenylist/allowdenylist_test.go
@@ -317,7 +317,7 @@ func TestCatastrophicBacktrackTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 	var exp = "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-	exp = strings.Repeat(exp, 2^10)
+	exp = strings.Repeat(exp, 1024)
 
 	timeout := regexpDefaultTimeout
 	t.Logf("regexp.DefaultMatchTimeout set to: %v", timeout)


### PR DESCRIPTION
**What this PR does / why we need it:**

`TestCatastrophicBacktrackTimeout` builds its input like this:

```go
var exp = "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
exp = strings.Repeat(exp, 2^10)
```

In Go `^` is bitwise XOR, not exponentiation, so `2^10` evaluates to `8`. The input is 432 bytes rather than the ~55 KB the expression was clearly meant to produce.

The test passes either way — that regex backtracks catastrophically on both inputs, and the assertion is on the match timeout firing, not on the input size — so this only corrects the intent.

Verified with the longer input: the test still aborts on the timeout, at 60.15s against its 60s + 500ms bound. `go vet` and `gofmt` are clean.

**How does this change affect the cardinality of KSM:** does not change cardinality

**Which issue(s) this PR fixes:**
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected a stress-test input to reliably exercise repeated-pattern handling.
  * Improved test validity by generating the intended 1,024 repetitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->