### PR TITLE
test(e2e): move metrics stability test out of shell (#3113)

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -198,7 +198,7 @@ docker images -a
 # Use Docker's machine-readable output - the human table columns/spacing can change between Docker versions.
 KUBE_STATE_METRICS_IMAGE_TAG="$(
     docker images --format '{{.Repository}} {{.Tag}}' \
-        | awk -v repo="${KUBE_STATE_METRICS_IMAGE_NAME}" '$1 == repo && $2 != "latest" { print $2; exit }'
+        | awk -v repo="${KUBE_STATE_METRICS_IMAGE_NAME}" '$1 == repo && $2 != "latest" { if (!found) { print $2; found=1 } }'
 )"
 if [[ -z "${KUBE_STATE_METRICS_IMAGE_TAG}" ]]; then
     echo "ERROR: could not determine a local image tag for ${KUBE_STATE_METRICS_IMAGE_NAME} (excluding 'latest')." >&2
@@ -247,18 +247,9 @@ echo "start e2e test for kube-state-metrics"
 KSM_HTTP_METRICS_URL='http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy'
 KSM_TELEMETRY_URL='http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:telemetry/proxy'
 
-go test -v ./tests/e2e/main_test.go --ksm-http-metrics-url=${KSM_HTTP_METRICS_URL} --ksm-telemetry-url=${KSM_TELEMETRY_URL}
+echo "running metrics stability test..."
+go test -v ./tests/e2e --ksm-http-metrics-url=${KSM_HTTP_METRICS_URL} --ksm-telemetry-url=${KSM_TELEMETRY_URL} -run TestMetricsStability
 
-# TODO: re-implement the following test cases in Go with the goal of removing this file.
-echo "access kube-state-metrics metrics endpoint"
-curl -s "http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy/metrics" >${KUBE_STATE_METRICS_LOG_DIR}/metrics
-
-KUBE_STATE_METRICS_STATUS=$(curl -s "http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy/healthz")
-if [[ "${KUBE_STATE_METRICS_STATUS}" == "OK" ]]; then
-    echo "kube-state-metrics is still running after accessing metrics endpoint"
-fi
-
-# wait for klog to flush to log file
 sleep 33
 klog_err=E$(date +%m%d)
 echo "check for errors in logs"

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -248,7 +248,7 @@ KSM_HTTP_METRICS_URL='http://localhost:8001/api/v1/namespaces/kube-system/servic
 KSM_TELEMETRY_URL='http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:telemetry/proxy'
 
 echo "running metrics stability test..."
-go test -v ./tests/e2e --ksm-http-metrics-url=${KSM_HTTP_METRICS_URL} --ksm-telemetry-url=${KSM_TELEMETRY_URL} -run TestMetricsStability
+go test -v ./tests/e2e/main_test.go ./tests/e2e/metrics_stability_test.go --ksm-http-metrics-url=${KSM_HTTP_METRICS_URL} --ksm-telemetry-url=${KSM_TELEMETRY_URL}
 
 sleep 33
 klog_err=E$(date +%m%d)

--- a/tests/e2e/metrics_stability_test.go
+++ b/tests/e2e/metrics_stability_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMetricsStability(t *testing.T) {
+	if framework == nil || framework.KsmClient == nil {
+		t.Fatal("e2e framework not initialized, run via TestMain with --ksm-http-metrics-url and --ksm-telemetry-url")
+	}
+
+	buf := &bytes.Buffer{}
+	if err := framework.KsmClient.Metrics(buf); err != nil {
+		t.Fatalf("failed to fetch metrics endpoint: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("metrics endpoint returned empty body")
+	}
+
+	ok, err := framework.KsmClient.IsHealthz()
+	if err != nil {
+		t.Fatalf("healthz check after metrics fetch failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("kube-state-metrics unhealthy after metrics fetch")
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
**What this PR does / why we need it:**

(Same content as the issue #3113.)

The e2e shell script had a todo comment suggesting bash based tests be moved to go tests 

https://github.com/kubernetes/kube-state-metrics/blob/3e685f693a83dee42ed3e5e175f3c1cd17648428/tests/e2e.sh#L252

Moving these to Go makes things more maintainable.

```sh
echo "access kube-state-metrics metrics endpoint"
curl -s "http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy/metrics" >${KUBE_STATE_METRICS_LOG_DIR}/metrics

KUBE_STATE_METRICS_STATUS=$(curl -s "http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy/healthz")
if [[ "${KUBE_STATE_METRICS_STATUS}" == "OK" ]]; then
    echo "kube-state-metrics is still running after accessing metrics endpoint"
fi
```

**How**

Test has to check KSM is available, hit the metrics endpoint and then the health endpoint.

*Also adjusted the tag check:*
Use awk found-flag instead of exit for first-match image tag selection in e2e script




**How does this change affect the cardinality of KSM:** *(increases, decreases or does not change cardinality)*

It does not, test only.

**Which issue(s) this PR fixes:**
Fixes #3113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage confirming that metrics remain available and non-empty.
  - Added health checks to verify the service remains operational during metrics stability validation.
  - Updated the test workflow to run the focused metrics stability scenarios for more targeted coverage.
  - Improved image tag selection during test setup to consistently use the appropriate non-`latest` tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->